### PR TITLE
Fix Completed Flips tab: price accuracy and mobile-trade confidence tracking

### DIFF
--- a/src/main/java/com/flipsmart/CompletedFlip.java
+++ b/src/main/java/com/flipsmart/CompletedFlip.java
@@ -56,5 +56,8 @@ public class CompletedFlip
 
 	@SerializedName("is_successful")
 	private boolean isSuccessful;
+
+	@SerializedName("is_estimated")
+	private boolean isEstimated;
 }
 

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3674,6 +3674,31 @@ public class FlipFinderPanel extends PluginPanel
 		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(), backgroundColor);
 		JPanel topPanel = header.topPanel;
 
+		// If this flip's data may be incomplete (offline fills), add a warning icon to the header
+		if (flip.isEstimated())
+		{
+			JLabel warningLabel = new JLabel("\u26A0");
+			warningLabel.setForeground(new Color(255, 200, 0)); // yellow
+			warningLabel.setFont(FONT_BOLD_13);
+			warningLabel.setToolTipText(
+				"<html>Profit may be approximate.<br>"
+				+ "Some fills for this flip were recorded from offline sync<br>"
+				+ "(e.g. trades completed on OSRS Mobile).</html>");
+			warningLabel.setBorder(new EmptyBorder(0, 0, 0, 4));
+
+			// Insert warning into the EAST icons panel of the top header
+			Component eastComponent = ((BorderLayout) header.topPanel.getLayout()).getLayoutComponent(BorderLayout.EAST);
+			if (eastComponent instanceof JPanel)
+			{
+				((JPanel) eastComponent).add(warningLabel, 0);  // add at index 0 = leftmost in the icons row
+			}
+			else
+			{
+				// Fallback: add to topPanel directly
+				header.topPanel.add(warningLabel, BorderLayout.EAST);
+			}
+		}
+
 		// Details section with profit/loss info - use GridBagLayout for tighter column spacing
 		JPanel detailsPanel = new JPanel(new GridBagLayout());
 		detailsPanel.setBackground(backgroundColor);

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -1279,6 +1279,7 @@ public class FlipSmartApiClient
 		public final Integer recommendedSellPrice;
 		public final String rsn;
 		public final Integer totalQuantity;
+		public final boolean isOfflineFill;
 
 		private TransactionRequest(Builder builder)
 		{
@@ -1291,6 +1292,7 @@ public class FlipSmartApiClient
 			this.recommendedSellPrice = builder.recommendedSellPrice;
 			this.rsn = builder.rsn;
 			this.totalQuantity = builder.totalQuantity;
+			this.isOfflineFill = builder.isOfflineFill;
 		}
 
 		public static Builder builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
@@ -1309,6 +1311,7 @@ public class FlipSmartApiClient
 			private Integer recommendedSellPrice;
 			private String rsn;
 			private Integer totalQuantity;
+			private boolean isOfflineFill = false;
 
 			private Builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
 			{
@@ -1323,6 +1326,7 @@ public class FlipSmartApiClient
 			public Builder recommendedSellPrice(Integer price) { this.recommendedSellPrice = price; return this; }
 			public Builder rsn(String rsn) { this.rsn = rsn; return this; }
 			public Builder totalQuantity(Integer qty) { this.totalQuantity = qty; return this; }
+			public Builder isOfflineFill(boolean value) { this.isOfflineFill = value; return this; }
 
 			public TransactionRequest build() { return new TransactionRequest(this); }
 		}
@@ -1359,7 +1363,8 @@ public class FlipSmartApiClient
 		{
 			jsonBody.addProperty("total_quantity", request.totalQuantity);
 		}
