### PR TITLE
Hotfix: disable loss-minimizing sell price in panel (#438)

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3987,16 +3987,11 @@ public class FlipFinderPanel extends PluginPanel
 		int buyPrice = flip.getAverageBuyPrice();
 		int minProfitablePrice = calculateMinProfitableSellPrice(buyPrice);
 		
-		// Check if we've exceeded the time threshold
-		boolean pastThreshold = shouldUseLossMinimizingPrice(flip, dailyVolume);
-		
-		if (pastThreshold && currentMarketPrice != null)
-		{
-			// Past threshold: prioritize selling, even at potential loss
-			// Use current market price, but at minimum use the market price
-			// that gives best chance of selling
-			return currentMarketPrice;
-		}
+		// HOTFIX (#438): Disabled loss-minimizing sell price. Never recommend selling
+		// below breakeven — always use original target or minimum profitable price.
+		// The time-threshold logic will be re-enabled once the sell-side readjustment
+		// bugs are fixed (Step 3 below-breakeven, login timer reset, plugin price overwrite).
+		// Original code: if (pastThreshold && currentMarketPrice != null) return currentMarketPrice;
 		
 		// Before threshold: prioritize profit
 		if (flip.getRecommendedSellPrice() != null && flip.getRecommendedSellPrice() >= minProfitablePrice)


### PR DESCRIPTION
## Summary

This hotfix disables the time-threshold loss-minimizing path in `calculateSmartSellPrice` inside `FlipFinderPanel.java`. The method was falling through to return the current market price once a time threshold was exceeded, even when that price was below breakeven — causing the plugin to display a recommended sell price that guaranteed a loss. The fix removes this path so the plugin always recommends the original target sell price or the minimum profitable price.

This is the plugin-side half of a two-part hotfix. The backend half (disabling sell-side readjustment at the API level) is in Flip-Smart/flip-smart#447.

## Changes

### 🐛 Bug Fixes
- Removed the `pastThreshold && currentMarketPrice != null` branch in `calculateSmartSellPrice` that returned the raw current market price regardless of profitability
- Added a comment preserving the original logic inline so the time-threshold path can be cleanly re-enabled once the underlying sell-side readjustment bugs are resolved (below-breakeven Step 3, login timer reset, plugin price overwrite)

## Testing

### Automated Tests
- Build passes (`./gradlew build`)

### Manual Testing
- [ ] Verify that an active sell offer past the time threshold no longer shows a sell price below the breakeven price
- [ ] Verify that the recommended sell price still updates correctly when the API returns a new target sell price above breakeven

## Deployment Notes

- No new environment variables or configuration changes
- No database migrations
- The disabled logic is preserved in a comment and will be re-enabled in a follow-up once the sell-side readjustment spec is implemented

## Related Issues

Closes Flip-Smart/flip-smart#438
Pairs with backend PR: Flip-Smart/flip-smart#447