### PR TITLE
Plugin implementation for the new GE transactions and flip tracking

### DIFF
--- a/src/main/java/com/flipsmart/ActiveFlip.java
+++ b/src/main/java/com/flipsmart/ActiveFlip.java
@@ -1,0 +1,39 @@
+package com.flipsmart;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+/**
+ * Represents an active flip (item bought but not yet sold)
+ */
+@Data
+public class ActiveFlip
+{
+	@SerializedName("item_id")
+	private int itemId;
+
+	@SerializedName("item_name")
+	private String itemName;
+
+	@SerializedName("total_quantity")
+	private int totalQuantity;
+
+	@SerializedName("average_buy_price")
+	private int averageBuyPrice;
+
+	@SerializedName("total_invested")
+	private int totalInvested;
+
+	@SerializedName("first_buy_time")
+	private String firstBuyTime;
+
+	@SerializedName("last_buy_time")
+	private String lastBuyTime;
+
+	@SerializedName("transaction_count")
+	private int transactionCount;
+
+	@SerializedName("recommended_sell_price")
+	private Integer recommendedSellPrice;
+}
+

--- a/src/main/java/com/flipsmart/ActiveFlipsResponse.java
+++ b/src/main/java/com/flipsmart/ActiveFlipsResponse.java
@@ -1,0 +1,23 @@
+package com.flipsmart;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * Response from the active flips API endpoint
+ */
+@Data
+public class ActiveFlipsResponse
+{
+	@SerializedName("active_flips")
+	private List<ActiveFlip> activeFlips;
+
+	@SerializedName("total_items")
+	private int totalItems;
+
+	@SerializedName("total_invested")
+	private int totalInvested;
+}
+

--- a/src/main/java/com/flipsmart/CompletedFlip.java
+++ b/src/main/java/com/flipsmart/CompletedFlip.java
@@ -1,0 +1,60 @@
+package com.flipsmart;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+/**
+ * Represents a completed flip (matched buy/sell pair)
+ */
+@Data
+public class CompletedFlip
+{
+	@SerializedName("id")
+	private int id;
+
+	@SerializedName("item_id")
+	private int itemId;
+
+	@SerializedName("item_name")
+	private String itemName;
+
+	@SerializedName("quantity")
+	private int quantity;
+
+	@SerializedName("buy_price_per_item")
+	private int buyPricePerItem;
+
+	@SerializedName("buy_total")
+	private int buyTotal;
+
+	@SerializedName("buy_time")
+	private String buyTime;
+
+	@SerializedName("sell_price_per_item")
+	private int sellPricePerItem;
+
+	@SerializedName("sell_total")
+	private int sellTotal;
+
+	@SerializedName("sell_time")
+	private String sellTime;
+
+	@SerializedName("gross_profit")
+	private int grossProfit;
+
+	@SerializedName("ge_tax")
+	private int geTax;
+
+	@SerializedName("net_profit")
+	private int netProfit;
+
+	@SerializedName("roi_percent")
+	private double roiPercent;
+
+	@SerializedName("flip_duration_seconds")
+	private int flipDurationSeconds;
+
+	@SerializedName("is_successful")
+	private boolean isSuccessful;
+}
+

--- a/src/main/java/com/flipsmart/CompletedFlipsResponse.java
+++ b/src/main/java/com/flipsmart/CompletedFlipsResponse.java
@@ -1,0 +1,20 @@
+package com.flipsmart;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * Response from the completed flips API endpoint
+ */
+@Data
+public class CompletedFlipsResponse
+{
+	@SerializedName("flips")
+	private List<CompletedFlip> flips;
+
+	@SerializedName("count")
+	private int count;
+}
+

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -22,18 +22,25 @@ public class FlipFinderPanel extends PluginPanel
 	private final FlipSmartConfig config;
 	private final FlipSmartApiClient apiClient;
 	private final ItemManager itemManager;
-	private final JPanel listContainer = new JPanel();
+	private final JPanel recommendedListContainer = new JPanel();
+	private final JPanel activeFlipsListContainer = new JPanel();
+	private final JPanel completedFlipsListContainer = new JPanel();
 	private final JLabel statusLabel = new JLabel("Loading...");
 	private final JButton refreshButton = new JButton("Refresh");
 	private final JComboBox<FlipSmartConfig.FlipStyle> flipStyleDropdown;
 	private final List<FlipRecommendation> currentRecommendations = new ArrayList<>();
+	private final List<ActiveFlip> currentActiveFlips = new ArrayList<>();
+	private final List<CompletedFlip> currentCompletedFlips = new ArrayList<>();
+	private final JTabbedPane tabbedPane = new JTabbedPane();
+	private final FlipSmartPlugin plugin;  // Reference to plugin to store recommended prices
 