-		
+		jsonBody.addProperty("is_offline_fill", request.isOfflineFill);
+
 		RequestBody body = RequestBody.create(JSON, jsonBody.toString());
 		
 		Request.Builder requestBuilder = new Request.Builder()

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1122,7 +1122,7 @@ public class FlipSmartPlugin extends Plugin
 			log.debug("Login burst: initializing tracking for slot {} with {} items sold", slot, quantitySold);
 			TrackedOffer existing = session.getTrackedOffer(slot);
 			session.putTrackedOffer(slot, TrackedOffer.createWithPreservedTimestamps(
-				itemId, itemName, totalQuantity, price, quantitySold, existing, state));
+				itemId, itemName, totalQuantity, price, quantitySold, (long) spent, existing, state));
 			return;
 		}
 

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1121,8 +1121,10 @@ public class FlipSmartPlugin extends Plugin
 		{
 			log.debug("Login burst: initializing tracking for slot {} with {} items sold", slot, quantitySold);
 			TrackedOffer existing = session.getTrackedOffer(slot);
-			session.putTrackedOffer(slot, TrackedOffer.createWithPreservedTimestamps(
-				itemId, itemName, totalQuantity, price, quantitySold, (long) spent, existing, state));
+			TrackedOffer updated = TrackedOffer.createWithPreservedTimestamps(
+				itemId, itemName, totalQuantity, price, quantitySold, existing, state);
+			updated.setPreviousSpent(spent);
+			session.putTrackedOffer(slot, updated);
 			return;
 		}
 

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -416,7 +416,9 @@ public class GrandExchangeTracker
 		if (collectedOffer.isBuy() && collectedOffer.getPreviousQuantitySold() > 0
 			&& session.getRecommendedPrice(collectedOffer.getItemId()) == null)
 		{
-			int buyPrice = collectedOffer.getPrice();
+			int buyPrice = (collectedOffer.getPreviousSpent() > 0 && collectedOffer.getPreviousQuantitySold() > 0)
+				? (int)(collectedOffer.getPreviousSpent() / collectedOffer.getPreviousQuantitySold())
+				: collectedOffer.getPrice();
 			int fallbackSellPrice = (int) Math.ceil((buyPrice + 1) / 0.98);
 			session.setRecommendedPrice(collectedOffer.getItemId(), fallbackSellPrice);
 			log.info("No recommended sell price for {} - using fallback {} gp (bought at {} gp)",

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -503,7 +503,7 @@ public class GrandExchangeTracker
 		// Update tracked offer BEFORE notifying auto-recommend so getCompletedOffers()
 		// sees the BOUGHT/SOLD state when promptCollection() is called
 		session.putTrackedOffer(ctx.slot, TrackedOffer.createWithPreservedTimestamps(
-			ctx.itemId, ctx.itemName, ctx.totalQuantity, ctx.price, ctx.quantitySold, previousOffer, ctx.state));
+			ctx.itemId, ctx.itemName, ctx.totalQuantity, ctx.price, ctx.quantitySold, (long) ctx.spent, previousOffer, ctx.state));
 
 		notifyAutoRecommendOnCompletion(ctx);
 

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -508,8 +508,10 @@ public class GrandExchangeTracker
 
 		// Update tracked offer BEFORE notifying auto-recommend so getCompletedOffers()
 		// sees the BOUGHT/SOLD state when promptCollection() is called
-		session.putTrackedOffer(ctx.slot, TrackedOffer.createWithPreservedTimestamps(
-			ctx.itemId, ctx.itemName, ctx.totalQuantity, ctx.price, ctx.quantitySold, (long) ctx.spent, previousOffer, ctx.state));
+		TrackedOffer updated = TrackedOffer.createWithPreservedTimestamps(
+			ctx.itemId, ctx.itemName, ctx.totalQuantity, ctx.price, ctx.quantitySold, previousOffer, ctx.state);
+		updated.setPreviousSpent(ctx.spent);
+		session.putTrackedOffer(ctx.slot, updated);
 
 		notifyAutoRecommendOnCompletion(ctx);
 

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -249,7 +249,9 @@ public class GrandExchangeTracker
 		if (previousOffer != null && ctx.quantitySold > previousOffer.getPreviousQuantitySold())
 		{
 			int newQuantity = ctx.quantitySold - previousOffer.getPreviousQuantitySold();
-			int pricePerItem = ctx.spent / ctx.quantitySold;
+			long previousSpent = previousOffer.getPreviousSpent();
+			long incrementalSpent = ctx.spent - previousSpent;
+			int pricePerItem = (newQuantity > 0) ? (int)(incrementalSpent / newQuantity) : 0;
 
 			log.info("Recording final transaction before cancellation: {} {} x{}/{} @ {} gp each",
 				ctx.isBuy ? "BUY" : "SELL",
@@ -469,7 +471,7 @@ public class GrandExchangeTracker
 
 		if (newQuantity > 0)
 		{
-			recordFillTransaction(ctx, newQuantity);
+			recordFillTransaction(ctx, newQuantity, previousOffer);
 		}
 
 		// Reset adjustment timer on partial fills (not yet fully completed)
@@ -540,9 +542,11 @@ public class GrandExchangeTracker
 		}
 	}
 
