### PR TITLE
fix: Remove Thread.interrupt() call on unowned thread

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -624,7 +624,6 @@ public class FlipFinderPanel extends PluginPanel
 				}
 				catch (InterruptedException e)
 				{
-					Thread.currentThread().interrupt();
 					log.debug("Refresh token auth interrupted: {}", e.getMessage());
 					SwingUtilities.invokeLater(this::tryLegacyPasswordAuth);
 				}


### PR DESCRIPTION
## Summary
Per Plugin Hub review feedback removes the `Thread.currentThread().interrupt()` call in the InterruptedException catch block.

We should not call `Thread.interrupt()` on threads we don't own - the executor service thread is managed by the framework, so re-interrupting it is incorrect behavior.