-	public FlipFinderPanel(FlipSmartConfig config, FlipSmartApiClient apiClient, ItemManager itemManager)
+	public FlipFinderPanel(FlipSmartConfig config, FlipSmartApiClient apiClient, ItemManager itemManager, FlipSmartPlugin plugin)
 	{
 		super(false);
 		this.config = config;
 		this.apiClient = apiClient;
 		this.itemManager = itemManager;
+		this.plugin = plugin;
 
 		setLayout(new BorderLayout());
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
@@ -116,34 +123,148 @@ public class FlipFinderPanel extends PluginPanel
 		topPanel.add(controlsPanel);
 		topPanel.add(statusPanel);
 
-		// List container
-		listContainer.setLayout(new BoxLayout(listContainer, BoxLayout.Y_AXIS));
-		listContainer.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		// Recommended flips list container
+		recommendedListContainer.setLayout(new BoxLayout(recommendedListContainer, BoxLayout.Y_AXIS));
+		recommendedListContainer.setBackground(ColorScheme.DARK_GRAY_COLOR);
 
-		JScrollPane scrollPane = new JScrollPane(listContainer);
-		scrollPane.setBackground(ColorScheme.DARK_GRAY_COLOR);
-		scrollPane.getVerticalScrollBar().setPreferredSize(new Dimension(8, 0));
-		scrollPane.setBorder(BorderFactory.createEmptyBorder());
-		scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-		scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+		JScrollPane recommendedScrollPane = new JScrollPane(recommendedListContainer);
+		recommendedScrollPane.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		recommendedScrollPane.getVerticalScrollBar().setPreferredSize(new Dimension(8, 0));
+		recommendedScrollPane.setBorder(BorderFactory.createEmptyBorder());
+		recommendedScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+		recommendedScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+
+		// Active flips list container
+		activeFlipsListContainer.setLayout(new BoxLayout(activeFlipsListContainer, BoxLayout.Y_AXIS));
+		activeFlipsListContainer.setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		JScrollPane activeFlipsScrollPane = new JScrollPane(activeFlipsListContainer);
+		activeFlipsScrollPane.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		activeFlipsScrollPane.getVerticalScrollBar().setPreferredSize(new Dimension(8, 0));
+		activeFlipsScrollPane.setBorder(BorderFactory.createEmptyBorder());
+		activeFlipsScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+		activeFlipsScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+
+		// Completed flips list container
+		completedFlipsListContainer.setLayout(new BoxLayout(completedFlipsListContainer, BoxLayout.Y_AXIS));
+		completedFlipsListContainer.setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		JScrollPane completedFlipsScrollPane = new JScrollPane(completedFlipsListContainer);
+		completedFlipsScrollPane.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		completedFlipsScrollPane.getVerticalScrollBar().setPreferredSize(new Dimension(8, 0));
+		completedFlipsScrollPane.setBorder(BorderFactory.createEmptyBorder());
+		completedFlipsScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+		completedFlipsScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+
+		// Create tabbed pane with custom UI for full-width tabs
+		tabbedPane.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		tabbedPane.setForeground(Color.WHITE);
+		tabbedPane.setTabPlacement(JTabbedPane.TOP);
+		
+		// Custom UI to make tabs fill the full width
+		tabbedPane.setUI(new javax.swing.plaf.basic.BasicTabbedPaneUI() {
+			@Override
+			protected int calculateTabWidth(int tabPlacement, int tabIndex, java.awt.FontMetrics metrics) {
+				// Calculate equal width for all tabs
+				int totalWidth = tabbedPane.getWidth();
+				int tabCount = tabbedPane.getTabCount();
+				if (tabCount > 0 && totalWidth > 0) {
+					return totalWidth / tabCount;
+				}
+				return super.calculateTabWidth(tabPlacement, tabIndex, metrics);
+			}
+			
+			@Override
+			protected void paintTabBackground(java.awt.Graphics g, int tabPlacement, int tabIndex,
+											  int x, int y, int w, int h, boolean isSelected) {
+				// Paint background for tabs
+				g.setColor(isSelected ? ColorScheme.DARKER_GRAY_COLOR : ColorScheme.DARK_GRAY_COLOR);
+				g.fillRect(x, y, w, h);
+			}
+			
+			@Override
+			protected void paintTabBorder(java.awt.Graphics g, int tabPlacement, int tabIndex,
+										  int x, int y, int w, int h, boolean isSelected) {
+				// Paint border/underline for selected tab
+				if (isSelected) {
+					g.setColor(ColorScheme.BRAND_ORANGE);
+					g.fillRect(x, y + h - 3, w, 3);
+				}
+			}
+			
+			@Override
+			protected void paintContentBorder(java.awt.Graphics g, int tabPlacement, int selectedIndex) {
+				// Don't paint content border
+			}
+		});
+		
+		tabbedPane.addTab("Recommended", recommendedScrollPane);
+		tabbedPane.addTab("Active Flips", activeFlipsScrollPane);
+		tabbedPane.addTab("Completed", completedFlipsScrollPane);
+		
+		// Add listener to update status when switching tabs
+		tabbedPane.addChangeListener(e ->
+		{
+			int selectedIndex = tabbedPane.getSelectedIndex();
+			if (selectedIndex == 1 && !currentActiveFlips.isEmpty())
+			{
+				// Switched to Active Flips tab, update status
+				int itemCount = currentActiveFlips.size();
+				int invested = currentActiveFlips.stream()
+					.mapToInt(ActiveFlip::getTotalInvested)
+					.sum();
+				statusLabel.setText(String.format("%d active %s | %s invested",
+					itemCount,
+					itemCount == 1 ? "flip" : "flips",
+					formatGP(invested)));
+			}
+			else if (selectedIndex == 2 && !currentCompletedFlips.isEmpty())
+			{
+				// Switched to Completed Flips tab, update status
+				int flipCount = currentCompletedFlips.size();
+				int totalProfit = currentCompletedFlips.stream()
+					.mapToInt(CompletedFlip::getNetProfit)
+					.sum();
+				statusLabel.setText(String.format("%d completed | %s profit",
+					flipCount,
+					formatGP(totalProfit)));
+			}
+			else if (selectedIndex == 0 && !currentRecommendations.isEmpty())
+			{
+				// Switched back to Recommended tab, restore original status
+				FlipFinderResponse response = new FlipFinderResponse();
+				response.setRecommendations(currentRecommendations);
+				updateStatusLabel(response);
+			}
+		});
 
 		add(topPanel, BorderLayout.NORTH);
-		add(scrollPane, BorderLayout.CENTER);
+		add(tabbedPane, BorderLayout.CENTER);
 
 		// Initial load
 		refresh();
 	}
 
 	/**
-	 * Refresh flip recommendations
+	 * Refresh flip recommendations, active flips, and completed flips
 	 */
 	public void refresh()
 	{
+		refreshRecommendations();
+		refreshActiveFlips();
+		refreshCompletedFlips();
+	}
+
+	/**
+	 * Refresh recommended flips
+	 */
+	private void refreshRecommendations()
+	{
 		statusLabel.setText("Loading recommendations...");
 		refreshButton.setEnabled(false);
-		listContainer.removeAll();
-		listContainer.revalidate();
-		listContainer.repaint();
+		recommendedListContainer.removeAll();
+		recommendedListContainer.revalidate();
+		recommendedListContainer.repaint();
 
 		// Fetch recommendations asynchronously
 		Integer cashStack = getCashStack();
@@ -160,18 +281,24 @@ public class FlipFinderPanel extends PluginPanel
 
 				if (response == null)
 				{
-					showError("Failed to fetch recommendations. Check your API settings.");
+					showErrorInRecommended("Failed to fetch recommendations. Check your API settings.");
 					return;
 				}
 
 				if (response.getRecommendations() == null || response.getRecommendations().isEmpty())
 				{
-					showError("No flip recommendations found matching your criteria.");
+					showErrorInRecommended("No flip recommendations found matching your criteria.");
 					return;
 				}
 
 				currentRecommendations.clear();
 				currentRecommendations.addAll(response.getRecommendations());
+
+				// Store recommended sell prices in the plugin for transaction tracking
+				for (FlipRecommendation rec : response.getRecommendations())
+				{
+					plugin.setRecommendedSellPrice(rec.getItemId(), rec.getRecommendedSellPrice());
+				}
 
 				updateStatusLabel(response);
 				populateRecommendations(response.getRecommendations());
@@ -181,10 +308,249 @@ public class FlipFinderPanel extends PluginPanel
 			SwingUtilities.invokeLater(() ->
 			{
 				refreshButton.setEnabled(true);
-				showError("Error: " + throwable.getMessage());
+				showErrorInRecommended("Error: " + throwable.getMessage());
 			});
 			return null;
 		});
