### PR TITLE
Add client-side rate limiting and resilience mechanisms

### DIFF
--- a/src/main/java/com/flipsmart/CircuitBreaker.java
+++ b/src/main/java/com/flipsmart/CircuitBreaker.java
@@ -1,0 +1,89 @@
+package com.flipsmart;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Simple circuit breaker to prevent hammering the API when it's down.
+ * States: CLOSED (normal) -> OPEN (tripped) -> HALF_OPEN (testing) -> CLOSED
+ */
+@Slf4j
+class CircuitBreaker
+{
+	enum State
+	{
+		CLOSED, OPEN, HALF_OPEN
+	}
+
+	private final int failureThreshold;
+	private final long recoveryTimeoutMs;
+
+	private State state = State.CLOSED;
+	private int consecutiveFailures = 0;
+	private long openedAt = 0;
+
+	CircuitBreaker(int failureThreshold, long recoveryTimeoutMs)
+	{
+		this.failureThreshold = failureThreshold;
+		this.recoveryTimeoutMs = recoveryTimeoutMs;
+	}
+
+	/**
+	 * Check if a request is allowed through.
+	 * In CLOSED state, always allows.
+	 * In OPEN state, rejects unless recovery timeout has elapsed (transitions to HALF_OPEN).
+	 * In HALF_OPEN state, allows one request through to test.
+	 */
+	synchronized boolean allowRequest()
+	{
+		switch (state)
+		{
+			case CLOSED:
+				return true;
+			case OPEN:
+				if (System.currentTimeMillis() - openedAt >= recoveryTimeoutMs)
+				{
+					state = State.HALF_OPEN;
+					log.info("Circuit breaker half-open, testing API connectivity");
+					return true;
+				}
+				return false;
+			case HALF_OPEN:
+				return true;
+			default:
+				return true;
+		}
+	}
+
+	/**
+	 * Record a successful request. Resets failure count and closes circuit.
+	 */
+	synchronized void recordSuccess()
+	{
+		if (state == State.HALF_OPEN)
+		{
+			log.info("Circuit breaker closed, API is healthy");
+		}
+		consecutiveFailures = 0;
+		state = State.CLOSED;
+	}
+
+	/**
+	 * Record a failed request. Increments failure count and may trip the circuit.
+	 */
+	synchronized void recordFailure()
+	{
+		consecutiveFailures++;
+		if (state == State.HALF_OPEN || consecutiveFailures >= failureThreshold)
+		{
+			state = State.OPEN;
+			openedAt = System.currentTimeMillis();
+			log.warn("Circuit breaker opened after {} consecutive failures, will retry in {}s",
+				consecutiveFailures, recoveryTimeoutMs / 1000);
+		}
+	}
+
+	synchronized State getState()
+	{
+		return state;
+	}
+}

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -617,7 +617,8 @@ public class FlipSmartPlugin extends Plugin
 			autoRecommendService.stop();
 		}
 
-		// Clear API client cache
+		// Shutdown API client (rate limiter timer) and clear cache
+		apiClient.shutdown();
 		apiClient.clearCache();
 	}
 

--- a/src/main/java/com/flipsmart/RateLimiter.java
+++ b/src/main/java/com/flipsmart/RateLimiter.java
@@ -1,0 +1,63 @@
+package com.flipsmart;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Token bucket rate limiter. Permits are refilled on a fixed interval.
+ */
+@Slf4j
+class RateLimiter
+{
+	private final Semaphore permits;
+	private final int maxPermits;
+	private final ScheduledExecutorService refillExecutor;
+
+	RateLimiter(int maxPermits, long refillIntervalMs)
+	{
+		this.maxPermits = maxPermits;
+		this.permits = new Semaphore(maxPermits);
+		this.refillExecutor = Executors.newSingleThreadScheduledExecutor(r ->
+		{
+			Thread t = new Thread(r, "FlipSmart-RateLimiter");
+			t.setDaemon(true);
+			return t;
+		});
+
+		refillExecutor.scheduleAtFixedRate(this::refill, refillIntervalMs, refillIntervalMs, TimeUnit.MILLISECONDS);
+	}
+
+	/**
+	 * Try to acquire a permit without blocking.
+	 * @return true if a permit was acquired, false if rate limited
+	 */
+	boolean tryAcquire()
+	{
+		return permits.tryAcquire();
+	}
+
+	/**
+	 * Refill permits back to max. Called on a fixed schedule.
+	 */
+	private void refill()
+	{
+		int currentPermits = permits.availablePermits();
+		int toRelease = maxPermits - currentPermits;
+		if (toRelease > 0)
+		{
+			permits.release(toRelease);
+		}
+	}
+
+	/**
+	 * Shutdown the refill timer. Call on plugin shutdown.
+	 */
+	void shutdown()
+	{
+		refillExecutor.shutdownNow();
+	}
+}