-	private void recordFillTransaction(OfferContext ctx, int newQuantity)
+	private void recordFillTransaction(OfferContext ctx, int newQuantity, TrackedOffer previousOffer)
 	{
-		int pricePerItem = ctx.spent / ctx.quantitySold;
+		long previousSpent = (previousOffer != null) ? previousOffer.getPreviousSpent() : 0L;
+		long incrementalSpent = ctx.spent - previousSpent;
+		int pricePerItem = (newQuantity > 0) ? (int)(incrementalSpent / newQuantity) : 0;
 
 		log.info("Recording transaction: {} {} x{} @ {} gp each (slot {}, {}/{} filled)",
 			ctx.isBuy ? "BUY" : "SELL",

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -303,7 +303,7 @@ public class GrandExchangeTracker
 		String rsn = getRsn().orElse(null);
 		if (rsn != null && cancelledOffer != null)
 		{
-			int pricePerItem = ctx.spent / ctx.quantitySold;
+			int pricePerItem = (ctx.quantitySold > 0) ? (int)((long) ctx.spent / ctx.quantitySold) : 0;
 			log.info("Syncing cancelled order quantity to backend: {} x{} (was {})",
 				ctx.itemName, ctx.quantitySold, cancelledOffer.getTotalQuantity());
 			apiClient.syncActiveFlipAsync(
@@ -370,7 +370,9 @@ public class GrandExchangeTracker
 					collectedOffer.getItemName(),
 					collectedQty,
 					collectedOffer.getTotalQuantity(),
-					collectedOffer.getPrice(),
+					collectedOffer.getPreviousSpent() > 0 && collectedOffer.getPreviousQuantitySold() > 0
+						? (int)(collectedOffer.getPreviousSpent() / collectedOffer.getPreviousQuantitySold())
+						: collectedOffer.getPrice(),
 					rsn
 				);
 			}

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -463,12 +463,15 @@ public class OfflineSyncService
 			return;
 		}
 
+		int syncPrice = (persistedOffer.getPreviousSpent() > 0 && persistedOffer.getPreviousQuantitySold() > 0)
+			? (int)(persistedOffer.getPreviousSpent() / persistedOffer.getPreviousQuantitySold())
+			: persistedOffer.getPrice();
 		apiClient.syncActiveFlipAsync(
 			persistedOffer.getItemId(),
 			persistedOffer.getItemName(),
 			actualFills,
 			persistedOffer.getTotalQuantity(),
-			persistedOffer.getPrice(),
+			syncPrice,
 			rsn
 		);
 	}

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -303,9 +303,24 @@ public class OfflineSyncService
 
 		Integer recommendedSellPrice = currentOffer.isBuy() ? session.getRecommendedPrice(currentOffer.getItemId()) : null;
 
-		int fillPrice = (currentOffer.getPreviousSpent() > 0 && currentOffer.getPreviousQuantitySold() > 0)
-			? (int)(currentOffer.getPreviousSpent() / currentOffer.getPreviousQuantitySold())
-			: currentOffer.getPrice();
+		// Compute exact price for offline fills using spent delta:
+		// (currentSpent - persistedSpent) / offlineFills gives the avg price of just the offline fills
+		long spentDelta = currentOffer.getPreviousSpent() - persistedOffer.getPreviousSpent();
+		int fillPrice;
+		if (spentDelta > 0 && offlineFills > 0)
+		{
+			fillPrice = (int)(spentDelta / offlineFills);
+		}
+		else if (currentOffer.getPreviousSpent() > 0 && currentOffer.getPreviousQuantitySold() > 0)
+		{
+			// Fallback: cumulative average (e.g. if persistedOffer predates previousSpent tracking)
+			fillPrice = (int)(currentOffer.getPreviousSpent() / currentOffer.getPreviousQuantitySold());
+		}
+		else
+		{
+			// Last-resort fallback: offer price
+			fillPrice = currentOffer.getPrice();
+		}
 		apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
 			.builder(currentOffer.getItemId(), currentOffer.getItemName(), currentOffer.isBuy(),
 				offlineFills, fillPrice)
