### PR TITLE
Reset flipping timer on partial fills

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -907,7 +907,7 @@ public class AutoRecommendService
 			return;
 		}
 
-		long age = now - staleOffer.getCreatedAtMillis();
+		long age = now - staleOffer.getEffectiveLastActivityAtMillis();
 		log.info("Auto-recommend: Stale & uncompetitive offer for {} (age: {}m)",
 			staleOffer.getItemName(), age / 60000);
 
@@ -929,7 +929,7 @@ public class AutoRecommendService
 				continue;
 			}
 
-			long age = now - offer.getCreatedAtMillis();
+			long age = now - offer.getEffectiveLastActivityAtMillis();
 			if (age >= INACTIVITY_TIMEOUT_MS && !session.isStaleNotified(offer.getItemId()))
 			{
 				return offer;
@@ -1048,7 +1048,7 @@ public class AutoRecommendService
 		// Set a temporary long deadline to prevent duplicate calls while API responds
 		entry.setValue(now + 5 * 60 * 1000L);
 
-		int minutesSince = (int) ((now - offer.getCreatedAtMillis()) / 60000);
+		int minutesSince = (int) ((now - offer.getEffectiveLastActivityAtMillis()) / 60000);
 		String timeframe = config.flipTimeframe().getApiValue();
 		String itemName = offer.getItemName();
 
@@ -1164,7 +1164,7 @@ public class AutoRecommendService
 			}
 
 			long delayMs = AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS;
-			long offerAgeMs = now - offer.getCreatedAtMillis();
+			long offerAgeMs = now - offer.getEffectiveLastActivityAtMillis();
 			long remainingMs = delayMs - offerAgeMs;
 
 			if (remainingMs <= 0)
