### PR TITLE
Fix suggestion profit/margin/cost mismatch when price offset is configured

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -831,14 +831,22 @@ public class AutoRecommendService
 	private List<FlipRecommendation> filterAndSortRecommendations(List<FlipRecommendation> newRecommendations)
 	{
 		Set<Integer> activeItemIds = plugin.getActiveFlipItemIds();
+		int priceOffset = config.priceOffset();
+		int minProfit = config.minimumProfit();
 		List<FlipRecommendation> filtered = new ArrayList<>();
 		for (FlipRecommendation rec : newRecommendations)
 		{
-			if (!activeItemIds.contains(rec.getItemId()))
-			{
-				filtered.add(rec);
-			}
 			itemNames.put(rec.getItemId(), rec.getItemName());
+			if (activeItemIds.contains(rec.getItemId()))
+			{
+				continue;
+			}
+			// Skip items whose offset-adjusted profit falls below the minimum
+			if (FocusedFlip.calculateAdjustedProfit(rec, priceOffset) < minProfit)
+			{
+				continue;
+			}
+			filtered.add(rec);
 		}
 		filtered.sort(Comparator.comparingDouble(FlipRecommendation::getVolumePerHour));
 		return filtered;
@@ -1783,14 +1791,24 @@ public class AutoRecommendService
 	{
 		currentIndex++;
 
+		int priceOffset = config.priceOffset();
+		int minProfit = config.minimumProfit();
+
 		while (currentIndex < recommendationQueue.size())
 		{
 			FlipRecommendation next = recommendationQueue.get(currentIndex);
-			if (!plugin.getActiveFlipItemIds().contains(next.getItemId()))
+			if (plugin.getActiveFlipItemIds().contains(next.getItemId()))
 			{
-				break;
+				currentIndex++;
+				continue;
 			}
-			currentIndex++;
+			// Skip items whose offset-adjusted profit falls below the minimum
+			if (FocusedFlip.calculateAdjustedProfit(next, priceOffset) < minProfit)
+			{
+				currentIndex++;
+				continue;
+			}
+			break;
 		}
 
 		if (currentIndex >= recommendationQueue.size())

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -54,10 +54,7 @@ public class AutoRecommendService
 
 	// Stale offer queue — guides user through stale offers one at a time
 	private final List<TrackedOffer> staleOfferQueue = new ArrayList<>();
-	// Recommended re-sell prices for stale sell offers (itemId -> price)
 	private final Map<Integer, Integer> staleResellPrices = new HashMap<>();
-
-	// Deferred actions — queued when user is busy interacting with GE
 	private final List<Runnable> deferredActions = new ArrayList<>();
 
 	// Queue state - guarded by synchronized(this)
@@ -86,7 +83,6 @@ public class AutoRecommendService
 	// ObjIntConsumer<message, itemId> — itemId <= 0 means no icon
 	private volatile ObjIntConsumer<String> onOverlayMessageChanged;
 
-	// Callback when a stale offer is prompted (for GE slot highlighting)
 	private volatile java.util.function.IntConsumer onStaleOfferPrompted;
 
 	// Provider for the panel's displayed (smart) sell price — preferred over session's stored price
@@ -359,8 +355,6 @@ public class AutoRecommendService
 					itemId, rec.getRecommendedSellPrice());
 			}
 
-			// If all GE slots are now full, clear the buy overlay so it doesn't
-			// keep showing a recommendation the user can't act on (fixes #393)
 			if (!hasAvailableGESlots())
 			{
 				log.info("Auto-recommend: Non-focused buy filled last GE slot - clearing focus");
@@ -691,24 +685,11 @@ public class AutoRecommendService
 		}
 	}
 
-	// =====================
-	// Alert Deferral
-	// =====================
-
-	/**
-	 * Check if the user is actively interacting with the GE interface.
-	 * When busy, focus-changing events should be deferred to avoid interrupting
-	 * the user mid-offer setup.
-	 */
 	private boolean isUserBusy()
 	{
 		return isBusyStep(plugin.getFlipAssistOverlayStep());
 	}
 
