### PR TITLE
fix: Save refresh token for Discord login session persistence

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -930,6 +930,12 @@ public class FlipFinderPanel extends PluginPanel
 						// Success! Set the token and switch to main panel
 						stopDeviceAuthPolling();
 						apiClient.setAuthToken(status.getAccessToken());
+						// Save refresh token for session persistence across client restarts
+						if (status.getRefreshToken() != null)
+						{
+							apiClient.setRefreshToken(status.getRefreshToken());
+							saveRefreshToken(status.getRefreshToken());
+						}
 						SwingUtilities.invokeLater(() ->
 							onAuthenticationSuccess("Login successful!", true));
 						break;

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -741,18 +741,22 @@ public class FlipSmartApiClient
 		private String status;  // pending, authorized, expired
 		private String accessToken;
 		private String tokenType;
-		
+		private String refreshToken;  // For session persistence across client restarts
+
 		/** Default constructor required for Gson deserialization */
 		public DeviceStatusResponse() { }
-		
+
 		public String getStatus() { return status; }
 		public void setStatus(String status) { this.status = status; }
-		
+
 		public String getAccessToken() { return accessToken; }
 		public void setAccessToken(String accessToken) { this.accessToken = accessToken; }
-		
+
 		public String getTokenType() { return tokenType; }
 		public void setTokenType(String tokenType) { this.tokenType = tokenType; }
+
+		public String getRefreshToken() { return refreshToken; }
+		public void setRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
 	}
 	
 	/**
@@ -877,8 +881,12 @@ public class FlipSmartApiClient
 					if ("authorized".equals(statusResponse.getStatus()) && json.has(ACCESS_TOKEN_KEY))
 					{
 						statusResponse.setAccessToken(json.get(ACCESS_TOKEN_KEY).getAsString());
-						statusResponse.setTokenType(json.has("token_type") 
+						statusResponse.setTokenType(json.has("token_type")
 							? json.get("token_type").getAsString() : "bearer");
+						if (json.has("refresh_token"))
+						{
+							statusResponse.setRefreshToken(json.get("refresh_token").getAsString());
+						}
 					}
 					
 					future.complete(statusResponse);


### PR DESCRIPTION
## Summary
- Discord login sessions now persist by saving the refresh token returned by the backend after Discord login
- Added refreshToken field to DeviceStatusResponse
- Extract refresh_token from API response
- Save to config after Discord login

## Related Issues
Fixes #62

## Test plan
- [x] Verify plugin extracts refresh_token from device status response
- [x] Verify refresh token is saved to config after Discord login
- [x] Verify session persists across client restarts