@@ -1218,7 +1218,7 @@ public class AutoRecommendService
 
 	private void scheduleMissingBuyTimer(TrackedOffer offer, long now)
 	{
-		long offerAgeMs = now - offer.getCreatedAtMillis();
+		long offerAgeMs = now - offer.getEffectiveLastActivityAtMillis();
 		long deadline = offerAgeMs >= AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS
 			? now - 1 : now + (AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS - offerAgeMs);
 		adjustmentDeadlines.put(offer.getItemId(), deadline);
@@ -1229,7 +1229,7 @@ public class AutoRecommendService
 	private void scheduleMissingSellTimer(TrackedOffer offer, long now)
 	{
 		Integer buyPrice = buyPrices.getOrDefault(offer.getItemId(), offer.getPrice());
-		long offerAgeMs = now - offer.getCreatedAtMillis();
+		long offerAgeMs = now - offer.getEffectiveLastActivityAtMillis();
 		long deadline = offerAgeMs >= AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS
 			? now - 1 : now + (AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS - offerAgeMs);
 		SellAdjustmentState state = new SellAdjustmentState(
@@ -1455,7 +1455,7 @@ public class AutoRecommendService
 		}
 
 		// Timer expired — call the adjustment API
-		int minutesSince = (int) ((now - offer.getCreatedAtMillis()) / 60000);
+		int minutesSince = (int) ((now - offer.getEffectiveLastActivityAtMillis()) / 60000);
 		callSellAdjustmentApi(state, offer, minutesSince);
 
 		// Set a temporary long deadline to prevent duplicate calls (API callback will reschedule)
@@ -1575,7 +1575,7 @@ public class AutoRecommendService
 			}
 
 			long delayMs = AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS;
-			long offerAgeMs = now - offer.getCreatedAtMillis();
+			long offerAgeMs = now - offer.getEffectiveLastActivityAtMillis();
 			long remainingMs = delayMs - offerAgeMs;
 
 			long deadline;

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -969,6 +969,14 @@ public class AutoRecommendService
 		long deadline = System.currentTimeMillis() + delay;
 		adjustmentDeadlines.put(itemId, deadline);
 		log.info("Auto-recommend: Adjustment timer reset for item {} ({}m)", itemId, delay / 60000);
+
+		// Clear stale-notified flag so the 15-minute inactivity check can fire again
+		// if the offer goes quiet after this fill
+		PlayerSession session = plugin.getSession();
+		if (session != null)
+		{
+			session.removeStaleNotified(itemId);
+		}
 	}
 
 	/**
@@ -1415,6 +1423,13 @@ public class AutoRecommendService
 		state.deadline = System.currentTimeMillis() + AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS;
 		log.info("Auto-recommend: Sell adjustment timer reset for item {} ({}m)", itemId,
 			AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS / 60000);
+
+		// Clear stale-notified flag so the inactivity check can fire again
+		PlayerSession session = plugin.getSession();
+		if (session != null)
+		{
+			session.removeStaleNotified(itemId);
+		}
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
@@ -284,12 +284,12 @@ public class GrandExchangeSlotOverlay extends Overlay
 
 		// Draw timer in top-right corner — uses locally persisted timestamps
 		// that survive plugin restarts via OfflineSyncService
-		if (config.showOfferTimers() && trackedOffer != null && trackedOffer.getCreatedAtMillis() > 0)
+		if (config.showOfferTimers() && trackedOffer != null && trackedOffer.getEffectiveLastActivityAtMillis() > 0)
 		{
 			boolean isComplete = offer.getState() == GrandExchangeOfferState.BOUGHT ||
 								 offer.getState() == GrandExchangeOfferState.SOLD;
 
-			long realStartTime = trackedOffer.getCreatedAtMillis();
+			long realStartTime = trackedOffer.getEffectiveLastActivityAtMillis();
 
 			String timerText;
 			if (isComplete && trackedOffer.getCompletedAtMillis() > 0)

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -511,6 +511,13 @@ public class GrandExchangeTracker
 		TrackedOffer updated = TrackedOffer.createWithPreservedTimestamps(
 			ctx.itemId, ctx.itemName, ctx.totalQuantity, ctx.price, ctx.quantitySold, previousOffer, ctx.state);
 		updated.setPreviousSpent(ctx.spent);
+
+		// Reset activity timestamp on every fill for timer display & stale detection
+		if (newQuantity > 0)
+		{
+			updated.setLastActivityAtMillis(System.currentTimeMillis());
+		}
+
 		session.putTrackedOffer(ctx.slot, updated);
 
 		notifyAutoRecommendOnCompletion(ctx);

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -635,11 +635,16 @@ public class GrandExchangeTracker
 
 	private void handleNewOfferNoFills(OfferContext ctx, TrackedOffer previousOffer)
 	{
-		// Preserve createdAtMillis from existing offer if same item (avoids timer reset on re-sent events)
+		// Preserve timestamps from existing offer if same item (avoids timer reset on re-sent events)
 		if (previousOffer != null && previousOffer.getItemId() == ctx.itemId && previousOffer.getCreatedAtMillis() > 0)
 		{
-			session.putTrackedOffer(ctx.slot, new TrackedOffer(ctx.itemId, ctx.itemName, ctx.isBuy,
-				ctx.totalQuantity, ctx.price, 0, previousOffer.getCreatedAtMillis()));
+			TrackedOffer preserved = new TrackedOffer(ctx.itemId, ctx.itemName, ctx.isBuy,
+				ctx.totalQuantity, ctx.price, 0, previousOffer.getCreatedAtMillis());
+			if (previousOffer.getLastActivityAtMillis() > 0)
+			{
+				preserved.setLastActivityAtMillis(previousOffer.getLastActivityAtMillis());
+			}
+			session.putTrackedOffer(ctx.slot, preserved);
 		}
 		else
 		{

--- a/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
+++ b/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
@@ -271,7 +271,7 @@ public class ManualAdjustmentTracker
 
 	private void processExpiredTimer(OfferAdjustmentState state, TrackedOffer offer)
 	{
-		long minutesSinceOffer = (System.currentTimeMillis() - offer.getCreatedAtMillis()) / 60000;
+		long minutesSinceOffer = (System.currentTimeMillis() - offer.getEffectiveLastActivityAtMillis()) / 60000;
 		String timeframe = config.flipTimeframe().getApiValue();
 
 		apiClient.getFlipAdjustmentAsync(FlipSmartApiClient.FlipAdjustmentRequest.builder()

--- a/src/main/java/com/flipsmart/PlayerSession.java
+++ b/src/main/java/com/flipsmart/PlayerSession.java
@@ -462,4 +462,9 @@ public class PlayerSession
 	{
 		staleNotifiedAutoRecommendItemIds.clear();
 	}
+
+	public void removeStaleNotified(int itemId)
+	{
+		staleNotifiedAutoRecommendItemIds.remove(itemId);
+	}
 }

--- a/src/main/java/com/flipsmart/TrackedOffer.java
+++ b/src/main/java/com/flipsmart/TrackedOffer.java
@@ -21,6 +21,7 @@ public class TrackedOffer
 	private long previousSpent;  // cumulative GP spent/received — long to handle values > 2.1B
 	private long createdAtMillis;  // Timestamp when offer was created (for timer display)
 	private long completedAtMillis;  // Timestamp when offer completed (0 if not complete)
+	private long lastActivityAtMillis;  // Timestamp of most recent fill (for timer display & stale detection)
 
 	public TrackedOffer(int itemId, String itemName, boolean isBuy, int totalQuantity, int price, int quantitySold)
 	{
@@ -39,6 +40,7 @@ public class TrackedOffer
 		this.price = price;
 		this.previousQuantitySold = quantitySold;
 		this.createdAtMillis = createdAtMillis;
+		this.lastActivityAtMillis = createdAtMillis;
 	}
 
 	/**
@@ -68,6 +70,12 @@ public class TrackedOffer
 			: System.currentTimeMillis();
 
 		TrackedOffer offer = new TrackedOffer(itemId, itemName, isBuyState(state), totalQuantity, price, quantitySold, originalTimestamp);
+
+		// Preserve lastActivityAtMillis from existing offer (or default to creation time)
+		if (existing != null && existing.getLastActivityAtMillis() > 0)
+		{
+			offer.setLastActivityAtMillis(existing.getLastActivityAtMillis());
+		}
 
 		if (state == GrandExchangeOfferState.BOUGHT || state == GrandExchangeOfferState.SOLD)
 		{
@@ -118,5 +126,22 @@ public class TrackedOffer
 	public void setCreatedAtMillis(long createdAtMillis)
 	{
 		this.createdAtMillis = createdAtMillis;
+	}
+
+	/**
+	 * Update the last activity timestamp (called on each partial fill).
+	 */
+	public void setLastActivityAtMillis(long lastActivityAtMillis)
+	{
+		this.lastActivityAtMillis = lastActivityAtMillis;
+	}
+
+	/**
+	 * Get the effective last activity time. Falls back to createdAtMillis
+	 * for offers persisted before this field was added.
+	 */
+	public long getEffectiveLastActivityAtMillis()
+	{
+		return lastActivityAtMillis > 0 ? lastActivityAtMillis : createdAtMillis;
 	}
 }