-	/**
-	 * Execute an action immediately if the user is not busy, or defer it
-	 * until the user finishes their current GE interaction.
-	 */
 	private synchronized void executeOrDefer(Runnable action)
 	{
 		if (isUserBusy())
@@ -722,10 +703,6 @@ public class AutoRecommendService
 		}
 	}
 
-	/**
-	 * Called when the overlay step changes. If the user transitions from a busy
-	 * state to an idle state, drain deferred actions by re-evaluating priorities.
-	 */
 	public synchronized void onOverlayStepChanged(FlipAssistStep newStep)
 	{
 		if (!active || deferredActions.isEmpty())
@@ -752,10 +729,6 @@ public class AutoRecommendService
 			|| step == FlipAssistStep.CONFIRM_SELL;
 	}
 
-	/**
-	 * Ensure a sell price is available for an item. If the stored price was lost
-	 * (e.g., plugin restart), try to recover it from the recommendation queue.
-	 */
 	private void ensureSellPriceAvailable(int itemId)
 	{
 		PlayerSession session = plugin.getSession();
@@ -773,11 +746,6 @@ public class AutoRecommendService
 		}
 	}
 
-	/**
-	 * Update the sell price for an item after a sell cancellation.
-	 * Prefers the recommendation queue price (reflects current market),
-	 * falls back to the existing stored price from the original buy.
-	 */
 	private void updateSellPriceFromQueueOrFallback(int itemId)
 	{
 		FlipRecommendation rec = findRecommendationForItem(itemId);
@@ -837,16 +805,11 @@ public class AutoRecommendService
 		for (FlipRecommendation rec : newRecommendations)
 		{
 			itemNames.put(rec.getItemId(), rec.getItemName());
-			if (activeItemIds.contains(rec.getItemId()))
+			if (!activeItemIds.contains(rec.getItemId())
+				&& FocusedFlip.calculateAdjustedProfit(rec, priceOffset) >= minProfit)
 			{
-				continue;
+				filtered.add(rec);
 			}
-			// Skip items whose offset-adjusted profit falls below the minimum
-			if (FocusedFlip.calculateAdjustedProfit(rec, priceOffset) < minProfit)
-			{
-				continue;
-			}
-			filtered.add(rec);
 		}
 		filtered.sort(Comparator.comparingDouble(FlipRecommendation::getVolumePerHour));
 		return filtered;
@@ -1797,18 +1760,12 @@ public class AutoRecommendService
 		while (currentIndex < recommendationQueue.size())
 		{
 			FlipRecommendation next = recommendationQueue.get(currentIndex);
-			if (plugin.getActiveFlipItemIds().contains(next.getItemId()))
+			if (!plugin.getActiveFlipItemIds().contains(next.getItemId())
+				&& FocusedFlip.calculateAdjustedProfit(next, priceOffset) >= minProfit)
 			{
-				currentIndex++;
-				continue;
+				break;
 			}
-			// Skip items whose offset-adjusted profit falls below the minimum
-			if (FocusedFlip.calculateAdjustedProfit(next, priceOffset) < minProfit)
-			{
-				currentIndex++;
-				continue;
-			}
-			break;
+			currentIndex++;
 		}
 
 		if (currentIndex >= recommendationQueue.size())

--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -462,10 +462,6 @@ public class FlipAssistOverlay extends Overlay
 		return new Dimension(HINT_PANEL_WIDTH, panelHeight);
 	}
 