+	}
+
+	/**
+	 * Refresh active flips
+	 */
+	private void refreshActiveFlips()
+	{
+		activeFlipsListContainer.removeAll();
+		activeFlipsListContainer.revalidate();
+		activeFlipsListContainer.repaint();
+
+		apiClient.getActiveFlipsAsync().thenAccept(response ->
+		{
+			SwingUtilities.invokeLater(() ->
+			{
+				if (response == null)
+				{
+					showErrorInActiveFlips("Failed to fetch active flips. Check your API settings.");
+					return;
+				}
+
+				currentActiveFlips.clear();
+				if (response.getActiveFlips() != null)
+				{
+					currentActiveFlips.addAll(response.getActiveFlips());
+				}
+
+				// Get pending orders from plugin
+				java.util.List<FlipSmartPlugin.PendingOrder> pendingOrders = plugin.getPendingBuyOrders();
+
+				if (currentActiveFlips.isEmpty() && pendingOrders.isEmpty())
+				{
+					showNoActiveFlips();
+					return;
+				}
+
+				// Update status label with active flips info
+				if (!currentActiveFlips.isEmpty())
+				{
+					updateActiveFlipsStatus(response);
+				}
+				else if (!pendingOrders.isEmpty())
+				{
+					statusLabel.setText(String.format("%d pending %s",
+						pendingOrders.size(),
+						pendingOrders.size() == 1 ? "order" : "orders"));
+				}
+
+				// Display both active flips and pending orders
+				displayActiveFlipsAndPending(currentActiveFlips, pendingOrders);
+			});
+		}).exceptionally(throwable ->
+		{
+			SwingUtilities.invokeLater(() ->
+			{
+				showErrorInActiveFlips("Error: " + throwable.getMessage());
+			});
+			return null;
+		});
+	}
+	
+	/**
+	 * Update pending orders display (called when GE offers change)
+	 */
+	public void updatePendingOrders(java.util.List<FlipSmartPlugin.PendingOrder> pendingOrders)
+	{
+		// Only update if we're on the Active Flips tab
+		if (tabbedPane.getSelectedIndex() == 1)
+		{
+			refreshActiveFlips();
+		}
+	}
+
+	/**
+	 * Refresh completed flips
+	 */
+	private void refreshCompletedFlips()
+	{
+		completedFlipsListContainer.removeAll();
+		completedFlipsListContainer.revalidate();
+		completedFlipsListContainer.repaint();
+
+		// Fetch last 50 completed flips
+		apiClient.getCompletedFlipsAsync(50).thenAccept(response ->
+		{
+			SwingUtilities.invokeLater(() ->
+			{
+				if (response == null)
+				{
+					showErrorInCompletedFlips("Failed to fetch completed flips. Check your API settings.");
+					return;
+				}
+
+				currentCompletedFlips.clear();
+				if (response.getFlips() != null)
+				{
+					currentCompletedFlips.addAll(response.getFlips());
+				}
+
+				if (currentCompletedFlips.isEmpty())
+				{
+					showNoCompletedFlips();
+					return;
+				}
+
+				// Update status if on completed flips tab
+				if (tabbedPane.getSelectedIndex() == 2)
+				{
+					int totalProfit = currentCompletedFlips.stream()
+						.mapToInt(CompletedFlip::getNetProfit)
+						.sum();
+					statusLabel.setText(String.format("%d completed | %s profit",
+						currentCompletedFlips.size(),
+						formatGP(totalProfit)));
+				}
+
+				populateCompletedFlips(currentCompletedFlips);
+			});
+		}).exceptionally(throwable ->
+		{
+			SwingUtilities.invokeLater(() ->
+			{
+				showErrorInCompletedFlips("Error: " + throwable.getMessage());
+			});
+			return null;
+		});
+	}
+
+	/**
+	 * Show error message in completed flips tab
+	 */
+	private void showErrorInCompletedFlips(String message)
+	{
+		completedFlipsListContainer.removeAll();
+
+		PluginErrorPanel errorPanel = new PluginErrorPanel();
+		errorPanel.setContent("Completed Flips", message);
+		completedFlipsListContainer.add(errorPanel);
+
+		completedFlipsListContainer.revalidate();
+		completedFlipsListContainer.repaint();
+	}
+
+	/**
+	 * Show message when there are no completed flips
+	 */
+	private void showNoCompletedFlips()
+	{
+		completedFlipsListContainer.removeAll();
+
+		JPanel emptyPanel = new JPanel();
+		emptyPanel.setLayout(new BoxLayout(emptyPanel, BoxLayout.Y_AXIS));
+		emptyPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		emptyPanel.setBorder(new EmptyBorder(60, 20, 60, 20));
+
+		JLabel titleLabel = new JLabel("No completed flips");
+		titleLabel.setForeground(Color.WHITE);
+		titleLabel.setFont(new Font("Arial", Font.BOLD, 16));
+		titleLabel.setHorizontalAlignment(SwingConstants.CENTER);
+		titleLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+		JLabel instructionLabel = new JLabel("<html><center>Complete your first flip to see it here!<br>Buy and sell items to track your profits</center></html>");
+		instructionLabel.setForeground(new Color(180, 180, 180));
+		instructionLabel.setFont(new Font("Arial", Font.PLAIN, 13));
+		instructionLabel.setHorizontalAlignment(SwingConstants.CENTER);
+		instructionLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+		emptyPanel.add(titleLabel);
+		emptyPanel.add(Box.createRigidArea(new Dimension(0, 15)));
+		emptyPanel.add(instructionLabel);
+
+		completedFlipsListContainer.add(emptyPanel);
+
+		statusLabel.setText("0 completed flips");
+
+		completedFlipsListContainer.revalidate();
+		completedFlipsListContainer.repaint();
+	}
+
+	/**
+	 * Populate the completed flips list
+	 */
+	private void populateCompletedFlips(java.util.List<CompletedFlip> flips)
+	{
+		completedFlipsListContainer.removeAll();
+
+		for (CompletedFlip flip : flips)
+		{
+			completedFlipsListContainer.add(createCompletedFlipPanel(flip));
+			completedFlipsListContainer.add(Box.createRigidArea(new Dimension(0, 5)));
+		}
+
+		completedFlipsListContainer.revalidate();
+		completedFlipsListContainer.repaint();
+	}
+	
+	/**
+	 * Display both active flips and pending orders
+	 */
+	private void displayActiveFlipsAndPending(java.util.List<ActiveFlip> activeFlips, java.util.List<FlipSmartPlugin.PendingOrder> pendingOrders)
+	{
+		activeFlipsListContainer.removeAll();
+		
+		// First show pending orders (orders not yet filled)
+		if (!pendingOrders.isEmpty())
+		{
+			for (FlipSmartPlugin.PendingOrder pending : pendingOrders)
+			{
+				activeFlipsListContainer.add(createPendingOrderPanel(pending));
+				activeFlipsListContainer.add(Box.createRigidArea(new Dimension(0, 5)));
+			}
+		}
+		
+		// Then show active flips (items that have filled)
+		for (ActiveFlip flip : activeFlips)
+		{
+			activeFlipsListContainer.add(createActiveFlipPanel(flip));
+			activeFlipsListContainer.add(Box.createRigidArea(new Dimension(0, 5)));
+		}
+
+		activeFlipsListContainer.revalidate();
+		activeFlipsListContainer.repaint();
+	}
+
+	/**
+	 * Update status label with active flips information
+	 */
+	private void updateActiveFlipsStatus(ActiveFlipsResponse response)
+	{
+		int itemCount = response.getTotalItems();
+		int invested = response.getTotalInvested();
+		
+		if (tabbedPane.getSelectedIndex() == 1) // Active Flips tab
+		{
+			statusLabel.setText(String.format("%d active %s | %s invested",
+				itemCount,
+				itemCount == 1 ? "flip" : "flips",
+				formatGP(invested)));
+		}
 	}
 
 	/**
@@ -221,19 +587,73 @@ public class FlipFinderPanel extends PluginPanel
 	}
 
 	/**
-	 * Show an error message
+	 * Show an error message in recommended tab
 	 */
