### PR TITLE
Add offline fill confidence tracking and warning icon for estimated flips

### DIFF
--- a/src/main/java/com/flipsmart/CompletedFlip.java
+++ b/src/main/java/com/flipsmart/CompletedFlip.java
@@ -56,5 +56,8 @@ public class CompletedFlip
 
 	@SerializedName("is_successful")
 	private boolean isSuccessful;
+
+	@SerializedName("is_estimated")
+	private boolean isEstimated;
 }
 

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3674,6 +3674,31 @@ public class FlipFinderPanel extends PluginPanel
 		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(), backgroundColor);
 		JPanel topPanel = header.topPanel;
 
+		// If this flip's data may be incomplete (offline fills), add a warning icon to the header
+		if (flip.isEstimated())
+		{
+			JLabel warningLabel = new JLabel("\u26A0");
+			warningLabel.setForeground(new Color(255, 200, 0)); // yellow
+			warningLabel.setFont(FONT_BOLD_13);
+			warningLabel.setToolTipText(
+				"<html>Profit may be approximate.<br>"
+				+ "Some fills for this flip were recorded from offline sync<br>"
+				+ "(e.g. trades completed on OSRS Mobile).</html>");
+			warningLabel.setBorder(new EmptyBorder(0, 0, 0, 4));
+
+			// Insert warning into the EAST icons panel of the top header
+			Component eastComponent = ((BorderLayout) header.topPanel.getLayout()).getLayoutComponent(BorderLayout.EAST);
+			if (eastComponent instanceof JPanel)
+			{
+				((JPanel) eastComponent).add(warningLabel, 0);  // add at index 0 = leftmost in the icons row
+			}
+			else
+			{
+				// Fallback: add to topPanel directly
+				header.topPanel.add(warningLabel, BorderLayout.EAST);
+			}
+		}
+
 		// Details section with profit/loss info - use GridBagLayout for tighter column spacing
 		JPanel detailsPanel = new JPanel(new GridBagLayout());
 		detailsPanel.setBackground(backgroundColor);

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -1279,6 +1279,7 @@ public class FlipSmartApiClient
 		public final Integer recommendedSellPrice;
 		public final String rsn;
 		public final Integer totalQuantity;
+		public final boolean isOfflineFill;
 
 		private TransactionRequest(Builder builder)
 		{
@@ -1291,6 +1292,7 @@ public class FlipSmartApiClient
 			this.recommendedSellPrice = builder.recommendedSellPrice;
 			this.rsn = builder.rsn;
 			this.totalQuantity = builder.totalQuantity;
+			this.isOfflineFill = builder.isOfflineFill;
 		}
 
 		public static Builder builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
@@ -1309,6 +1311,7 @@ public class FlipSmartApiClient
 			private Integer recommendedSellPrice;
 			private String rsn;
 			private Integer totalQuantity;
+			private boolean isOfflineFill = false;
 
 			private Builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
 			{
@@ -1323,6 +1326,7 @@ public class FlipSmartApiClient
 			public Builder recommendedSellPrice(Integer price) { this.recommendedSellPrice = price; return this; }
 			public Builder rsn(String rsn) { this.rsn = rsn; return this; }
 			public Builder totalQuantity(Integer qty) { this.totalQuantity = qty; return this; }
+			public Builder isOfflineFill(boolean value) { this.isOfflineFill = value; return this; }
 
 			public TransactionRequest build() { return new TransactionRequest(this); }
 		}
@@ -1359,7 +1363,8 @@ public class FlipSmartApiClient
 		{
 			jsonBody.addProperty("total_quantity", request.totalQuantity);
 		}
-		
+		jsonBody.addProperty("is_offline_fill", request.isOfflineFill);
+
 		RequestBody body = RequestBody.create(JSON, jsonBody.toString());
 		
 		Request.Builder requestBuilder = new Request.Builder()

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -303,9 +303,24 @@ public class OfflineSyncService
 
 		Integer recommendedSellPrice = currentOffer.isBuy() ? session.getRecommendedPrice(currentOffer.getItemId()) : null;
 
-		int fillPrice = (currentOffer.getPreviousSpent() > 0 && currentOffer.getPreviousQuantitySold() > 0)
-			? (int)(currentOffer.getPreviousSpent() / currentOffer.getPreviousQuantitySold())
-			: currentOffer.getPrice();
+		// Compute exact price for offline fills using spent delta:
+		// (currentSpent - persistedSpent) / offlineFills gives the avg price of just the offline fills
+		long spentDelta = currentOffer.getPreviousSpent() - persistedOffer.getPreviousSpent();
+		int fillPrice;
+		if (spentDelta > 0 && offlineFills > 0)
+		{
+			fillPrice = (int)(spentDelta / offlineFills);
+		}
+		else if (currentOffer.getPreviousSpent() > 0 && currentOffer.getPreviousQuantitySold() > 0)
+		{
+			// Fallback: cumulative average (e.g. if persistedOffer predates previousSpent tracking)
+			fillPrice = (int)(currentOffer.getPreviousSpent() / currentOffer.getPreviousQuantitySold());
+		}
+		else
+		{
+			// Last-resort fallback: offer price
+			fillPrice = currentOffer.getPrice();
+		}
 		apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
 			.builder(currentOffer.getItemId(), currentOffer.getItemName(), currentOffer.isBuy(),
 				offlineFills, fillPrice)
