### PR TITLE
Add detailed API error messages and URL-encode RSN parameters

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1397,7 +1397,7 @@ public class FlipFinderPanel extends PluginPanel
 				}
 				else
 				{
-					showErrorInRecommended("Failed to fetch recommendations. Check your API settings.");
+					showErrorInRecommended(getDetailedErrorMessage("recommendations"));
 				}
 				restoreScrollPosition(recommendedScrollPane, scrollPos);
 				return;
@@ -1460,7 +1460,7 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				if (response == null)
 				{
-					showErrorInActiveFlips("Failed to fetch active flips. Check your API settings.");
+					showErrorInActiveFlips(getDetailedErrorMessage("active flips"));
 					restoreScrollPosition(activeFlipsScrollPane, scrollPos);
 					return;
 				}
@@ -1623,7 +1623,7 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				if (response == null)
 				{
-					showErrorInCompletedFlips("Failed to fetch completed flips. Check your API settings.");
+					showErrorInCompletedFlips(getDetailedErrorMessage("completed flips"));
 					restoreScrollPosition(completedFlipsScrollPane, scrollPos);
 					return;
 				}
@@ -1822,6 +1822,45 @@ public class FlipFinderPanel extends PluginPanel
 	{
 		statusLabel.setText(ERROR_DIALOG_TITLE);
 		showErrorInContainer(recommendedListContainer, "Flip Finder", message);
+	}
+
+	/**
+	 * Get a detailed error message based on the last API error.
+	 * Maps HTTP codes and error types to user-friendly messages.
+	 */
+	private String getDetailedErrorMessage(String resource)
+	{
+		FlipSmartApiClient.ApiError error = apiClient.getLastApiError();
+		if (error == null)
+		{
+			return "Failed to fetch " + resource + ". Please try again.";
+		}
+
+		switch (error.httpCode)
+		{
+			case 401:
+				return "Session expired. Please log in again.";
+			case 403:
+				if ("premium_required".equals(error.errorType) || "web_premium_required".equals(error.errorType))
+				{
+					return "Premium subscription required for this feature.";
+				}
+				if ("rsn_blocked".equals(error.errorType))
+				{
+					return "Subscribe to Premium to get flip suggestions for this account.";
+				}
+				return "Access denied: " + error.message;
+			case 422:
+				return "Invalid RSN or request parameters. Please check your settings.";
+			case 429:
+				return "Too many requests. Please wait a moment and try again.";
+			case 500:
+			case 502:
+			case 503:
+				return "Server error. The API may be temporarily unavailable.";
+			default:
+				return error.message;
+		}
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -8,6 +8,8 @@ import okhttp3.*;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -117,6 +119,15 @@ public class FlipSmartApiClient
 			return PRODUCTION_API_URL;
 		}
 		return configuredUrl;