-	private void showError(String message)
+	private void showErrorInRecommended(String message)
 	{
 		statusLabel.setText("Error");
-		listContainer.removeAll();
+		recommendedListContainer.removeAll();
 
 		PluginErrorPanel errorPanel = new PluginErrorPanel();
 		errorPanel.setContent("Flip Finder", message);
-		listContainer.add(errorPanel);
+		recommendedListContainer.add(errorPanel);
 
-		listContainer.revalidate();
-		listContainer.repaint();
+		recommendedListContainer.revalidate();
+		recommendedListContainer.repaint();
+	}
+
+	/**
+	 * Show an error message in active flips tab
+	 */
+	private void showErrorInActiveFlips(String message)
+	{
+		activeFlipsListContainer.removeAll();
+
+		PluginErrorPanel errorPanel = new PluginErrorPanel();
+		errorPanel.setContent("Active Flips", message);
+		activeFlipsListContainer.add(errorPanel);
+
+		activeFlipsListContainer.revalidate();
+		activeFlipsListContainer.repaint();
+	}
+
+	/**
+	 * Show message when there are no active flips
+	 */
+	private void showNoActiveFlips()
+	{
+		activeFlipsListContainer.removeAll();
+
+		JPanel emptyPanel = new JPanel();
+		emptyPanel.setLayout(new BoxLayout(emptyPanel, BoxLayout.Y_AXIS));
+		emptyPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		emptyPanel.setBorder(new EmptyBorder(60, 20, 60, 20));
+
+		// Main message
+		JLabel titleLabel = new JLabel("No active flips");
+		titleLabel.setForeground(Color.WHITE);
+		titleLabel.setFont(new Font("Arial", Font.BOLD, 16));
+		titleLabel.setHorizontalAlignment(SwingConstants.CENTER);
+		titleLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+		// Instructions
+		JLabel instructionLabel = new JLabel("<html><center>Buy items from the Recommended tab<br>to start tracking your flips</center></html>");
+		instructionLabel.setForeground(new Color(180, 180, 180));
+		instructionLabel.setFont(new Font("Arial", Font.PLAIN, 13));
+		instructionLabel.setHorizontalAlignment(SwingConstants.CENTER);
+		instructionLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+		emptyPanel.add(titleLabel);
+		emptyPanel.add(Box.createRigidArea(new Dimension(0, 15)));
+		emptyPanel.add(instructionLabel);
+
+		activeFlipsListContainer.add(emptyPanel);
+
+		// Update status label
+		statusLabel.setText("0 active flips");
+
+		activeFlipsListContainer.revalidate();
+		activeFlipsListContainer.repaint();
 	}
 
 	/**
@@ -241,16 +661,33 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private void populateRecommendations(List<FlipRecommendation> recommendations)
 	{
-		listContainer.removeAll();
+		recommendedListContainer.removeAll();
 
 		for (FlipRecommendation rec : recommendations)
 		{
-			listContainer.add(createRecommendationPanel(rec));
-			listContainer.add(Box.createRigidArea(new Dimension(0, 5)));
+			recommendedListContainer.add(createRecommendationPanel(rec));
+			recommendedListContainer.add(Box.createRigidArea(new Dimension(0, 5)));
 		}
 
-		listContainer.revalidate();
-		listContainer.repaint();
+		recommendedListContainer.revalidate();
+		recommendedListContainer.repaint();
+	}
+
+	/**
+	 * Populate the active flips list
+	 */
+	private void populateActiveFlips(List<ActiveFlip> activeFlips)
+	{
+		activeFlipsListContainer.removeAll();
+
+		for (ActiveFlip flip : activeFlips)
+		{
+			activeFlipsListContainer.add(createActiveFlipPanel(flip));
+			activeFlipsListContainer.add(Box.createRigidArea(new Dimension(0, 5)));
+		}
+
+		activeFlipsListContainer.revalidate();
+		activeFlipsListContainer.repaint();
 	}
 
 	/**
@@ -501,6 +938,539 @@ public class FlipFinderPanel extends PluginPanel
 	public List<FlipRecommendation> getCurrentRecommendations()
 	{
 		return new ArrayList<>(currentRecommendations);
+	}
+
+	/**
+	 * Create a panel for an active flip with current market data
+	 */
+	private JPanel createActiveFlipPanel(ActiveFlip flip)
+	{
+		JPanel panel = new JPanel();
+		panel.setLayout(new BorderLayout());
+		panel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		panel.setBorder(new EmptyBorder(8, 8, 8, 8));
+		panel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+		panel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 100));
+
+		// Top section: Item icon and name
+		JPanel topPanel = new JPanel(new BorderLayout());
+		topPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+		JPanel namePanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 0));
+		namePanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+		// Get item image
+		AsyncBufferedImage itemImage = itemManager.getImage(flip.getItemId());
+		JLabel iconLabel = new JLabel();
+		if (itemImage != null)
+		{
+			iconLabel.setIcon(new ImageIcon(itemImage));
+			itemImage.onLoaded(() ->
+			{
+				iconLabel.setIcon(new ImageIcon(itemImage));
+				iconLabel.revalidate();
+				iconLabel.repaint();
+			});
+		}
+		else
+		{
+			iconLabel.setPreferredSize(new Dimension(32, 32));
+		}
+
+		JLabel nameLabel = new JLabel(flip.getItemName());
+		nameLabel.setForeground(Color.WHITE);
+		nameLabel.setFont(new Font("Arial", Font.BOLD, 13));
+
+		namePanel.add(iconLabel);
+		namePanel.add(nameLabel);
+		topPanel.add(namePanel, BorderLayout.WEST);
+
+		// Details section with market data
+		JPanel detailsPanel = new JPanel(new GridLayout(3, 2, 5, 2));
+		detailsPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		detailsPanel.setBorder(new EmptyBorder(3, 38, 0, 0));
+
+		// Row 1: Quantity and Buy Price (exact price for easy GE input)
+		JLabel qtyLabel = new JLabel(String.format("Qty: %d", flip.getTotalQuantity()));
+		qtyLabel.setForeground(new Color(200, 200, 200));
+		qtyLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+		JLabel buyPriceLabel = new JLabel(String.format("Buy: %s", formatGPExact(flip.getAverageBuyPrice())));
+		buyPriceLabel.setForeground(new Color(255, 120, 120)); // Light red for buy
+		buyPriceLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+		// Row 2: Total Invested and Target Sell Price (exact price for GE input)
+		JLabel investedLabel = new JLabel(String.format("Invested: %s", formatGP(flip.getTotalInvested())));
+		investedLabel.setForeground(new Color(255, 200, 100)); // Gold
+		investedLabel.setFont(new Font("Arial", Font.BOLD, 11));
+
+		// Fetch current market price for this item
+		JLabel sellPriceLabel = new JLabel("Sell: Loading...");
+		sellPriceLabel.setForeground(new Color(120, 255, 120)); // Light green for sell
+		sellPriceLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+		// Row 3: Potential Profit and ROI
+		JLabel profitLabel = new JLabel("Profit: Loading...");
+		profitLabel.setForeground(Color.LIGHT_GRAY);
+		profitLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+		JLabel roiLabel = new JLabel("ROI: Loading...");
+		roiLabel.setForeground(Color.LIGHT_GRAY);
+		roiLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+		detailsPanel.add(qtyLabel);
+		detailsPanel.add(buyPriceLabel);
+		detailsPanel.add(investedLabel);
+		detailsPanel.add(sellPriceLabel);
+		detailsPanel.add(profitLabel);
+		detailsPanel.add(roiLabel);
+
+		panel.add(topPanel, BorderLayout.NORTH);
+		panel.add(detailsPanel, BorderLayout.CENTER);
+
+		// Use recommended sell price if available, otherwise fetch current market price
+		if (flip.getRecommendedSellPrice() != null && flip.getRecommendedSellPrice() > 0)
+		{
+			// Use recommended price from when the flip was suggested
+			int recommendedSellPrice = flip.getRecommendedSellPrice();
+			
+			// Update sell price
+			sellPriceLabel.setText(String.format("Sell: %s", formatGPExact(recommendedSellPrice)));
+
+			// Calculate GE tax (2% capped at 5M)
+			int geTax = Math.min((int)(recommendedSellPrice * 0.02), 5_000_000);
+			
+			// Calculate potential profit (per item)
+			int profitPerItem = recommendedSellPrice - flip.getAverageBuyPrice() - geTax;
+			int totalProfit = profitPerItem * flip.getTotalQuantity();
+
+			// Calculate ROI
+			double roi = (profitPerItem * 100.0) / flip.getAverageBuyPrice();
+
+			// Update profit label with color
+			String profitText = Math.abs(totalProfit) >= 100_000 
+				? formatGP(totalProfit) 
+				: formatGPExact(totalProfit);
+			profitLabel.setText(String.format("Profit: %s", profitText));
+			profitLabel.setForeground(totalProfit > 0 ? new Color(100, 255, 100) : new Color(255, 100, 100));
+			profitLabel.setFont(new Font("Arial", Font.BOLD, 11));
+
+			// Update ROI label with color
+			roiLabel.setText(String.format("ROI: %.1f%%", roi));
+			roiLabel.setForeground(roi > 0 ? new Color(100, 255, 100) : new Color(255, 100, 100));
+			roiLabel.setFont(new Font("Arial", Font.BOLD, 11));
+		}
+		else
+		{
+			// Fallback: fetch current market price
+			apiClient.getItemAnalysisAsync(flip.getItemId()).thenAccept(analysis ->
+			{
+				SwingUtilities.invokeLater(() ->
+				{
+					if (analysis != null && analysis.getCurrentPrices() != null)
+					{
+						FlipAnalysis.CurrentPrices prices = analysis.getCurrentPrices();
+						Integer currentSellPrice = prices.getHigh();
+						Integer geTax = prices.getGeTax();
+
+						if (currentSellPrice != null && geTax != null)
+						{
+							// Update sell price with exact number for easy GE input
+							sellPriceLabel.setText(String.format("Sell: %s*", formatGPExact(currentSellPrice)));
+
+							// Calculate potential profit (per item)
+							int profitPerItem = currentSellPrice - flip.getAverageBuyPrice() - geTax;
+							int totalProfit = profitPerItem * flip.getTotalQuantity();
+
+							// Calculate ROI
+							double roi = (profitPerItem * 100.0) / flip.getAverageBuyPrice();
+
+							// Update profit label with color
+							String profitText = Math.abs(totalProfit) >= 100_000 
+								? formatGP(totalProfit) 
+								: formatGPExact(totalProfit);
+							profitLabel.setText(String.format("Profit: %s*", profitText));
+							profitLabel.setForeground(totalProfit > 0 ? new Color(100, 255, 100) : new Color(255, 100, 100));
+							profitLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+							// Update ROI label with color
+							roiLabel.setText(String.format("ROI: %.1f%%*", roi));
+							roiLabel.setForeground(roi > 0 ? new Color(100, 255, 100) : new Color(255, 100, 100));
+							roiLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+						}
+						else
+						{
+							sellPriceLabel.setText("Sell: N/A");
+							profitLabel.setText("Profit: N/A");
+							roiLabel.setText("ROI: N/A");
+						}
+					}
+					else
+					{
+						sellPriceLabel.setText("Sell: N/A");
+						profitLabel.setText("Profit: N/A");
+						roiLabel.setText("ROI: N/A");
+					}
+				});
+			});
+		}
+
+		// Add hover effect and context menu
+		panel.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseEntered(MouseEvent e)
+			{
+				panel.setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
+				topPanel.setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
+				namePanel.setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
+				detailsPanel.setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
+			}
+
+			@Override
+			public void mouseExited(MouseEvent e)
+			{
+				panel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+				topPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+				namePanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+				detailsPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+			}
+
+			@Override
+			public void mousePressed(MouseEvent e)
+			{
+				showContextMenu(e, flip);
+			}
+
+			@Override
+			public void mouseReleased(MouseEvent e)
+			{
+				showContextMenu(e, flip);
+			}
+
+			private void showContextMenu(MouseEvent e, ActiveFlip flip)
+			{
+				if (e.isPopupTrigger())
+				{
+					JPopupMenu contextMenu = new JPopupMenu();
+					
+					JMenuItem dismissItem = new JMenuItem("Dismiss from Active Flips");
+					dismissItem.addActionListener(ae -> dismissActiveFlip(flip));
+					contextMenu.add(dismissItem);
+					
+					contextMenu.show(e.getComponent(), e.getX(), e.getY());
+				}
+			}
+		});
+
+		return panel;
+	}
+
+	/**
+	 * Create a panel for a pending order (not yet filled)
+	 */
+	private JPanel createPendingOrderPanel(FlipSmartPlugin.PendingOrder pending)
+	{
+		JPanel panel = new JPanel();
+		panel.setLayout(new BorderLayout());
+		panel.setBackground(new Color(55, 55, 65)); // Slightly different color for pending
+		panel.setBorder(new EmptyBorder(8, 8, 8, 8));
+		panel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 100));
+
+		// Top section: Item icon and name
+		JPanel topPanel = new JPanel(new BorderLayout());
+		topPanel.setBackground(new Color(55, 55, 65));
+
+		JPanel namePanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 0));
+		namePanel.setBackground(new Color(55, 55, 65));
+
+		// Get item image
+		AsyncBufferedImage itemImage = itemManager.getImage(pending.itemId);
+		JLabel iconLabel = new JLabel();
+		if (itemImage != null)
+		{
+			iconLabel.setIcon(new ImageIcon(itemImage));
+			itemImage.onLoaded(() ->
+			{
+				iconLabel.setIcon(new ImageIcon(itemImage));
+				iconLabel.revalidate();
+				iconLabel.repaint();
+			});
+		}
+		else
+		{
+			iconLabel.setPreferredSize(new Dimension(32, 32));
+		}
+
+		JLabel nameLabel = new JLabel(pending.itemName + " [PENDING]");
+		nameLabel.setForeground(new Color(255, 200, 100)); // Yellow to indicate pending
+		nameLabel.setFont(new Font("Arial", Font.BOLD, 13));
+
+		namePanel.add(iconLabel);
+		namePanel.add(nameLabel);
+		topPanel.add(namePanel, BorderLayout.WEST);
+
+		// Details section - same grid layout as active flips
+		JPanel detailsPanel = new JPanel(new GridLayout(3, 2, 5, 2));
+		detailsPanel.setBackground(new Color(55, 55, 65));
+		detailsPanel.setBorder(new EmptyBorder(3, 38, 0, 0));
+
+		// Row 1: Quantity and Offer Price
+		JLabel qtyLabel = new JLabel(String.format("Qty: %d", pending.quantity));
+		qtyLabel.setForeground(new Color(200, 200, 200));
+		qtyLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+		JLabel offerLabel = new JLabel(String.format("Offer: %s", formatGPExact(pending.pricePerItem)));
+		offerLabel.setForeground(new Color(255, 120, 120)); // Light red like buy prices
+		offerLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+		// Row 2: Invested (potential) and Target Sell
+		int potentialInvestment = pending.quantity * pending.pricePerItem;
+		JLabel investedLabel = new JLabel(String.format("If filled: %s", formatGP(potentialInvestment)));
+		investedLabel.setForeground(new Color(200, 200, 200));
+		investedLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+		JLabel sellLabel = new JLabel();
+		if (pending.recommendedSellPrice != null && pending.recommendedSellPrice > 0)
+		{
+			sellLabel.setText(String.format("Sell: %s", formatGPExact(pending.recommendedSellPrice)));
+			sellLabel.setForeground(new Color(120, 255, 120)); // Light green for sell
+		}
+		else
+		{
+			sellLabel.setText("Sell: --");
+			sellLabel.setForeground(Color.LIGHT_GRAY);
+		}
+		sellLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+		// Row 3: Status and Expected ROI
+		JLabel statusLabel = new JLabel(String.format("GE Slot %d: Waiting", pending.slot + 1));
+		statusLabel.setForeground(new Color(180, 180, 180));
+		statusLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+		JLabel roiLabel = new JLabel();
+		if (pending.recommendedSellPrice != null && pending.recommendedSellPrice > 0)
+		{
+			int geTax = Math.min((int)(pending.recommendedSellPrice * 0.02), 5_000_000);
+			int profitPerItem = pending.recommendedSellPrice - pending.pricePerItem - geTax;
+			double roi = (profitPerItem * 100.0) / pending.pricePerItem;
+			roiLabel.setText(String.format("ROI: %.1f%%", roi));
+			roiLabel.setForeground(roi > 0 ? new Color(100, 255, 100) : new Color(255, 100, 100));
+		}
+		else
+		{
+			roiLabel.setText("ROI: --");
+			roiLabel.setForeground(Color.LIGHT_GRAY);
+		}
+		roiLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+		detailsPanel.add(qtyLabel);
+		detailsPanel.add(offerLabel);
+		detailsPanel.add(investedLabel);
+		detailsPanel.add(sellLabel);
+		detailsPanel.add(statusLabel);
+		detailsPanel.add(roiLabel);
+
+		panel.add(topPanel, BorderLayout.NORTH);
+		panel.add(detailsPanel, BorderLayout.CENTER);
+
+		return panel;
+	}
+	
+	/**
+	 * Create a panel for a completed flip
+	 */
+	private JPanel createCompletedFlipPanel(CompletedFlip flip)
+	{
+		JPanel panel = new JPanel();
+		panel.setLayout(new BorderLayout());
+		// Color based on profit/loss
+		Color backgroundColor = flip.isSuccessful() ? 
+			new Color(40, 60, 40) : // Dark green for profit
+			new Color(60, 40, 40);  // Dark red for loss
+		panel.setBackground(backgroundColor);
+		panel.setBorder(new EmptyBorder(8, 8, 8, 8));
+		panel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 100));
+
+		// Top section: Item icon and name
+		JPanel topPanel = new JPanel(new BorderLayout());
+		topPanel.setBackground(backgroundColor);
+
+		JPanel namePanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 0));
+		namePanel.setBackground(backgroundColor);
+
+		// Get item image
+		AsyncBufferedImage itemImage = itemManager.getImage(flip.getItemId());
+		JLabel iconLabel = new JLabel();
+		if (itemImage != null)
+		{
+			iconLabel.setIcon(new ImageIcon(itemImage));
+			itemImage.onLoaded(() ->
+			{
+				iconLabel.setIcon(new ImageIcon(itemImage));
+				iconLabel.revalidate();
+				iconLabel.repaint();
+			});
+		}
+		else
+		{
+			iconLabel.setPreferredSize(new Dimension(32, 32));
+		}
+
+		JLabel nameLabel = new JLabel(flip.getItemName());
+		nameLabel.setForeground(Color.WHITE);
+		nameLabel.setFont(new Font("Arial", Font.BOLD, 13));
+
+		namePanel.add(iconLabel);
+		namePanel.add(nameLabel);
+		topPanel.add(namePanel, BorderLayout.WEST);
+
+		// Details section with profit/loss info
+		JPanel detailsPanel = new JPanel(new GridLayout(3, 2, 5, 2));
+		detailsPanel.setBackground(backgroundColor);
+		detailsPanel.setBorder(new EmptyBorder(3, 38, 0, 0));
+
+		// Row 1: Quantity and Buy Price
+		JLabel qtyLabel = new JLabel(String.format("Qty: %d", flip.getQuantity()));
+		qtyLabel.setForeground(new Color(200, 200, 200));
+		qtyLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+		JLabel buyPriceLabel = new JLabel(String.format("Buy: %s", formatGPExact(flip.getBuyPricePerItem())));
+		buyPriceLabel.setForeground(new Color(255, 120, 120));
+		buyPriceLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+		// Row 2: Invested and Sell Price
+		JLabel investedLabel = new JLabel(String.format("Cost: %s", formatGP(flip.getBuyTotal())));
+		investedLabel.setForeground(new Color(200, 200, 200));
+		investedLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+		JLabel sellPriceLabel = new JLabel(String.format("Sell: %s", formatGPExact(flip.getSellPricePerItem())));
+		sellPriceLabel.setForeground(new Color(120, 255, 120));
+		sellPriceLabel.setFont(new Font("Arial", Font.PLAIN, 11));
+
+		// Row 3: Net Profit and ROI
+		JLabel profitLabel = new JLabel(String.format("Profit: %s", formatGP(flip.getNetProfit())));
+		Color profitColor = flip.isSuccessful() ? 
+			new Color(100, 255, 100) : // Bright green
+			new Color(255, 100, 100);  // Bright red
+		profitLabel.setForeground(profitColor);
+		profitLabel.setFont(new Font("Arial", Font.BOLD, 11));
+
+		JLabel roiLabel = new JLabel(String.format("ROI: %.1f%%", flip.getRoiPercent()));
+		roiLabel.setForeground(profitColor);
+		roiLabel.setFont(new Font("Arial", Font.BOLD, 11));
+
+		detailsPanel.add(qtyLabel);
+		detailsPanel.add(buyPriceLabel);
+		detailsPanel.add(investedLabel);
+		detailsPanel.add(sellPriceLabel);
+		detailsPanel.add(profitLabel);
+		detailsPanel.add(roiLabel);
+
+		panel.add(topPanel, BorderLayout.NORTH);
+		panel.add(detailsPanel, BorderLayout.CENTER);
+
+		// Add click to show more details
+		panel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+		panel.addMouseListener(new MouseAdapter()
+		{
+			private boolean expanded = false;
+
+			@Override
+			public void mouseClicked(MouseEvent e)
+			{
+				if (!expanded)
+				{
+					// Add extra details
+					JPanel extraDetails = new JPanel();
+					extraDetails.setLayout(new BoxLayout(extraDetails, BoxLayout.Y_AXIS));
+					extraDetails.setBackground(backgroundColor);
+					extraDetails.setBorder(new EmptyBorder(5, 38, 0, 0));
+
+					// Duration
+					int hours = flip.getFlipDurationSeconds() / 3600;
+					int minutes = (flip.getFlipDurationSeconds() % 3600) / 60;
+					String duration = hours > 0 ? 
+						String.format("%dh %dm", hours, minutes) :
+						String.format("%dm", minutes);
+
+					JLabel durationLabel = new JLabel(String.format("Duration: %s", duration));
+					durationLabel.setForeground(new Color(180, 180, 180));
+					durationLabel.setFont(new Font("Arial", Font.PLAIN, 10));
+
+					// GE Tax
+					JLabel taxLabel = new JLabel(String.format("GE Tax: %s", formatGP(flip.getGeTax())));
+					taxLabel.setForeground(new Color(180, 180, 180));
+					taxLabel.setFont(new Font("Arial", Font.PLAIN, 10));
+
+					extraDetails.add(durationLabel);
+					extraDetails.add(Box.createRigidArea(new Dimension(0, 2)));
+					extraDetails.add(taxLabel);
+
+					panel.add(extraDetails, BorderLayout.SOUTH);
+					expanded = true;
+				}
+				else
+				{
+					// Remove extra details
+					if (panel.getComponentCount() > 2)
+					{
+						panel.remove(2);
+						expanded = false;
+					}
+				}
+
+				panel.revalidate();
+				panel.repaint();
+			}
+		});
+
+		return panel;
+	}
+	
+	/**
+	 * Dismiss an active flip (remove from tracking)
+	 */
+	private void dismissActiveFlip(ActiveFlip flip)
+	{
+		int result = JOptionPane.showConfirmDialog(
+			this,
+			String.format("Remove %s from active flips?\n\nThis will hide it from tracking.\nUse this if you sold/used the items outside of the GE.", flip.getItemName()),
+			"Dismiss Active Flip",
+			JOptionPane.YES_NO_OPTION,
+			JOptionPane.QUESTION_MESSAGE
+		);
+
+		if (result == JOptionPane.YES_OPTION)
+		{
+			// Dismiss asynchronously
+			apiClient.dismissActiveFlipAsync(flip.getItemId()).thenAccept(success ->
+			{
+				SwingUtilities.invokeLater(() ->
+				{
+					if (success)
+					{
+						// Refresh the active flips list
+						refreshActiveFlips();
+						JOptionPane.showMessageDialog(
+							this,
+							String.format("%s has been removed from active flips.", flip.getItemName()),
+							"Dismissed",
+							JOptionPane.INFORMATION_MESSAGE
+						);
+					}
+					else
+					{
+						JOptionPane.showMessageDialog(
+							this,
+							"Failed to dismiss active flip. Please try again.",
+							"Error",
+							JOptionPane.ERROR_MESSAGE
+						);
+					}
+				});
+			});
+		}
 	}
 }
 


