### PR TITLE
feat: Add total order quantity tracking and full sync on login

### DIFF
--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -534,7 +534,7 @@ public class FlipSmartApiClient
 	}
 
 	/**
-	 * Data class for transaction request parameters
+	 * Data class for transaction request parameters (use Builder to construct)
 	 */
 	public static class TransactionRequest
 	{
@@ -548,19 +548,51 @@ public class FlipSmartApiClient
 		public final String rsn;
 		public final Integer totalQuantity;
 
-		public TransactionRequest(int itemId, String itemName, boolean isBuy, int quantity,
-								  int pricePerItem, Integer geSlot, Integer recommendedSellPrice,
-								  String rsn, Integer totalQuantity)
+		private TransactionRequest(Builder builder)
 		{
-			this.itemId = itemId;
-			this.itemName = itemName;
-			this.isBuy = isBuy;
-			this.quantity = quantity;
-			this.pricePerItem = pricePerItem;
-			this.geSlot = geSlot;
-			this.recommendedSellPrice = recommendedSellPrice;
-			this.rsn = rsn;
-			this.totalQuantity = totalQuantity;
+			this.itemId = builder.itemId;
+			this.itemName = builder.itemName;
+			this.isBuy = builder.isBuy;
+			this.quantity = builder.quantity;
+			this.pricePerItem = builder.pricePerItem;
+			this.geSlot = builder.geSlot;
+			this.recommendedSellPrice = builder.recommendedSellPrice;
+			this.rsn = builder.rsn;
+			this.totalQuantity = builder.totalQuantity;
+		}
+
+		public static Builder builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
+		{
+			return new Builder(itemId, itemName, isBuy, quantity, pricePerItem);
+		}
+
+		public static class Builder
+		{
+			private final int itemId;
+			private final String itemName;
+			private final boolean isBuy;
+			private final int quantity;
+			private final int pricePerItem;
+			private Integer geSlot;
+			private Integer recommendedSellPrice;
+			private String rsn;
+			private Integer totalQuantity;
+
+			private Builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
+			{
+				this.itemId = itemId;
+				this.itemName = itemName;
+				this.isBuy = isBuy;
+				this.quantity = quantity;
+				this.pricePerItem = pricePerItem;
+			}
+
+			public Builder geSlot(Integer geSlot) { this.geSlot = geSlot; return this; }
+			public Builder recommendedSellPrice(Integer price) { this.recommendedSellPrice = price; return this; }
+			public Builder rsn(String rsn) { this.rsn = rsn; return this; }
+			public Builder totalQuantity(Integer qty) { this.totalQuantity = qty; return this; }
+
+			public TransactionRequest build() { return new TransactionRequest(this); }
 		}
 	}
 

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -660,12 +660,14 @@ public class FlipSmartPlugin extends Plugin
 				
 				Integer recommendedSellPrice = currentOffer.isBuy ? recommendedPrices.get(currentOffer.itemId) : null;
 				
-				apiClient.recordTransactionAsync(new FlipSmartApiClient.TransactionRequest(
-					currentOffer.itemId, currentOffer.itemName, currentOffer.isBuy,
-					currentOffer.previousQuantitySold, currentOffer.price, slot,
-					recommendedSellPrice, getCurrentRsnSafe().orElse(null),
-					currentOffer.totalQuantity
-				));
+				apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
+					.builder(currentOffer.itemId, currentOffer.itemName, currentOffer.isBuy,
+						currentOffer.previousQuantitySold, currentOffer.price)
+					.geSlot(slot)
+					.recommendedSellPrice(recommendedSellPrice)
+					.rsn(getCurrentRsnSafe().orElse(null))
+					.totalQuantity(currentOffer.totalQuantity)
+					.build());
 				
 				// For buy orders with fills, add to collected tracking so it shows in active flips
 				if (currentOffer.isBuy && currentOffer.previousQuantitySold > 0)
@@ -694,12 +696,14 @@ public class FlipSmartPlugin extends Plugin
 		
 		Integer recommendedSellPrice = currentOffer.isBuy ? recommendedPrices.get(currentOffer.itemId) : null;
 		
