### PR TITLE
Add Discord login button with device authorization flow

### DIFF
--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -441,6 +441,12 @@ public class FlipSmartPlugin extends Plugin
 			clientToolbar.removeNavigation(flipFinderNavButton);
 		}
 		
+		// Shutdown flip finder panel (cleanup device auth polling, etc.)
+		if (flipFinderPanel != null)
+		{
+			flipFinderPanel.shutdown();
+		}
+		
 		// Stop auto-refresh timer
 		stopFlipFinderRefreshTimer();
 		
@@ -1726,6 +1732,20 @@ public class FlipSmartPlugin extends Plugin
 			{
 				log.info("Flip Assist focus cleared");
 				flipAssistOverlay.clearFocus();
+			}
+		});
+		
+		// Connect auth success callback to sync RSN after Discord login
+		flipFinderPanel.setOnAuthSuccess(() -> {
+			// Sync RSN to API if we have one (player is logged in)
+			if (currentRsn != null && !currentRsn.isEmpty())
+			{
+				log.info("Auth success callback - syncing RSN: {}", currentRsn);
+				apiClient.updateRSN(currentRsn);
+			}
+			else
+			{
+				log.debug("Auth success callback - no RSN to sync yet");
 			}
 		});
 


### PR DESCRIPTION
## Summary
- Adds "Login with Discord" button to the plugin login panel
- Implements device authorization flow for Discord OAuth in desktop app
- Syncs RSN to user account after successful authentication

## Changes

### Login Panel (`FlipFinderPanel.java`)
- Add Discord login button (Discord purple color)
- Implement browser opening for verification URL
- Implement polling with ScheduledExecutorService
- Add `onAuthSuccess` callback for RSN sync
- Add `shutdown()` method for cleanup

### API Client (`FlipSmartApiClient.java`)
- `startDeviceAuthAsync()` - requests device code from API
- `pollDeviceStatusAsync()` - polls for authorization status
- `setAuthToken()` - sets JWT token after successful auth

### Plugin (`FlipSmartPlugin.java`)
- Connect `onAuthSuccess` callback to sync RSN after any login method
- Call `shutdown()` on panel when plugin stops

## How It Works
1. User clicks "Login with Discord" in plugin
2. Plugin calls `POST /auth/device/start` to get device code
3. Plugin opens browser to frontend authorization page
4. User authorizes with Discord in browser
5. Plugin polls `GET /auth/device/status` every 5 seconds
6. When authorized, plugin receives JWT token and syncs RSN
7. User is logged in and can start tracking flips

## Related PRs
- Backend: Flip-Smart/flip-smart#140
- Frontend: Flip-Smart/flip-smart-eng#38

## Test Plan
- [ ] Click "Login with Discord" - browser opens to auth page
- [ ] Complete Discord OAuth - plugin shows "Login successful!"
- [ ] RSN syncs to account - website shows RSN in dropdown
- [ ] Transactions sync - active flips appear on website
- [ ] Timeout handling - expired codes show appropriate error
- [ ] Email/password login still works