### PR DESCRIPTION
# Transaction Tracking & Enhanced Flip Management - RuneLite Plugin

## Overview
Major update adding comprehensive transaction tracking, active flip monitoring, and completed flip history to the FlipSmart RuneLite plugin. Players can now automatically track all GE transactions, monitor in-progress flips, and view their flip performance history.

## New Features

### 1. Automatic Transaction Tracking
- **GE Event Monitoring**: Subscribes to `onGrandExchangeOfferChanged` events
- **Partial Fill Support**: Each partial fill is recorded as a separate transaction
- **Smart Detection**: Tracks all 8 GE slots independently
- **Login Burst Window**: 5-second window prevents double-counting transactions on login/world hop
- **Cancellation Handling**: Records cancelled orders with `is_cancelled` flag

### 2. Three-Tab Interface
Redesigned Flip Finder panel with tabbed navigation:

#### Tab 1: Recommended Flips (Enhanced)
- Shows AI-powered flip recommendations (existing functionality)
- Stores recommended sell prices when viewing recommendations
- Automatic price caching for ROI tracking

#### Tab 2: Active Flips (NEW)
- **Active Flips Display**:
  - Items bought and waiting to be sold
  - Quantity, average buy price, total invested
  - Recommended sell price from original suggestion
  - Expected profit and ROI
  - Hover effects and interactive UI
  - Right-click menu to manually dismiss flips
  
