### PR TITLE
RL Feedback: Address Caching Issues

### DIFF
--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -27,7 +27,7 @@ public class FlipSmartApiClient
 	
 	// Cache to avoid spamming the API
 	private final Map<Integer, CachedAnalysis> analysisCache = new ConcurrentHashMap<>();
-	private static final long CACHE_DURATION_MS = 60_000; // 1 minute cache
+	private static final long CACHE_DURATION_MS = 180_000; // 3 minute cache
 	
 	// JWT token management
 	private volatile String jwtToken = null;
@@ -494,6 +494,7 @@ public class FlipSmartApiClient
 		return executeAuthenticatedAsync(requestBuilder, jsonData ->
 		{
 			FlipAnalysis analysis = gson.fromJson(jsonData, FlipAnalysis.class);
+			removedExpiredCacheEntries();
 			analysisCache.put(itemId, new CachedAnalysis(analysis));
 			return analysis;
 		});
@@ -633,6 +634,14 @@ public class FlipSmartApiClient
 	public void invalidateCache(int itemId)
 	{
 		analysisCache.remove(itemId);
+	}
+
+	/**
+	 * Removes expired entries from the cache
+	 */
+	private void removedExpiredCacheEntries()
+	{
+		analysisCache.entrySet().removeIf(entry -> entry.getValue().isExpired());
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -30,8 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @PluginDescriptor(
 	name = "Flip Smart",
 	description = "A tool to help with item flipping in the Grand Exchange",
-	tags = {"grand exchange", "flipping", "trading", "money making"},
-	enabledByDefault = false
+	tags = {"grand exchange", "flipping", "trading", "money making"}
 )
 public class FlipSmartPlugin extends Plugin
 {
@@ -206,6 +205,9 @@ public class FlipSmartPlugin extends Plugin
 		
 		// Stop auto-refresh timer
 		stopFlipFinderRefreshTimer();
+		
+		// Clear API client cache
+		apiClient.clearCache();
 	}
 
 	@Subscribe


### PR DESCRIPTION
This MR changes a few of the meta data for default RL properties and also addresses the cache issue. The cache was never being cleared which could lead to memory leaks, now it prunes items > 3 minutes old and also clears the cache on shut down.