### PR TITLE
feat(plugin): GE History tab reader for offline fill price backfill

### DIFF
--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -66,6 +66,7 @@ public class FlipAssistOverlay extends Overlay
 	private static final String HINT_MESSAGE = "Click on a flip suggestion to start";
 	private static final String UPGRADE_MESSAGE = "Upgrade to Premium for more flip slots";
 	private static final String LOGIN_MESSAGE = "Log in to use Flip Assist";
+	private static final String HISTORY_PROMPT_MESSAGE = "Open GE History tab to improve offline fill accuracy";
 	
 	// GE Interface IDs
 	private static final int GE_INTERFACE_GROUP = 465;
@@ -87,7 +88,8 @@ public class FlipAssistOverlay extends Overlay
 	private final FlipSmartConfig config;
 	private final ItemManager itemManager;
 	private final TradeActivityLog tradeActivityLog;
-	
+	private final GEHistoryService geHistoryService;
+
 	@Getter
 	private FocusedFlip focusedFlip;
 
@@ -148,7 +150,7 @@ public class FlipAssistOverlay extends Overlay
 	}
 
 	@Inject
-	private FlipAssistOverlay(FlipSmartPlugin flipSmartPlugin, Client client, ClientThread clientThread, FlipSmartConfig config, ItemManager itemManager, TradeActivityLog tradeActivityLog)
+	private FlipAssistOverlay(FlipSmartPlugin flipSmartPlugin, Client client, ClientThread clientThread, FlipSmartConfig config, ItemManager itemManager, TradeActivityLog tradeActivityLog, GEHistoryService geHistoryService)
 	{
 		this.flipSmartPlugin = flipSmartPlugin;
 		this.client = client;
@@ -156,6 +158,7 @@ public class FlipAssistOverlay extends Overlay
 		this.config = config;
 		this.itemManager = itemManager;
 		this.tradeActivityLog = tradeActivityLog;
+		this.geHistoryService = geHistoryService;
 		
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_WIDGETS);
@@ -275,6 +278,10 @@ public class FlipAssistOverlay extends Overlay
 			if (!flipSmartPlugin.getApiClient().isAuthenticated())
 			{
 				return renderHintBox(graphics, LOGIN_MESSAGE);
+			}
+			if (isGrandExchangeOpen() && geHistoryService.hasUnverifiedOfflineFills())
+			{
+				return renderHintBox(graphics, HISTORY_PROMPT_MESSAGE);
 			}
 			return renderHintBox(graphics, HINT_MESSAGE);
 		}
@@ -532,6 +539,10 @@ public class FlipAssistOverlay extends Overlay
 	private Color getHintLineColor(String line)
 	{
 		String trimmed = line.trim();
+		if (trimmed.startsWith("Open GE History"))
+		{
+			return COLOR_BUY;
+		}
 		if (trimmed.endsWith("gp"))
 		{
 			return COLOR_BUY;

--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -253,7 +253,38 @@ public class FlipAssistOverlay extends Overlay
 		{
 			return null;
 		}
-		
+
+		// Stacked GE-History banner: shown above whatever else the overlay
+		// renders, whenever offline fills are pending and GE is open. Lets
+		// the prompt survive autoStatusMessage / focused-flip states that
+		// otherwise suppress the idle hint box.
+		Dimension bannerSize = null;
+		boolean showHistoryBanner = isGrandExchangeOpen() && geHistoryService.hasUnverifiedOfflineFills();
+		if (showHistoryBanner)
+		{
+			bannerSize = renderHistoryPromptBanner(graphics);
+			graphics.translate(0, bannerSize.height + 4);
+		}
+
+		Dimension mainSize = renderMain(graphics);
+
+		if (showHistoryBanner)
+		{
+			graphics.translate(0, -(bannerSize.height + 4));
+			if (mainSize == null)
+			{
+				return new Dimension(bannerSize.width, bannerSize.height);
+			}
+			return new Dimension(
+				Math.max(mainSize.width, bannerSize.width),
+				mainSize.height + bannerSize.height + 4
+			);
+		}
+		return mainSize;
+	}
+
+	private Dimension renderMain(Graphics2D graphics)
+	{
 		// If no flip is focused, show hint box only when GE is open (or showAssistantAlways)
 		if (focusedFlip == null)
 		{
@@ -342,6 +373,53 @@ public class FlipAssistOverlay extends Overlay
 		return new Dimension(PANEL_WIDTH, panelHeight);
 	}
 	
+	/**
+	 * Standalone green "Open GE History" banner. Renders above whatever else
+	 * the overlay shows so the prompt isn't hidden by autoStatusMessage or
+	 * focused-flip states.
+	 */
+	private Dimension renderHistoryPromptBanner(Graphics2D graphics)
+	{
+		graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+		graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+		graphics.setFont(FontManager.getRunescapeSmallFont());
+		FontMetrics fm = graphics.getFontMetrics();
+
+		String message = "Open GE History tab — recover offline trade prices";
+		int padding = 8;
+		int lineHeight = fm.getHeight();
+		int width = HINT_PANEL_WIDTH;
+		int height = lineHeight + padding * 2;
+
+		// Pulsing green-tinted glow to draw the eye
+		long elapsed = System.currentTimeMillis() - animationStartTime;
+		double pulsePhase = (elapsed % PULSE_DURATION) / (double) PULSE_DURATION;
+		float pulseAlpha = (float) (0.5 + 0.5 * Math.sin(pulsePhase * 2 * Math.PI));
+
+		Color glow = new Color(COLOR_BUY.getRed(), COLOR_BUY.getGreen(), COLOR_BUY.getBlue(), (int)(60 * pulseAlpha));
+		graphics.setColor(glow);
+		graphics.fillRoundRect(-3, -3, width + 6, height + 6, 10, 10);
+
+		// Body
+		graphics.setColor(COLOR_BG_DARK);
+		graphics.fillRoundRect(0, 0, width, height, 8, 8);
+
+		// Green border
+		Color border = new Color(COLOR_BUY.getRed(), COLOR_BUY.getGreen(), COLOR_BUY.getBlue(),
+			(int)(150 + 100 * pulseAlpha));
+		graphics.setColor(border);
+		graphics.setStroke(new BasicStroke(1.5f));
+		graphics.drawRoundRect(0, 0, width, height, 8, 8);
+
+		// Text in green
+		graphics.setColor(COLOR_PROFIT);
+		int textX = padding;
+		int textY = padding + fm.getAscent();
+		graphics.drawString(message, textX, textY);
+
+		return new Dimension(width, height);
+	}
+
 	/**
 	 * Render a small hint box with a title and message.
 	 * When an item icon is present, shows a two-line layout:

--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -254,37 +254,6 @@ public class FlipAssistOverlay extends Overlay
 			return null;
 		}
 
-		// Stacked GE-History banner: shown above whatever else the overlay
-		// renders, whenever offline fills are pending and GE is open. Lets
-		// the prompt survive autoStatusMessage / focused-flip states that
-		// otherwise suppress the idle hint box.
-		Dimension bannerSize = null;
-		boolean showHistoryBanner = isGrandExchangeOpen() && geHistoryService.hasUnverifiedOfflineFills();
-		if (showHistoryBanner)
-		{
-			bannerSize = renderHistoryPromptBanner(graphics);
-			graphics.translate(0, bannerSize.height + 4);
-		}
-
-		Dimension mainSize = renderMain(graphics);
-
-		if (showHistoryBanner)
-		{
-			graphics.translate(0, -(bannerSize.height + 4));
-			if (mainSize == null)
-			{
-				return new Dimension(bannerSize.width, bannerSize.height);
-			}
-			return new Dimension(
-				Math.max(mainSize.width, bannerSize.width),
-				mainSize.height + bannerSize.height + 4
-			);
-		}
-		return mainSize;
-	}
-
-	private Dimension renderMain(Graphics2D graphics)
-	{
 		// If no flip is focused, show hint box only when GE is open (or showAssistantAlways)
 		if (focusedFlip == null)
 		{
@@ -373,53 +342,6 @@ public class FlipAssistOverlay extends Overlay
 		return new Dimension(PANEL_WIDTH, panelHeight);
 	}
 	
-	/**
-	 * Standalone green "Open GE History" banner. Renders above whatever else
-	 * the overlay shows so the prompt isn't hidden by autoStatusMessage or
-	 * focused-flip states.
-	 */
-	private Dimension renderHistoryPromptBanner(Graphics2D graphics)
-	{
-		graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-		graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-		graphics.setFont(FontManager.getRunescapeSmallFont());
-		FontMetrics fm = graphics.getFontMetrics();
-
-		String message = "Open GE History tab — recover offline trade prices";
-		int padding = 8;
-		int lineHeight = fm.getHeight();
-		int width = HINT_PANEL_WIDTH;
-		int height = lineHeight + padding * 2;
-
-		// Pulsing green-tinted glow to draw the eye
-		long elapsed = System.currentTimeMillis() - animationStartTime;
-		double pulsePhase = (elapsed % PULSE_DURATION) / (double) PULSE_DURATION;
-		float pulseAlpha = (float) (0.5 + 0.5 * Math.sin(pulsePhase * 2 * Math.PI));
-
-		Color glow = new Color(COLOR_BUY.getRed(), COLOR_BUY.getGreen(), COLOR_BUY.getBlue(), (int)(60 * pulseAlpha));
-		graphics.setColor(glow);
-		graphics.fillRoundRect(-3, -3, width + 6, height + 6, 10, 10);
-
-		// Body
-		graphics.setColor(COLOR_BG_DARK);
-		graphics.fillRoundRect(0, 0, width, height, 8, 8);
-
-		// Green border
-		Color border = new Color(COLOR_BUY.getRed(), COLOR_BUY.getGreen(), COLOR_BUY.getBlue(),
-			(int)(150 + 100 * pulseAlpha));
-		graphics.setColor(border);
-		graphics.setStroke(new BasicStroke(1.5f));
-		graphics.drawRoundRect(0, 0, width, height, 8, 8);
-
-		// Text in green
-		graphics.setColor(COLOR_PROFIT);
-		int textX = padding;
-		int textY = padding + fm.getAscent();
-		graphics.drawString(message, textX, textY);
-
-		return new Dimension(width, height);
-	}
-
 	/**
 	 * Render a small hint box with a title and message.
 	 * When an item icon is present, shows a two-line layout:

--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -261,6 +261,15 @@ public class FlipAssistOverlay extends Overlay
 			{
 				return null;
 			}
+			// History-backfill prompt takes priority over auto-recommend status
+			// messages ("Monitoring active offers", "Collect profit from GE", etc.).
+			// Offline trade recovery is one-shot per session — once the user
+			// closes the History tab the data is gone — so the prompt has to
+			// surface even when the auto-recommend overlay is otherwise active.
+			if (isGrandExchangeOpen() && geHistoryService.hasUnverifiedOfflineFills())
+			{
+				return renderHintBox(graphics, HISTORY_PROMPT_MESSAGE);
+			}
 			if (autoStatusMessage != null)
 			{
 				return renderHintBox(graphics, autoStatusMessage);
@@ -278,10 +287,6 @@ public class FlipAssistOverlay extends Overlay
 			if (!flipSmartPlugin.getApiClient().isAuthenticated())
 			{
 				return renderHintBox(graphics, LOGIN_MESSAGE);
-			}
-			if (isGrandExchangeOpen() && geHistoryService.hasUnverifiedOfflineFills())
-			{
-				return renderHintBox(graphics, HISTORY_PROMPT_MESSAGE);
 			}
 			return renderHintBox(graphics, HINT_MESSAGE);
 		}

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -1440,6 +1440,66 @@ public class FlipSmartApiClient
 	}
 
 	/**
+	 * Single GE History row, used by recordHistoryBackfillBatchAsync.
+	 */
+	public static class HistoryBackfillEntry
+	{
+		public final int itemId;
+		public final String itemName;
+		public final boolean isBuy;
+		public final int quantity;
+		public final int pricePerItem;
+
+		public HistoryBackfillEntry(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
+		{
+			this.itemId = itemId;
+			this.itemName = itemName;
+			this.isBuy = isBuy;
+			this.quantity = quantity;
+			this.pricePerItem = pricePerItem;
+		}
+	}
+
+	/**
+	 * Post every visible GE History row in a single batch. The server reconciles
+	 * each row against the player's recent transactions via sum-and-delta dedup,
+	 * inserting only the missing quantity per row (or skipping if real-time
+	 * already captured the trade).
+	 */
+	public CompletableFuture<Void> recordHistoryBackfillBatchAsync(String rsn, java.util.List<HistoryBackfillEntry> entries)
+	{
+		String apiUrl = getApiUrl();
+		String url = String.format("%s/transactions/history-backfill-batch", apiUrl);
+
+		JsonObject body = new JsonObject();
+		body.addProperty("rsn", rsn);
+		com.google.gson.JsonArray arr = new com.google.gson.JsonArray();
+		for (HistoryBackfillEntry e : entries)
+		{
+			JsonObject o = new JsonObject();
+			o.addProperty(JSON_KEY_ITEM_ID, e.itemId);
+			if (e.itemName != null) o.addProperty("item_name", e.itemName);
+			o.addProperty("is_buy", e.isBuy);
+			o.addProperty(JSON_KEY_QUANTITY, e.quantity);
+			o.addProperty("price_per_item", e.pricePerItem);
+			arr.add(o);
+		}
+		body.add("entries", arr);
+
+		RequestBody rb = RequestBody.create(JSON, body.toString());
+		Request.Builder requestBuilder = new Request.Builder().url(url).post(rb);
+
+		return executeAuthenticatedAsync(requestBuilder, jsonData ->
+		{
+			JsonObject resp = gson.fromJson(jsonData, JsonObject.class);
+			log.info("History backfill batch: inserted={} deduped={}",
+				resp.has("inserted") ? resp.get("inserted").getAsInt() : 0,
+				resp.has("deduped") ? resp.get("deduped").getAsInt() : 0);
+			return null;
+		}).thenApply(v -> null);
+	}
+
+	/**
 	 * Fetch active flips from the API asynchronously
 	 * @param rsn Optional RSN to filter by (for multi-account support)
 	 */

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -1313,7 +1313,6 @@ public class FlipSmartApiClient
 		public final Integer recommendedSellPrice;
 		public final String rsn;
 		public final Integer totalQuantity;
-		public final boolean isHistoryBackfill;
 
 		private TransactionRequest(Builder builder)
 		{
@@ -1326,7 +1325,6 @@ public class FlipSmartApiClient
 			this.recommendedSellPrice = builder.recommendedSellPrice;
 			this.rsn = builder.rsn;
 			this.totalQuantity = builder.totalQuantity;
-			this.isHistoryBackfill = builder.isHistoryBackfill;
 		}
 
 		public static Builder builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
@@ -1345,7 +1343,6 @@ public class FlipSmartApiClient
 			private Integer recommendedSellPrice;
 			private String rsn;
 			private Integer totalQuantity;
-			private boolean isHistoryBackfill = false;
 
 			private Builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
 			{
@@ -1360,7 +1357,6 @@ public class FlipSmartApiClient
 			public Builder recommendedSellPrice(Integer price) { this.recommendedSellPrice = price; return this; }
 			public Builder rsn(String rsn) { this.rsn = rsn; return this; }
 			public Builder totalQuantity(Integer qty) { this.totalQuantity = qty; return this; }
-			public Builder isHistoryBackfill(boolean value) { this.isHistoryBackfill = value; return this; }
 
 			public TransactionRequest build() { return new TransactionRequest(this); }
 		}
@@ -1396,10 +1392,6 @@ public class FlipSmartApiClient
 		if (request.totalQuantity != null && request.totalQuantity > 0)
 		{
 			jsonBody.addProperty("total_quantity", request.totalQuantity);
-		}
-		if (request.isHistoryBackfill)
-		{
-			jsonBody.addProperty("is_history_backfill", true);
 		}
 
 		RequestBody body = RequestBody.create(JSON, jsonBody.toString());

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -28,6 +28,7 @@ public class FlipSmartApiClient
 	private static final String REFRESH_TOKEN_KEY = "refresh_token";
 	private static final String JSON_KEY_ITEM_ID = "item_id";
 	private static final String JSON_KEY_QUANTITY = "quantity";
+	private static final String JSON_KEY_PRICE_PER_ITEM = "price_per_item";
 	private static final String JSON_KEY_IS_PREMIUM = "is_premium";
 	private static final String JSON_KEY_RSN_ENTITLEMENT = "rsn_entitlement";
 	private static final String JSON_KEY_STATUS = "status";
@@ -1376,7 +1377,7 @@ public class FlipSmartApiClient
 		jsonBody.addProperty("item_name", request.itemName);
 		jsonBody.addProperty("is_buy", request.isBuy);
 		jsonBody.addProperty(JSON_KEY_QUANTITY, request.quantity);
-		jsonBody.addProperty("price_per_item", request.pricePerItem);
+		jsonBody.addProperty(JSON_KEY_PRICE_PER_ITEM,request.pricePerItem);
 		if (request.geSlot != null)
 		{
 			jsonBody.addProperty("ge_slot", request.geSlot);
@@ -1473,7 +1474,7 @@ public class FlipSmartApiClient
 			if (e.itemName != null) o.addProperty("item_name", e.itemName);
 			o.addProperty("is_buy", e.isBuy);
 			o.addProperty(JSON_KEY_QUANTITY, e.quantity);
-			o.addProperty("price_per_item", e.pricePerItem);
+			o.addProperty(JSON_KEY_PRICE_PER_ITEM,e.pricePerItem);
 			arr.add(o);
 		}
 		body.add("entries", arr);
@@ -1645,7 +1646,7 @@ public class FlipSmartApiClient
 		requestBody.addProperty(JSON_KEY_ITEM_ID, itemId);
 		requestBody.addProperty("filled_quantity", filledQuantity);
 		requestBody.addProperty("order_quantity", orderQuantity);
-		requestBody.addProperty("price_per_item", pricePerItem);
+		requestBody.addProperty(JSON_KEY_PRICE_PER_ITEM,pricePerItem);
 		requestBody.addProperty("rsn", rsn);
 		
 		RequestBody body = RequestBody.create(JSON, requestBody.toString());

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -1313,6 +1313,7 @@ public class FlipSmartApiClient
 		public final Integer recommendedSellPrice;
 		public final String rsn;
 		public final Integer totalQuantity;
+		public final boolean isHistoryBackfill;
 
 		private TransactionRequest(Builder builder)
 		{
@@ -1325,6 +1326,7 @@ public class FlipSmartApiClient
 			this.recommendedSellPrice = builder.recommendedSellPrice;
 			this.rsn = builder.rsn;
 			this.totalQuantity = builder.totalQuantity;
+			this.isHistoryBackfill = builder.isHistoryBackfill;
 		}
 
 		public static Builder builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
@@ -1343,6 +1345,7 @@ public class FlipSmartApiClient
 			private Integer recommendedSellPrice;
 			private String rsn;
 			private Integer totalQuantity;
+			private boolean isHistoryBackfill = false;
 
 			private Builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
 			{
@@ -1357,6 +1360,7 @@ public class FlipSmartApiClient
 			public Builder recommendedSellPrice(Integer price) { this.recommendedSellPrice = price; return this; }
 			public Builder rsn(String rsn) { this.rsn = rsn; return this; }
 			public Builder totalQuantity(Integer qty) { this.totalQuantity = qty; return this; }
+			public Builder isHistoryBackfill(boolean value) { this.isHistoryBackfill = value; return this; }
 
 			public TransactionRequest build() { return new TransactionRequest(this); }
 		}
@@ -1392,6 +1396,10 @@ public class FlipSmartApiClient
 		if (request.totalQuantity != null && request.totalQuantity > 0)
 		{
 			jsonBody.addProperty("total_quantity", request.totalQuantity);
+		}
+		if (request.isHistoryBackfill)
+		{
+			jsonBody.addProperty("is_history_backfill", true);
 		}
 
 		RequestBody body = RequestBody.create(JSON, jsonBody.toString());

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -895,6 +895,8 @@ public class FlipSmartPlugin extends Plugin
 		{
 			syncRSN();
 		}
+
+		geHistoryService.onGameTick();
 	}
 
 	private void handleLogoutState()

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -20,7 +20,9 @@ import net.runelite.api.events.GrandExchangeOfferChanged;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.ScriptPostFired;
 import net.runelite.api.events.VarClientIntChanged;
+import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.ScriptID;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.client.callback.ClientThread;
@@ -116,6 +118,9 @@ public class FlipSmartPlugin extends Plugin
 
 	@Inject
 	private WebhookSyncService webhookSyncService;
+
+	@Inject
+	private GEHistoryService geHistoryService;
 
 	@Inject
 	private Gson gson;
@@ -896,6 +901,7 @@ public class FlipSmartPlugin extends Plugin
 	{
 		session.onLogout();
 		offlineSyncService.persistOfferState();
+		geHistoryService.reset();
 		persistAutoRecommendState();
 
 		// Stop auto-recommend on logout
@@ -1307,6 +1313,15 @@ public class FlipSmartPlugin extends Plugin
 		if (event.getIndex() == FlipAssistInputListener.VARCLIENT_INPUT_TYPE && flipAssistInputListener != null)
 		{
 			flipAssistInputListener.updateInputType(client.getVarcIntValue(FlipAssistInputListener.VARCLIENT_INPUT_TYPE));
+		}
+	}
+
+	@Subscribe
+	public void onWidgetLoaded(WidgetLoaded event)
+	{
+		if (event.getGroupId() == InterfaceID.GE_HISTORY)
+		{
+			geHistoryService.onHistoryWidgetLoaded();
 		}
 	}
 

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -701,6 +701,13 @@ public class FlipSmartPlugin extends Plugin
 		grandExchangeTracker.setOnFocusClear(this::handleGETrackerFocusClear);
 		grandExchangeTracker.setDisplayedSellPriceProvider(itemId -> flipFinderPanel != null ? flipFinderPanel.getDisplayedSellPrice(itemId) : null);
 		grandExchangeTracker.setOneShotScheduler(this::scheduleOneShot);
+
+		geHistoryService.setOnBackfillComplete(() -> {
+			if (flipFinderPanel != null)
+			{
+				javax.swing.SwingUtilities.invokeLater(flipFinderPanel::refresh);
+			}
+		});
 	}
 
 	private void handleGETrackerFocusChanged(FocusedFlip focus)

--- a/src/main/java/com/flipsmart/GEHistoryEntry.java
+++ b/src/main/java/com/flipsmart/GEHistoryEntry.java
@@ -1,0 +1,30 @@
+package com.flipsmart;
+
+import lombok.Getter;
+
+/**
+ * Represents a single entry from the in-game GE History tab (interface 383).
+ */
+@Getter
+public class GEHistoryEntry
+{
+	private final int itemId;
+	private final boolean isBuy;
+	private final int quantity;
+	private final int pricePerItem;
+
+	public GEHistoryEntry(int itemId, boolean isBuy, int quantity, int pricePerItem)
+	{
+		this.itemId = itemId;
+		this.isBuy = isBuy;
+		this.quantity = quantity;
+		this.pricePerItem = pricePerItem;
+	}
+
+	@Override
+	public String toString()
+	{
+		return String.format("GEHistoryEntry{%s itemId=%d, qty=%d, price=%d}",
+			isBuy ? "BUY" : "SELL", itemId, quantity, pricePerItem);
+	}
+}

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -228,11 +228,24 @@ public class GEHistoryService
 			recentlyPersistedOffers.putAll(offers);
 		}
 		log.info("GE History: snapshot loaded with {} persisted offers", recentlyPersistedOffers.size());