- **Pending Orders Display**:
  - Shows GE buy orders immediately upon placement
  - Displays orders with 0 fills (not yet started)
  - Darker background to distinguish from filled orders
  - Shows offer price, quantity, and GE slot
  - Auto-removes when order fills or is cancelled

#### Tab 3: Completed Flips (NEW)
- Historical flip performance (last 50 flips)
- Color-coded by profit (green) or loss (red)
- Buy/sell prices with exact GP formatting (comma-separated)
- Net profit (after GE tax) and ROI percentage
- Click to expand for details (flip duration, GE tax paid)
- Status bar shows total completed and total profit

### 3. Enhanced UI/UX

#### Price Formatting
- **Exact GP with commas**: "1,234,567" for easy GE input
- **Abbreviated totals**: "1.2M" for invested/profit amounts
- **Color coding**: Buy prices (red), sell prices (green)

#### Dynamic Status Label
- Context-aware based on active tab:
  - Recommended: "10 flips found | 2.5M+ potential profit"
  - Active Flips: "5 active flips | 125K invested"
  - Completed: "15 completed | 50K profit"

#### Visual Polish
- Full-width tabs with custom UI
- Item icons (32x32) for quick recognition
- Interactive hover effects
- Smooth scrolling with custom scrollbar sizing
- Professional color scheme matching RuneLite standards

