### PR TITLE
Fix stale flip cleanup race condition during plugin restart

### DIFF
--- a/src/main/java/com/flipsmart/ActiveFlipTracker.java
+++ b/src/main/java/com/flipsmart/ActiveFlipTracker.java
@@ -2,6 +2,8 @@ package com.flipsmart;
 
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.GrandExchangeOffer;
+import net.runelite.api.GrandExchangeOfferState;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.client.callback.ClientThread;
@@ -172,7 +174,35 @@ public class ActiveFlipTracker
 
 	private Set<Integer> collectAllActiveItemIds()
 	{
-		return session.getActiveFlipItemIds();
+		Set<Integer> itemIds = session.getActiveFlipItemIds();
+
+		// Also read directly from the game client's GE state as the definitive
+		// source of truth. This protects against the race condition where
+		// trackedOffers may not be fully populated from login burst events.
+		GrandExchangeOffer[] offers = client.getGrandExchangeOffers();
+		if (offers != null)
+		{
+			int addedFromClient = 0;
+			for (GrandExchangeOffer offer : offers)
+			{
+				if (offer != null && offer.getState() != GrandExchangeOfferState.EMPTY)
+				{
+					if (itemIds.add(offer.getItemId()))
+					{
+						addedFromClient++;
+						log.info("Cleanup safety: item {} found in GE client state but not in tracked offers",
+							offer.getItemId());
+					}
+				}
+			}
+			if (addedFromClient > 0)
+			{
+				log.warn("Cleanup safety caught {} items from client GE state that were missing from session tracking",
+					addedFromClient);
+			}
+		}
+
+		return itemIds;
 	}
 
 	private void handleCleanupResult(Boolean success)

--- a/src/main/java/com/flipsmart/ActiveFlipTracker.java
+++ b/src/main/java/com/flipsmart/ActiveFlipTracker.java
@@ -185,14 +185,12 @@ public class ActiveFlipTracker
 			int addedFromClient = 0;
 			for (GrandExchangeOffer offer : offers)
 			{
-				if (offer != null && offer.getState() != GrandExchangeOfferState.EMPTY)
+				if (offer != null && offer.getState() != GrandExchangeOfferState.EMPTY
+					&& itemIds.add(offer.getItemId()))
 				{
-					if (itemIds.add(offer.getItemId()))
-					{
-						addedFromClient++;
-						log.info("Cleanup safety: item {} found in GE client state but not in tracked offers",
-							offer.getItemId());
-					}
+					addedFromClient++;
+					log.info("Cleanup safety: item {} found in GE client state but not in tracked offers",
+						offer.getItemId());
 				}
 			}
 			if (addedFromClient > 0)

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1048,7 +1048,7 @@ public class FlipSmartPlugin extends Plugin
 
 	private void performStaleFlipCleanup()
 	{
-		if (!session.getTrackedOffers().isEmpty() || session.getCollectedItemIds().isEmpty())
+		if (!session.getTrackedOffers().isEmpty() || !session.getCollectedItemIds().isEmpty())
 		{
 			activeFlipTracker.cleanupStaleActiveFlips();
 			scheduleOneShot(INVENTORY_VALIDATION_DELAY_MS, () ->
@@ -1056,7 +1056,7 @@ public class FlipSmartPlugin extends Plugin
 		}
 		else
 		{
-			log.info("Skipping cleanup - no GE offers detected yet, may not be safe");
+			log.info("Skipping cleanup - no GE offers or collected items detected, may not be safe");
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes a race condition during plugin restart where the stale flip cleanup could incorrectly dismiss active flips. The root cause was twofold: `collectAllActiveItemIds()` relied solely on `trackedOffers` (which may not be fully populated from login burst events), and `performStaleFlipCleanup()` had an inverted guard condition that caused cleanup to run when it should have been skipped.

## Changes

### Bug Fixes

- **Use client GE state as source of truth** — `collectAllActiveItemIds()` in `ActiveFlipTracker` now reads directly from `client.getGrandExchangeOffers()` (the game client's definitive view of all 8 GE slots) in addition to `session.getActiveFlipItemIds()`. This prevents active flips from being dismissed when `trackedOffers` isn't fully populated from login burst events. Logs a warning when the safety net catches items that would have been missed.

- **Fix inverted guard condition** — `performStaleFlipCleanup()` in `FlipSmartPlugin` had `session.getCollectedItemIds().isEmpty()` instead of `!session.getCollectedItemIds().isEmpty()`, causing cleanup to run when collected items were empty — the opposite of the intended behaviour. Updated the accompanying log message to reflect both conditions clearly.

## Testing

### Automated Tests
- Build passes with `./gradlew build`

### Manual Testing
- [x] Restart plugin while GE offers are active — verify active flips are not dismissed
- [x] Log in with active GE offers present — verify cleanup safety net warning appears if `trackedOffers` was behind client state
- [x] Verify cleanup still runs correctly when GE offers and collected items are present

## Deployment Notes

- No environment variable or configuration changes required
- No database migrations

## Checklist

- [x] Bug fix verified with code diff
- [x] Build passes
- [x] No `Thread.currentThread().interrupt()` calls added
- [x] No debug code left in

## Related Issues

Closes Flip-Smart/flip-smart#433