+		// Any prior-session activity is reason enough to prompt the user to
+		// open History — the slot-diff and stale-collected-item detections
+		// only catch a subset of cases. Backend dedup makes the backfill safe
+		// regardless: covered rows dedupe, missing ones get inserted.
+		if (!recentlyPersistedOffers.isEmpty())
+		{
+			maybeSendChatPrompt();
+		}
 	}
 
 	public boolean hasUnverifiedOfflineFills()
 	{
-		return !historyReadThisSession && !pendingOfflineFillItemIds.isEmpty();
+		// Prompt the overlay banner whenever we haven't yet read the History
+		// this session and there's *any* signal that offline activity might
+		// have happened — either the narrow per-item detection registered
+		// something, or the user simply had persisted offer state from the
+		// prior session.
+		return !historyReadThisSession && (!pendingOfflineFillItemIds.isEmpty() || !recentlyPersistedOffers.isEmpty());
 	}
 
 	public void reset()

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -42,6 +42,7 @@ public class GEHistoryService
 	private final Map<Integer, TrackedOffer> recentlyPersistedOffers = new ConcurrentHashMap<>();
 	private volatile boolean historyReadThisSession = false;
 	private volatile boolean widgetStructureLogged = false;
+	private volatile int pendingHistoryReadTicks = 0;
 
 	@Inject
 	public GEHistoryService(Client client, FlipSmartApiClient apiClient, PlayerSession session)
@@ -54,26 +55,53 @@ public class GEHistoryService
 	public void onHistoryWidgetLoaded()
 	{
 		log.info("GE History widget loaded (group {})", InterfaceID.GE_HISTORY);
-		Widget listWidget = client.getWidget(InterfaceID.GE_HISTORY, GE_HISTORY_LIST_CHILD);
-		if (listWidget == null || listWidget.isHidden())
+		// WidgetLoaded fires when the interface is *created*, but list rows are
+		// populated by clientscripts that run afterward. Defer two ticks so the
+		// scripts have time to write the row widgets before we scan them.
+		pendingHistoryReadTicks = 2;
+	}
+
+	/**
+	 * Called from FlipSmartPlugin.onGameTick. Counts down ticks after WidgetLoaded
+	 * to give clientscripts time to populate the list rows before we read them.
+	 */
+	public void onGameTick()
+	{
+		if (pendingHistoryReadTicks <= 0)
 		{
-			log.info("GE History list widget at child {} is null or hidden — skipping", GE_HISTORY_LIST_CHILD);
 			return;
 		}
+		pendingHistoryReadTicks--;
+		if (pendingHistoryReadTicks > 0)
+		{
+			return;
+		}
+		readHistoryNow();
+	}
 
+	private void readHistoryNow()
+	{
 		historyReadThisSession = true;
 		pendingOfflineFillItemIds.clear();
 
 		if (!widgetStructureLogged)
 		{
-			logWidgetStructure(listWidget);
+			dumpHistoryGroup();
 			widgetStructureLogged = true;
+		}
+
+		Widget listWidget = client.getWidget(InterfaceID.GE_HISTORY, GE_HISTORY_LIST_CHILD);
+		if (listWidget == null)
+		{
+			log.info("Deferred read: list widget at child {} still null", GE_HISTORY_LIST_CHILD);
+			return;
 		}
 
 		List<GEHistoryEntry> entries = parseHistoryEntries(listWidget);
 		if (entries.isEmpty())
 		{
-			log.info("Parsed 0 history entries — widget offsets likely need calibration. See structure dump above.");
+			log.info("Deferred read: parsed 0 history entries from child {} — see group dump above to recalibrate offsets",
+				GE_HISTORY_LIST_CHILD);
 			return;
 		}
 
@@ -83,6 +111,43 @@ public class GEHistoryService
 			log.debug("  parsed: {}", entry);
 		}
 		backfillOfflineFills(entries);
+	}
+
+	/** Dump every child index 0..47 of group GE_HISTORY so we can see where row data actually lives. */
+	private void dumpHistoryGroup()
+	{
+		log.info("=== Dumping all children of GE_HISTORY group {} ===", InterfaceID.GE_HISTORY);
+		for (int idx = 0; idx < 48; idx++)
+		{
+			Widget w = client.getWidget(InterfaceID.GE_HISTORY, idx);
+			if (w == null) continue;
+			Widget[] dyn = w.getDynamicChildren();
+			Widget[] kid = w.getChildren();
+			Widget[] nest = w.getNestedChildren();
+			int dynN = dyn == null ? 0 : dyn.length;
+			int kidN = kid == null ? -1 : kid.length;
+			int nestN = nest == null ? 0 : nest.length;
+			log.info("  child[{}]: type={} w={} h={} hidden={} text='{}' itemId={} sprite={} dyn={} kid={} nest={}",
+				idx, w.getType(), w.getWidth(), w.getHeight(), w.isHidden(),
+				w.getText() == null ? "" : w.getText(),
+				w.getItemId(), w.getSpriteId(),
+				dynN, kidN, nestN);
+			Widget[] sample = firstNonEmpty(dyn, kid, nest);
+			if (sample != null && sample.length > 0)
+			{
+				int max = Math.min(sample.length, 8);
+				for (int j = 0; j < max; j++)
+				{
+					Widget c = sample[j];
+					if (c == null) continue;
+					log.info("    [{}.{}]: type={} itemId={} qty={} text='{}' color={}",
+						idx, j, c.getType(), c.getItemId(), c.getItemQuantity(),
+						c.getText() == null ? "" : c.getText(),
+						Integer.toHexString(c.getTextColor()));
+				}
+			}
+		}
+		log.info("=== end group dump ===");
 	}
 
 	public void registerOfflineFill(int itemId)
@@ -125,6 +190,7 @@ public class GEHistoryService
 		recentlyPersistedOffers.clear();
 		historyReadThisSession = false;
 		widgetStructureLogged = false;
+		pendingHistoryReadTicks = 0;
 	}
 
 	private List<GEHistoryEntry> parseHistoryEntries(Widget listWidget)

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -219,7 +219,7 @@ public class GEHistoryService
 			int parsed = parseDigits(text);
 			if (parsed > 0) acc.price = parsed;
 		}
-		else if (acc.quantity <= 0 && text.matches(".*\\d+.*"))
+		else if (acc.quantity <= 0 && containsDigit(text))
 		{
 			int parsed = parseDigits(text);
 			if (parsed > 0) acc.quantity = parsed;
@@ -330,6 +330,15 @@ public class GEHistoryService
 		for (int c : SELL_COLORS)
 		{
 			if (color == c) return true;
+		}
+		return false;
+	}
+
+	private static boolean containsDigit(String text)
+	{
+		for (int i = 0; i < text.length(); i++)
+		{
+			if (Character.isDigit(text.charAt(i))) return true;
 		}
 		return false;
 	}

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -334,36 +334,37 @@ public class GEHistoryService
 		for (int i = 0; i < children.length; i++)
 		{
 			Widget rowWidget = children[i];
-			if (rowWidget == null || rowWidget.isHidden())
+			if (rowWidget != null && !rowWidget.isHidden())
 			{
-				continue;
-			}
-
-			Widget[] subChildren = rowWidget.getDynamicChildren();
-			if (subChildren == null || subChildren.length == 0)
-			{
-				subChildren = rowWidget.getChildren();
-			}
-			if (subChildren == null || subChildren.length < 3)
-			{
-				continue;
-			}
-
-			try
-			{
-				GEHistoryEntry entry = parseRowFromSubChildren(subChildren);
-				if (entry != null)
+				Widget[] subChildren = rowWidget.getDynamicChildren();
+				if (subChildren == null || subChildren.length == 0)
 				{
-					entries.add(entry);
+					subChildren = rowWidget.getChildren();
 				}
-			}
-			catch (Exception e)
-			{
-				log.debug("Failed to parse container row {}: {}", i, e.getMessage());
+				if (subChildren != null && subChildren.length >= 3)
+				{
+					tryParseContainerRow(i, subChildren, entries);
+				}
 			}
 		}
 
 		return entries;
+	}
+
+	private void tryParseContainerRow(int rowIndex, Widget[] subChildren, List<GEHistoryEntry> entries)
+	{
+		try
+		{
+			GEHistoryEntry entry = parseRowFromSubChildren(subChildren);
+			if (entry != null)
+			{
+				entries.add(entry);
+			}
+		}
+		catch (Exception e)
+		{
+			log.debug("Failed to parse container row {}: {}", rowIndex, e.getMessage());
+		}
 	}
 
 	private GEHistoryEntry parseRowFromSubChildren(Widget[] subChildren)

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -29,16 +29,13 @@ import java.util.concurrent.ConcurrentHashMap;
 @Singleton
 public class GEHistoryService
 {
-	// Confirmed via in-game widget dump: list at child 3 has 240 dynamic
-	// children laid out as 30 rows × 8 children each.
-	//   offset 2: "Bought:" / "Sold:" header (type=4, text-only)
-	//   offset 4: item sprite (type=5, carries itemId + itemQuantity natively)
-	//   offset 5: price text "<col=...>X coins</col><br>= Y each"
+	// Row layout in the GE History list (child 3 of group 383): each entry
+	// is anchored by a "Bought:" / "Sold:" header widget; the next item
+	// sprite (carries itemId + itemQuantity natively) and the next text
+	// containing "each" (the per-item price) within the following ~6
+	// children belong to that header. We walk children rather than
+	// fixed-stride to handle variable-width rows.
 	private static final int GE_HISTORY_LIST_CHILD = 3;
-	private static final int CHILDREN_PER_ROW = 8;
-	private static final int BUY_SELL_INDICATOR_OFFSET = 2;
-	private static final int ITEM_SPRITE_OFFSET = 4;
-	private static final int PRICE_TEXT_OFFSET = 5;
 
 	private final Client client;
 	private final FlipSmartApiClient apiClient;
@@ -152,7 +149,10 @@ public class GEHistoryService
 			Widget[] sample = firstNonEmpty(dyn, kid, nest);
 			if (sample != null && sample.length > 0)
 			{
-				int max = Math.min(sample.length, 8);
+				// Cap at 80 children for the row-list child (idx==3) so we see
+				// 10+ rows and can spot variable-stride layouts. Other children
+				// stay at 8 to keep noise down.
+				int max = Math.min(sample.length, idx == GE_HISTORY_LIST_CHILD ? 80 : 8);
 				for (int j = 0; j < max; j++)
 				{
 					Widget c = sample[j];
@@ -245,13 +245,69 @@ public class GEHistoryService
 		}
 		log.debug("GE History parser: found {} children to scan", children.length);
 
+		// Walk the children looking for "Bought:" / "Sold:" header markers.
+		// Each header anchors a row; the item sprite (carries itemId+qty) and
+		// the price text follow within the next ~6 widgets. This is robust to
+		// variable per-row stride that breaks fixed-offset indexing.
 		List<GEHistoryEntry> entries = new ArrayList<>();
-		int rowCount = children.length / CHILDREN_PER_ROW;
-		for (int row = 0; row < rowCount; row++)
+		for (int i = 0; i < children.length; i++)
 		{
-			tryParseFlatRow(row, children, row * CHILDREN_PER_ROW, entries);
+			Widget w = children[i];
+			if (w == null) continue;
+			String text = w.getText();
+			if (text == null) continue;
+			boolean isBuy;
+			if ("Bought:".equals(text)) isBuy = true;
+			else if ("Sold:".equals(text)) isBuy = false;
+			else continue;
+			tryParseRowAt(children, i, isBuy, entries);
 		}
 		return entries;
+	}
+
+	private void tryParseRowAt(Widget[] children, int headerIdx, boolean isBuy, List<GEHistoryEntry> entries)
+	{
+		Widget itemWidget = null;
+		Widget priceWidget = null;
+		// Scan the next several widgets after the header; stop early at the
+		// next header marker so we never bleed into the following row.
+		int end = Math.min(children.length, headerIdx + 8);
+		for (int j = headerIdx + 1; j < end; j++)
+		{
+			Widget w = children[j];
+			if (w == null) continue;
+			String text = w.getText();
+			if (text != null && ("Bought:".equals(text) || "Sold:".equals(text)))
+			{
+				break;
+			}
+			if (itemWidget == null && w.getItemId() > 0)
+			{
+				itemWidget = w;
+			}
+			if (priceWidget == null && text != null && text.contains("each"))
+			{
+				priceWidget = w;
+			}
+		}
+		if (itemWidget == null || priceWidget == null)
+		{
+			log.debug("Row at {} ({}): missing itemWidget={} priceWidget={}",
+				headerIdx, isBuy ? "Bought" : "Sold", itemWidget != null, priceWidget != null);
+			return;
+		}
+		int itemId = itemWidget.getItemId();
+		int qty = itemWidget.getItemQuantity();
+		int price = parsePerItemPrice(priceWidget);
+		if (qty > 0 && price > 0)
+		{
+			entries.add(new GEHistoryEntry(itemId, isBuy, qty, price));
+		}
+		else
+		{
+			log.debug("Row at {} ({}): id={} qty={} price={} — dropped",
+				headerIdx, isBuy ? "Bought" : "Sold", itemId, qty, price);
+		}
 	}
 
 	private void logWidgetStructure(Widget listWidget)
@@ -288,30 +344,6 @@ public class GEHistoryService
 		log.info("=== end widget structure ===");
 	}
 
