### PR TITLE
fix: Send filled GE slots to prevent strategy tier degradation

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1329,8 +1329,11 @@ public class FlipFinderPanel extends PluginPanel
 		// Pass RSN for RSN-level access enforcement
 		String rsn = plugin.getCurrentRsnSafe().orElse(null);
 
+		// Pass filled GE slots for strategy tier inference
+		Integer filledSlots = getFilledSlots();
+
 		// Use unified /flip-finder endpoint with all parameters
-		apiClient.getFlipRecommendationsAsync(cashStack, flipStyle, limit, randomSeed, timeframe, rsn).thenAccept(response ->
+		apiClient.getFlipRecommendationsAsync(cashStack, flipStyle, limit, randomSeed, timeframe, rsn, filledSlots).thenAccept(response ->
 		{
 			handleRecommendationsResponse(response, scrollPos);
 		}).exceptionally(throwable ->
@@ -1741,6 +1744,16 @@ public class FlipFinderPanel extends PluginPanel
 	{
 		// This will be overridden by the plugin
 		// For now, return null to get all recommendations
+		return null;
+	}
+
+	/**
+	 * Get the number of currently filled GE slots.
+	 * Returns null if not available.
+	 * Can be overridden by subclasses to provide actual filled slot count.
+	 */
+	protected Integer getFilledSlots()
+	{
 		return null;
 	}
 

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -1112,10 +1112,12 @@ public class FlipSmartApiClient
 	 * @param randomSeed Random seed for variety in suggestions (optional)
 	 * @param timeframe Target flip timeframe (30m, 2h, 4h, 12h) or null for Active mode
 	 * @param rsn Player's RuneScape Name (optional, for RSN-level access enforcement)
+	 * @param filledSlots Number of GE slots currently filled (optional, for strategy tier inference)
 	 * @return CompletableFuture with flip recommendations
 	 */
 	public CompletableFuture<FlipFinderResponse> getFlipRecommendationsAsync(
-		Integer cashStack, String flipStyle, int limit, Integer randomSeed, String timeframe, String rsn)
+		Integer cashStack, String flipStyle, int limit, Integer randomSeed, String timeframe, String rsn,
+		Integer filledSlots)
 	{
 		String apiUrl = getApiUrl();
 
@@ -1143,6 +1145,11 @@ public class FlipSmartApiClient
 			urlBuilder.append(String.format("&rsn=%s", rsn));
 		}
 
+		if (filledSlots != null)
+		{
+			urlBuilder.append(String.format("&filled_slots=%d", filledSlots));
+		}
+
 		String url = urlBuilder.toString();
 		Request.Builder requestBuilder = new Request.Builder()
 			.url(url)
@@ -1153,7 +1160,7 @@ public class FlipSmartApiClient
 	}
 
 	/**
-	 * @deprecated Use {@link #getFlipRecommendationsAsync(Integer, String, int, Integer, String, String)} instead.
+	 * @deprecated Use {@link #getFlipRecommendationsAsync(Integer, String, int, Integer, String, String, Integer)} instead.
 	 * This method uses the deprecated /flip-finder/timeframe endpoint.
 	 *
 	 * Fetch timeframe-based flip recommendations from the API asynchronously.

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -2414,6 +2414,12 @@ public class FlipSmartPlugin extends Plugin
 			{
 				return session.getCurrentCashStack() > 0 ? session.getCurrentCashStack() : null;
 			}
+
+			@Override
+			protected Integer getFilledSlots()
+			{
+				return session.getTrackedOffers().size();
+			}
 		};
 		
 		// Connect Flip Assist focus callback


### PR DESCRIPTION
## Summary

Sends the count of filled GE slots to the backend flip-finder endpoint to enable accurate strategy tier selection throughout a session. Previously, as users placed GE offers, their inventory cash dropped and auto-refresh caused progressively worse strategy tiers, resulting in the last few GE slots receiving cheap, low-quality items despite the user being a high-value player.

## Changes

### 🐛 Bug Fixes
- **Strategy tier degradation fixed**: Backend now receives filled GE slot count to infer effective cash stack, preventing tier downgrade during auto-refresh
- Users with high total capital no longer receive progressively worse recommendations as they fill GE slots

### ♻️ Refactoring
- **FlipSmartApiClient.java**: Added `Integer filledSlots` parameter to `getFlipRecommendationsAsync()` and appends `&filled_slots=N` to request URL
- **FlipFinderPanel.java**: Added base `getFilledSlots()` method (returns null by default) and calls it when fetching recommendations
- **FlipSmartPlugin.java**: Overrides `getFilledSlots()` to return `session.getTrackedOffers().size()`, providing actual filled slot count

## Testing

### Manual Testing
- [x] Verified plugin builds successfully: `./gradlew clean build`
- [x] Tested with backend `feature/v4-target-price-algorithm` branch
- [ ] Tested that first GE slot receives high-tier recommendation
- [ ] Verified subsequent slots maintain similar quality instead of degrading
- [ ] Confirmed `filled_slots` parameter appears in API request logs

## API Changes

**Modified Request Parameters**:
- `GET /flip-finder` - Added optional `filled_slots` query parameter (integer)

**Backend Dependency**:
- Requires backend PR on `feature/v4-target-price-algorithm` branch in `flip-smart` repository
- Backend uses `filled_slots` to calculate effective cash stack: `inventory_cash + (filled_slots * average_offer_value)`

## Deployment Notes

- [ ] No environment variables changed
- [ ] No new dependencies
- [ ] No configuration changes required
- [x] Backward compatible - `filled_slots` parameter is optional (backend defaults to 0 if not provided)

## Checklist

- [x] Code follows RuneLite plugin style guidelines
- [x] No `Thread.currentThread().interrupt()` on framework-managed threads
- [x] Commits are clean and descriptive
- [x] No debug logging left in production code
- [x] Tested with backend integration
- [ ] Reviewed by teammate

## Related Issues

No associated GitHub issue.

## Technical Details

**Problem**: 
When users auto-refresh recommendations after placing GE offers, their inventory cash decreases (e.g., 10M → 1M after placing a 9M offer). The backend strategy tier system only sees the inventory cash (1M) and downgrades to a lower tier, recommending cheap items for remaining slots.

**Solution**:
Pass `filled_slots` count so backend can calculate: `effective_cash = inventory_cash + (filled_slots × avg_offer_value)`. This maintains the user's original strategy tier throughout the session.

**Implementation Pattern**:
- Base `FlipFinderPanel` defines nullable `getFilledSlots()` for flexibility
- `FlipSmartPlugin` overrides with session tracking data
- API client includes parameter if non-null, omits if null (backward compatible)