### PR TITLE
Fix minimum profit filter not applied in Flip Finder results

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2032,8 +2032,15 @@ public class FlipFinderPanel extends PluginPanel
 		FlipRecommendation autoRecCurrent = (service != null && service.isActive())
 			? service.getCurrentRecommendation() : null;
 
+		int minProfit = config.minimumProfit();
+
 		for (FlipRecommendation rec : recommendations)
 		{
+			if (rec.getPotentialProfit() < minProfit)
+			{
+				continue;
+			}
+
 			JPanel panel = createRecommendationPanel(rec);
 
 			// Highlight if this is the current auto-recommend item

--- a/src/main/java/com/flipsmart/FlipSmartConfig.java
+++ b/src/main/java/com/flipsmart/FlipSmartConfig.java
@@ -146,13 +146,13 @@ public interface FlipSmartConfig extends Config
 	@ConfigItem(
 		keyName = "minProfit",
 		name = "Minimum Profit",
-		description = "Minimum profit margin to highlight (in GP)",
+		description = "Hide recommendations with total profit below this value (in GP)",
 		section = flipFinderSection,
 		position = 4
 	)
 	default int minimumProfit()
 	{
-		return 100;
+		return 10000;
 	}
 
 	// ============================================


### PR DESCRIPTION
## Summary

The minimum profit config option (`minimumProfit()`) existed in `FlipSmartConfig` but was never wired up after the UI was refactored from `FlipSmartOverlay` to `FlipFinderPanel`. As a result, the filter had no effect and all recommendations were shown regardless of profit. This PR adds the missing filter check and updates the default value to a more practical threshold.

## Changes

### Bug Fixes
- Added minimum profit filtering in `FlipFinderPanel.populateRecommendations()` — recommendations where `potentialProfit < minimumProfit` are now skipped before rendering

### Refactoring
- Updated default `minimumProfit` from 100gp to 10,000gp to provide a meaningful out-of-the-box filter
- Updated config item description from "Minimum profit margin to highlight (in GP)" to "Hide recommendations with total profit below this value (in GP)" to accurately reflect the new behaviour

## Testing

### Automated Tests
- Build passes with no errors or warnings

### Manual Testing
- [x] Open Flip Finder panel with default settings — verify recommendations below 10,000gp profit are hidden
- [x] Change minimum profit setting to 0 — verify all recommendations appear
- [x] Change minimum profit setting to a high value (e.g. 500,000gp) — verify only high-profit items are shown
- [x] Verify existing recommendations still display correctly when above the threshold

## Deployment Notes

- No environment variables or configuration changes required beyond the plugin config update
- Existing users with `minimumProfit` set to the old default of 100gp will have their filter updated to 10,000gp on next load (config default change)

## Checklist

- [x] Bug is reproducible without the fix
- [x] Fix addresses root cause (missing filter call in `populateRecommendations`)
- [x] Default value updated to a sensible threshold
- [x] Config description updated to accurately describe behaviour
- [x] Build passes

## Related Issues

Closes Flip-Smart/flip-smart#424