-	private void tryParseFlatRow(int row, Widget[] children, int base, List<GEHistoryEntry> entries)
-	{
-		try
-		{
-			Widget itemWidget = safeGet(children, base + ITEM_SPRITE_OFFSET);
-			if (itemWidget == null || itemWidget.getItemId() <= 0)
-			{
-				return;
-			}
-			int itemId = itemWidget.getItemId();
-			int quantity = itemWidget.getItemQuantity();
-			int price = parsePerItemPrice(safeGet(children, base + PRICE_TEXT_OFFSET));
-			boolean isBuy = parseBoughtSold(safeGet(children, base + BUY_SELL_INDICATOR_OFFSET));
-			if (quantity > 0 && price > 0)
-			{
-				entries.add(new GEHistoryEntry(itemId, isBuy, quantity, price));
-			}
-		}
-		catch (Exception e)
-		{
-			log.debug("Failed to parse flat row {}: {}", row, e.getMessage());
-		}
-	}
-
 	/** Price text is "<col=...>X coins</col><br>= Y each" — the per-item price is after the '='. */
 	private static int parsePerItemPrice(Widget widget)
 	{
@@ -321,14 +353,6 @@ public class GEHistoryService
 		int eqIdx = text.lastIndexOf('=');
 		String slice = (eqIdx >= 0) ? text.substring(eqIdx) : text;
 		return parseDigits(slice);
-	}
-
-	/** Header widget reads "Bought:" or "Sold:". */
-	private static boolean parseBoughtSold(Widget widget)
-	{
-		if (widget == null) return true;
-		String text = widget.getText();
-		return text == null || !text.toLowerCase().startsWith("sold");
 	}
 
 	private void backfillOfflineFills(List<GEHistoryEntry> entries)
@@ -427,11 +451,6 @@ public class GEHistoryService
 		{
 			return -1;
 		}
-	}
-
-	private static Widget safeGet(Widget[] array, int index)
-	{
-		return (index >= 0 && index < array.length) ? array[index] : null;
 	}
 
 	@SafeVarargs

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Reads the in-game GE History tab to recover actual fill prices for trades
@@ -43,9 +44,8 @@ public class GEHistoryService
 
 	private final Set<Integer> pendingOfflineFillItemIds = ConcurrentHashMap.newKeySet();
 	private final Map<Integer, TrackedOffer> recentlyPersistedOffers = new ConcurrentHashMap<>();
+	private final AtomicInteger pendingHistoryReadTicks = new AtomicInteger(0);
 	private volatile boolean historyReadThisSession = false;
-	private volatile boolean widgetStructureLogged = false;
-	private volatile int pendingHistoryReadTicks = 0;
 	private volatile boolean chatPromptSent = false;
 	private volatile Runnable onBackfillComplete;
 
@@ -64,120 +64,57 @@ public class GEHistoryService
 
 	public void onHistoryWidgetLoaded()
 	{
-		log.info("GE History widget loaded (group {})", InterfaceID.GE_HISTORY);
 		// WidgetLoaded fires when the interface is *created*, but list rows are
 		// populated by clientscripts that run afterward. Defer two ticks so the
 		// scripts have time to write the row widgets before we scan them.
-		pendingHistoryReadTicks = 2;
+		pendingHistoryReadTicks.set(2);
 	}
 
-	/**
-	 * Called from FlipSmartPlugin.onGameTick. Counts down ticks after WidgetLoaded
-	 * to give clientscripts time to populate the list rows before we read them.
-	 */
+	/** Called from FlipSmartPlugin.onGameTick. */
 	public void onGameTick()
 	{
-		if (pendingHistoryReadTicks <= 0)
+		int prev = pendingHistoryReadTicks.get();
+		if (prev <= 0)
 		{
 			return;
 		}
-		pendingHistoryReadTicks--;
-		if (pendingHistoryReadTicks > 0)
+		if (pendingHistoryReadTicks.decrementAndGet() == 0)
 		{
-			return;
+			readHistoryNow();
 		}
-		readHistoryNow();
 	}
 
 	private void readHistoryNow()
 	{
-		// Don't clear pendingOfflineFillItemIds yet — backfillOfflineFills
-		// reads from it to decide which History rows to post. Clearing too
-		// early skips every match. historyReadThisSession alone is enough
-		// to flip hasUnverifiedOfflineFills() to false (it ANDs both) and
-		// to gate further registerOfflineFill calls.
+		// historyReadThisSession alone gates hasUnverifiedOfflineFills() and
+		// further registerOfflineFill calls; pendingOfflineFillItemIds is
+		// allowed to stay populated until reset() so future reads (e.g. user
+		// reopens History) can still see what we'd registered.
 		historyReadThisSession = true;
-
-		if (!widgetStructureLogged)
-		{
-			dumpHistoryGroup();
-			widgetStructureLogged = true;
-		}
 
 		Widget listWidget = client.getWidget(InterfaceID.GE_HISTORY, GE_HISTORY_LIST_CHILD);
 		if (listWidget == null)
 		{
-			log.info("Deferred read: list widget at child {} still null", GE_HISTORY_LIST_CHILD);
 			return;
 		}
 
 		List<GEHistoryEntry> entries = parseHistoryEntries(listWidget);
 		if (entries.isEmpty())
 		{
-			log.info("Deferred read: parsed 0 history entries from child {} — see group dump above to recalibrate offsets",
-				GE_HISTORY_LIST_CHILD);
 			return;
 		}
 
-		log.info("Read {} GE history entries", entries.size());
-		for (GEHistoryEntry entry : entries)
-		{
-			log.debug("  parsed: {}", entry);
-		}
+		log.debug("Read {} GE history entries", entries.size());
 		backfillOfflineFills(entries);
-	}
-
-	/** Dump every child index 0..47 of group GE_HISTORY so we can see where row data actually lives. */
-	private void dumpHistoryGroup()
-	{
-		log.info("=== Dumping all children of GE_HISTORY group {} ===", InterfaceID.GE_HISTORY);
-		for (int idx = 0; idx < 48; idx++)
-		{
-			Widget w = client.getWidget(InterfaceID.GE_HISTORY, idx);
-			if (w == null) continue;
-			Widget[] dyn = w.getDynamicChildren();
-			Widget[] kid = w.getChildren();
-			Widget[] nest = w.getNestedChildren();
-			int dynN = dyn == null ? 0 : dyn.length;
-			int kidN = kid == null ? -1 : kid.length;
-			int nestN = nest == null ? 0 : nest.length;
-			log.info("  child[{}]: type={} w={} h={} hidden={} text='{}' itemId={} sprite={} dyn={} kid={} nest={}",
-				idx, w.getType(), w.getWidth(), w.getHeight(), w.isHidden(),
-				w.getText() == null ? "" : w.getText(),
-				w.getItemId(), w.getSpriteId(),
-				dynN, kidN, nestN);
-			Widget[] sample = firstNonEmpty(dyn, kid, nest);
-			if (sample != null && sample.length > 0)
-			{
-				// Cap at 80 children for the row-list child (idx==3) so we see
-				// 10+ rows and can spot variable-stride layouts. Other children
-				// stay at 8 to keep noise down.
-				int max = Math.min(sample.length, idx == GE_HISTORY_LIST_CHILD ? 80 : 8);
-				for (int j = 0; j < max; j++)
-				{
-					Widget c = sample[j];
-					if (c == null) continue;
-					log.info("    [{}.{}]: type={} itemId={} qty={} text='{}' color={}",
-						idx, j, c.getType(), c.getItemId(), c.getItemQuantity(),
-						c.getText() == null ? "" : c.getText(),
-						Integer.toHexString(c.getTextColor()));
-				}
-			}
-		}
-		log.info("=== end group dump ===");
 	}
 
 	public void registerOfflineFill(int itemId)
 	{
-		if (!historyReadThisSession)
+		if (!historyReadThisSession && pendingOfflineFillItemIds.add(itemId))
 		{
-			boolean added = pendingOfflineFillItemIds.add(itemId);
-			if (added)
-			{
-				log.info("GE History: registered offline fill for itemId={} (pending count {})",
-					itemId, pendingOfflineFillItemIds.size());
-				maybeSendChatPrompt();
-			}
+			log.debug("Registered offline fill for itemId={} (pending count {})",
+				itemId, pendingOfflineFillItemIds.size());
+			maybeSendChatPrompt();
 		}
 	}
 
@@ -205,12 +142,6 @@ public class GEHistoryService
 	}
 
 	/**
-	 * Snapshot of offers persisted at the previous session's logout — used as
-	 * additional anchors when backfilling, so fully-completed offline trades
-	 * (whose live TrackedOffer no longer exists) can still be matched by
-	 * itemId + isBuy and have their estimated price replaced.
-	 */
-	/**
 	 * Runs after a History-backfill batch lands on the API. Used by the
 	 * plugin to refresh Active Flips / Completed panels so backfilled trades
 	 * appear without the user having to manually reload.
@@ -220,6 +151,12 @@ public class GEHistoryService
 		this.onBackfillComplete = callback;
 	}
 
+	/**
+	 * Snapshot of offers persisted at the previous session's logout — used
+	 * for item-name resolution in the backfill payload, and as the trigger
+	 * for the chat prompt (any persisted state means there might be offline
+	 * activity worth backfilling).
+	 */
 	public void setRecentlyPersistedOffers(Map<Integer, TrackedOffer> offers)
 	{
 		recentlyPersistedOffers.clear();
@@ -227,11 +164,9 @@ public class GEHistoryService
 		{
 			recentlyPersistedOffers.putAll(offers);
 		}
-		log.info("GE History: snapshot loaded with {} persisted offers", recentlyPersistedOffers.size());
 		// Any prior-session activity is reason enough to prompt the user to
-		// open History — the slot-diff and stale-collected-item detections
-		// only catch a subset of cases. Backend dedup makes the backfill safe
-		// regardless: covered rows dedupe, missing ones get inserted.
+		// open History. Backend dedup makes the backfill safe regardless:
+		// covered rows dedupe, missing ones get inserted.
 		if (!recentlyPersistedOffers.isEmpty())
 		{
 			maybeSendChatPrompt();
@@ -253,8 +188,7 @@ public class GEHistoryService
 		pendingOfflineFillItemIds.clear();
 		recentlyPersistedOffers.clear();
 		historyReadThisSession = false;
-		widgetStructureLogged = false;
-		pendingHistoryReadTicks = 0;
+		pendingHistoryReadTicks.set(0);
 		chatPromptSent = false;
 	}
 
@@ -263,10 +197,8 @@ public class GEHistoryService
 		Widget[] children = firstNonEmpty(listWidget.getDynamicChildren(), listWidget.getChildren(), listWidget.getNestedChildren());
 		if (children == null)
 		{
-			log.info("GE History list widget has no dynamic/child/nested children at all");
 			return new ArrayList<>();
 		}
-		log.debug("GE History parser: found {} children to scan", children.length);
 
 		// Walk the children looking for "Bought:" / "Sold:" header markers.
 		// Each header anchors a row; the item sprite (carries itemId+qty) and
@@ -315,8 +247,6 @@ public class GEHistoryService
 		}
 		if (itemWidget == null || priceWidget == null)
 		{
-			log.debug("Row at {} ({}): missing itemWidget={} priceWidget={}",
-				headerIdx, isBuy ? "Bought" : "Sold", itemWidget != null, priceWidget != null);
 			return;
 		}
 		int itemId = itemWidget.getItemId();
@@ -326,45 +256,6 @@ public class GEHistoryService
 		{
 			entries.add(new GEHistoryEntry(itemId, isBuy, qty, price));
 		}
-		else
-		{
-			log.debug("Row at {} ({}): id={} qty={} price={} — dropped",
-				headerIdx, isBuy ? "Bought" : "Sold", itemId, qty, price);
-		}
-	}
-
-	private void logWidgetStructure(Widget listWidget)
-	{
-		log.info("=== GE History widget structure (group {}, child {}) ===",
-			InterfaceID.GE_HISTORY, GE_HISTORY_LIST_CHILD);
-		log.info("List widget: type={}, w={}, h={}, hidden={}",
-			listWidget.getType(), listWidget.getWidth(), listWidget.getHeight(), listWidget.isHidden());
-
-		Widget[] dyn = listWidget.getDynamicChildren();
-		Widget[] kid = listWidget.getChildren();
-		Widget[] nest = listWidget.getNestedChildren();
-		log.info("dynamicChildren={}, getChildren()={}, nestedChildren={}",
-			dyn == null ? "null" : dyn.length,
-			kid == null ? "null" : kid.length,
-			nest == null ? "null" : nest.length);
-
-		Widget[] sample = firstNonEmpty(dyn, kid, nest);
-		if (sample == null)
-		{
-			log.info("No children to dump.");
-			return;
-		}
-		int max = Math.min(sample.length, 24);
-		for (int i = 0; i < max; i++)
-		{
-			Widget c = sample[i];
-			if (c == null) continue;
-			log.info("  [{}]: type={} itemId={} qty={} text='{}' spriteId={} color={}",
-				i, c.getType(), c.getItemId(), c.getItemQuantity(),
-				c.getText() == null ? "" : c.getText(),
-				c.getSpriteId(), Integer.toHexString(c.getTextColor()));
-		}
-		log.info("=== end widget structure ===");
 	}
 
 	/** Price text is "<col=...>X coins</col><br>= Y each" — the per-item price is after the '='. */
@@ -380,27 +271,20 @@ public class GEHistoryService
 
 	private void backfillOfflineFills(List<GEHistoryEntry> entries)
 	{
-		if (!session.isOfflineSyncCompleted())
+		if (!session.isOfflineSyncCompleted() || entries.isEmpty())
 		{
-			log.info("Backfill skipped: offline sync has not completed yet");
 			return;
 		}
 		Optional<String> rsnOpt = session.getRsnSafe();
 		if (rsnOpt.isEmpty())
-		{
-			log.info("Backfill skipped: no RSN available on session");
-			return;
-		}
-		if (entries.isEmpty())
 		{
 			return;
 		}
 		String rsn = rsnOpt.get();
 
 		// Resolve item names from live + persisted-offer state when available.
-		// History rows don't carry the resolved item name on their own widget
-		// data — only the sprite + a free-text label that includes color tags.
-		// The backend tolerates a null item_name; this just gives nicer logs.
+		// The backend tolerates null but resolves from prior transactions on
+		// its side too; this just gives nicer logs.
 		Map<Integer, String> nameByItem = new HashMap<>();
 		for (TrackedOffer o : session.getTrackedOffers().values()) nameByItem.put(o.getItemId(), o.getItemName());
 		for (TrackedOffer o : recentlyPersistedOffers.values()) nameByItem.putIfAbsent(o.getItemId(), o.getItemName());
@@ -414,8 +298,7 @@ public class GEHistoryService
 			));
 		}
 