@@ -313,6 +328,7 @@ public class OfflineSyncService
 			.recommendedSellPrice(recommendedSellPrice)
 			.rsn(getRsnSafe().orElse(null))
 			.totalQuantity(currentOffer.getTotalQuantity())
+			.isOfflineFill(true)
 			.build());
 	}
 

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -267,9 +267,12 @@ public class OfflineSyncService
 		Integer recommendedSellPrice = offer.isBuy()
 			? session.getRecommendedPrice(offer.getItemId()) : null;
 
+		int actualPrice = (offer.getPreviousSpent() > 0 && offer.getPreviousQuantitySold() > 0)
+			? (int)(offer.getPreviousSpent() / offer.getPreviousQuantitySold())
+			: offer.getPrice();
 		apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
 			.builder(offer.getItemId(), offer.getItemName(), offer.isBuy(),
-				offer.getPreviousQuantitySold(), offer.getPrice())
+				offer.getPreviousQuantitySold(), actualPrice)
 			.geSlot(slot)
 			.recommendedSellPrice(recommendedSellPrice)
 			.rsn(getRsnSafe().orElse(null))
@@ -300,9 +303,12 @@ public class OfflineSyncService
 
 		Integer recommendedSellPrice = currentOffer.isBuy() ? session.getRecommendedPrice(currentOffer.getItemId()) : null;
 
+		int fillPrice = (currentOffer.getPreviousSpent() > 0 && currentOffer.getPreviousQuantitySold() > 0)
+			? (int)(currentOffer.getPreviousSpent() / currentOffer.getPreviousQuantitySold())
+			: currentOffer.getPrice();
 		apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
 			.builder(currentOffer.getItemId(), currentOffer.getItemName(), currentOffer.isBuy(),
-				offlineFills, currentOffer.getPrice())
+				offlineFills, fillPrice)
 			.geSlot(slot)
 			.recommendedSellPrice(recommendedSellPrice)
 			.rsn(getRsnSafe().orElse(null))
@@ -377,12 +383,15 @@ public class OfflineSyncService
 			return;
 		}
 
+		int sellPrice = (persistedOffer.getPreviousSpent() > 0 && persistedOffer.getPreviousQuantitySold() > 0)
+			? (int)(persistedOffer.getPreviousSpent() / persistedOffer.getPreviousQuantitySold())
+			: persistedOffer.getPrice();
 		apiClient.recordTransactionAsync(
 			persistedOffer.getItemId(),
 			persistedOffer.getItemName(),
 			"SELL",
 			soldQuantity,
-			persistedOffer.getPrice(),
+			sellPrice,
 			rsn
 		);
 	}

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -277,6 +277,7 @@ public class OfflineSyncService
 			.recommendedSellPrice(recommendedSellPrice)
 			.rsn(getRsnSafe().orElse(null))
 			.totalQuantity(offer.getTotalQuantity())
+			.isOfflineFill(true)
 			.build());
 
 		if (offer.isBuy() && offer.getPreviousQuantitySold() > 0)
@@ -402,14 +403,11 @@ public class OfflineSyncService
 		int sellPrice = (persistedOffer.getPreviousSpent() > 0 && persistedOffer.getPreviousQuantitySold() > 0)
 			? (int)(persistedOffer.getPreviousSpent() / persistedOffer.getPreviousQuantitySold())
 			: persistedOffer.getPrice();
-		apiClient.recordTransactionAsync(
-			persistedOffer.getItemId(),
-			persistedOffer.getItemName(),
-			"SELL",
-			soldQuantity,
-			sellPrice,
-			rsn
-		);
+		apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
+			.builder(persistedOffer.getItemId(), persistedOffer.getItemName(), false, soldQuantity, sellPrice)
+			.rsn(rsn)
+			.isOfflineFill(true)
+			.build());
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/TrackedOffer.java
+++ b/src/main/java/com/flipsmart/TrackedOffer.java
@@ -18,12 +18,13 @@ public class TrackedOffer
 	private int totalQuantity;
 	private int price;
 	private int previousQuantitySold;