@@ -313,6 +328,7 @@ public class OfflineSyncService
 			.recommendedSellPrice(recommendedSellPrice)
 			.rsn(getRsnSafe().orElse(null))
 			.totalQuantity(currentOffer.getTotalQuantity())
+			.isOfflineFill(true)
 			.build());
 	}
 

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -277,6 +277,7 @@ public class OfflineSyncService
 			.recommendedSellPrice(recommendedSellPrice)
 			.rsn(getRsnSafe().orElse(null))
 			.totalQuantity(offer.getTotalQuantity())
+			.isOfflineFill(true)
 			.build());
 
 		if (offer.isBuy() && offer.getPreviousQuantitySold() > 0)
@@ -402,14 +403,11 @@ public class OfflineSyncService
 		int sellPrice = (persistedOffer.getPreviousSpent() > 0 && persistedOffer.getPreviousQuantitySold() > 0)
 			? (int)(persistedOffer.getPreviousSpent() / persistedOffer.getPreviousQuantitySold())
 			: persistedOffer.getPrice();
-		apiClient.recordTransactionAsync(
-			persistedOffer.getItemId(),
-			persistedOffer.getItemName(),
-			"SELL",
-			soldQuantity,
-			sellPrice,
-			rsn
-		);
+		apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
+			.builder(persistedOffer.getItemId(), persistedOffer.getItemName(), false, soldQuantity, sellPrice)
+			.rsn(rsn)
+			.isOfflineFill(true)
+			.build());
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Implements confidence tracking and exact offline fill pricing for the Completed Flips tab. When fills occur while RuneLite is not running (e.g. via OSRS Mobile), the plugin now computes the actual average price from spent delta rather than falling back to cumulative average or listed offer price. Flips that include any offline-sourced fills are tagged as estimated and display a warning icon in the panel.

## Changes

### New Features
- **Exact offline fill prices**: `OfflineSyncService.recordOfflineFillsIfAny` computes `(currentSpent - persistedSpent) / offlineFills` to derive the actual average price of fills that occurred while the plugin was not running. Fallback chain retained (cumulative avg → offer price) for backwards compat with old persisted offers.
- **Offline fill tagging**: All 3 transaction-recording paths in `OfflineSyncService` (`recordNewOfferFromSync`, `recordOfflineFillsIfAny`, `recordOfflineSellTransaction`) now tag transactions with `isOfflineFill=true` so the backend can mark the associated flip as estimated.
- **Warning icon on estimated flips**: The Completed Flips panel renders a yellow warning icon next to the item name when the backend reports `is_estimated: true`. Hovering the icon shows: "Profit may be approximate. Some fills for this flip were recorded from offline sync (e.g. trades completed on OSRS Mobile)."

## Testing

### Build Verification
- `./gradlew build` — BUILD SUCCESSFUL

### Manual Testing
- [ ] Place a GE buy order in RuneLite
- [ ] Simulate offline activity: close RuneLite or go idle while fills occur
- [ ] Return to RuneLite — plugin detects offline fills and records them
- [ ] Sell the items
- [ ] Open the Completed Flips tab — verify the flip shows a yellow warning icon next to the item name
- [ ] Hover the icon — verify the tooltip text appears
- [ ] For a flip completed entirely live (no offline activity) — verify NO warning icon appears

## Backend Dependency

This PR requires backend support for the `is_offline_fill` request field and `is_estimated` response field. The companion backend PR is on `flip-smart` repo on the same branch name (`feature/offline-fill-confidence-tracking-426`). Both PRs should be reviewed and merged together.

## Deployment Notes

- [ ] No environment variable changes
- [ ] No new dependencies
- [ ] Requires companion backend PR to be merged for `is_estimated` flag to be returned
- [ ] Backwards compatible: old persisted offers without spent data fall back to cumulative average

## Checklist

- [x] Build passes (`./gradlew build`)
- [x] Fallback chain preserved for backwards compatibility
- [x] Warning icon only renders when `flip.isEstimated()` is true
- [x] No `Thread.currentThread().interrupt()` calls added
- [x] No Claude Code config added to this public repo

## Related Issues

Related to Flip-Smart/flip-smart#426