-		log.info("Backfill: posting {} GE history rows for batch reconciliation (server applies sum-and-delta dedup)",
-			batch.size());
+		log.debug("Posting {} GE history rows for batch reconciliation", batch.size());
 		apiClient.recordHistoryBackfillBatchAsync(rsn, batch)
 			.whenComplete((v, ex) ->
 			{

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -13,13 +13,11 @@ import net.runelite.client.chat.QueuedMessage;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -380,37 +378,39 @@ public class GEHistoryService
 			log.info("Backfill skipped: no RSN available on session");
 			return;
 		}
+		if (entries.isEmpty())
+		{
+			return;
+		}
 		String rsn = rsnOpt.get();
-		if (pendingOfflineFillItemIds.isEmpty())
-		{
-			log.info("Backfill skipped: no offline fills registered this session");
-			return;
-		}
-		List<TrackedOffer> candidates = new ArrayList<>(session.getTrackedOffers().values());
-		candidates.addAll(recentlyPersistedOffers.values());
-		log.info("Backfill: {} history entries vs {} candidate offers ({} live + {} persisted), {} pending item ids",
-			entries.size(), candidates.size(),
-			session.getTrackedOffers().size(), recentlyPersistedOffers.size(),
-			pendingOfflineFillItemIds.size());
-		Map<Integer, TrackedOffer> matchedOffers = new HashMap<>();
-		List<CompletableFuture<Void>> postFutures = new ArrayList<>();
 
-		for (GEHistoryEntry entry : entries)
-		{
-			tryBackfillEntry(entry, candidates, matchedOffers, rsn, postFutures);
-		}
-		if (matchedOffers.isEmpty())
-		{
-			log.info("Backfill: no history entries matched a registered offline fill");
-			return;
-		}
-		log.info("Backfilled {} offline fills with actual prices from GE history", matchedOffers.size());
+		// Resolve item names from live + persisted-offer state when available.
+		// History rows don't carry the resolved item name on their own widget
+		// data — only the sprite + a free-text label that includes color tags.
+		// The backend tolerates a null item_name; this just gives nicer logs.
+		Map<Integer, String> nameByItem = new HashMap<>();
+		for (TrackedOffer o : session.getTrackedOffers().values()) nameByItem.put(o.getItemId(), o.getItemName());
+		for (TrackedOffer o : recentlyPersistedOffers.values()) nameByItem.putIfAbsent(o.getItemId(), o.getItemName());
 
-		// After all backfill posts complete, ping the panel so newly-paired
-		// flips appear in Active/Completed without the user reloading.
-		CompletableFuture.allOf(postFutures.toArray(new CompletableFuture[0]))
+		List<FlipSmartApiClient.HistoryBackfillEntry> batch = new ArrayList<>(entries.size());
+		for (GEHistoryEntry e : entries)
+		{
+			batch.add(new FlipSmartApiClient.HistoryBackfillEntry(
+				e.getItemId(), nameByItem.get(e.getItemId()),
+				e.isBuy(), e.getQuantity(), e.getPricePerItem()
+			));
+		}
+
+		log.info("Backfill: posting {} GE history rows for batch reconciliation (server applies sum-and-delta dedup)",
+			batch.size());
+		apiClient.recordHistoryBackfillBatchAsync(rsn, batch)
 			.whenComplete((v, ex) ->
 			{
+				if (ex != null)
+				{
+					log.warn("History backfill batch failed: {}", ex.getMessage());
+					return;
+				}
 				Runnable cb = onBackfillComplete;
 				if (cb != null)
 				{
@@ -418,48 +418,6 @@ public class GEHistoryService
 					catch (Exception e) { log.debug("onBackfillComplete callback threw: {}", e.getMessage()); }
 				}
 			});
-	}
-
-	private void tryBackfillEntry(
-		GEHistoryEntry entry,
-		Collection<TrackedOffer> candidates,
-		Map<Integer, TrackedOffer> matchedOffers,
-		String rsn,
-		List<CompletableFuture<Void>> postFutures)
-	{
-		// Only backfill items we registered as offline-completed this session.
-		// Without this gate, opening the History tab would replay every visible
-		// row (up to 30 entries spanning prior sessions) on every read.
-		if (!pendingOfflineFillItemIds.contains(entry.getItemId()))
-		{
-			return;
-		}
-		if (matchedOffers.containsKey(entry.getItemId()))
-		{
-			return;
-		}
-		for (TrackedOffer offer : candidates)
-		{
-			if (offer.getItemId() == entry.getItemId() && offer.isBuy() == entry.isBuy())
-			{
-				matchedOffers.put(entry.getItemId(), offer);
-				postFutures.add(postBackfill(entry, offer, rsn));
-				return;
-			}
-		}
-	}
-
-	private CompletableFuture<Void> postBackfill(GEHistoryEntry entry, TrackedOffer offer, String rsn)
-	{
-		int actualPrice = entry.getPricePerItem();
-		log.info("GE History backfill: {} {} — estimated {}gp, actual {}gp",
-			entry.isBuy() ? "BUY" : "SELL", offer.getItemName(), offer.getPrice(), actualPrice);
-		return apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
-			.builder(entry.getItemId(), offer.getItemName(), entry.isBuy(), entry.getQuantity(), actualPrice)
-			.rsn(rsn)
-			.totalQuantity(offer.getTotalQuantity())
-			.isHistoryBackfill(true)
-			.build());
 	}
 
 	private static int parseDigits(String text)

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -1,0 +1,603 @@
+package com.flipsmart;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.widgets.Widget;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Reads the in-game GE History tab (interface 383) to extract actual fill prices
+ * for trades completed while offline. Cross-references against tracked offers to
+ * backfill estimated prices with actual execution prices.
+ */
+@Slf4j
+@Singleton
+public class GEHistoryService
+{
+	private static final int GE_HISTORY_LIST_CHILD = 3;
+
+	/**
+	 * Number of dynamic child widgets per history row.
+	 * Discovered via Widget Inspector — adjust if the game updates the layout.
+	 */
+	private static final int CHILDREN_PER_ROW = 6;
+
+	/**
+	 * Child offset within each row for the item sprite (carries itemId).
+	 * Set to -1 until discovered via in-game Widget Inspector.
+	 */
+	private static final int ITEM_SPRITE_OFFSET = 2;
+
+	/**
+	 * Child offset within each row for the quantity text.
+	 */
+	private static final int QUANTITY_TEXT_OFFSET = 4;
+
+	/**
+	 * Child offset within each row for the price text.
+	 */
+	private static final int PRICE_TEXT_OFFSET = 5;
+
+	/**
+	 * Child offset within each row for the buy/sell indicator.
+	 * Buy entries use a different sprite or text color than sell entries.
+	 */
+	private static final int BUY_SELL_INDICATOR_OFFSET = 1;
+
+	private final Client client;
+	private final FlipSmartApiClient apiClient;
+	private final PlayerSession session;
+
+	private boolean widgetStructureLogged = false;
+	private long lastReadAtMillis = 0;
+	private List<GEHistoryEntry> lastReadEntries = Collections.emptyList();
+
+	private final Set<Integer> pendingOfflineFillItemIds = ConcurrentHashMap.newKeySet();
+	private volatile boolean historyReadThisSession = false;
+
+	@Inject
+	public GEHistoryService(
+		Client client,
+		FlipSmartApiClient apiClient,
+		PlayerSession session)
+	{
+		this.client = client;
+		this.apiClient = apiClient;
+		this.session = session;
+	}
+
+	/**
+	 * Called when the GE History widget (group 383) is loaded.
+	 * Reads history entries and cross-references with tracked offers.
+	 */
+	public void onHistoryWidgetLoaded()
+	{
+		Widget listWidget = client.getWidget(InterfaceID.GE_HISTORY, GE_HISTORY_LIST_CHILD);
+		if (listWidget == null || listWidget.isHidden())
+		{
+			log.debug("GE History list widget not available");
+			return;
+		}
+
+		if (!widgetStructureLogged)
+		{
+			logWidgetStructure(listWidget);
+			widgetStructureLogged = true;
+		}
+
+		historyReadThisSession = true;
+		pendingOfflineFillItemIds.clear();
+
+		List<GEHistoryEntry> entries = parseHistoryEntries(listWidget);
+		if (entries.isEmpty())
+		{
+			log.debug("No history entries parsed from GE History tab (widget structure may need calibration)");
+			return;
+		}
+
+		lastReadEntries = entries;
+		lastReadAtMillis = System.currentTimeMillis();
+
+		log.info("Read {} GE history entries", entries.size());
+		for (GEHistoryEntry entry : entries)
+		{
+			log.debug("  {}", entry);
+		}
+
+		backfillOfflineFills(entries);
+	}
+
+	/**
+	 * Register that an offline fill was detected for the given item.
+	 * Called by OfflineSyncService when it reports estimated offline fills.
+	 */
+	public void registerOfflineFill(int itemId)
+	{
+		if (!historyReadThisSession)
+		{
+			pendingOfflineFillItemIds.add(itemId);
+		}
+	}
+
+	/**
+	 * Returns true if there are offline fills that haven't been verified
+	 * against GE history yet. Used by the Flip Assist overlay to prompt
+	 * the player to open the History tab.
+	 */
+	public boolean hasUnverifiedOfflineFills()
+	{
+		return !historyReadThisSession && !pendingOfflineFillItemIds.isEmpty();
+	}
+
+	/**
+	 * Reset state on logout/session end.
+	 */
+	public void reset()
+	{
+		pendingOfflineFillItemIds.clear();
+		historyReadThisSession = false;
+		widgetStructureLogged = false;
+		lastReadEntries = Collections.emptyList();
+		lastReadAtMillis = 0;
+	}
+
+	/**
+	 * Dump the widget tree structure for development/debugging.
+	 * Run once per session to discover the exact child layout.
+	 */
+	private void logWidgetStructure(Widget listWidget)
+	{
+		log.info("=== GE History Widget Structure (group {}, child {}) ===",
+			InterfaceID.GE_HISTORY, GE_HISTORY_LIST_CHILD);
+		log.info("Widget type={}, width={}, height={}, text='{}'",
+			listWidget.getType(), listWidget.getWidth(), listWidget.getHeight(), listWidget.getText());
+
+		Widget[] dynamicChildren = listWidget.getDynamicChildren();
+		if (dynamicChildren == null || dynamicChildren.length == 0)
+		{
+			log.info("No dynamic children found - trying getChildren()");
+			Widget[] children = listWidget.getChildren();
+			if (children != null)
+			{
+				log.info("getChildren() returned {} entries (some may be null)", children.length);
+				logChildWidgets(children, "getChildren");
+			}
+			else
+			{
+				log.info("No children found at all. Trying static/nested children...");
+				Widget[] staticChildren = listWidget.getStaticChildren();
+				if (staticChildren != null && staticChildren.length > 0)
+				{
+					log.info("staticChildren: {} entries", staticChildren.length);
+					logChildWidgets(staticChildren, "static");
+				}
+				Widget[] nestedChildren = listWidget.getNestedChildren();
+				if (nestedChildren != null && nestedChildren.length > 0)
+				{
+					log.info("nestedChildren: {} entries", nestedChildren.length);
+					logChildWidgets(nestedChildren, "nested");
+				}
+			}
+		}
+		else
+		{
+			log.info("dynamicChildren: {} entries", dynamicChildren.length);
+			logChildWidgets(dynamicChildren, "dynamic");
+		}
+		log.info("=== End GE History Widget Structure ===");
+	}
+
+	private void logChildWidgets(Widget[] children, String source)
+	{
+		int logged = 0;
+		for (int i = 0; i < children.length && logged < 30; i++)
+		{
+			Widget child = children[i];
+			if (child == null)
+			{
+				continue;
+			}
+			log.info("  [{}] {}[{}]: type={}, itemId={}, itemQty={}, text='{}', spriteId={}, " +
+					"textColor={}, width={}, height={}, hidden={}",
+				logged, source, i,
+				child.getType(),
+				child.getItemId(),
+				child.getItemQuantity(),
+				truncate(child.getText(), 40),
+				child.getSpriteId(),
+				child.getTextColor(),
+				child.getWidth(),
+				child.getHeight(),
+				child.isHidden());
+
+			Widget[] subChildren = child.getDynamicChildren();
+			if (subChildren != null && subChildren.length > 0)
+			{
+				for (int j = 0; j < Math.min(subChildren.length, 8); j++)
+				{
+					Widget sub = subChildren[j];
+					if (sub == null) continue;
+					log.info("    [{}][{}]: type={}, itemId={}, itemQty={}, text='{}', spriteId={}, textColor={}",
+						i, j, sub.getType(), sub.getItemId(), sub.getItemQuantity(),
+						truncate(sub.getText(), 40), sub.getSpriteId(), sub.getTextColor());
+				}
+			}
+
+			logged++;
+		}
+	}
+
+	/**
+	 * Parse history entries from the widget's dynamic children.
+	 *
+	 * The GE history list uses flat dynamic children where every CHILDREN_PER_ROW
+	 * widgets represent one trade entry. The exact offsets (ITEM_SPRITE_OFFSET, etc.)
+	 * were determined via Widget Inspector. If parsing fails, check the debug log
+	 * from logWidgetStructure() and adjust the offsets.
+	 */
+	private List<GEHistoryEntry> parseHistoryEntries(Widget listWidget)
+	{
+		Widget[] dynamicChildren = listWidget.getDynamicChildren();
+		if (dynamicChildren == null || dynamicChildren.length == 0)
+		{
+			Widget[] children = listWidget.getChildren();
+			if (children == null || children.length == 0)
+			{
+				return tryNestedParsing(listWidget);
+			}
+			dynamicChildren = children;
+		}
+
+		List<GEHistoryEntry> entries = new ArrayList<>();
+
+		// First try: flat layout where every N children = one row
+		if (dynamicChildren.length >= CHILDREN_PER_ROW)
+		{
+			entries = parseFlatLayout(dynamicChildren);
+		}
+
+		// Second try: each child is a row container with its own sub-children
+		if (entries.isEmpty())
+		{
+			entries = parseContainerLayout(dynamicChildren);
+		}
+
+		return entries;
+	}
+
+	/**
+	 * Flat layout: dynamic children are a flat array, every CHILDREN_PER_ROW widgets = one row.
+	 */
+	private List<GEHistoryEntry> parseFlatLayout(Widget[] children)
+	{
+		List<GEHistoryEntry> entries = new ArrayList<>();
+		int rowCount = children.length / CHILDREN_PER_ROW;
+
+		for (int row = 0; row < rowCount; row++)
+		{
+			int baseIdx = row * CHILDREN_PER_ROW;
+
+			try
+			{
+				Widget itemWidget = safeGet(children, baseIdx + ITEM_SPRITE_OFFSET);
+				Widget qtyWidget = safeGet(children, baseIdx + QUANTITY_TEXT_OFFSET);
+				Widget priceWidget = safeGet(children, baseIdx + PRICE_TEXT_OFFSET);
+				Widget buySellWidget = safeGet(children, baseIdx + BUY_SELL_INDICATOR_OFFSET);
+
+				if (itemWidget == null)
+				{
+					continue;
+				}
+
+				int itemId = itemWidget.getItemId();
+				if (itemId <= 0)
+				{
+					continue;
+				}
+
+				int quantity = parseQuantity(qtyWidget);
+				int price = parsePrice(priceWidget);
+				boolean isBuy = parseBuySell(buySellWidget);
+
+				if (quantity > 0 && price > 0)
+				{
+					entries.add(new GEHistoryEntry(itemId, isBuy, quantity, price));
+				}
+			}
+			catch (Exception e)
+			{
+				log.debug("Failed to parse flat row {}: {}", row, e.getMessage());
+			}
+		}
+
+		return entries;
+	}
+
+	/**
+	 * Container layout: each top-level child is a row with its own sub-children.
+	 */
+	private List<GEHistoryEntry> parseContainerLayout(Widget[] children)
+	{
+		List<GEHistoryEntry> entries = new ArrayList<>();
+
+		for (int i = 0; i < children.length; i++)
+		{
+			Widget rowWidget = children[i];
+			if (rowWidget == null || rowWidget.isHidden())
+			{
+				continue;
+			}
+
+			Widget[] subChildren = rowWidget.getDynamicChildren();
+			if (subChildren == null || subChildren.length == 0)
+			{
+				subChildren = rowWidget.getChildren();
+			}
+			if (subChildren == null || subChildren.length < 3)
+			{
+				continue;
+			}
+
+			try
+			{
+				GEHistoryEntry entry = parseRowFromSubChildren(subChildren);
+				if (entry != null)
+				{
+					entries.add(entry);
+				}
+			}
+			catch (Exception e)
+			{
+				log.debug("Failed to parse container row {}: {}", i, e.getMessage());
+			}
+		}
+
+		return entries;
+	}
+
+	private GEHistoryEntry parseRowFromSubChildren(Widget[] subChildren)
+	{
+		int itemId = -1;
+		int quantity = -1;
+		int price = -1;
+		boolean isBuy = true;
+
+		for (Widget sub : subChildren)
+		{
+			if (sub == null) continue;
+
+			if (sub.getItemId() > 0 && itemId <= 0)
+			{
+				itemId = sub.getItemId();
+				if (sub.getItemQuantity() > 0)
+				{
+					quantity = sub.getItemQuantity();
+				}
+			}
+
+			String text = sub.getText();
+			if (text != null && !text.isEmpty())
+			{
+				if (text.contains("gp") || text.contains("coin") || text.contains(","))
+				{
+					int parsed = parseGpString(text);
+					if (parsed > 0) price = parsed;
+				}
+				else if (text.matches(".*\\d+.*") && quantity <= 0)
+				{
+					int parsed = parseNumericString(text);
+					if (parsed > 0) quantity = parsed;
+				}
+			}
+
+			if (sub.getTextColor() == 0x00ff00 || sub.getTextColor() == 0x0dc10d)
+			{
+				isBuy = true;
+			}
+			else if (sub.getTextColor() == 0xff0000 || sub.getTextColor() == 0xd40000)
+			{
+				isBuy = false;
+			}
+		}
+
+		if (itemId > 0 && quantity > 0 && price > 0)
+		{
+			return new GEHistoryEntry(itemId, isBuy, quantity, price);
+		}
+		return null;
+	}
+
+	/**
+	 * Fallback: try nested children of the list widget.
+	 */
+	private List<GEHistoryEntry> tryNestedParsing(Widget listWidget)
+	{
+		Widget[] nested = listWidget.getNestedChildren();
+		if (nested != null && nested.length > 0)
+		{
+			return parseContainerLayout(nested);
+		}
+		return Collections.emptyList();
+	}
+
+	/**
+	 * Cross-reference history entries with tracked offers to find offline fills
+	 * where we estimated the price. Re-report with actual prices from history.
+	 */
+	private void backfillOfflineFills(List<GEHistoryEntry> entries)
+	{
+		if (!session.isOfflineSyncCompleted())
+		{
+			log.debug("Offline sync not yet completed — skipping backfill");
+			return;
+		}
+
+		Optional<String> rsnOpt = session.getRsnSafe();
+		if (rsnOpt.isEmpty())
+		{
+			log.debug("No RSN available — skipping backfill");
+			return;
+		}
+		String rsn = rsnOpt.get();
+
+		Map<Integer, TrackedOffer> trackedOffers = session.getTrackedOffers();
+		Map<Integer, TrackedOffer> matchedOffers = new HashMap<>();
+
+		for (GEHistoryEntry entry : entries)
+		{
+			for (Map.Entry<Integer, TrackedOffer> offerEntry : trackedOffers.entrySet())
+			{
+				TrackedOffer offer = offerEntry.getValue();
+				if (offer.getItemId() != entry.getItemId() || offer.isBuy() != entry.isBuy())
+				{
+					continue;
+				}
+
+				int estimatedPrice = offer.getPrice();
+				int actualPrice = entry.getPricePerItem();
+
+				if (estimatedPrice != actualPrice && !matchedOffers.containsKey(entry.getItemId()))
+				{
+					matchedOffers.put(entry.getItemId(), offer);
+					log.info("GE History backfill: {} {} — estimated {}gp, actual {}gp (delta: {}gp)",
+						entry.isBuy() ? "BUY" : "SELL",
+						offer.getItemName(),
+						estimatedPrice, actualPrice, actualPrice - estimatedPrice);
+
+					apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
+						.builder(entry.getItemId(), offer.getItemName(), entry.isBuy(),
+							entry.getQuantity(), actualPrice)
+						.rsn(rsn)
+						.totalQuantity(offer.getTotalQuantity())
+						.isHistoryBackfill(true)
+						.build());
+				}
+			}
+		}
+
+		if (matchedOffers.isEmpty())
+		{
+			log.debug("No offline fills to backfill from GE history");
+		}
+		else
+		{
+			log.info("Backfilled {} offline fills with actual prices from GE history", matchedOffers.size());
+		}
+	}
+
+	public List<GEHistoryEntry> getLastReadEntries()
+	{
+		return Collections.unmodifiableList(lastReadEntries);
+	}
+
+	public long getLastReadAtMillis()
+	{
+		return lastReadAtMillis;
+	}
+
+	// =====================
+	// Parsing Helpers
+	// =====================
+
+	private int parseQuantity(Widget widget)
+	{
+		if (widget == null) return -1;
+		if (widget.getItemQuantity() > 0) return widget.getItemQuantity();
+		return parseNumericString(widget.getText());
+	}
+
+	private int parsePrice(Widget widget)
+	{
+		if (widget == null) return -1;
+		String text = widget.getText();
+		if (text == null || text.isEmpty()) return -1;
+		return parseGpString(text);
+	}
+
+	private boolean parseBuySell(Widget widget)
+	{
+		if (widget == null) return true;
+
+		int color = widget.getTextColor();
+		if (color == 0xff0000 || color == 0xd40000 || color == 0xff981f)
+		{
+			return false;
+		}
+
+		String text = widget.getText();
+		if (text != null)
+		{
+			String lower = text.toLowerCase();
+			if (lower.contains("sold") || lower.contains("sell"))
+			{
+				return false;
+			}
+		}
+
+		int spriteId = widget.getSpriteId();
+		if (spriteId > 0)
+		{
+			// Sell sprites typically have a red/orange arrow
+			// This may need adjustment after Widget Inspector discovery
+		}
+
+		return true;
+	}
+
+	private int parseGpString(String text)
+	{
+		if (text == null) return -1;
+		String cleaned = text.replaceAll("[^0-9]", "");
+		if (cleaned.isEmpty()) return -1;
+		try
+		{
+			long val = Long.parseLong(cleaned);
+			return val > Integer.MAX_VALUE ? -1 : (int) val;
+		}
+		catch (NumberFormatException e)
+		{
+			return -1;
+		}
+	}
+
+	private int parseNumericString(String text)
+	{
+		if (text == null) return -1;
+		String cleaned = text.replaceAll("[^0-9]", "");
+		if (cleaned.isEmpty()) return -1;
+		try
+		{
+			return Integer.parseInt(cleaned);
+		}
+		catch (NumberFormatException e)
+		{
+			return -1;
+		}
+	}
+
+	private Widget safeGet(Widget[] array, int index)
+	{
+		if (index >= 0 && index < array.length)
+		{
+			return array[index];
+		}
+		return null;
+	}
+
+	private String truncate(String text, int maxLen)
+	{
+		if (text == null) return "";
+		return text.length() > maxLen ? text.substring(0, maxLen) + "..." : text;
+	}
+}

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -48,6 +49,7 @@ public class GEHistoryService
 	private volatile boolean widgetStructureLogged = false;
 	private volatile int pendingHistoryReadTicks = 0;
 	private volatile boolean chatPromptSent = false;