-	/**
-	 * Determine the color for a hint box line.
-	 * Lines ending in "gp" or standalone item names (no colon, no action verb) are green.
-	 */
 	private Color getHintLineColor(String line)
 	{
 		String trimmed = line.trim();
@@ -473,7 +469,6 @@ public class FlipAssistOverlay extends Overlay
 		{
 			return COLOR_BUY;
 		}
-		// Item name lines: don't contain action words or colons
 		if (!trimmed.contains(":") && !trimmed.isEmpty()
 			&& !trimmed.startsWith("Consider") && !trimmed.startsWith("Re-sell")
 			&& !trimmed.startsWith("Adjust") && !trimmed.startsWith("Margin")

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2033,10 +2033,12 @@ public class FlipFinderPanel extends PluginPanel
 			? service.getCurrentRecommendation() : null;
 
 		int minProfit = config.minimumProfit();
+		int priceOffset = config.priceOffset();
 
 		for (FlipRecommendation rec : recommendations)
 		{
-			if (rec.getPotentialProfit() < minProfit)
+			int adjustedProfit = FocusedFlip.calculateAdjustedProfit(rec, priceOffset);
+			if (adjustedProfit < minProfit)
 			{
 				continue;
 			}
@@ -2087,8 +2089,18 @@ public class FlipFinderPanel extends PluginPanel
 	{
 		JPanel detailsPanel = createDetailsPanel(ColorScheme.DARKER_GRAY_COLOR);
 
+		// Apply price offset to displayed values so they match Flip Assist
+		int priceOffset = config.priceOffset();
+		int displayBuyPrice = Math.max(1, rec.getRecommendedBuyPrice() + priceOffset);
+		int displaySellPrice = Math.max(1, rec.getRecommendedSellPrice() - priceOffset);
+		int displayMargin = displaySellPrice - displayBuyPrice;
+		int geTax = Math.min((int)(displaySellPrice * 0.02), 5_000_000);
+		int displayProfit = (displayMargin - geTax) * rec.getRecommendedQuantity();
+		int displayCost = displayBuyPrice * rec.getRecommendedQuantity();
+		double displayRoi = displayBuyPrice > 0 ? ((double)(displayMargin - geTax) / displayBuyPrice) * 100 : 0;
+
 		// Recommended Buy/Sell prices
-		JLabel priceLabel = new JLabel(formatBuySellText(rec.getRecommendedBuyPrice(), rec.getRecommendedSellPrice()));
+		JLabel priceLabel = new JLabel(formatBuySellText(displayBuyPrice, displaySellPrice));
 		priceLabel.setForeground(Color.LIGHT_GRAY);
 		priceLabel.setFont(FONT_PLAIN_12);
 
@@ -2100,12 +2112,12 @@ public class FlipFinderPanel extends PluginPanel
 
 		// Margin and ROI
 		JLabel marginLabel = new JLabel(String.format("Margin: %s (%s ROI)",
-			formatGP(rec.getMargin()), rec.getFormattedROI()));
+			formatGP(displayMargin - geTax), GpUtils.formatROI(displayRoi)));
 		marginLabel.setForeground(COLOR_PROFIT_GREEN);
 		marginLabel.setFont(FONT_PLAIN_12);
 
 		// Potential profit and total cost
-		JLabel profitLabel = new JLabel(formatProfitCostText(rec.getPotentialProfit(), rec.getTotalCost()));
+		JLabel profitLabel = new JLabel(formatProfitCostText(displayProfit, displayCost));
 		profitLabel.setForeground(new Color(255, 215, 0));
 		profitLabel.setFont(FONT_PLAIN_12);
 

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -248,10 +248,6 @@ public class FlipSmartPlugin extends Plugin
 		return autoRecommendService != null ? autoRecommendService.getLastOverlayMessage() : null;
 	}
 
-	/**
-	 * Get the current Flip Assist overlay step, used by AutoRecommendService
-	 * to determine if the user is busy with a GE interaction.
-	 */
 	public FlipAssistOverlay.FlipAssistStep getFlipAssistOverlayStep()
 	{
 		return flipAssistOverlay != null ? flipAssistOverlay.getCurrentStep() : FlipAssistOverlay.FlipAssistStep.SELECT_ITEM;
@@ -545,12 +541,10 @@ public class FlipSmartPlugin extends Plugin
 			updateInventoryHighlightForFocus(focus);
 		});
 
-		// Wire callback: highlight GE slot for adjustment
 		manualAdjustmentTracker.setOnHighlightSlot((slot, recommendedPrice) ->
 			geSlotOverlay.setAdjustmentHighlight(slot, recommendedPrice));
 		manualAdjustmentTracker.setOnClearHighlight(geSlotOverlay::clearAdjustmentHighlight);
 
-		// Wire callback: highlight inventory item for sell adjustments
 		manualAdjustmentTracker.setOnHighlightInventoryItem(inventoryHighlightOverlay::addHighlight);
 		manualAdjustmentTracker.setOnClearInventoryItem(inventoryHighlightOverlay::removeHighlight);
 