### PR DESCRIPTION
## Summary

Implements timer reset on any partial fill for buy and sell offers. Previously, overlay timers and stale detection used the offer creation timestamp, so partial fills had no effect on how long an offer appeared to have been sitting. Now every fill updates a `lastActivityAtMillis` timestamp, resetting the displayed timer and all inactivity/stale calculations to 0.

## Changes

### New Features
- `lastActivityAtMillis` field on `TrackedOffer` — updated on every partial fill, falls back to `createdAtMillis` for backward compatibility with persisted offers
- `getEffectiveLastActivityAtMillis()` helper that transparently handles the fallback, requiring no callers to know about the migration
- `PlayerSession.removeStaleNotified(itemId)` — allows the 15-minute inactivity re-prompt to fire again after a new quiet period begins following a fill

### Bug Fixes / Behaviour Changes
- Overlay timer now counts up from the most recent fill instead of offer creation
- All 8 stale-detection and adjustment-timer calculations in `AutoRecommendService` now use last activity time
- `ManualAdjustmentTracker.processExpiredTimer()` now uses last activity time
- `handleNewOfferNoFills` preserves `lastActivityAtMillis` from the previous offer on re-sent GE events, preventing a spurious timer reset
- Stale-notified flag is cleared on each fill (via `resetAdjustmentTimer` and `resetSellAdjustmentTimer`) so re-prompts can fire after the next quiet period

## Testing

### Automated Tests
- Plugin builds cleanly with `./gradlew build`
- No new test infrastructure needed — behaviour is exercised via the existing GE event pipeline

### Manual Testing
- [ ] Buy an item — confirm overlay timer resets on each partial fill
- [ ] Sell an item — confirm overlay timer resets on each partial fill
- [ ] Let an offer sit 15+ minutes without fills — confirm stale notification fires
- [ ] Receive a fill after stale notification — confirm timer resets and re-prompt is allowed after another quiet period
- [ ] Cancel and re-place the same offer at a different price — confirm timer does not reset (re-sent event preservation)

## Deployment Notes

- [ ] No environment variables or configuration changes required
- [ ] No database migrations
- [ ] Backward compatible: offers persisted before this change fall back to `createdAtMillis` via `getEffectiveLastActivityAtMillis()`

## Checklist

- [x] All 7 commits are focused and independently understandable
- [x] Backward-compatible fallback in place for pre-existing persisted offers
- [x] No `Thread.currentThread().interrupt()` calls added
- [x] No console debug code left in

## Related Issues

Closes Flip-Smart/flip-smart#373