+	private long previousSpent;  // cumulative GP spent/received — long to handle values > 2.1B
 	private long createdAtMillis;  // Timestamp when offer was created (for timer display)
 	private long completedAtMillis;  // Timestamp when offer completed (0 if not complete)
 
 	public TrackedOffer(int itemId, String itemName, boolean isBuy, int totalQuantity, int price, int quantitySold)
 	{
-		this(itemId, itemName, isBuy, totalQuantity, price, quantitySold, System.currentTimeMillis(), 0);
+		this(itemId, itemName, isBuy, totalQuantity, price, quantitySold, 0L, System.currentTimeMillis(), 0);
 	}
 
 	/**
@@ -31,13 +32,13 @@ public class TrackedOffer
 	 */
 	public TrackedOffer(int itemId, String itemName, boolean isBuy, int totalQuantity, int price, int quantitySold, long createdAtMillis)
 	{
-		this(itemId, itemName, isBuy, totalQuantity, price, quantitySold, createdAtMillis, 0);
+		this(itemId, itemName, isBuy, totalQuantity, price, quantitySold, 0L, createdAtMillis, 0);
 	}
 
 	/**
-	 * Constructor with explicit timestamps (for preserving completion state)
+	 * Constructor with explicit timestamps and spent (for preserving completion state)
 	 */
-	public TrackedOffer(int itemId, String itemName, boolean isBuy, int totalQuantity, int price, int quantitySold, long createdAtMillis, long completedAtMillis)
+	public TrackedOffer(int itemId, String itemName, boolean isBuy, int totalQuantity, int price, int quantitySold, long spent, long createdAtMillis, long completedAtMillis)
 	{
 		this.itemId = itemId;
 		this.itemName = itemName;
@@ -45,8 +46,17 @@ public class TrackedOffer
 		this.totalQuantity = totalQuantity;
 		this.price = price;
 		this.previousQuantitySold = quantitySold;
+		this.previousSpent = spent;
 		this.createdAtMillis = createdAtMillis;
 		this.completedAtMillis = completedAtMillis;
+	}
+
+	/**
+	 * Constructor with explicit timestamps (for preserving completion state) — backwards compat
+	 */
+	public TrackedOffer(int itemId, String itemName, boolean isBuy, int totalQuantity, int price, int quantitySold, long createdAtMillis, long completedAtMillis)
+	{
+		this(itemId, itemName, isBuy, totalQuantity, price, quantitySold, 0L, createdAtMillis, completedAtMillis);
 	}
 
 	/**
@@ -68,7 +78,7 @@ public class TrackedOffer
 	 */
 	public static TrackedOffer createWithPreservedTimestamps(
 		int itemId, String itemName, int totalQuantity,
-		int price, int quantitySold, TrackedOffer existing,
+		int price, int quantitySold, long spent, TrackedOffer existing,
 		GrandExchangeOfferState state)
 	{
 		long originalTimestamp = (existing != null && existing.getCreatedAtMillis() > 0)
@@ -83,7 +93,18 @@ public class TrackedOffer
 				: System.currentTimeMillis();
 		}
 