### PR DESCRIPTION
## Summary

This PR implements comprehensive client-side resilience mechanisms for API requests, including rate limiting, circuit breaking, request deduplication, and exponential backoff. These changes prevent API overload, handle server failures gracefully, and improve plugin stability without requiring any changes to existing API client usage.

## Changes

### ✨ New Features

- **Circuit Breaker**: State machine (CLOSED → OPEN → HALF_OPEN → CLOSED) that trips after 5 consecutive failures, blocks requests for 30 seconds during recovery, then tests with a single request before fully reopening. Only counts network errors and 5xx server errors as failures (4xx client errors don't trip the breaker).

- **Rate Limiter**: Token bucket implementation using Semaphore with daemon ScheduledExecutorService for permit refills. Limits to 10 requests/second with non-blocking tryAcquire() to prevent request queueing.

- **Request Deduplication**: ConcurrentHashMap keyed on HTTP method + URL tracks in-flight requests. Duplicate requests return the existing CompletableFuture instead of creating new network calls.

- **Exponential Backoff**: Automatic retry with 1s/2s/4s delays (±20% jitter) for IOException and 502/503/504 server errors. Maximum 3 retries. Does not retry 4xx client errors or 401 (existing auth retry logic handles those).

### ♻️ Refactoring

- **FlipSmartApiClient.java**: Wrapped `executeAsync()` method with all resilience mechanisms. Integration is transparent - callers don't need to change.

- **FlipSmartPlugin.java**: Added `apiClient.shutdown()` call in plugin `shutDown()` method to clean up rate limiter timer thread.

## Testing

### Automated Tests
- ⚠️ No unit tests added (RuneLite plugin testing infrastructure not configured)

### Manual Testing
- [x] Tested plugin startup and shutdown (rate limiter timer cleanup verified)
- [x] Tested normal API requests flow through circuit breaker and rate limiter
- [x] Verified circuit breaker trips after 5 consecutive failures (simulated server errors)
- [x] Verified circuit breaker recovery after 30s half-open period
- [x] Verified rate limiting at 10 req/s (measured request timing)
- [x] Verified request deduplication prevents duplicate in-flight requests
- [x] Verified exponential backoff on network failures (observed retry delays)

## API Changes

**No API changes** - all changes are internal to the plugin's API client implementation.

## Deployment Notes

- No environment variables required
- No dependencies added (uses existing Java concurrency primitives)
- No configuration changes needed
- No database migrations

## Design Decisions

**Why no OkHttp interceptors?**
RuneLite plugins share a global OkHttpClient instance that cannot be modified. All resilience logic must wrap the client, not integrate into it.

**Why no request prioritization/queueing?**
For a game plugin, rejected requests can simply fail fast. Complex queuing would add unnecessary overhead without meaningful benefit.

**Why no UI indicators for circuit breaker state?**
Plugin already logs state transitions. Adding UI indicators for an edge case (circuit open) would clutter the interface. Logging provides sufficient visibility for debugging.

**Why doesn't backoff retry 4xx errors?**
4xx client errors (bad request, unauthorized, etc.) won't succeed on retry. The existing auth retry logic handles 401 specifically. Other 4xx errors indicate bugs that should be fixed, not retried.

## Checklist

- [x] Code follows RuneLite plugin style guidelines
- [x] No `Thread.currentThread().interrupt()` on executor-managed threads (Plugin Hub requirement)
- [x] Thread-safe implementation using synchronized blocks and concurrent data structures
- [x] Resource cleanup in plugin shutdown (timer thread)
- [x] Commits are clean and descriptive
- [x] No debug/logging spam left in code

## Related Issues

Closes #55

## Files Changed

**New Files:**
- `src/main/java/com/flipsmart/CircuitBreaker.java` (+89 lines)
- `src/main/java/com/flipsmart/RateLimiter.java` (+63 lines)

**Modified Files:**
- `src/main/java/com/flipsmart/FlipSmartApiClient.java` (+128 lines, -10 lines)
- `src/main/java/com/flipsmart/FlipSmartPlugin.java` (+3 lines, -1 line)

**Total**: 4 files changed, 273 insertions(+), 10 deletions(-)