+	private volatile Runnable onBackfillComplete;
 
 	@Inject
 	public GEHistoryService(
@@ -210,6 +212,16 @@ public class GEHistoryService
 	 * (whose live TrackedOffer no longer exists) can still be matched by
 	 * itemId + isBuy and have their estimated price replaced.
 	 */
+	/**
+	 * Runs after a History-backfill batch lands on the API. Used by the
+	 * plugin to refresh Active Flips / Completed panels so backfilled trades
+	 * appear without the user having to manually reload.
+	 */
+	public void setOnBackfillComplete(Runnable callback)
+	{
+		this.onBackfillComplete = callback;
+	}
+
 	public void setRecentlyPersistedOffers(Map<Integer, TrackedOffer> offers)
 	{
 		recentlyPersistedOffers.clear();
@@ -381,26 +393,39 @@ public class GEHistoryService
 			session.getTrackedOffers().size(), recentlyPersistedOffers.size(),
 			pendingOfflineFillItemIds.size());
 		Map<Integer, TrackedOffer> matchedOffers = new HashMap<>();
+		List<CompletableFuture<Void>> postFutures = new ArrayList<>();
 
 		for (GEHistoryEntry entry : entries)
 		{
-			tryBackfillEntry(entry, candidates, matchedOffers, rsn);
+			tryBackfillEntry(entry, candidates, matchedOffers, rsn, postFutures);
 		}
 		if (matchedOffers.isEmpty())
 		{
 			log.info("Backfill: no history entries matched a registered offline fill");
+			return;
 		}
-		else
-		{
-			log.info("Backfilled {} offline fills with actual prices from GE history", matchedOffers.size());
-		}
+		log.info("Backfilled {} offline fills with actual prices from GE history", matchedOffers.size());
+
+		// After all backfill posts complete, ping the panel so newly-paired
+		// flips appear in Active/Completed without the user reloading.
+		CompletableFuture.allOf(postFutures.toArray(new CompletableFuture[0]))
+			.whenComplete((v, ex) ->
+			{
+				Runnable cb = onBackfillComplete;
+				if (cb != null)
+				{
+					try { cb.run(); }
+					catch (Exception e) { log.debug("onBackfillComplete callback threw: {}", e.getMessage()); }
+				}
+			});
 	}
 
 	private void tryBackfillEntry(
 		GEHistoryEntry entry,
 		Collection<TrackedOffer> candidates,
 		Map<Integer, TrackedOffer> matchedOffers,
-		String rsn)
+		String rsn,
+		List<CompletableFuture<Void>> postFutures)
 	{
 		// Only backfill items we registered as offline-completed this session.
 		// Without this gate, opening the History tab would replay every visible
@@ -418,18 +443,18 @@ public class GEHistoryService
 			if (offer.getItemId() == entry.getItemId() && offer.isBuy() == entry.isBuy())
 			{
 				matchedOffers.put(entry.getItemId(), offer);
-				postBackfill(entry, offer, rsn);
+				postFutures.add(postBackfill(entry, offer, rsn));
 				return;
 			}
 		}
 	}
 
-	private void postBackfill(GEHistoryEntry entry, TrackedOffer offer, String rsn)
+	private CompletableFuture<Void> postBackfill(GEHistoryEntry entry, TrackedOffer offer, String rsn)
 	{
 		int actualPrice = entry.getPricePerItem();
 		log.info("GE History backfill: {} {} — estimated {}gp, actual {}gp",
 			entry.isBuy() ? "BUY" : "SELL", offer.getItemName(), offer.getPrice(), actualPrice);
-		apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
+		return apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
 			.builder(entry.getItemId(), offer.getItemName(), entry.isBuy(), entry.getQuantity(), actualPrice)
 			.rsn(rsn)
 			.totalQuantity(offer.getTotalQuantity())

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -8,6 +8,7 @@ import net.runelite.api.widgets.Widget;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,7 @@ public class GEHistoryService
 	private final PlayerSession session;
 
 	private final Set<Integer> pendingOfflineFillItemIds = ConcurrentHashMap.newKeySet();
+	private final Map<Integer, TrackedOffer> recentlyPersistedOffers = new ConcurrentHashMap<>();
 	private volatile boolean historyReadThisSession = false;
 
 	@Inject
@@ -77,6 +79,21 @@ public class GEHistoryService
 		}
 	}
 
+	/**
+	 * Snapshot of offers persisted at the previous session's logout — used as
+	 * additional anchors when backfilling, so fully-completed offline trades
+	 * (whose live TrackedOffer no longer exists) can still be matched by
+	 * itemId + isBuy and have their estimated price replaced.
+	 */
+	public void setRecentlyPersistedOffers(Map<Integer, TrackedOffer> offers)
+	{
+		recentlyPersistedOffers.clear();
+		if (offers != null)
+		{
+			recentlyPersistedOffers.putAll(offers);
+		}
+	}
+
 	public boolean hasUnverifiedOfflineFills()
 	{
 		return !historyReadThisSession && !pendingOfflineFillItemIds.isEmpty();
@@ -85,6 +102,7 @@ public class GEHistoryService
 	public void reset()
 	{
 		pendingOfflineFillItemIds.clear();
+		recentlyPersistedOffers.clear();
 		historyReadThisSession = false;
 	}
 
@@ -251,12 +269,13 @@ public class GEHistoryService
 			return;
 		}
 		String rsn = rsnOpt.get();