### 4. Manual Flip Dismissal
- Right-click context menu on active flip panels
- Confirmation dialog before dismissal
- Removes item from active tracking via API
- Useful for abandoning flips or clearing inventory items

### 5. Thread Safety
- Item names cached during GE offer events (client thread)
- Avoids calling `getItemComposition()` on UI thread
- Eliminates `AssertionError: must be called on client thread` errors

## Technical Implementation

### New Java Classes
- **`ActiveFlip.java`** - Model for active flip data
- **`ActiveFlipsResponse.java`** - API response wrapper
- **`CompletedFlip.java`** - Model for completed flip data
- **`CompletedFlipsResponse.java`** - API response wrapper

### Modified Classes

#### `FlipSmartPlugin.java`
- Added `onGrandExchangeOfferChanged()` event handler
- Implemented `TrackedOffer` class for GE slot tracking
- Implemented `PendingOrder` class for unfilled buy orders
- Added `recommendedSellPrices` map for price caching
- Added `pendingBuyOrders` map for local order tracking
- Added login burst window logic (5 seconds)
- Thread-safe item name storage

#### `FlipSmartApiClient.java`
- Added `recordTransaction()` with `recommendedSellPrice` parameter
- Added `recordTransactionAsync()` for non-blocking calls
- Added `getActiveFlips()` and `getActiveFlipsAsync()`
- Added `dismissActiveFlip()` and `dismissActiveFlipAsync()`
- Added `getCompletedFlips()` and `getCompletedFlipsAsync()`
- Enhanced error handling and token refresh logic