-		apiClient.recordTransactionAsync(new FlipSmartApiClient.TransactionRequest(
-			currentOffer.itemId, currentOffer.itemName, currentOffer.isBuy,
-			offlineFills, currentOffer.price, slot,
-			recommendedSellPrice, getCurrentRsnSafe().orElse(null),
-			currentOffer.totalQuantity
-		));
+		apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
+			.builder(currentOffer.itemId, currentOffer.itemName, currentOffer.isBuy,
+				offlineFills, currentOffer.price)
+			.geSlot(slot)
+			.recommendedSellPrice(recommendedSellPrice)
+			.rsn(getCurrentRsnSafe().orElse(null))
+			.totalQuantity(currentOffer.totalQuantity)
+			.build());
 	}
 	
 	/**
@@ -1126,17 +1130,13 @@ public class FlipSmartPlugin extends Plugin
 					// Get recommended sell price if available
 					Integer recommendedSellPrice = isBuy ? recommendedPrices.get(itemId) : null;
 					
-					apiClient.recordTransactionAsync(new FlipSmartApiClient.TransactionRequest(
-						itemId,
-						previousOffer.itemName,
-						isBuy,
-						newQuantity,
-						pricePerItem,
-						slot,
-						recommendedSellPrice,
-						getCurrentRsnSafe().orElse(null),
-						previousOffer.totalQuantity
-					));
+					apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
+						.builder(itemId, previousOffer.itemName, isBuy, newQuantity, pricePerItem)
+						.geSlot(slot)
+						.recommendedSellPrice(recommendedSellPrice)
+						.rsn(getCurrentRsnSafe().orElse(null))
+						.totalQuantity(previousOffer.totalQuantity)
+						.build());
 				}
 				
 				log.info("Order cancelled: {} {} - {} items filled out of {}",
@@ -1233,17 +1233,13 @@ public class FlipSmartPlugin extends Plugin
 				Integer recommendedSellPrice = isBuy ? recommendedPrices.get(itemId) : null;
 				
 				// Record the transaction asynchronously with total order quantity
-				apiClient.recordTransactionAsync(new FlipSmartApiClient.TransactionRequest(
-					itemId,
-					itemName,
-					isBuy,
-					newQuantity,
-					pricePerItem,
-					slot,
-					recommendedSellPrice,
-					getCurrentRsnSafe().orElse(null),
-					totalQuantity
-				));
+				apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
+					.builder(itemId, itemName, isBuy, newQuantity, pricePerItem)
+					.geSlot(slot)
+					.recommendedSellPrice(recommendedSellPrice)
+					.rsn(getCurrentRsnSafe().orElse(null))
+					.totalQuantity(totalQuantity)
+					.build());
 				
 				// Clear recommended price after recording (only for buys)
 				if (isBuy && recommendedSellPrice != null)
@@ -1289,17 +1285,13 @@ public class FlipSmartPlugin extends Plugin
 				
 				Integer recommendedSellPrice = recommendedPrices.get(itemId);
 				
-				apiClient.recordTransactionAsync(new FlipSmartApiClient.TransactionRequest(
-					itemId,
-					itemName,
-					true, // isBuy
-					0, // quantity (0 fills)
-					price,
-					slot,
-					recommendedSellPrice,
-					getCurrentRsnSafe().orElse(null),
-					totalQuantity
-				));
+				apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
+					.builder(itemId, itemName, true, 0, price)
+					.geSlot(slot)
+					.recommendedSellPrice(recommendedSellPrice)
+					.rsn(getCurrentRsnSafe().orElse(null))
+					.totalQuantity(totalQuantity)
+					.build());
 			}
 			
 			// Refresh the flip finder panel when any new order is submitted


### PR DESCRIPTION
## Summary
Add total order quantity tracking and implement full sync on login to ensure plugin and webapp stay consistently synchronized.

## Changes
- Added `totalQuantity` parameter to `recordTransactionAsync()` for order size tracking
- Implemented full sync on login: clears backend active flips and re-records current GE state
- Added immediate recording of new buy orders (even with 0 fills)
- Changed verbose info logs to debug level
- Fixed Sonar issues: proper InterruptedException handling, null-safe Boolean check

## Why
Users reported inconsistencies between the plugin's active flips display and the webapp. Partial fills weren't being recorded, and newly placed orders with 0 fills weren't showing on the webapp.

## Files Changed
- `FlipSmartApiClient.java` - Added totalQuantity parameter overload
- `FlipSmartPlugin.java` - Full sync logic, immediate order recording