@@ -565,13 +559,6 @@ public class FlipSmartPlugin extends Plugin
 		grandExchangeTracker.setConfig(config);
 	}
 
-	/**
-	 * Update inventory highlights when the focused flip changes.
-	 * Highlights the item in inventory when a sell-focused flip is active.
-	 */
-	/**
-	 * Find the GE slot for an item and highlight it with the adjustment amber border.
-	 */
 	private void highlightSlotForItem(int itemId)
 	{
 		geSlotOverlay.clearAllAdjustmentHighlights();
@@ -600,7 +587,6 @@ public class FlipSmartPlugin extends Plugin
 		updateInventoryHighlightForFocus(focus);
 		if (focus != null)
 		{
-			// Clear stale offer GE slot highlights when focus moves to a new recommendation
 			geSlotOverlay.clearAllAdjustmentHighlights();
 			log.info("Auto-recommend focus set: {} {} @ {} gp",
 				focus.getStep(), focus.getItemName(), focus.getCurrentStepPrice());

--- a/src/main/java/com/flipsmart/FocusedFlip.java
+++ b/src/main/java/com/flipsmart/FocusedFlip.java
@@ -119,5 +119,18 @@ public class FocusedFlip
 	{
 		return step == FlipStep.SELL;
 	}
+
+	/**
+	 * Calculate the expected profit for a recommendation after applying the price offset.
+	 * This matches the profit shown in the Flip Assist overlay.
+	 */
+	public static int calculateAdjustedProfit(FlipRecommendation rec, int priceOffset)
+	{
+		int adjBuy = Math.max(1, rec.getRecommendedBuyPrice() + priceOffset);
+		int adjSell = Math.max(1, rec.getRecommendedSellPrice() - priceOffset);
+		int margin = adjSell - adjBuy;
+		int geTax = Math.min((int)(adjSell * 0.02), 5_000_000);
+		return (margin - geTax) * rec.getRecommendedQuantity();
+	}
 }
 

--- a/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
@@ -378,8 +378,6 @@ public class GrandExchangeSlotOverlay extends Overlay
 		tooltip.x = mousePos.getX() + 15;
 		tooltip.y = mousePos.getY() - 30;
 
-		// Look up buy price for sell offers (for P/L display)
-		// Prefer active flip data from API (survives restarts), fall back to local tracking
 		if (!isOfferBuyType(offer) && config.showProfitLoss())
 		{
 			tooltip.buyPrice = getBuyPriceForItem(offer.getItemId());
@@ -393,9 +391,6 @@ public class GrandExchangeSlotOverlay extends Overlay
 		return tooltip;
 	}
 
-	/**
-	 * Get the buy price for an item from cached active flips (API data).
-	 */
 	private Integer getBuyPriceForItem(int itemId)
 	{
 		java.util.List<ActiveFlip> activeFlips = plugin.getCurrentActiveFlips();
@@ -611,7 +606,6 @@ public class GrandExchangeSlotOverlay extends Overlay
 		{
 			if (line.equals("---"))
 			{
-				// Draw a subtle divider line
 				int dividerY = textY - fm.getAscent() + DIVIDER_HEIGHT / 2;
 				graphics.setColor(new Color(80, 80, 80));
 				graphics.drawLine(x + padding, dividerY, x + padding + maxWidth, dividerY);

--- a/src/main/java/com/flipsmart/InventoryHighlightOverlay.java
+++ b/src/main/java/com/flipsmart/InventoryHighlightOverlay.java
@@ -12,10 +12,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * Overlay that draws a pulsing orange glow around the outline of inventory
- * items that have pending sell adjustment recommendations.
- */
 @Slf4j
 public class InventoryHighlightOverlay extends WidgetItemOverlay
 {
@@ -23,7 +19,6 @@ public class InventoryHighlightOverlay extends WidgetItemOverlay
 
 	private final Set<Integer> highlightedItemIds = ConcurrentHashMap.newKeySet();
 
-	// Cache outline images keyed by (itemId, quantity) to handle stack-variant sprites
 	private final Map<Long, BufferedImage> outlineCache = new ConcurrentHashMap<>();
 
 	@Inject
@@ -76,8 +71,6 @@ public class InventoryHighlightOverlay extends WidgetItemOverlay
 		long elapsed = System.currentTimeMillis() % 1500;
 		float pulseAlpha = (float) (0.5 + 0.5 * Math.sin(elapsed / 1500.0 * 2 * Math.PI));
 
-		// Clip out the top-left corner where quantity text is rendered
-		// so the glow doesn't obscure it
 		Shape originalClip = graphics.getClip();
 		java.awt.geom.Area clipArea = new java.awt.geom.Area(new Rectangle(
 			bounds.x - 10, bounds.y - 10,
@@ -86,7 +79,6 @@ public class InventoryHighlightOverlay extends WidgetItemOverlay
 			bounds.x, bounds.y, bounds.width / 2, bounds.height / 3)));
 		graphics.setClip(clipArea);
 
-		// Draw expanded glow layers for outer glow effect
 		Composite originalComposite = graphics.getComposite();
 		for (int i = 2; i >= 1; i--)
 		{
@@ -100,7 +92,6 @@ public class InventoryHighlightOverlay extends WidgetItemOverlay
 				null);
 		}
 
-		// Draw the crisp inner outline
 		float innerAlpha = 0.7f + 0.3f * pulseAlpha;
 		graphics.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, innerAlpha));
 		graphics.drawImage(outline, bounds.x, bounds.y, bounds.width, bounds.height, null);
@@ -109,10 +100,6 @@ public class InventoryHighlightOverlay extends WidgetItemOverlay
 		graphics.setClip(originalClip);
 	}
 