+	}
+
+	/**
+	 * URL-encode a value for use in query parameters.
+	 * Handles RSNs with spaces and special characters.
+	 */
+	private static String urlEncode(String value)
+	{
+		return URLEncoder.encode(value, StandardCharsets.UTF_8);
 	}
 
 	/**
@@ -806,7 +817,7 @@ public class FlipSmartApiClient
 		String url = String.format("%s/auth/entitlements", getApiUrl());
 		if (rsn != null && !rsn.isEmpty())
 		{
-			url += "?rsn=" + rsn;
+			url += "?rsn=" + urlEncode(rsn);
 		}
 
 		Request request = withAuthHeader(new Request.Builder()
@@ -1094,7 +1105,7 @@ public class FlipSmartApiClient
 		}
 		
 		String apiUrl = getApiUrl();
-		String url = String.format("%s/auth/rsn?rsn=%s", apiUrl, rsn);
+		String url = String.format("%s/auth/rsn?rsn=%s", apiUrl, urlEncode(rsn));
 		
 		Request.Builder requestBuilder = new Request.Builder()
 			.url(url)
@@ -1193,7 +1204,7 @@ public class FlipSmartApiClient
 
 		if (rsn != null && !rsn.isEmpty())
 		{
-			urlBuilder.append(String.format("&rsn=%s", rsn));
+			urlBuilder.append(String.format("&rsn=%s", urlEncode(rsn)));
 		}
 
 		if (filledSlots != null)
@@ -1396,7 +1407,7 @@ public class FlipSmartApiClient
 		String url;
 		if (rsn != null && !rsn.isEmpty())
 		{
-			url = String.format("%s/transactions/active-flips?rsn=%s", apiUrl, rsn);
+			url = String.format("%s/transactions/active-flips?rsn=%s", apiUrl, urlEncode(rsn));
 		}
 		else
 		{
@@ -1438,7 +1449,7 @@ public class FlipSmartApiClient
 		String url;
 		if (rsn != null && !rsn.isEmpty())
 		{
-			url = String.format("%s/transactions/active-flips/%d?rsn=%s", apiUrl, itemId, rsn);
+			url = String.format("%s/transactions/active-flips/%d?rsn=%s", apiUrl, itemId, urlEncode(rsn));
 		}
 		else
 		{
@@ -1476,7 +1487,7 @@ public class FlipSmartApiClient
 		String url;
 		if (rsn != null && !rsn.isEmpty())
 		{
-			url = String.format("%s/transactions/active-flips/cleanup?rsn=%s", apiUrl, rsn);
+			url = String.format("%s/transactions/active-flips/cleanup?rsn=%s", apiUrl, urlEncode(rsn));
 		}
 		else
 		{
@@ -1577,7 +1588,7 @@ public class FlipSmartApiClient
 	public CompletableFuture<Boolean> markActiveFlipSellingAsync(int itemId, String rsn)
 	{
 		String apiUrl = getApiUrl();
-		String url = String.format("%s/transactions/active-flips/%d/mark-selling?rsn=%s", apiUrl, itemId, rsn);
+		String url = String.format("%s/transactions/active-flips/%d/mark-selling?rsn=%s", apiUrl, itemId, urlEncode(rsn));
 
 		Request.Builder requestBuilder = new Request.Builder()
 			.url(url)
@@ -1605,7 +1616,7 @@ public class FlipSmartApiClient
 		String url;
 		if (rsn != null && !rsn.isEmpty())
 		{
-			url = String.format("%s/flips/completed?limit=%d&rsn=%s", apiUrl, limit, rsn);
+			url = String.format("%s/flips/completed?limit=%d&rsn=%s", apiUrl, limit, urlEncode(rsn));
 		}
 		else
 		{
@@ -1639,7 +1650,7 @@ public class FlipSmartApiClient
 		String url;
 		if (rsn != null && !rsn.isEmpty())
 		{
-			url = String.format("%s/flips/statistics?days=%d&rsn=%s", apiUrl, days, rsn);
+			url = String.format("%s/flips/statistics?days=%d&rsn=%s", apiUrl, days, urlEncode(rsn));
 		}
 		else
 		{
@@ -1811,7 +1822,7 @@ public class FlipSmartApiClient
 	public CompletableFuture<BankSnapshotStatusResponse> checkBankSnapshotStatusAsync(String rsn)
 	{
 		String apiUrl = getApiUrl();
-		String url = String.format("%s/bank/snapshot/status?rsn=%s", apiUrl, rsn);
+		String url = String.format("%s/bank/snapshot/status?rsn=%s", apiUrl, urlEncode(rsn));
 
 		Request.Builder requestBuilder = new Request.Builder()
 			.url(url)

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -131,13 +131,43 @@ public class FlipSmartApiClient
 	}
 
 	/**
+	 * Structured API error from the server response.
+	 * Provides HTTP status code, error type, and human-readable message.
+	 */
+	public static class ApiError
+	{
+		public final int httpCode;
+		public final String errorType;
+		public final String message;
+
+		public ApiError(int httpCode, String errorType, String message)
+		{
+			this.httpCode = httpCode;
+			this.errorType = errorType;
+			this.message = message;
+		}
+	}
+
+	// Most recent API error (set on failed requests, cleared on success)
+	private volatile ApiError lastApiError = null;
+
+	/**
+	 * Get the last API error from a failed request.
+	 * Returns null if the last request succeeded.
+	 */
+	public ApiError getLastApiError()
+	{
+		return lastApiError;
+	}
+
+	/**
 	 * Authentication result with status and message
 	 */
 	public static class AuthResult
 	{
 		public final boolean success;
 		public final String message;
-		
+
 		public AuthResult(boolean success, String message)
 		{
 			this.success = success;
@@ -212,15 +242,62 @@ public class FlipSmartApiClient
 					
 					if (!response.isSuccessful())
 					{
-						log.debug("Request returned error: {}", response.code());
+						int code = response.code();
+						String errorType = "unknown";
+						String errorMessage = "Error " + code;
+
+						// Parse error response body for structured error details
+						try
+						{
+							okhttp3.ResponseBody errorBody = response.body();
+							if (errorBody != null)
+							{
+								String errorJson = errorBody.string();
+								JsonObject errorObj = gson.fromJson(errorJson, JsonObject.class);
+								if (errorObj != null && errorObj.has("detail"))
+								{
+									if (errorObj.get("detail").isJsonObject())
+									{
+										JsonObject detail = errorObj.getAsJsonObject("detail");
+										if (detail.has("error"))
+										{
+											errorType = detail.get("error").getAsString();
+										}
+										if (detail.has("message"))
+										{
+											errorMessage = detail.get("message").getAsString();
+										}
+									}
+									else if (errorObj.get("detail").isJsonArray())
+									{
+										// FastAPI validation errors (422) return detail as array
+										errorType = "validation_error";
+										errorMessage = "Invalid request parameters";
+									}
+									else
+									{
+										errorMessage = errorObj.get("detail").getAsString();
+									}
+								}
+							}
+						}
+						catch (Exception e)
+						{
+							log.debug("Could not parse error response body: {}", e.getMessage());
+						}
+
+						lastApiError = new ApiError(code, errorType, errorMessage);
+						log.debug("Request returned error {}: {} - {}", code, errorType, errorMessage);
+
 						if (errorHandler != null)
 						{
-							errorHandler.accept("Error " + response.code());
+							errorHandler.accept(errorMessage);
 						}
 						future.complete(null);
 						return;
 					}
 
+					lastApiError = null;
 					okhttp3.ResponseBody responseBody = response.body();
 					String jsonData = responseBody != null ? responseBody.string() : "";
 					T result = responseHandler.apply(jsonData);


### PR DESCRIPTION
## Summary

This PR bundles two related improvements to API communication in the RuneLite plugin. First, RSN query parameters are now URL-encoded so account names containing spaces (e.g. "My Alt 4") produce valid URLs. Second, API error responses are now parsed and mapped to specific user-facing messages instead of showing a generic fallback, making it far easier for users to understand and resolve issues.

## Changes

### ✨ New Features
- Added `getDetailedErrorMessage()` helper in `FlipFinderPanel` that maps HTTP status codes and API error types to actionable user messages
- Added `ApiError` inner class in `FlipSmartApiClient` to hold structured error details (type, message) parsed from response bodies

### 🐛 Bug Fixes
- Fixed API calls breaking for OSRS accounts with spaces in their name by URL-encoding RSN query parameters across all 10 usages (flip-finder, transactions, flips, and bank endpoints)

### ♻️ Refactoring
- All three tab error handlers (Recommended, Active Flips, Completed) updated to use the new detailed error messages instead of the generic fallback

## Error Message Mapping

| Condition | Message shown to user |
|---|---|
| HTTP 401 | "Session expired. Please log in again." |
| HTTP 403 + `premium_required` | "Premium subscription required for this feature." |
| HTTP 403 + `rsn_blocked` | "Subscribe to Premium to get flip suggestions for this account." |
| HTTP 422 | "Invalid RSN or request parameters. Please check your settings." |
| HTTP 429 | "Too many requests. Please wait a moment and try again." |
| HTTP 500/502/503 | "Server error. The API may be temporarily unavailable." |
| Other errors | Previous generic fallback message |

## Testing

### Automated Tests
- Plugin builds cleanly via Gradle

### Manual Testing
- [ ] Verify API calls succeed for RSNs with spaces (e.g. "My Alt 4")
- [ ] Verify 401 response shows "Session expired" message in the panel
- [ ] Verify 403 premium_required shows correct premium message
- [ ] Verify 403 rsn_blocked shows correct RSN blocked message
- [ ] Verify 422 shows validation error message
- [ ] Verify 429 shows rate limit message
- [ ] Verify 500 shows server error message

## Deployment Notes

- [ ] No environment variable changes
- [ ] No new dependencies
- [ ] No database migrations

## Checklist

- [x] Code follows RuneLite Plugin Hub coding standards
- [x] No `Thread.currentThread().interrupt()` calls on unowned threads
- [x] No debug code or unnecessary logging left in

## Related Issues

Closes Flip-Smart/flip-smart#350