### PR TITLE
Fix active flips showing wrong item name/icon when GE slot is reused

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -508,8 +508,12 @@ public class AutoRecommendService
 	 * @param filledQuantity how many items were filled before cancellation
 	 * @param totalQuantity  the original order quantity
 	 */
-	public synchronized void onOfferCancelled(int itemId, boolean wasBuy, int filledQuantity, int totalQuantity)
+	public synchronized void onOfferCancelled(int itemId, String itemName, boolean wasBuy, int filledQuantity, int totalQuantity)
 	{
+		if (itemName != null)
+		{
+			itemNames.put(itemId, itemName);
+		}
 		promptedStaleItems.remove(itemId);
 		staleOfferQueue.removeIf(o -> o.getItemId() == itemId);
 		staleResellPrices.remove(itemId);

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -225,7 +225,7 @@ public class GrandExchangeTracker
 		// Notify auto-recommend AFTER tracked offer removal
 		if (isAutoRecommendActive())
 		{
-			autoRecommendService.onOfferCancelled(ctx.itemId, ctx.isBuy, ctx.quantitySold, totalQuantity);
+			autoRecommendService.onOfferCancelled(ctx.itemId, ctx.itemName, ctx.isBuy, ctx.quantitySold, totalQuantity);
 		}
 	}
 
@@ -238,7 +238,7 @@ public class GrandExchangeTracker
 		{
 			session.addCollectedItem(ctx.itemId, remaining);
 			log.info("Sell cancelled for {} - re-added {} unsold items to collected",
-				sellOffer != null ? sellOffer.getItemName() : ctx.itemName, remaining);
+				ctx.itemName, remaining);
 		}
 	}
 
@@ -253,7 +253,7 @@ public class GrandExchangeTracker
 
 			log.info("Recording final transaction before cancellation: {} {} x{}/{} @ {} gp each",
 				ctx.isBuy ? "BUY" : "SELL",
-				previousOffer.getItemName(),
+				ctx.itemName,
 				newQuantity,
 				previousOffer.getTotalQuantity(),
 				pricePerItem);
@@ -261,7 +261,7 @@ public class GrandExchangeTracker
 			Integer recommendedSellPrice = ctx.isBuy ? session.getRecommendedPrice(ctx.itemId) : null;
 
 			apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
-				.builder(ctx.itemId, previousOffer.getItemName(), ctx.isBuy, newQuantity, pricePerItem)
+				.builder(ctx.itemId, ctx.itemName, ctx.isBuy, newQuantity, pricePerItem)
 				.geSlot(ctx.slot)
 				.recommendedSellPrice(recommendedSellPrice)
 				.rsn(getRsn().orElse(null))
@@ -271,7 +271,7 @@ public class GrandExchangeTracker
 
 		log.info("Order cancelled: {} {} - {} items filled out of {}",
 			ctx.isBuy ? "BUY" : "SELL",
-			previousOffer != null ? previousOffer.getItemName() : ctx.itemName,
+			ctx.itemName,
 			ctx.quantitySold,
 			ctx.totalQuantity);
 	}
@@ -281,7 +281,7 @@ public class GrandExchangeTracker
 		TrackedOffer previousOffer = session.getTrackedOffer(ctx.slot);
 		log.info("Order cancelled with no fills: {} {}",
 			ctx.isBuy ? "BUY" : "SELL",
-			previousOffer != null ? previousOffer.getItemName() : ctx.itemName);
+			ctx.itemName);
 
 		if (ctx.isBuy)
 		{
@@ -303,10 +303,10 @@ public class GrandExchangeTracker
 		{
 			int pricePerItem = ctx.spent / ctx.quantitySold;
 			log.info("Syncing cancelled order quantity to backend: {} x{} (was {})",
-				cancelledOffer.getItemName(), ctx.quantitySold, cancelledOffer.getTotalQuantity());
+				ctx.itemName, ctx.quantitySold, cancelledOffer.getTotalQuantity());
 			apiClient.syncActiveFlipAsync(
 				ctx.itemId,
-				cancelledOffer.getItemName(),
+				ctx.itemName,
 				ctx.quantitySold,
 				ctx.quantitySold,
 				pricePerItem,


### PR DESCRIPTION
## Summary

When a Grand Exchange slot is reused (e.g., a Pineapple offer is cancelled, then an Ancient Crystal is placed in the same slot), cancel handlers were reading item names from the session's `TrackedOffer`, which still held the previous item's data. This caused the Active Flips panel to display the wrong item name and icon. The fix ensures all cancel-related code paths use `ctx.itemName`, which is always freshly resolved from the GE event.

## Changes

### Bug Fixes
- **GrandExchangeTracker**: All cancel-related code paths (`recordFinalCancellationFill`, `handleZeroFillCancellation`, `syncCancelledPartialBuy`, `reAddUnsoldItemsOnSellCancel`, and associated log statements) now use `ctx.itemName` instead of `previousOffer.getItemName()` / `cancelledOffer.getItemName()`
- **AutoRecommendService**: `onOfferCancelled` now accepts an `itemName` parameter and stores it in the `itemNames` map, preventing the "Item 12345" fallback when a partially-filled cancelled buy needs to be resold

## Root Cause

`ctx.itemName` is always resolved fresh from the GE event via `ItemUtils.getItemName(itemManager, itemId)` and reflects the current offer in the slot. `previousOffer.getItemName()` / `cancelledOffer.getItemName()` pull from the session's `TrackedOffer`, which is only updated when a new offer is recorded — so after a slot is reused, it still carries the prior item's name until the new offer is registered.

## Testing

### Automated Tests
- Plugin builds cleanly via `./gradlew build`

### Manual Testing
- [x] Place a buy offer for any item in a GE slot
- [x] Cancel the offer (zero or partial fills)
- [x] Immediately place a different item in the same slot
- [x] Verify the Active Flips panel shows the correct new item name and icon
- [x] Verify partial-fill cancel of a buy correctly names the item in the sell queue (no "Item 12345" fallback)
- [x] Confirm cancel logs show the correct item name

## Deployment Notes

- [ ] No environment variable changes
- [ ] No new dependencies
- [ ] No database migrations
- [ ] No breaking API changes — `onOfferCancelled` signature change is internal to the plugin

## Checklist

- [x] Bug is reproducible and fix addresses root cause
- [x] All cancel code paths updated consistently
- [x] Logging updated to use correct item name
- [x] `AutoRecommendService.itemNames` map kept accurate for cancelled buys
- [x] No debug code left in

## Related Issues

Closes Flip-Smart/flip-smart#432