-		Map<Integer, TrackedOffer> trackedOffers = session.getTrackedOffers();
+		List<TrackedOffer> candidates = new ArrayList<>(session.getTrackedOffers().values());
+		candidates.addAll(recentlyPersistedOffers.values());
 		Map<Integer, TrackedOffer> matchedOffers = new HashMap<>();
 
 		for (GEHistoryEntry entry : entries)
 		{
-			tryBackfillEntry(entry, trackedOffers, matchedOffers, rsn);
+			tryBackfillEntry(entry, candidates, matchedOffers, rsn);
 		}
 		if (!matchedOffers.isEmpty())
 		{
@@ -266,7 +285,7 @@ public class GEHistoryService
 
 	private void tryBackfillEntry(
 		GEHistoryEntry entry,
-		Map<Integer, TrackedOffer> trackedOffers,
+		Collection<TrackedOffer> candidates,
 		Map<Integer, TrackedOffer> matchedOffers,
 		String rsn)
 	{
@@ -274,7 +293,7 @@ public class GEHistoryService
 		{
 			return;
 		}
-		for (TrackedOffer offer : trackedOffers.values())
+		for (TrackedOffer offer : candidates)
 		{
 			if (offer.getItemId() == entry.getItemId()
 				&& offer.isBuy() == entry.isBuy()

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -94,8 +94,12 @@ public class GEHistoryService
 
 	private void readHistoryNow()
 	{
+		// Don't clear pendingOfflineFillItemIds yet — backfillOfflineFills
+		// reads from it to decide which History rows to post. Clearing too
+		// early skips every match. historyReadThisSession alone is enough
+		// to flip hasUnverifiedOfflineFills() to false (it ANDs both) and
+		// to gate further registerOfflineFill calls.
 		historyReadThisSession = true;
-		pendingOfflineFillItemIds.clear();
 
 		if (!widgetStructureLogged)
 		{

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -180,45 +180,63 @@ public class GEHistoryService
 
 	private GEHistoryEntry parseRowFromSubChildren(Widget[] subChildren)
 	{
+		RowAcc acc = new RowAcc();
+		for (Widget sub : subChildren)
+		{
+			if (sub != null)
+			{
+				absorbSub(sub, acc);
+			}
+		}
+		return acc.toEntry();
+	}
+
+	private void absorbSub(Widget sub, RowAcc acc)
+	{
+		if (sub.getItemId() > 0 && acc.itemId <= 0)
+		{
+			acc.itemId = sub.getItemId();
+			if (sub.getItemQuantity() > 0)
+			{
+				acc.quantity = sub.getItemQuantity();
+			}
+		}
+		absorbText(sub.getText(), acc);
+		if (isSellColor(sub.getTextColor()))
+		{
+			acc.isBuy = false;
+		}
+	}
+
+	private static void absorbText(String text, RowAcc acc)
+	{
+		if (text == null || text.isEmpty())
+		{
+			return;
+		}
+		if (text.contains("gp") || text.contains("coin") || text.contains(","))
+		{
+			int parsed = parseDigits(text);
+			if (parsed > 0) acc.price = parsed;
+		}
+		else if (acc.quantity <= 0 && text.matches(".*\\d+.*"))
+		{
+			int parsed = parseDigits(text);
+			if (parsed > 0) acc.quantity = parsed;
+		}
+	}
+
+	private static final class RowAcc
+	{
 		int itemId = -1;
 		int quantity = -1;
 		int price = -1;
 		boolean isBuy = true;
 
-		for (Widget sub : subChildren)
+		GEHistoryEntry toEntry()
 		{
-			if (sub == null)
-			{
-				continue;
-			}
-			if (sub.getItemId() > 0 && itemId <= 0)
-			{
-				itemId = sub.getItemId();
-				if (sub.getItemQuantity() > 0)
-				{
-					quantity = sub.getItemQuantity();
-				}
-			}
-			String text = sub.getText();
-			if (text != null && !text.isEmpty())
-			{
-				if (text.contains("gp") || text.contains("coin") || text.contains(","))
-				{
-					int parsed = parseDigits(text);
-					if (parsed > 0) price = parsed;
-				}
-				else if (quantity <= 0 && text.matches(".*\\d+.*"))
-				{
-					int parsed = parseDigits(text);
-					if (parsed > 0) quantity = parsed;
-				}
-			}
-			if (isSellColor(sub.getTextColor()))
-			{
-				isBuy = false;
-			}
+			return (itemId > 0 && quantity > 0 && price > 0) ? new GEHistoryEntry(itemId, isBuy, quantity, price) : null;
 		}
-		return (itemId > 0 && quantity > 0 && price > 0) ? new GEHistoryEntry(itemId, isBuy, quantity, price) : null;
 	}
 
 	private void backfillOfflineFills(List<GEHistoryEntry> entries)
@@ -238,31 +256,48 @@ public class GEHistoryService
 
 		for (GEHistoryEntry entry : entries)
 		{
-			for (TrackedOffer offer : trackedOffers.values())
-			{
-				if (offer.getItemId() != entry.getItemId() || offer.isBuy() != entry.isBuy())
-				{
-					continue;
-				}
-				int actualPrice = entry.getPricePerItem();
-				if (offer.getPrice() != actualPrice && !matchedOffers.containsKey(entry.getItemId()))
-				{
-					matchedOffers.put(entry.getItemId(), offer);
-					log.info("GE History backfill: {} {} — estimated {}gp, actual {}gp",
-						entry.isBuy() ? "BUY" : "SELL", offer.getItemName(), offer.getPrice(), actualPrice);
-					apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
-						.builder(entry.getItemId(), offer.getItemName(), entry.isBuy(), entry.getQuantity(), actualPrice)
-						.rsn(rsn)
-						.totalQuantity(offer.getTotalQuantity())
-						.isHistoryBackfill(true)
-						.build());
-				}
-			}
+			tryBackfillEntry(entry, trackedOffers, matchedOffers, rsn);
 		}
 		if (!matchedOffers.isEmpty())
 		{
 			log.info("Backfilled {} offline fills with actual prices from GE history", matchedOffers.size());
 		}
+	}
+
+	private void tryBackfillEntry(
+		GEHistoryEntry entry,
+		Map<Integer, TrackedOffer> trackedOffers,
+		Map<Integer, TrackedOffer> matchedOffers,
+		String rsn)
+	{
+		if (matchedOffers.containsKey(entry.getItemId()))
+		{
+			return;
+		}
+		for (TrackedOffer offer : trackedOffers.values())
+		{
+			if (offer.getItemId() == entry.getItemId()
+				&& offer.isBuy() == entry.isBuy()
+				&& offer.getPrice() != entry.getPricePerItem())
+			{
+				matchedOffers.put(entry.getItemId(), offer);
+				postBackfill(entry, offer, rsn);
+				return;
+			}
+		}
+	}
+
+	private void postBackfill(GEHistoryEntry entry, TrackedOffer offer, String rsn)
+	{
+		int actualPrice = entry.getPricePerItem();
+		log.info("GE History backfill: {} {} — estimated {}gp, actual {}gp",
+			entry.isBuy() ? "BUY" : "SELL", offer.getItemName(), offer.getPrice(), actualPrice);
+		apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
+			.builder(entry.getItemId(), offer.getItemName(), entry.isBuy(), entry.getQuantity(), actualPrice)
+			.rsn(rsn)
+			.totalQuantity(offer.getTotalQuantity())
+			.isHistoryBackfill(true)
+			.build());
 	}
 
 	private int parseQuantity(Widget widget)
@@ -302,7 +337,7 @@ public class GEHistoryService
 	private static int parseDigits(String text)
 	{
 		if (text == null) return -1;
-		String cleaned = text.replaceAll("[^0-9]", "");
+		String cleaned = text.replaceAll("\\D", "");
 		if (cleaned.isEmpty()) return -1;
 		try
 		{

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -1,9 +1,14 @@
 package com.flipsmart;
 
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.Widget;
+import net.runelite.client.chat.ChatColorType;
+import net.runelite.client.chat.ChatMessageBuilder;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -37,19 +42,26 @@ public class GEHistoryService
 	private final Client client;
 	private final FlipSmartApiClient apiClient;
 	private final PlayerSession session;
+	private final ChatMessageManager chatMessageManager;
 
 	private final Set<Integer> pendingOfflineFillItemIds = ConcurrentHashMap.newKeySet();
 	private final Map<Integer, TrackedOffer> recentlyPersistedOffers = new ConcurrentHashMap<>();
 	private volatile boolean historyReadThisSession = false;
 	private volatile boolean widgetStructureLogged = false;
 	private volatile int pendingHistoryReadTicks = 0;
+	private volatile boolean chatPromptSent = false;
 
 	@Inject
-	public GEHistoryService(Client client, FlipSmartApiClient apiClient, PlayerSession session)
+	public GEHistoryService(
+		Client client,
+		FlipSmartApiClient apiClient,
+		PlayerSession session,
+		ChatMessageManager chatMessageManager)
 	{
 		this.client = client;
 		this.apiClient = apiClient;
 		this.session = session;
+		this.chatMessageManager = chatMessageManager;
 	}
 
 	public void onHistoryWidgetLoaded()
@@ -159,8 +171,32 @@ public class GEHistoryService
 			{
 				log.info("GE History: registered offline fill for itemId={} (pending count {})",
 					itemId, pendingOfflineFillItemIds.size());
+				maybeSendChatPrompt();
 			}
 		}
+	}
+
+	private void maybeSendChatPrompt()
+	{
+		if (chatPromptSent)
+		{
+			return;
+		}
+		chatPromptSent = true;
+		String msg = new ChatMessageBuilder()
+			.append(ChatColorType.HIGHLIGHT)
+			.append("[Flip Smart] ")
+			.append(ChatColorType.NORMAL)
+			.append("Offline trades detected. Open the Grand Exchange and click the ")
+			.append(ChatColorType.HIGHLIGHT)
+			.append("History")
+			.append(ChatColorType.NORMAL)
+			.append(" tab to recover their actual fill prices.")
+			.build();
+		chatMessageManager.queue(QueuedMessage.builder()
+			.type(ChatMessageType.CONSOLE)
+			.runeLiteFormattedMessage(msg)
+			.build());
 	}
 
 	/**
@@ -191,6 +227,7 @@ public class GEHistoryService
 		historyReadThisSession = false;
 		widgetStructureLogged = false;
 		pendingHistoryReadTicks = 0;
+		chatPromptSent = false;
 	}
 
 	private List<GEHistoryEntry> parseHistoryEntries(Widget listWidget)

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -41,6 +41,7 @@ public class GEHistoryService
 	private final Set<Integer> pendingOfflineFillItemIds = ConcurrentHashMap.newKeySet();
 	private final Map<Integer, TrackedOffer> recentlyPersistedOffers = new ConcurrentHashMap<>();
 	private volatile boolean historyReadThisSession = false;
+	private volatile boolean widgetStructureLogged = false;
 
 	@Inject
 	public GEHistoryService(Client client, FlipSmartApiClient apiClient, PlayerSession session)
@@ -52,22 +53,35 @@ public class GEHistoryService
 
 	public void onHistoryWidgetLoaded()
 	{
+		log.info("GE History widget loaded (group {})", InterfaceID.GE_HISTORY);
 		Widget listWidget = client.getWidget(InterfaceID.GE_HISTORY, GE_HISTORY_LIST_CHILD);
 		if (listWidget == null || listWidget.isHidden())
 		{
+			log.info("GE History list widget at child {} is null or hidden — skipping", GE_HISTORY_LIST_CHILD);
 			return;
 		}
 
 		historyReadThisSession = true;
 		pendingOfflineFillItemIds.clear();
 
+		if (!widgetStructureLogged)
+		{
+			logWidgetStructure(listWidget);
+			widgetStructureLogged = true;
+		}
+
 		List<GEHistoryEntry> entries = parseHistoryEntries(listWidget);
 		if (entries.isEmpty())
 		{
+			log.info("Parsed 0 history entries — widget offsets likely need calibration. See structure dump above.");
 			return;
 		}
 
 		log.info("Read {} GE history entries", entries.size());
+		for (GEHistoryEntry entry : entries)
+		{
+			log.debug("  parsed: {}", entry);
+		}
 		backfillOfflineFills(entries);
 	}
 
@@ -75,7 +89,12 @@ public class GEHistoryService
 	{
 		if (!historyReadThisSession)
 		{
-			pendingOfflineFillItemIds.add(itemId);
+			boolean added = pendingOfflineFillItemIds.add(itemId);
+			if (added)
+			{
+				log.info("GE History: registered offline fill for itemId={} (pending count {})",
+					itemId, pendingOfflineFillItemIds.size());
+			}
 		}
 	}
 
@@ -92,6 +111,7 @@ public class GEHistoryService
 		{
 			recentlyPersistedOffers.putAll(offers);
 		}
+		log.info("GE History: snapshot loaded with {} persisted offers", recentlyPersistedOffers.size());
 	}
 
 	public boolean hasUnverifiedOfflineFills()
@@ -104,6 +124,7 @@ public class GEHistoryService
 		pendingOfflineFillItemIds.clear();
 		recentlyPersistedOffers.clear();
 		historyReadThisSession = false;
+		widgetStructureLogged = false;
 	}
 
 	private List<GEHistoryEntry> parseHistoryEntries(Widget listWidget)
@@ -111,15 +132,52 @@ public class GEHistoryService
 		Widget[] children = firstNonEmpty(listWidget.getDynamicChildren(), listWidget.getChildren(), listWidget.getNestedChildren());
 		if (children == null)
 		{
+			log.info("GE History list widget has no dynamic/child/nested children at all");
 			return new ArrayList<>();
 		}
+		log.debug("GE History parser: found {} children to scan", children.length);
 
 		List<GEHistoryEntry> entries = (children.length >= CHILDREN_PER_ROW) ? parseFlatLayout(children) : new ArrayList<>();
 		if (entries.isEmpty())
 		{
+			log.debug("Flat-layout parse returned 0 entries; falling back to container layout");
 			entries = parseContainerLayout(children);
 		}
 		return entries;
+	}
+
+	private void logWidgetStructure(Widget listWidget)
+	{
+		log.info("=== GE History widget structure (group {}, child {}) ===",
+			InterfaceID.GE_HISTORY, GE_HISTORY_LIST_CHILD);
+		log.info("List widget: type={}, w={}, h={}, hidden={}",
+			listWidget.getType(), listWidget.getWidth(), listWidget.getHeight(), listWidget.isHidden());
+
+		Widget[] dyn = listWidget.getDynamicChildren();
+		Widget[] kid = listWidget.getChildren();
+		Widget[] nest = listWidget.getNestedChildren();
+		log.info("dynamicChildren={}, getChildren()={}, nestedChildren={}",
+			dyn == null ? "null" : dyn.length,
+			kid == null ? "null" : kid.length,
+			nest == null ? "null" : nest.length);
+
+		Widget[] sample = firstNonEmpty(dyn, kid, nest);
+		if (sample == null)
+		{
+			log.info("No children to dump.");
+			return;
+		}
+		int max = Math.min(sample.length, 24);
+		for (int i = 0; i < max; i++)
+		{
+			Widget c = sample[i];
+			if (c == null) continue;
+			log.info("  [{}]: type={} itemId={} qty={} text='{}' spriteId={} color={}",
+				i, c.getType(), c.getItemId(), c.getItemQuantity(),
+				c.getText() == null ? "" : c.getText(),
+				c.getSpriteId(), Integer.toHexString(c.getTextColor()));
+		}
+		log.info("=== end widget structure ===");
 	}
 
 	private List<GEHistoryEntry> parseFlatLayout(Widget[] children)
@@ -261,23 +319,32 @@ public class GEHistoryService
 	{
 		if (!session.isOfflineSyncCompleted())
 		{
+			log.info("Backfill skipped: offline sync has not completed yet");
 			return;
 		}
 		Optional<String> rsnOpt = session.getRsnSafe();
 		if (rsnOpt.isEmpty())
 		{
+			log.info("Backfill skipped: no RSN available on session");
 			return;
 		}
 		String rsn = rsnOpt.get();
 		List<TrackedOffer> candidates = new ArrayList<>(session.getTrackedOffers().values());
 		candidates.addAll(recentlyPersistedOffers.values());
+		log.info("Backfill: {} history entries vs {} candidate offers ({} live + {} persisted)",
+			entries.size(), candidates.size(),
+			session.getTrackedOffers().size(), recentlyPersistedOffers.size());
 		Map<Integer, TrackedOffer> matchedOffers = new HashMap<>();
 
 		for (GEHistoryEntry entry : entries)
 		{
 			tryBackfillEntry(entry, candidates, matchedOffers, rsn);
 		}
-		if (!matchedOffers.isEmpty())
+		if (matchedOffers.isEmpty())
+		{
+			log.info("Backfill: no history entries matched a tracked or persisted offer");
+		}
+		else
 		{
 			log.info("Backfilled {} offline fills with actual prices from GE history", matchedOffers.size());
 		}

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -29,15 +29,16 @@ import java.util.concurrent.ConcurrentHashMap;
 @Singleton
 public class GEHistoryService
 {
+	// Confirmed via in-game widget dump: list at child 3 has 240 dynamic
+	// children laid out as 30 rows × 8 children each.
+	//   offset 2: "Bought:" / "Sold:" header (type=4, text-only)
+	//   offset 4: item sprite (type=5, carries itemId + itemQuantity natively)
+	//   offset 5: price text "<col=...>X coins</col><br>= Y each"
 	private static final int GE_HISTORY_LIST_CHILD = 3;
-	private static final int CHILDREN_PER_ROW = 6;
-	private static final int ITEM_SPRITE_OFFSET = 2;
-	private static final int QUANTITY_TEXT_OFFSET = 4;
+	private static final int CHILDREN_PER_ROW = 8;
+	private static final int BUY_SELL_INDICATOR_OFFSET = 2;
+	private static final int ITEM_SPRITE_OFFSET = 4;
 	private static final int PRICE_TEXT_OFFSET = 5;
-	private static final int BUY_SELL_INDICATOR_OFFSET = 1;
-
-	// Sell-side text colors observed on the History widget
-	private static final int[] SELL_COLORS = {0xff0000, 0xd40000, 0xff981f};
 
 	private final Client client;
 	private final FlipSmartApiClient apiClient;
@@ -240,11 +241,11 @@ public class GEHistoryService
 		}
 		log.debug("GE History parser: found {} children to scan", children.length);
 
-		List<GEHistoryEntry> entries = (children.length >= CHILDREN_PER_ROW) ? parseFlatLayout(children) : new ArrayList<>();
-		if (entries.isEmpty())
+		List<GEHistoryEntry> entries = new ArrayList<>();
+		int rowCount = children.length / CHILDREN_PER_ROW;
+		for (int row = 0; row < rowCount; row++)
 		{
-			log.debug("Flat-layout parse returned 0 entries; falling back to container layout");
-			entries = parseContainerLayout(children);
+			tryParseFlatRow(row, children, row * CHILDREN_PER_ROW, entries);
 		}
 		return entries;
 	}
@@ -283,31 +284,19 @@ public class GEHistoryService
 		log.info("=== end widget structure ===");
 	}
 
-	private List<GEHistoryEntry> parseFlatLayout(Widget[] children)
-	{
-		List<GEHistoryEntry> entries = new ArrayList<>();
-		int rowCount = children.length / CHILDREN_PER_ROW;
-		for (int row = 0; row < rowCount; row++)
-		{
-			int base = row * CHILDREN_PER_ROW;
-			tryParseFlatRow(row, children, base, entries);
-		}
-		return entries;
-	}
-
 	private void tryParseFlatRow(int row, Widget[] children, int base, List<GEHistoryEntry> entries)
 	{
 		try
 		{
 			Widget itemWidget = safeGet(children, base + ITEM_SPRITE_OFFSET);
-			int itemId = (itemWidget != null) ? itemWidget.getItemId() : -1;
-			if (itemId <= 0)
+			if (itemWidget == null || itemWidget.getItemId() <= 0)
 			{
 				return;
 			}
-			int quantity = parseQuantity(safeGet(children, base + QUANTITY_TEXT_OFFSET));
-			int price = parsePrice(safeGet(children, base + PRICE_TEXT_OFFSET));
-			boolean isBuy = parseBuySell(safeGet(children, base + BUY_SELL_INDICATOR_OFFSET));
+			int itemId = itemWidget.getItemId();
+			int quantity = itemWidget.getItemQuantity();
+			int price = parsePerItemPrice(safeGet(children, base + PRICE_TEXT_OFFSET));
+			boolean isBuy = parseBoughtSold(safeGet(children, base + BUY_SELL_INDICATOR_OFFSET));
 			if (quantity > 0 && price > 0)
 			{
 				entries.add(new GEHistoryEntry(itemId, isBuy, quantity, price));
@@ -319,103 +308,23 @@ public class GEHistoryService
 		}
 	}
 
-	private List<GEHistoryEntry> parseContainerLayout(Widget[] children)
+	/** Price text is "<col=...>X coins</col><br>= Y each" — the per-item price is after the '='. */
+	private static int parsePerItemPrice(Widget widget)
 	{
-		List<GEHistoryEntry> entries = new ArrayList<>();
-		for (int i = 0; i < children.length; i++)
-		{
-			Widget rowWidget = children[i];
-			if (rowWidget != null && !rowWidget.isHidden())
-			{
-				Widget[] subChildren = rowWidget.getDynamicChildren();
-				if (subChildren == null || subChildren.length == 0)
-				{
-					subChildren = rowWidget.getChildren();
-				}
-				if (subChildren != null && subChildren.length >= 3)
-				{
-					tryParseContainerRow(i, subChildren, entries);
-				}
-			}
-		}
-		return entries;
+		if (widget == null) return -1;
+		String text = widget.getText();
+		if (text == null || text.isEmpty()) return -1;
+		int eqIdx = text.lastIndexOf('=');
+		String slice = (eqIdx >= 0) ? text.substring(eqIdx) : text;
+		return parseDigits(slice);
 	}
 
-	private void tryParseContainerRow(int rowIndex, Widget[] subChildren, List<GEHistoryEntry> entries)
+	/** Header widget reads "Bought:" or "Sold:". */
+	private static boolean parseBoughtSold(Widget widget)
 	{
-		try
-		{
-			GEHistoryEntry entry = parseRowFromSubChildren(subChildren);
-			if (entry != null)
-			{
-				entries.add(entry);
-			}
-		}
-		catch (Exception e)
-		{
-			log.debug("Failed to parse container row {}: {}", rowIndex, e.getMessage());
-		}
-	}
-
-	private GEHistoryEntry parseRowFromSubChildren(Widget[] subChildren)
-	{
-		RowAcc acc = new RowAcc();
-		for (Widget sub : subChildren)
-		{
-			if (sub != null)
-			{
-				absorbSub(sub, acc);
-			}
-		}
-		return acc.toEntry();
-	}
-
-	private void absorbSub(Widget sub, RowAcc acc)
-	{
-		if (sub.getItemId() > 0 && acc.itemId <= 0)
-		{
-			acc.itemId = sub.getItemId();
-			if (sub.getItemQuantity() > 0)
-			{
-				acc.quantity = sub.getItemQuantity();
-			}
-		}
-		absorbText(sub.getText(), acc);
-		if (isSellColor(sub.getTextColor()))
-		{
-			acc.isBuy = false;
-		}
-	}
-
-	private static void absorbText(String text, RowAcc acc)
-	{
-		if (text == null || text.isEmpty())
-		{
-			return;
-		}
-		if (text.contains("gp") || text.contains("coin") || text.contains(","))
-		{
-			int parsed = parseDigits(text);
-			if (parsed > 0) acc.price = parsed;
-		}
-		else if (acc.quantity <= 0 && containsDigit(text))
-		{
-			int parsed = parseDigits(text);
-			if (parsed > 0) acc.quantity = parsed;
-		}
-	}
-
-	private static final class RowAcc
-	{
-		int itemId = -1;
-		int quantity = -1;
-		int price = -1;
-		boolean isBuy = true;
-
-		GEHistoryEntry toEntry()
-		{
-			return (itemId > 0 && quantity > 0 && price > 0) ? new GEHistoryEntry(itemId, isBuy, quantity, price) : null;
-		}
+		if (widget == null) return true;
+		String text = widget.getText();
+		return text == null || !text.toLowerCase().startsWith("sold");
 	}
 
 	private void backfillOfflineFills(List<GEHistoryEntry> entries)
@@ -487,49 +396,6 @@ public class GEHistoryService
 			.totalQuantity(offer.getTotalQuantity())
 			.isHistoryBackfill(true)
 			.build());
-	}
-
-	private int parseQuantity(Widget widget)
-	{
-		if (widget == null) return -1;
-		if (widget.getItemQuantity() > 0) return widget.getItemQuantity();
-		return parseDigits(widget.getText());
-	}
-
-	private int parsePrice(Widget widget)
-	{
-		return (widget == null) ? -1 : parseDigits(widget.getText());
-	}
-
-	private boolean parseBuySell(Widget widget)
-	{
-		if (widget == null) return true;
-		if (isSellColor(widget.getTextColor())) return false;
-		String text = widget.getText();
-		if (text != null)
-		{
-			String lower = text.toLowerCase();
-			if (lower.contains("sold") || lower.contains("sell")) return false;
-		}
-		return true;
-	}
-
-	private static boolean isSellColor(int color)
-	{
-		for (int c : SELL_COLORS)
-		{
-			if (color == c) return true;
-		}
-		return false;
-	}
-
-	private static boolean containsDigit(String text)
-	{
-		for (int i = 0; i < text.length(); i++)
-		{
-			if (Character.isDigit(text.charAt(i))) return true;
-		}
-		return false;
 	}
 
 	private static int parseDigits(String text)

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -207,55 +207,81 @@ public class GEHistoryService
 		List<GEHistoryEntry> entries = new ArrayList<>();
 		for (int i = 0; i < children.length; i++)
 		{
-			Widget w = children[i];
-			if (w == null) continue;
-			String text = w.getText();
-			if (text == null) continue;
-			boolean isBuy;
-			if ("Bought:".equals(text)) isBuy = true;
-			else if ("Sold:".equals(text)) isBuy = false;
-			else continue;
-			tryParseRowAt(children, i, isBuy, entries);
+			Boolean isBuy = headerToIsBuy(children[i]);
+			if (isBuy != null)
+			{
+				tryParseRowAt(children, i, isBuy, entries);
+			}
 		}
 		return entries;
 	}
 