-		return new TrackedOffer(itemId, itemName, isBuyState(state), totalQuantity, price, quantitySold, originalTimestamp, completedTimestamp);
+		return new TrackedOffer(itemId, itemName, isBuyState(state), totalQuantity, price, quantitySold, spent, originalTimestamp, completedTimestamp);
+	}
+
+	/**
+	 * Backwards-compatible overload that passes 0 for spent.
+	 */
+	public static TrackedOffer createWithPreservedTimestamps(
+		int itemId, String itemName, int totalQuantity,
+		int price, int quantitySold, TrackedOffer existing,
+		GrandExchangeOfferState state)
+	{
+		return createWithPreservedTimestamps(itemId, itemName, totalQuantity, price, quantitySold, 0L, existing, state);
 	}
 
 	/**
@@ -100,6 +121,14 @@ public class TrackedOffer
 	public void setPreviousQuantitySold(int quantitySold)
 	{
 		this.previousQuantitySold = quantitySold;
+	}
+
+	/**
+	 * Update the cumulative GP spent/received for this offer.
+	 */
+	public void setPreviousSpent(long spent)
+	{
+		this.previousSpent = spent;
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/TrackedOffer.java
+++ b/src/main/java/com/flipsmart/TrackedOffer.java
@@ -24,7 +24,7 @@ public class TrackedOffer
 
 	public TrackedOffer(int itemId, String itemName, boolean isBuy, int totalQuantity, int price, int quantitySold)
 	{
-		this(itemId, itemName, isBuy, totalQuantity, price, quantitySold, 0L, System.currentTimeMillis(), 0);
+		this(itemId, itemName, isBuy, totalQuantity, price, quantitySold, System.currentTimeMillis());
 	}
 
 	/**
@@ -32,31 +32,13 @@ public class TrackedOffer
 	 */
 	public TrackedOffer(int itemId, String itemName, boolean isBuy, int totalQuantity, int price, int quantitySold, long createdAtMillis)
 	{
-		this(itemId, itemName, isBuy, totalQuantity, price, quantitySold, 0L, createdAtMillis, 0);
-	}
-
-	/**
-	 * Constructor with explicit timestamps and spent (for preserving completion state)
-	 */
-	public TrackedOffer(int itemId, String itemName, boolean isBuy, int totalQuantity, int price, int quantitySold, long spent, long createdAtMillis, long completedAtMillis)
-	{
 		this.itemId = itemId;
 		this.itemName = itemName;
 		this.isBuy = isBuy;
 		this.totalQuantity = totalQuantity;
 		this.price = price;
 		this.previousQuantitySold = quantitySold;
-		this.previousSpent = spent;
 		this.createdAtMillis = createdAtMillis;
-		this.completedAtMillis = completedAtMillis;
-	}
-
-	/**
-	 * Constructor with explicit timestamps (for preserving completion state) — backwards compat
-	 */
-	public TrackedOffer(int itemId, String itemName, boolean isBuy, int totalQuantity, int price, int quantitySold, long createdAtMillis, long completedAtMillis)
-	{
-		this(itemId, itemName, isBuy, totalQuantity, price, quantitySold, 0L, createdAtMillis, completedAtMillis);
 	}
 
 	/**
@@ -78,33 +60,24 @@ public class TrackedOffer
 	 */
 	public static TrackedOffer createWithPreservedTimestamps(
 		int itemId, String itemName, int totalQuantity,
-		int price, int quantitySold, long spent, TrackedOffer existing,
+		int price, int quantitySold, TrackedOffer existing,
 		GrandExchangeOfferState state)
 	{
 		long originalTimestamp = (existing != null && existing.getCreatedAtMillis() > 0)
 			? existing.getCreatedAtMillis()
 			: System.currentTimeMillis();
-		long completedTimestamp = 0;
+
+		TrackedOffer offer = new TrackedOffer(itemId, itemName, isBuyState(state), totalQuantity, price, quantitySold, originalTimestamp);
 
 		if (state == GrandExchangeOfferState.BOUGHT || state == GrandExchangeOfferState.SOLD)
 		{
-			completedTimestamp = (existing != null && existing.getCompletedAtMillis() > 0)
-				? existing.getCompletedAtMillis()
-				: System.currentTimeMillis();
+			offer.setCompletedAtMillis(
+				(existing != null && existing.getCompletedAtMillis() > 0)
+					? existing.getCompletedAtMillis()
+					: System.currentTimeMillis());
 		}
 
-		return new TrackedOffer(itemId, itemName, isBuyState(state), totalQuantity, price, quantitySold, spent, originalTimestamp, completedTimestamp);
-	}
-
-	/**
-	 * Backwards-compatible overload that passes 0 for spent.
-	 */
-	public static TrackedOffer createWithPreservedTimestamps(
-		int itemId, String itemName, int totalQuantity,
-		int price, int quantitySold, TrackedOffer existing,
-		GrandExchangeOfferState state)
-	{
-		return createWithPreservedTimestamps(itemId, itemName, totalQuantity, price, quantitySold, 0L, existing, state);
+		return offer;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Closes Flip-Smart/flip-smart#426. Fixes incorrect data in the Completed Flips tab and adds confidence tracking for cases where full data recovery isn't possible (e.g. mobile trades).

The original bug report stemmed from a user who traded on OSRS Mobile — this PR tackles both the price-calculation bugs AND the underlying mobile-trading data-completeness problem that caused the confusion in the first place.

## What's fixed

### 🐛 Price calculation bugs

- **Incremental fill price**: Changed `pricePerItem` from `ctx.spent / ctx.quantitySold` (cumulative average across all fills) to `(ctx.spent - previousSpent) / newQuantity` (incremental price for just the current fill). Previously the backend received mismatched data — incremental quantity paired with cumulative-average price — causing wrong cost calculations in flip records.
- **Offline sync execution price**: Fixed `OfflineSyncService` and collection handlers to use actual average execution price instead of `offer.getPrice()` (the listed offer price). GE fills can execute at better prices than listed.
- **Overflow guard**: Added guard in `syncCancelledPartialBuy` for large GP spent values.

### ✨ Mobile-trade handling

- **Exact offline fill prices via spent delta**: `OfflineSyncService.recordOfflineFillsIfAny` now computes `(currentSpent - persistedSpent) / offlineFills` to get the exact average price of fills that happened while the plugin wasn't running (e.g. mobile trades, plugin offline). Previously this fell back to cumulative average or offer price.
- **Confidence tracking**: All 3 transaction-recording paths in `OfflineSyncService` tag their transactions with `isOfflineFill=true` so the backend can flag the resulting flip as estimated.
- **Warning icon on estimated flips**: Completed flips show a yellow ⚠ icon next to the item name when their data was partially recovered from offline sync. Hover tooltip explains why. Users now know exactly which flips have reliable profit tracking and which may be approximate.

### ♻️ Foundational changes

- Added `previousSpent` (long) field to `TrackedOffer` to track cumulative GP spent, enabling incremental price calculations.
- Refactored `TrackedOffer` constructors to use setters for `previousSpent` and `completedAtMillis` to satisfy SonarCloud parameter-count limits.

## Backend dependency

This PR requires companion backend changes in Flip-Smart/flip-smart#434 for the `is_offline_fill` request field, `is_estimated` response field, and flip-taint logic. **Both PRs must be merged together.**

## Files Changed

- `TrackedOffer.java` — Added `previousSpent` field with setter-based initialization
- `GrandExchangeTracker.java` — Fixed price calculations in `recordFillTransaction`, `recordFinalCancellationFill`, `handleCollectedBuyOffer`, `syncCancelledPartialBuy`, `ensureFallbackSellPrice`
- `OfflineSyncService.java` — Spent delta calculation in `recordOfflineFillsIfAny`; `isOfflineFill=true` tagging in all offline sync paths; actual execution price in all 4 methods
- `FlipSmartPlugin.java` — Pass `spent` to `createWithPreservedTimestamps` in login-burst path
- `FlipSmartApiClient.java` — Added `isOfflineFill` field to `TransactionRequest.Builder`, serialized in request body
- `CompletedFlip.java` — Added `isEstimated` field (`@SerializedName("is_estimated")`)
- `FlipFinderPanel.java` — Render yellow ⚠ warning icon in `createCompletedFlipPanel` when flip is estimated

## Testing

### Automated
- ✅ `./gradlew build` — BUILD SUCCESSFUL
- ✅ Backend companion PR has 4 new tests for the taint logic, all passing
- ✅ No regressions in existing test suites

### Manual test plan

**Price accuracy:**
- [x] Place a GE buy order for a large quantity that will fill in batches
- [x] Wait for multiple partial fills at (ideally) different prices
- [x] Sell the items
- [x] Verify Completed Flips tab shows the correct buy price (weighted average of actual execution prices, not a cumulative-average artifact)

**Offline fill detection:**
- [x] Place a GE buy order, let some fills come through with the plugin running
- [x] Log out / close RuneLite (or simulate offline time)
- [x] Let more fills occur offline
- [x] Log back in — verify the offline fills are recorded with the exact spent-delta price
- [x] Sell the items — verify the flip shows a yellow ⚠ icon in the Completed Flips tab
- [x] Hover the icon — verify the tooltip text explains the reason

**Live flip (no warning):**
- [x] Complete a flip entirely while RuneLite is running
- [x] Verify the completed flip shows NO warning icon

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Backwards compatible: Yes — Gson deserializes old persisted `TrackedOffer` objects with `previousSpent = 0` (default long); transactions without `is_offline_fill` default to false on the backend
- [ ] Requires database migration: **Yes, in companion backend PR #434** (adds `is_offline_fill` and `is_estimated` columns)

## Related

- Closes Flip-Smart/flip-smart#426
- Requires Flip-Smart/flip-smart#434 (backend support)
- Supersedes closed PR #100 (commits bundled here)