-	/**
-	 * Generate an outline image from the item sprite. Uses the quantity-aware
-	 * sprite so the outline matches the actual rendered stack appearance.
-	 */
 	private BufferedImage generateOutline(int itemId, int quantity)
 	{
 		BufferedImage itemImage = itemManager.getImage(itemId, quantity, false);


### PR DESCRIPTION
## Summary

When users configure a price offset (e.g., +1gp), the Flip Assist overlay correctly adjusted buy/sell prices and recalculated profit, but the suggestion panel continued to display the backend's raw profit, margin, and cost values. This caused confusing mismatches — e.g., the suggestion card showing 110K profit while Flip Assist showed 88K for the same item. Additionally, the auto-recommend service was not filtering items against the minimum profit threshold using offset-adjusted values, so items that dropped below the user's configured minimum after offset adjustment were still being focused.

## Changes

### 🐛 Bug Fixes
- Suggestion card now displays offset-adjusted prices, margin, ROI, profit, and cost — matching what the Flip Assist overlay shows
- Min profit filter in `populateRecommendations()` now uses offset-adjusted profit instead of the backend's raw value
- `filterAndSortRecommendations()` in `AutoRecommendService` excludes items whose offset-adjusted profit falls below the minimum threshold
- `advanceToNext()` in `AutoRecommendService` skips items below min profit after offset when cycling through the queue

### ♻️ Refactoring
- Added `FocusedFlip.calculateAdjustedProfit()` static helper that encapsulates the offset-aware profit formula (with GE tax), shared between the panel display and auto-recommend logic

No behavior change when price offset is 0 (default).

## Testing

### Automated Tests
- ✅ Gradle build passing (`./gradlew build`)

### Manual Testing
- [x] Set a non-zero price offset (e.g., +1gp) and verify suggestion card profit matches Flip Assist overlay profit for the same item
- [x] Verify suggestion card margin, ROI, and cost also reflect the offset
- [x] Set min profit threshold and a non-zero offset; confirm items that fall below threshold after offset are excluded from suggestions
- [x] Verify auto-recommend does not cycle to items below min profit after offset
- [x] Confirm no change in behavior when price offset is 0

## Deployment Notes

- [ ] No environment variables or configuration changes required
- [ ] No new dependencies
- [ ] Client-side only change — no backend changes needed

## Checklist

- [x] Bug fix verified against Flip Assist overlay formula
- [x] Shared helper avoids duplication between panel and auto-recommend
- [x] No behavior change for default (zero) offset
- [x] Build passing