+	/** Returns TRUE for "Bought:", FALSE for "Sold:", null otherwise. */
+	private static Boolean headerToIsBuy(Widget w)
+	{
+		if (w == null) return null;
+		String text = w.getText();
+		if ("Bought:".equals(text)) return Boolean.TRUE;
+		if ("Sold:".equals(text)) return Boolean.FALSE;
+		return null;
+	}
+
 	private void tryParseRowAt(Widget[] children, int headerIdx, boolean isBuy, List<GEHistoryEntry> entries)
 	{
-		Widget itemWidget = null;
-		Widget priceWidget = null;
-		// Scan the next several widgets after the header; stop early at the
-		// next header marker so we never bleed into the following row.
-		int end = Math.min(children.length, headerIdx + 8);
-		for (int j = headerIdx + 1; j < end; j++)
-		{
-			Widget w = children[j];
-			if (w == null) continue;
-			String text = w.getText();
-			if (text != null && ("Bought:".equals(text) || "Sold:".equals(text)))
-			{
-				break;
-			}
-			if (itemWidget == null && w.getItemId() > 0)
-			{
-				itemWidget = w;
-			}
-			if (priceWidget == null && text != null && text.contains("each"))
-			{
-				priceWidget = w;
-			}
-		}
-		if (itemWidget == null || priceWidget == null)
-		{
-			return;
-		}
-		int itemId = itemWidget.getItemId();
-		int qty = itemWidget.getItemQuantity();
-		int price = parsePerItemPrice(priceWidget);
+		RowScan scan = scanRowFrom(children, headerIdx);
+		if (scan.itemWidget == null || scan.priceWidget == null) return;
+		int itemId = scan.itemWidget.getItemId();
+		int qty = scan.itemWidget.getItemQuantity();
+		int price = parsePerItemPrice(scan.priceWidget);
 		if (qty > 0 && price > 0)
 		{
 			entries.add(new GEHistoryEntry(itemId, isBuy, qty, price));
 		}
+	}
+
+	/**
+	 * Scan the children starting just after a header, capturing the first
+	 * item-bearing widget and the first "X each" price text. Stops at the
+	 * next header so we never bleed into the following row.
+	 */
+	private static RowScan scanRowFrom(Widget[] children, int headerIdx)
+	{
+		RowScan scan = new RowScan();
+		int end = Math.min(children.length, headerIdx + 8);
+		for (int j = headerIdx + 1; j < end; j++)
+		{
+			Widget w = children[j];
+			if (w != null && !absorbWidget(w, scan))
+			{
+				break;
+			}
+		}
+		return scan;
+	}
+
+	/** Returns false if the next-header marker is hit (caller should stop). */
+	private static boolean absorbWidget(Widget w, RowScan scan)
+	{
+		String text = w.getText();
+		if ("Bought:".equals(text) || "Sold:".equals(text))
+		{
+			return false;
+		}
+		if (scan.itemWidget == null && w.getItemId() > 0)
+		{
+			scan.itemWidget = w;
+		}
+		if (scan.priceWidget == null && text != null && text.contains("each"))
+		{
+			scan.priceWidget = w;
+		}
+		return true;
+	}
+
+	private static final class RowScan
+	{
+		Widget itemWidget;
+		Widget priceWidget;
 	}
 
 	/** Price text is "<col=...>X coins</col><br>= Y each" — the per-item price is after the '='. */

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -341,11 +341,17 @@ public class GEHistoryService
 			return;
 		}
 		String rsn = rsnOpt.get();
+		if (pendingOfflineFillItemIds.isEmpty())
+		{
+			log.info("Backfill skipped: no offline fills registered this session");
+			return;
+		}
 		List<TrackedOffer> candidates = new ArrayList<>(session.getTrackedOffers().values());
 		candidates.addAll(recentlyPersistedOffers.values());
-		log.info("Backfill: {} history entries vs {} candidate offers ({} live + {} persisted)",
+		log.info("Backfill: {} history entries vs {} candidate offers ({} live + {} persisted), {} pending item ids",
 			entries.size(), candidates.size(),
-			session.getTrackedOffers().size(), recentlyPersistedOffers.size());
+			session.getTrackedOffers().size(), recentlyPersistedOffers.size(),
+			pendingOfflineFillItemIds.size());
 		Map<Integer, TrackedOffer> matchedOffers = new HashMap<>();
 
 		for (GEHistoryEntry entry : entries)
@@ -354,7 +360,7 @@ public class GEHistoryService
 		}
 		if (matchedOffers.isEmpty())
 		{
-			log.info("Backfill: no history entries matched a tracked or persisted offer");
+			log.info("Backfill: no history entries matched a registered offline fill");
 		}
 		else
 		{
@@ -368,15 +374,20 @@ public class GEHistoryService
 		Map<Integer, TrackedOffer> matchedOffers,
 		String rsn)
 	{
+		// Only backfill items we registered as offline-completed this session.
+		// Without this gate, opening the History tab would replay every visible
+		// row (up to 30 entries spanning prior sessions) on every read.
+		if (!pendingOfflineFillItemIds.contains(entry.getItemId()))
+		{
+			return;
+		}
 		if (matchedOffers.containsKey(entry.getItemId()))
 		{
 			return;
 		}
 		for (TrackedOffer offer : candidates)
 		{
-			if (offer.getItemId() == entry.getItemId()
-				&& offer.isBuy() == entry.isBuy()
-				&& offer.getPrice() != entry.getPricePerItem())
+			if (offer.getItemId() == entry.getItemId() && offer.isBuy() == entry.isBuy())
 			{
 				matchedOffers.put(entry.getItemId(), offer);
 				postBackfill(entry, offer, rsn);

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -8,7 +8,6 @@ import net.runelite.api.widgets.Widget;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,83 +16,44 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Reads the in-game GE History tab (interface 383) to extract actual fill prices
- * for trades completed while offline. Cross-references against tracked offers to
- * backfill estimated prices with actual execution prices.
+ * Reads the in-game GE History tab to recover actual fill prices for trades
+ * completed while offline, then posts them to the API as is_history_backfill.
  */
 @Slf4j
 @Singleton
 public class GEHistoryService
 {
 	private static final int GE_HISTORY_LIST_CHILD = 3;
-
-	/**
-	 * Number of dynamic child widgets per history row.
-	 * Discovered via Widget Inspector — adjust if the game updates the layout.
-	 */
 	private static final int CHILDREN_PER_ROW = 6;
-
-	/**
-	 * Child offset within each row for the item sprite (carries itemId).
-	 * Set to -1 until discovered via in-game Widget Inspector.
-	 */
 	private static final int ITEM_SPRITE_OFFSET = 2;
-
-	/**
-	 * Child offset within each row for the quantity text.
-	 */
 	private static final int QUANTITY_TEXT_OFFSET = 4;
-
-	/**
-	 * Child offset within each row for the price text.
-	 */
 	private static final int PRICE_TEXT_OFFSET = 5;
-
-	/**
-	 * Child offset within each row for the buy/sell indicator.
-	 * Buy entries use a different sprite or text color than sell entries.
-	 */
 	private static final int BUY_SELL_INDICATOR_OFFSET = 1;
+
+	// Sell-side text colors observed on the History widget
+	private static final int[] SELL_COLORS = {0xff0000, 0xd40000, 0xff981f};
 
 	private final Client client;
 	private final FlipSmartApiClient apiClient;
 	private final PlayerSession session;
 
-	private boolean widgetStructureLogged = false;
-	private long lastReadAtMillis = 0;
-	private List<GEHistoryEntry> lastReadEntries = Collections.emptyList();
-
 	private final Set<Integer> pendingOfflineFillItemIds = ConcurrentHashMap.newKeySet();
 	private volatile boolean historyReadThisSession = false;
 
 	@Inject
-	public GEHistoryService(
-		Client client,
-		FlipSmartApiClient apiClient,
-		PlayerSession session)
+	public GEHistoryService(Client client, FlipSmartApiClient apiClient, PlayerSession session)
 	{
 		this.client = client;
 		this.apiClient = apiClient;
 		this.session = session;
 	}
 
-	/**
-	 * Called when the GE History widget (group 383) is loaded.
-	 * Reads history entries and cross-references with tracked offers.
-	 */
 	public void onHistoryWidgetLoaded()
 	{
 		Widget listWidget = client.getWidget(InterfaceID.GE_HISTORY, GE_HISTORY_LIST_CHILD);
 		if (listWidget == null || listWidget.isHidden())
 		{
-			log.debug("GE History list widget not available");
 			return;
-		}
-
-		if (!widgetStructureLogged)
-		{
-			logWidgetStructure(listWidget);
-			widgetStructureLogged = true;
 		}
 
 		historyReadThisSession = true;
@@ -102,26 +62,13 @@ public class GEHistoryService
 		List<GEHistoryEntry> entries = parseHistoryEntries(listWidget);
 		if (entries.isEmpty())
 		{
-			log.debug("No history entries parsed from GE History tab (widget structure may need calibration)");
 			return;
 		}
 
-		lastReadEntries = entries;
-		lastReadAtMillis = System.currentTimeMillis();
-
 		log.info("Read {} GE history entries", entries.size());
-		for (GEHistoryEntry entry : entries)
-		{
-			log.debug("  {}", entry);
-		}
-
 		backfillOfflineFills(entries);
 	}
 
-	/**
-	 * Register that an offline fill was detected for the given item.
-	 * Called by OfflineSyncService when it reports estimated offline fills.
-	 */
 	public void registerOfflineFill(int itemId)
 	{
 		if (!historyReadThisSession)
@@ -130,207 +77,72 @@ public class GEHistoryService
 		}
 	}
 
-	/**
-	 * Returns true if there are offline fills that haven't been verified
-	 * against GE history yet. Used by the Flip Assist overlay to prompt
-	 * the player to open the History tab.
-	 */
 	public boolean hasUnverifiedOfflineFills()
 	{
 		return !historyReadThisSession && !pendingOfflineFillItemIds.isEmpty();
 	}
 
-	/**
-	 * Reset state on logout/session end.
-	 */
 	public void reset()
 	{
 		pendingOfflineFillItemIds.clear();
 		historyReadThisSession = false;
-		widgetStructureLogged = false;
-		lastReadEntries = Collections.emptyList();
-		lastReadAtMillis = 0;
 	}
 
-	/**
-	 * Dump the widget tree structure for development/debugging.
-	 * Run once per session to discover the exact child layout.
-	 */
-	private void logWidgetStructure(Widget listWidget)
-	{
-		log.info("=== GE History Widget Structure (group {}, child {}) ===",
-			InterfaceID.GE_HISTORY, GE_HISTORY_LIST_CHILD);
-		log.info("Widget type={}, width={}, height={}, text='{}'",
-			listWidget.getType(), listWidget.getWidth(), listWidget.getHeight(), listWidget.getText());
-
-		Widget[] dynamicChildren = listWidget.getDynamicChildren();
-		if (dynamicChildren == null || dynamicChildren.length == 0)
-		{
-			log.info("No dynamic children found - trying getChildren()");
-			Widget[] children = listWidget.getChildren();
-			if (children != null)
-			{
-				log.info("getChildren() returned {} entries (some may be null)", children.length);
-				logChildWidgets(children, "getChildren");
-			}
-			else
-			{
-				log.info("No children found at all. Trying static/nested children...");
-				Widget[] staticChildren = listWidget.getStaticChildren();
-				if (staticChildren != null && staticChildren.length > 0)
-				{
-					log.info("staticChildren: {} entries", staticChildren.length);
-					logChildWidgets(staticChildren, "static");
-				}
-				Widget[] nestedChildren = listWidget.getNestedChildren();
-				if (nestedChildren != null && nestedChildren.length > 0)
-				{
-					log.info("nestedChildren: {} entries", nestedChildren.length);
-					logChildWidgets(nestedChildren, "nested");
-				}
-			}
-		}
-		else
-		{
-			log.info("dynamicChildren: {} entries", dynamicChildren.length);
-			logChildWidgets(dynamicChildren, "dynamic");
-		}
-		log.info("=== End GE History Widget Structure ===");
-	}
-
-	private void logChildWidgets(Widget[] children, String source)
-	{
-		int logged = 0;
-		for (int i = 0; i < children.length && logged < 30; i++)
-		{
-			Widget child = children[i];
-			if (child == null)
-			{
-				continue;
-			}
-			log.info("  [{}] {}[{}]: type={}, itemId={}, itemQty={}, text='{}', spriteId={}, " +
-					"textColor={}, width={}, height={}, hidden={}",
-				logged, source, i,
-				child.getType(),
-				child.getItemId(),
-				child.getItemQuantity(),
-				truncate(child.getText(), 40),
-				child.getSpriteId(),
-				child.getTextColor(),
-				child.getWidth(),
-				child.getHeight(),
-				child.isHidden());
-
-			Widget[] subChildren = child.getDynamicChildren();
-			if (subChildren != null && subChildren.length > 0)
-			{
-				for (int j = 0; j < Math.min(subChildren.length, 8); j++)
-				{
-					Widget sub = subChildren[j];
-					if (sub == null) continue;
-					log.info("    [{}][{}]: type={}, itemId={}, itemQty={}, text='{}', spriteId={}, textColor={}",
-						i, j, sub.getType(), sub.getItemId(), sub.getItemQuantity(),
-						truncate(sub.getText(), 40), sub.getSpriteId(), sub.getTextColor());
-				}
-			}
-
-			logged++;
-		}
-	}
-
-	/**
-	 * Parse history entries from the widget's dynamic children.
-	 *
-	 * The GE history list uses flat dynamic children where every CHILDREN_PER_ROW
-	 * widgets represent one trade entry. The exact offsets (ITEM_SPRITE_OFFSET, etc.)
-	 * were determined via Widget Inspector. If parsing fails, check the debug log
-	 * from logWidgetStructure() and adjust the offsets.
-	 */
 	private List<GEHistoryEntry> parseHistoryEntries(Widget listWidget)
 	{
-		Widget[] dynamicChildren = listWidget.getDynamicChildren();
-		if (dynamicChildren == null || dynamicChildren.length == 0)
+		Widget[] children = firstNonEmpty(listWidget.getDynamicChildren(), listWidget.getChildren(), listWidget.getNestedChildren());
+		if (children == null)
 		{
-			Widget[] children = listWidget.getChildren();
-			if (children == null || children.length == 0)
-			{
-				return tryNestedParsing(listWidget);
-			}
-			dynamicChildren = children;
+			return new ArrayList<>();
 		}
 
-		List<GEHistoryEntry> entries = new ArrayList<>();
-
-		// First try: flat layout where every N children = one row
-		if (dynamicChildren.length >= CHILDREN_PER_ROW)
-		{
-			entries = parseFlatLayout(dynamicChildren);
-		}
-
-		// Second try: each child is a row container with its own sub-children
+		List<GEHistoryEntry> entries = (children.length >= CHILDREN_PER_ROW) ? parseFlatLayout(children) : new ArrayList<>();
 		if (entries.isEmpty())
 		{
-			entries = parseContainerLayout(dynamicChildren);
+			entries = parseContainerLayout(children);
 		}
-
 		return entries;
 	}
 
-	/**
-	 * Flat layout: dynamic children are a flat array, every CHILDREN_PER_ROW widgets = one row.
-	 */
 	private List<GEHistoryEntry> parseFlatLayout(Widget[] children)
 	{
 		List<GEHistoryEntry> entries = new ArrayList<>();
 		int rowCount = children.length / CHILDREN_PER_ROW;
-
 		for (int row = 0; row < rowCount; row++)
 		{
-			int baseIdx = row * CHILDREN_PER_ROW;
-
-			try
-			{
-				Widget itemWidget = safeGet(children, baseIdx + ITEM_SPRITE_OFFSET);
-				Widget qtyWidget = safeGet(children, baseIdx + QUANTITY_TEXT_OFFSET);
-				Widget priceWidget = safeGet(children, baseIdx + PRICE_TEXT_OFFSET);
-				Widget buySellWidget = safeGet(children, baseIdx + BUY_SELL_INDICATOR_OFFSET);
-
-				if (itemWidget == null)
-				{
-					continue;
-				}
-
-				int itemId = itemWidget.getItemId();
-				if (itemId <= 0)
-				{
-					continue;
-				}
-
-				int quantity = parseQuantity(qtyWidget);
-				int price = parsePrice(priceWidget);
-				boolean isBuy = parseBuySell(buySellWidget);
-
-				if (quantity > 0 && price > 0)
-				{
-					entries.add(new GEHistoryEntry(itemId, isBuy, quantity, price));
-				}
-			}
-			catch (Exception e)
-			{
-				log.debug("Failed to parse flat row {}: {}", row, e.getMessage());
-			}
+			int base = row * CHILDREN_PER_ROW;
+			tryParseFlatRow(row, children, base, entries);
 		}
-
 		return entries;
 	}
 
-	/**
-	 * Container layout: each top-level child is a row with its own sub-children.
-	 */
+	private void tryParseFlatRow(int row, Widget[] children, int base, List<GEHistoryEntry> entries)
+	{
+		try
+		{
+			Widget itemWidget = safeGet(children, base + ITEM_SPRITE_OFFSET);
+			int itemId = (itemWidget != null) ? itemWidget.getItemId() : -1;
+			if (itemId <= 0)
+			{
+				return;
+			}
+			int quantity = parseQuantity(safeGet(children, base + QUANTITY_TEXT_OFFSET));
+			int price = parsePrice(safeGet(children, base + PRICE_TEXT_OFFSET));
+			boolean isBuy = parseBuySell(safeGet(children, base + BUY_SELL_INDICATOR_OFFSET));
+			if (quantity > 0 && price > 0)
+			{
+				entries.add(new GEHistoryEntry(itemId, isBuy, quantity, price));
+			}
+		}
+		catch (Exception e)
+		{
+			log.debug("Failed to parse flat row {}: {}", row, e.getMessage());
+		}
+	}
+
 	private List<GEHistoryEntry> parseContainerLayout(Widget[] children)
 	{
 		List<GEHistoryEntry> entries = new ArrayList<>();
-
 		for (int i = 0; i < children.length; i++)
 		{
 			Widget rowWidget = children[i];
@@ -347,7 +159,6 @@ public class GEHistoryService
 				}
 			}
 		}
-
 		return entries;
 	}
 
@@ -376,8 +187,10 @@ public class GEHistoryService
 
 		for (Widget sub : subChildren)
 		{
-			if (sub == null) continue;
-
+			if (sub == null)
+			{
+				continue;
+			}
 			if (sub.getItemId() > 0 && itemId <= 0)
 			{
 				itemId = sub.getItemId();
@@ -386,99 +199,59 @@ public class GEHistoryService
 					quantity = sub.getItemQuantity();
 				}
 			}
-
 			String text = sub.getText();
 			if (text != null && !text.isEmpty())
 			{
 				if (text.contains("gp") || text.contains("coin") || text.contains(","))
 				{
-					int parsed = parseGpString(text);
+					int parsed = parseDigits(text);
 					if (parsed > 0) price = parsed;
 				}
-				else if (text.matches(".*\\d+.*") && quantity <= 0)
+				else if (quantity <= 0 && text.matches(".*\\d+.*"))
 				{
-					int parsed = parseNumericString(text);
+					int parsed = parseDigits(text);
 					if (parsed > 0) quantity = parsed;
 				}
 			}
-
-			if (sub.getTextColor() == 0x00ff00 || sub.getTextColor() == 0x0dc10d)
-			{
-				isBuy = true;
-			}
-			else if (sub.getTextColor() == 0xff0000 || sub.getTextColor() == 0xd40000)
+			if (isSellColor(sub.getTextColor()))
 			{
 				isBuy = false;
 			}
 		}