#### `FlipFinderPanel.java`
- Redesigned with `JTabbedPane` (3 tabs)
- Added active flips list container and refresh logic
- Added completed flips list container and refresh logic
- Added pending orders display logic
- Implemented `createActiveFlipPanel()` with interactive features
- Implemented `createPendingOrderPanel()` with distinct styling
- Implemented `createCompletedFlipPanel()` with expandable details
- Added right-click context menu for dismissal
- Enhanced empty state messages
- Dynamic status label updates on tab switch
- Full-width tab UI with custom `BasicTabbedPaneUI`

## API Integration

### New API Calls
- `POST /transactions` - Record buy/sell transactions with recommended price
- `GET /transactions/active-flips` - Fetch active flips with ROI data
- `DELETE /transactions/active-flips/{item_id}` - Dismiss an active flip
- `GET /flips/completed?limit=50` - Fetch completed flip history

### Authentication
- All API calls use JWT Bearer token authentication
- Automatic token refresh on 401 errors
- Graceful error handling with user-friendly messages

## User Experience Improvements

### Before
- Manual flip tracking (external spreadsheets)
- No visibility into in-progress flips
- No historical performance data
- Price recommendations expire quickly

### After
- Fully automated transaction tracking
- Real-time active flip monitoring with pending orders
- Comprehensive flip history with profit/loss
- Recommended prices persist with active flips
- One-click flip dismissal
- Professional, interactive UI

## Screenshots
<img width="251" height="614" alt="Screenshot 2025-11-21 at 1 06 06 PM" src="https://github.com/user-attachments/assets/437a2123-9e79-4a99-a7c1-6f03eeb8b9bd" />
<img width="246" height="435" alt="Screenshot 2025-11-21 at 12 46 07 PM" src="https://github.com/user-attachments/assets/8f240f82-fce9-495b-8fae-06d808bd160b" />