### PR TITLE
Fix thread safety in FlipSmartApiClient

### DIFF
--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -81,6 +81,14 @@ public class FlipSmartApiClient
 		}
 	}
 
+	/**
+	 * Add Authorization header with Bearer token to a request builder.
+	 */
+	private Request.Builder withAuthHeader(Request.Builder builder)
+	{
+		return builder.header(HEADER_AUTHORIZATION, BEARER_PREFIX + getJwtToken());
+	}
+
 	@Inject
 	public FlipSmartApiClient(FlipSmartConfig config, Gson gson, OkHttpClient okHttpClient)
 	{
@@ -168,8 +176,7 @@ public class FlipSmartApiClient
 							if (authSuccess)
 							{
 								// Rebuild request with new token
-								Request retryRequest = request.newBuilder()
-									.header(HEADER_AUTHORIZATION, BEARER_PREFIX + getJwtToken())
+								Request retryRequest = withAuthHeader(request.newBuilder())
 									.build();
 
 								// Retry without auth retry to prevent infinite loop
@@ -227,10 +234,9 @@ public class FlipSmartApiClient
 				return CompletableFuture.completedFuture(null);
 			}
 
-			Request request = requestBuilder
-				.header(HEADER_AUTHORIZATION, BEARER_PREFIX + getJwtToken())
+			Request request = withAuthHeader(requestBuilder)
 				.build();
-			
+
 			return executeAsync(request, responseHandler, null, true);
 		});
 	}
@@ -752,9 +758,8 @@ public class FlipSmartApiClient
 			url += "?rsn=" + rsn;
 		}
 
-		Request request = new Request.Builder()
-			.url(url)
-			.header(HEADER_AUTHORIZATION, BEARER_PREFIX + getJwtToken())
+		Request request = withAuthHeader(new Request.Builder()
+			.url(url))
 			.get()
 			.build();
 
@@ -1614,9 +1619,8 @@ public class FlipSmartApiClient
 				urlBuilder.addQueryParameter("limit", String.valueOf(limit));
 			}
 
-			Request request = new Request.Builder()
-				.url(urlBuilder.build())
-				.header(HEADER_AUTHORIZATION, BEARER_PREFIX + getJwtToken())
+			Request request = withAuthHeader(new Request.Builder()
+				.url(urlBuilder.build()))
 				.get()
 				.build();
 


### PR DESCRIPTION
## Summary

This PR fixes critical thread safety issues in `FlipSmartApiClient` where authentication state was accessed inconsistently, causing potential race conditions. The fixes ensure all auth state (JWT token, token expiry, refresh token, premium status, and RSN blocked status) is properly synchronized, and wiki price fetch operations use atomic guards to prevent concurrent fetches.

## Changes

### 🐛 Bug Fixes
- **Fixed compound check-then-act race on JWT token validation** - Multiple methods were reading `jwtToken` and `tokenExpiry` separately without synchronization, allowing token expiry to change between the two reads
- **Fixed inconsistent auth state access** - Methods like `isPremium()`, `isRsnBlocked()`, and `getRefreshToken()` were reading fields marked as `volatile` but not using the `authLock`, while other code paths did use the lock
- **Fixed wiki price fetch race condition** - The `fetchWikiPrices()` method used a `volatile boolean` guard which created a check-then-act race; replaced with `AtomicBoolean.compareAndSet()` for atomic guard acquisition

### ♻️ Refactoring
- **Added `getJwtToken()` helper method** - Centralizes synchronized access to the JWT token, reducing boilerplate and ensuring consistency
- **Added `isTokenValid()` helper method** - Performs the compound check (token exists AND not expired) atomically under the lock
- **Replaced `volatile` with proper synchronization** - Removed `volatile` keyword from auth state fields (`jwtToken`, `tokenExpiry`, `refreshToken`, `isPremium`, `isRsnBlocked`) since they're now fully protected by `authLock`
- **Replaced volatile guards with atomic types for wiki prices** - Changed `wikiPriceFetchInProgress` to `AtomicBoolean` and `lastWikiPriceFetch` to `AtomicLong` for lock-free thread-safe access

## Testing

### Automated Tests
- ✅ Gradle build passing
- ✅ No compilation errors or warnings
- ✅ All existing tests pass

### Manual Testing
- [x] Verify login flow works correctly with multiple concurrent requests
- [x] Verify token refresh doesn't race with ongoing authenticated requests
- [x] Verify premium/blocked status updates are visible across threads
- [x] Verify wiki price fetching doesn't spawn duplicate concurrent fetches

## API Changes

**No API changes** - This is an internal thread safety fix with no changes to public interfaces.

## Deployment Notes

- [ ] No environment variables changed
- [ ] No new dependencies added
- [ ] No configuration changes required
- [ ] No database migrations required

## Checklist

- [x] Code follows RuneLite plugin hub style guidelines
- [x] No `Thread.currentThread().interrupt()` on executor-managed threads
- [x] Thread safety issues resolved with proper synchronization
- [x] Build passes with no errors
- [x] Commits are clean and descriptive
- [ ] Reviewed by maintainer

## Related Issues

Closes #47