-
-		if (itemId > 0 && quantity > 0 && price > 0)
-		{
-			return new GEHistoryEntry(itemId, isBuy, quantity, price);
-		}
-		return null;
+		return (itemId > 0 && quantity > 0 && price > 0) ? new GEHistoryEntry(itemId, isBuy, quantity, price) : null;
 	}
 
-	/**
-	 * Fallback: try nested children of the list widget.
-	 */
-	private List<GEHistoryEntry> tryNestedParsing(Widget listWidget)
-	{
-		Widget[] nested = listWidget.getNestedChildren();
-		if (nested != null && nested.length > 0)
-		{
-			return parseContainerLayout(nested);
-		}
-		return Collections.emptyList();
-	}
-
-	/**
-	 * Cross-reference history entries with tracked offers to find offline fills
-	 * where we estimated the price. Re-report with actual prices from history.
-	 */
 	private void backfillOfflineFills(List<GEHistoryEntry> entries)
 	{
 		if (!session.isOfflineSyncCompleted())
 		{
-			log.debug("Offline sync not yet completed — skipping backfill");
 			return;
 		}
-
 		Optional<String> rsnOpt = session.getRsnSafe();
 		if (rsnOpt.isEmpty())
 		{
-			log.debug("No RSN available — skipping backfill");
 			return;
 		}
 		String rsn = rsnOpt.get();
-
 		Map<Integer, TrackedOffer> trackedOffers = session.getTrackedOffers();
 		Map<Integer, TrackedOffer> matchedOffers = new HashMap<>();
 
 		for (GEHistoryEntry entry : entries)
 		{
-			for (Map.Entry<Integer, TrackedOffer> offerEntry : trackedOffers.entrySet())
+			for (TrackedOffer offer : trackedOffers.values())
 			{
-				TrackedOffer offer = offerEntry.getValue();
 				if (offer.getItemId() != entry.getItemId() || offer.isBuy() != entry.isBuy())
 				{
 					continue;
 				}
-
-				int estimatedPrice = offer.getPrice();
 				int actualPrice = entry.getPricePerItem();
-
-				if (estimatedPrice != actualPrice && !matchedOffers.containsKey(entry.getItemId()))
+				if (offer.getPrice() != actualPrice && !matchedOffers.containsKey(entry.getItemId()))
 				{
 					matchedOffers.put(entry.getItemId(), offer);
-					log.info("GE History backfill: {} {} — estimated {}gp, actual {}gp (delta: {}gp)",
-						entry.isBuy() ? "BUY" : "SELL",
-						offer.getItemName(),
-						estimatedPrice, actualPrice, actualPrice - estimatedPrice);
-
+					log.info("GE History backfill: {} {} — estimated {}gp, actual {}gp",
+						entry.isBuy() ? "BUY" : "SELL", offer.getItemName(), offer.getPrice(), actualPrice);
 					apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
-						.builder(entry.getItemId(), offer.getItemName(), entry.isBuy(),
-							entry.getQuantity(), actualPrice)
+						.builder(entry.getItemId(), offer.getItemName(), entry.isBuy(), entry.getQuantity(), actualPrice)
 						.rsn(rsn)
 						.totalQuantity(offer.getTotalQuantity())
 						.isHistoryBackfill(true)
@@ -486,77 +259,47 @@ public class GEHistoryService
 				}
 			}
 		}
-
-		if (matchedOffers.isEmpty())
-		{
-			log.debug("No offline fills to backfill from GE history");
-		}
-		else
+		if (!matchedOffers.isEmpty())
 		{
 			log.info("Backfilled {} offline fills with actual prices from GE history", matchedOffers.size());
 		}
 	}
 
-	public List<GEHistoryEntry> getLastReadEntries()
-	{
-		return Collections.unmodifiableList(lastReadEntries);
-	}
-
-	public long getLastReadAtMillis()
-	{
-		return lastReadAtMillis;
-	}
-
-	// =====================
-	// Parsing Helpers
-	// =====================
-
 	private int parseQuantity(Widget widget)
 	{
 		if (widget == null) return -1;
 		if (widget.getItemQuantity() > 0) return widget.getItemQuantity();
-		return parseNumericString(widget.getText());
+		return parseDigits(widget.getText());
 	}
 
 	private int parsePrice(Widget widget)
 	{
-		if (widget == null) return -1;
-		String text = widget.getText();
-		if (text == null || text.isEmpty()) return -1;
-		return parseGpString(text);
+		return (widget == null) ? -1 : parseDigits(widget.getText());
 	}
 
 	private boolean parseBuySell(Widget widget)
 	{
 		if (widget == null) return true;
-
-		int color = widget.getTextColor();
-		if (color == 0xff0000 || color == 0xd40000 || color == 0xff981f)
-		{
-			return false;
-		}
-
+		if (isSellColor(widget.getTextColor())) return false;
 		String text = widget.getText();
 		if (text != null)
 		{
 			String lower = text.toLowerCase();
-			if (lower.contains("sold") || lower.contains("sell"))
-			{
-				return false;
-			}
+			if (lower.contains("sold") || lower.contains("sell")) return false;
 		}
-
-		int spriteId = widget.getSpriteId();
-		if (spriteId > 0)
-		{
-			// Sell sprites typically have a red/orange arrow
-			// This may need adjustment after Widget Inspector discovery
-		}
-
 		return true;
 	}
 
-	private int parseGpString(String text)
+	private static boolean isSellColor(int color)
+	{
+		for (int c : SELL_COLORS)
+		{
+			if (color == c) return true;
+		}
+		return false;
+	}
+
+	private static int parseDigits(String text)
 	{
 		if (text == null) return -1;
 		String cleaned = text.replaceAll("[^0-9]", "");
@@ -564,7 +307,7 @@ public class GEHistoryService
 		try
 		{
 			long val = Long.parseLong(cleaned);
-			return val > Integer.MAX_VALUE ? -1 : (int) val;
+			return (val > Integer.MAX_VALUE) ? -1 : (int) val;
 		}
 		catch (NumberFormatException e)
 		{
@@ -572,33 +315,18 @@ public class GEHistoryService
 		}
 	}
 
-	private int parseNumericString(String text)
+	private static Widget safeGet(Widget[] array, int index)
 	{
-		if (text == null) return -1;
-		String cleaned = text.replaceAll("[^0-9]", "");
-		if (cleaned.isEmpty()) return -1;
-		try
-		{
-			return Integer.parseInt(cleaned);
-		}
-		catch (NumberFormatException e)
-		{
-			return -1;
-		}
+		return (index >= 0 && index < array.length) ? array[index] : null;
 	}
 
-	private Widget safeGet(Widget[] array, int index)
+	@SafeVarargs
+	private static Widget[] firstNonEmpty(Widget[]... candidates)
 	{
-		if (index >= 0 && index < array.length)
+		for (Widget[] c : candidates)
 		{
-			return array[index];
+			if (c != null && c.length > 0) return c;
 		}
 		return null;
-	}
-
-	private String truncate(String text, int maxLen)
-	{
-		if (text == null) return "";
-		return text.length() > maxLen ? text.substring(0, maxLen) + "..." : text;
 	}
 }

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -47,6 +47,7 @@ public class OfflineSyncService
 	private final Client client;
 	private final ClientThread clientThread;
 	private final ActiveFlipTracker activeFlipTracker;
+	private final GEHistoryService geHistoryService;
 
 	/** Callback invoked after sync is complete (for scheduling post-sync tasks) */
 	private Runnable onSyncComplete;
@@ -59,7 +60,8 @@ public class OfflineSyncService
 		Gson gson,
 		Client client,
 		ClientThread clientThread,
-		ActiveFlipTracker activeFlipTracker)
+		ActiveFlipTracker activeFlipTracker,
+		GEHistoryService geHistoryService)
 	{
 		this.session = session;
 		this.apiClient = apiClient;
@@ -68,6 +70,7 @@ public class OfflineSyncService
 		this.client = client;
 		this.clientThread = clientThread;
 		this.activeFlipTracker = activeFlipTracker;
+		this.geHistoryService = geHistoryService;
 	}
 
 	public void setOnSyncComplete(Runnable onSyncComplete)
@@ -354,6 +357,7 @@ public class OfflineSyncService
 				// Track inventory locally so a sell can be queued; backend rejects
 				// is_offline_fill submissions after #597, so no transaction is recorded.
 				session.addCollectedItem(currentOffer.getItemId(), currentOffer.getPreviousQuantitySold());
+				geHistoryService.registerOfflineFill(currentOffer.getItemId());
 			}
 		}
 	}
@@ -410,6 +414,7 @@ public class OfflineSyncService
 				log.debug("Sell slot empty for {} and no inventory - dismissing active flip",
 					persistedOffer.getItemName());
 				activeFlipTracker.dismissFlip(persistedOffer.getItemId());
+				geHistoryService.registerOfflineFill(persistedOffer.getItemId());
 			}
 		});
 	}
@@ -433,6 +438,7 @@ public class OfflineSyncService
 			{
 				log.debug("No {} found in inventory (had {} fills tracked). Items may have been sold/used offline.",
 					persistedOffer.getItemName(), trackedFills);
+				geHistoryService.registerOfflineFill(persistedOffer.getItemId());
 			}
 		});
 	}
@@ -448,6 +454,7 @@ public class OfflineSyncService
 		if (actualFills > trackedFills)
 		{
 			syncOfflineCompletedOrder(persistedOffer, inventoryCount, trackedFills, actualFills);
+			geHistoryService.registerOfflineFill(persistedOffer.getItemId());
 		}
 		else
 		{

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -431,9 +431,13 @@ public class OfflineSyncService
 			int inventoryCount = getInventoryCountForItem(persistedOffer.getItemId());
 			if (inventoryCount == 0)
 			{
-				log.debug("Sell slot empty for {} and no inventory - dismissing active flip",
+				// Register for History backfill instead of dismissing the local flip.
+				// dismissFlip marks the buy is_manually_closed=true and bumps
+				// quantity_sold=quantity on the API side, which then prevents the
+				// backfill SELL from pairing with the buy. Let the backfill close
+				// the flip naturally; the panel will refresh once it posts.
+				log.debug("Sell slot empty for {} with no inventory — flagging for History backfill",
 					persistedOffer.getItemName());
-				activeFlipTracker.dismissFlip(persistedOffer.getItemId());
 				geHistoryService.registerOfflineFill(persistedOffer.getItemId());
 			}
 		});

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -269,6 +269,11 @@ public class OfflineSyncService
 		log.debug("Loaded {} persisted offers, comparing with {} current offers",
 			persistedOffers.size(), session.getTrackedOffers().size());
 
+		// Hand the snapshot to GEHistoryService so fully-completed offline trades
+		// (whose live TrackedOffer no longer exists post-sync) can still be
+		// matched and backfilled when the user opens the History tab.
+		geHistoryService.setRecentlyPersistedOffers(persistedOffers);
+
 		if (!session.getTrackedOffers().isEmpty())
 		{
 			syncCurrentOffersWithPersisted(persistedOffers);

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -320,6 +320,10 @@ public class OfflineSyncService
 		}
 		for (int itemId : toRemove)
 		{
+			// A collected item disappearing without a tracked sell having
+			// happened in this session means it was sold offline. Register
+			// it for History backfill before we drop it from local state.
+			geHistoryService.registerOfflineFill(itemId);
 			session.removeCollectedItem(itemId);
 		}
 		return toRemove.size();
@@ -357,12 +361,23 @@ public class OfflineSyncService
 			{
 				restoreTimestampIfOlder(currentOffer, persistedOffer);
 			}
-			else if (currentOffer.isBuy() && currentOffer.getPreviousQuantitySold() > 0)
+			else
 			{
-				// Track inventory locally so a sell can be queued; backend rejects
-				// is_offline_fill submissions after #597, so no transaction is recorded.
-				session.addCollectedItem(currentOffer.getItemId(), currentOffer.getPreviousQuantitySold());
-				geHistoryService.registerOfflineFill(currentOffer.getItemId());
+				if (persistedOffer != null && persistedOffer.getItemId() != currentOffer.getItemId())
+				{
+					// Slot reused with a different item — the persisted offer must
+					// have completed offline (or been cancelled). Register it so
+					// the History backfill can disambiguate via the History tab,
+					// which only shows actual completions.
+					geHistoryService.registerOfflineFill(persistedOffer.getItemId());
+				}
+				if (currentOffer.isBuy() && currentOffer.getPreviousQuantitySold() > 0)
+				{
+					// Track inventory locally so a sell can be queued; backend rejects
+					// is_offline_fill submissions after #597, so no transaction is recorded.
+					session.addCollectedItem(currentOffer.getItemId(), currentOffer.getPreviousQuantitySold());
+					geHistoryService.registerOfflineFill(currentOffer.getItemId());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Reads the in-game **GE History** tab and posts every visible row to the backend, where it's reconciled via sum-and-delta dedup against the player's recent transactions. Recovers offline-completed trades — including the case where real-time `GrandExchangeOfferChanged` events captured a partial quantity and the rest filled offline.

Master commits `484494e` / `41d7d60` removed the offline-fill submission paths because the API rejects estimated prices (#597). GE History data is the actual fill price the game records — not an estimate — so the companion API change accepts and persists it on a separate flag, and a new batch endpoint handles dedup centrally.

## Architecture

**Plugin's job:** parse every visible History row on widget open, send the whole batch to the API.

**Server's job:** for each row, sum existing transactions for `(user_id, rsn, item_id, is_buy)` within 48h. Skip if covered, post the missing delta otherwise. Idempotent across repeated reads.

This keeps the History tab as the source of truth for what completed and avoids the failure modes the per-row matching approach had during real-world testing (partial real-time capture, slot-reuse race conditions, History buffer rolloff).

## Changes

- `GEHistoryService` reads the History widget on `WidgetLoaded(GE_HISTORY)`, defers 2 game ticks for clientscript population, walks children using "Bought:" / "Sold:" header anchors (handles variable per-row stride), parses entries
- `backfillOfflineFills` now builds one batch payload of all rows and POSTs to `/transactions/history-backfill-batch`; flip-finder panel refreshes on completion
- `OfflineSyncService` registers offline-detected items at four sites (slot reuse, empty sell slot, completed buy with extra inventory, stale collected items) — these still drive the chat prompt + Flip Assist banner UX, but no longer gate which rows get posted
- Removed `dismissFlip` call from offline-sell detection path (was setting `is_manually_closed=true` on the buy and breaking pairing)
- Flip Assist hint priority: History prompt now overrides `autoStatusMessage` so it surfaces during auto-recommend
- Chat message prompt: `[Flip Smart] Offline trades detected. Open the Grand Exchange and click the History tab to recover their actual fill prices.`

## Companion PR

Backend: Flip-Smart/flip-smart#606. **Must ship before this hits plugin-hub** so end-user clients have a backend that accepts the batch payload.

## Test plan

- [x] Build + tests pass (`./gradlew build`)
- [x] In-game widget structure dump confirmed parser offsets; header-anchored walk handles variable strides
- [x] End-to-end live test: parser read 17 rows correctly; backend posted 7 deltas, deduped 10
- [x] Verified Goading potion(4) (offline-completed sell) and Aranea boots (real-time + offline mixed buy) both reconcile correctly post-fix
- [x] Chat message + Flip Assist green hint both fire on offline-detection
- [ ] One-shot reconciliation script for existing orphan SELLs run on local dev (not committed)

Refs Flip-Smart/flip-smart#450