### PR TITLE
Fix stuck sell queue and stale GE slot timers

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -92,6 +92,9 @@ public class AutoRecommendService
 	// async callback result gets lost due to race conditions
 	private volatile String lastOverlayMessage;
 
+	// Currently-focused collected item sell prompt — used by skip() to remove stuck items
+	private volatile int focusedCollectedItemId = -1;
+
 
 	/**
 	 * Serializable snapshot of auto-recommend state for persistence.
@@ -280,6 +283,7 @@ public class AutoRecommendService
 			session.clearStaleNotifications();
 		}
 		currentIndex = 0;
+		focusedCollectedItemId = -1;
 
 		invokeFocusCallback(null);
 
@@ -668,6 +672,7 @@ public class AutoRecommendService
 	 */
 	private void focusNextAvailableAction()
 	{
+		focusedCollectedItemId = -1;
 		if (hasCollectedItemsToSell())
 		{
 			focusNextCollectedItemSell();
@@ -1776,6 +1781,18 @@ public class AutoRecommendService
 			return;
 		}
 
+		// If we're currently showing a collected-item sell prompt, skip it
+		int collectedId = focusedCollectedItemId;
+		if (collectedId >= 0)
+		{
+			PlayerSession session = plugin.getSession();
+			log.info("Auto-recommend: User skipped collected item sell prompt for item {}", collectedId);
+			session.removeCollectedItem(collectedId);
+			focusedCollectedItemId = -1;
+			focusNextAvailableAction();
+			return;
+		}
+
 		log.info("Auto-recommend: User skipped current recommendation");
 		advanceToNext();
 	}
@@ -1915,6 +1932,7 @@ public class AutoRecommendService
 					priceOffset
 				);
 
+				focusedCollectedItemId = sellableItemId;
 				invokeFocusCallback(focus);
 				invokeQueueAdvancedCallback();
 
@@ -1923,10 +1941,13 @@ public class AutoRecommendService
 				return;
 			}
 
-			// Collected item has no sell price - fall through to buy/wait
-			log.warn("Auto-recommend: Cannot focus sell for collected item {} (price={})",
+			// Collected item has no sell price — clean it up so it doesn't block the queue
+			log.warn("Auto-recommend: Removing collected item {} with no sell price (price={})",
 				sellableItemId, sellPrice);
+			plugin.getSession().removeCollectedItem(sellableItemId);
 		}
+
+		focusedCollectedItemId = -1;
 
 		// No sellable items can be properly displayed - check buy queue
 		if (hasAvailableGESlots() && currentIndex < recommendationQueue.size())
@@ -1988,16 +2009,10 @@ public class AutoRecommendService
 			return hasSellPrice(itemId) ? itemId : -1;
 		}
 
-		// Not in inventory, no buy offer — might be waiting in GE for collection
-		if (session.getCollectedQuantity(itemId) > 0 && hasSellPrice(itemId))
-		{
-			return itemId;
-		}
-
-		if (session.getCollectedQuantity(itemId) <= 0)
-		{
-			staleItems.add(itemId);
-		}
+		// Not in inventory and no active buy offer — item is no longer accessible.
+		// Even if collectedQuantity > 0, the tracking is stale (item was already
+		// collected and sold/used, or the state got out of sync). Mark for cleanup.
+		staleItems.add(itemId);
 		return -1;
 	}
 

--- a/src/main/java/com/flipsmart/TrackedOffer.java
+++ b/src/main/java/com/flipsmart/TrackedOffer.java
@@ -65,6 +65,13 @@ public class TrackedOffer
 		int price, int quantitySold, TrackedOffer existing,
 		GrandExchangeOfferState state)
 	{
+		// Only preserve timestamps from the same item — a slot reused for a
+		// different item must start with a fresh timestamp.
+		if (existing != null && existing.getItemId() != itemId)
+		{
+			existing = null;
+		}
+
 		long originalTimestamp = (existing != null && existing.getCreatedAtMillis() > 0)
 			? existing.getCreatedAtMillis()
 			: System.currentTimeMillis();


### PR DESCRIPTION
## Summary

Two independent bugs are fixed in this PR: the Flip Assist auto-recommend queue getting permanently stuck on collected items the user no longer has, and GE slot timers showing ~50 hours for newly placed offers when a slot is reused for a different item.

## Changes

### Bug Fixes

**Fix: Flip Assist queue stuck on unsellable collected items (`AutoRecommendService.java`)**

Three root causes allowed stale collected-item state to block the queue indefinitely:

- **Stale collected-item tracking removed**: `evaluateCollectedItem` previously treated any item with `collectedQuantity > 0` as still accessible (waiting in GE for collection), even when the item was absent from inventory and had no active buy offer. Items in that state are now unconditionally marked stale and removed, since the tracking is out of sync with reality.
- **Skip clears the focused collected-item prompt**: The skip button previously only advanced the recommendation queue index, so pressing it had no effect when the focused action was a collected-item sell prompt — the same stuck item would reappear on the next cycle. Skip now removes the currently-focused collected item (`focusedCollectedItemId`) and advances to the next action.
- **No-price collected items cleaned up immediately**: Items that reach `focusNextCollectedItemSell` but have no available sell price previously logged a warning and fell through, leaving the item in the list to block the queue indefinitely. They are now removed immediately so the queue can continue.

**Fix: GE slot timers showing ~50h for newly placed offers (`TrackedOffer.java`)**

- **Item ID guard added to `createWithPreservedTimestamps`**: Previously, when a GE slot was reused for a different item, this method copied the old item's creation timestamp onto the new offer because it matched only by slot number. New offers for a different item now receive the current timestamp instead of inheriting the prior item's age.

## Testing

### Automated Tests

No automated tests exist for these services yet.

### Manual Testing

- [x] Start Flip Assist in auto mode, let a buy fill, manually sell the items outside the plugin (bypassing the sell prompt), verify the plugin detects the items are gone, cleans up the collected entry, and moves on to the next action
- [x] If a sell prompt appears for an item you no longer have, press Skip — verify it clears the prompt rather than looping back to it
- [x] Place offers in GE slots that previously held different items, verify the timers show correct elapsed time rather than the prior item's age

## Deployment Notes

- No new dependencies
- No configuration changes
- No migrations required
- Plugin update distributed via RuneLite Plugin Hub on next release

## Checklist

- [x] Root causes identified and addressed individually
- [x] No `Thread.currentThread().interrupt()` calls added
- [x] Code follows existing style conventions
- [x] No debug/log spam added