### PR TITLE
Bank tracker: capture equipped gear + send item-level inventory (#354)

### DIFF
--- a/src/main/java/com/flipsmart/BankSnapshotService.java
+++ b/src/main/java/com/flipsmart/BankSnapshotService.java
@@ -131,13 +131,14 @@ public class BankSnapshotService
 				return;
 			}
 
-			long inventoryValue = calculateInventoryValue();
+			List<FlipSmartApiClient.BankItemId> inventoryItems = collectInventoryItems();
+			List<FlipSmartApiClient.BankItemId> gearItems = collectGearItems();
 			long geOffersValue = calculateGEOffersValue();
 
-			log.info("Capturing bank snapshot: {} tradeable items, inv={}, ge={} for RSN {}",
-				items.size(), inventoryValue, geOffersValue, rsn);
+			log.info("Capturing bank snapshot: {} bank items, {} inv items, {} gear items, ge={} for RSN {}",
+				items.size(), inventoryItems.size(), gearItems.size(), geOffersValue, rsn);
 
-			apiClient.createBankSnapshotAsync(rsn, items, inventoryValue, geOffersValue).thenAccept(response ->
+			apiClient.createBankSnapshotAsync(rsn, items, inventoryItems, gearItems, geOffersValue).thenAccept(response ->
 			{
 				if (response != null)
 				{
@@ -259,52 +260,59 @@ public class BankSnapshotService
 	}
 
 	/**
-	 * Calculate the total value of items in the player's inventory.
+	 * Collect tradeable items from the player's inventory.
+	 * The backend prices these server-side, so no GE price is computed here.
+	 * Coins (item_id 995) are included; backend prices coins as 1 GP each.
 	 */
-	private long calculateInventoryValue()
+	private List<FlipSmartApiClient.BankItemId> collectInventoryItems()
 	{
 		ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
 		if (inventory == null)
 		{
-			return 0;
+			return new ArrayList<>();
 		}
-
-		long totalValue = 0;
-
-		for (Item item : inventory.getItems())
-		{
-			totalValue += getInventoryItemValue(item);
-		}
-
-		return totalValue;
+		return collectItemIds(inventory.getItems());
 	}
 
 	/**
-	 * Get the GP value of a single inventory item.
-	 * Returns coin quantity directly, tradeable item value at GE price, or 0.
+	 * Collect tradeable equipped gear items from the EQUIPMENT container.
+	 * The backend prices these server-side.
 	 */
-	private long getInventoryItemValue(Item item)
+	private List<FlipSmartApiClient.BankItemId> collectGearItems()
 	{
-		int itemId = item.getId();
-		int quantity = item.getQuantity();
-
-		if (itemId <= 0 || quantity <= 0)
+		ItemContainer equipment = client.getItemContainer(InventoryID.EQUIPMENT);
+		if (equipment == null)
 		{
-			return 0;
+			return new ArrayList<>();
 		}
+		return collectItemIds(equipment.getItems());
+	}
 
-		if (itemId == COINS_ITEM_ID)
+	/**
+	 * Filter an item array to tradeable items (or coins) and return as a list
+	 * of BankItemId records (item_id + quantity, no client-side price).
+	 */
+	private List<FlipSmartApiClient.BankItemId> collectItemIds(Item[] items)
+	{
+		List<FlipSmartApiClient.BankItemId> out = new ArrayList<>();
+		if (items == null)
 		{
-			return quantity;
+			return out;
 		}
-
-		if (!ItemUtils.isTradeable(itemManager, itemId))
+		for (Item item : items)
 		{
-			return 0;
+			int itemId = item.getId();
+			int quantity = item.getQuantity();
+			if (itemId <= 0 || quantity <= 0)
+			{
+				continue;
+			}
+			if (itemId == COINS_ITEM_ID || ItemUtils.isTradeable(itemManager, itemId))
+			{
+				out.add(new FlipSmartApiClient.BankItemId(itemId, quantity));
+			}
 		}
-
-		int gePrice = itemManager.getItemPrice(itemId);
-		return gePrice > 0 ? (long) quantity * gePrice : 0;
+		return out;
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -1824,6 +1824,22 @@ public class FlipSmartApiClient
 	}
 
 	/**
+	 * Data class for an inventory or gear item.
+	 * Backend prices these server-side, so no value_per_item is sent.
+	 */
+	public static class BankItemId
+	{
+		public final int itemId;
+		public final int quantity;
+
+		public BankItemId(int itemId, int quantity)
+		{
+			this.itemId = itemId;
+			this.quantity = quantity;
+		}
+	}
+
+	/**
 	 * Check if a bank snapshot can be taken (rate limit check)
 	 *
 	 * @param rsn RuneScape Name to check
@@ -1843,27 +1859,31 @@ public class FlipSmartApiClient
 	}
 
 	/**
-	 * Create a bank snapshot with all items and total wealth components
+	 * Create a bank snapshot with bank items, equipped gear, inventory, and GE offers.
+	 *
+	 * Bank items carry plugin-supplied prices; backend re-prices them when zero
+	 * or when they're a known charged variant. Inventory and gear items are
+	 * priced server-side, so only item_id + quantity are sent.
 	 *
 	 * @param rsn RuneScape Name
-	 * @param items List of bank items with quantities and values
-	 * @param inventoryValue Total value of tradeable inventory items (excluding coins)
+	 * @param items Bank items with quantities and values
+	 * @param inventoryItems Tradeable inventory items (priced server-side)
+	 * @param gearItems Equipped gear items (priced server-side)
 	 * @param geOffersValue Total value locked in GE offers
 	 * @return CompletableFuture with BankSnapshotResponse
 	 */
 	public CompletableFuture<BankSnapshotResponse> createBankSnapshotAsync(
 		String rsn,
 		java.util.List<BankItem> items,
-		long inventoryValue,
+		java.util.List<BankItemId> inventoryItems,
+		java.util.List<BankItemId> gearItems,
 		long geOffersValue)
 	{
 		String apiUrl = getApiUrl();
 		String url = String.format("%s/bank/snapshot", apiUrl);
 
-		// Build the request body
 		JsonObject requestBody = new JsonObject();
 		requestBody.addProperty("rsn", rsn);
-		requestBody.addProperty("inventory_value", inventoryValue);
 		requestBody.addProperty("ge_offers_value", geOffersValue);
 
 		com.google.gson.JsonArray itemsArray = new com.google.gson.JsonArray();
@@ -1876,6 +1896,26 @@ public class FlipSmartApiClient
 			itemsArray.add(itemObj);
 		}
 		requestBody.add("items", itemsArray);
+
+		com.google.gson.JsonArray invArray = new com.google.gson.JsonArray();
+		for (BankItemId inv : inventoryItems)
+		{
+			JsonObject obj = new JsonObject();
+			obj.addProperty(JSON_KEY_ITEM_ID, inv.itemId);
+			obj.addProperty("quantity", inv.quantity);
+			invArray.add(obj);
+		}
+		requestBody.add("inventory_items", invArray);
+
+		com.google.gson.JsonArray gearArray = new com.google.gson.JsonArray();
+		for (BankItemId gear : gearItems)
+		{
+			JsonObject obj = new JsonObject();
+			obj.addProperty(JSON_KEY_ITEM_ID, gear.itemId);
+			obj.addProperty("quantity", gear.quantity);
+			gearArray.add(obj);
+		}
+		requestBody.add("gear_items", gearArray);
 
 		RequestBody body = RequestBody.create(JSON, requestBody.toString());
 		Request.Builder requestBuilder = new Request.Builder()

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -27,6 +27,7 @@ public class FlipSmartApiClient
 	private static final String ACCESS_TOKEN_KEY = "access_token";
 	private static final String REFRESH_TOKEN_KEY = "refresh_token";
 	private static final String JSON_KEY_ITEM_ID = "item_id";
+	private static final String JSON_KEY_QUANTITY = "quantity";
 	private static final String JSON_KEY_IS_PREMIUM = "is_premium";
 	private static final String JSON_KEY_RSN_ENTITLEMENT = "rsn_entitlement";
 	private static final String JSON_KEY_STATUS = "status";
@@ -1350,7 +1351,7 @@ public class FlipSmartApiClient
 		jsonBody.addProperty(JSON_KEY_ITEM_ID, request.itemId);
 		jsonBody.addProperty("item_name", request.itemName);
 		jsonBody.addProperty("is_buy", request.isBuy);
-		jsonBody.addProperty("quantity", request.quantity);
+		jsonBody.addProperty(JSON_KEY_QUANTITY, request.quantity);
 		jsonBody.addProperty("price_per_item", request.pricePerItem);
 		if (request.geSlot != null)
 		{
@@ -1891,7 +1892,7 @@ public class FlipSmartApiClient
 		{
 			JsonObject itemObj = new JsonObject();
 			itemObj.addProperty(JSON_KEY_ITEM_ID, item.itemId);
-			itemObj.addProperty("quantity", item.quantity);
+			itemObj.addProperty(JSON_KEY_QUANTITY, item.quantity);
 			itemObj.addProperty("value_per_item", item.valuePerItem);
 			itemsArray.add(itemObj);
 		}
@@ -1902,7 +1903,7 @@ public class FlipSmartApiClient
 		{
 			JsonObject obj = new JsonObject();
 			obj.addProperty(JSON_KEY_ITEM_ID, inv.itemId);
-			obj.addProperty("quantity", inv.quantity);
+			obj.addProperty(JSON_KEY_QUANTITY, inv.quantity);
 			invArray.add(obj);
 		}
 		requestBody.add("inventory_items", invArray);
@@ -1912,7 +1913,7 @@ public class FlipSmartApiClient
 		{
 			JsonObject obj = new JsonObject();
 			obj.addProperty(JSON_KEY_ITEM_ID, gear.itemId);
-			obj.addProperty("quantity", gear.quantity);
+			obj.addProperty(JSON_KEY_QUANTITY, gear.quantity);
 			gearArray.add(obj);
 		}
 		requestBody.add("gear_items", gearArray);


### PR DESCRIPTION
## Summary

Extends the bank snapshot feature to capture equipped gear alongside inventory and bank items, giving the backend a complete picture of the player's tradeable wealth. Inventory items are now sent as individual item IDs and quantities (rather than a pre-summed GP value), allowing the backend to price them with the latest GE data.

This is **Part 2 of 3 for #354** (plugin; web app PR follows). The backend PR for #354 must be deployed before this plugin update ships — the new payload fields (`inventory_items[]` and `gear_items[]`) require the updated backend endpoint, which includes backwards-compatibility handling for older plugin versions.

## Changes

### ✨ New Features
- `BankSnapshotService.collectGearItems()` — reads `InventoryID.EQUIPMENT` (container 94) and returns tradeable equipped items as `BankItemId` records; fulfills AC1 (equipped gear included in snapshots)
- `BankSnapshotService.collectInventoryItems()` — replaces the old `calculateInventoryValue()` aggregate; now sends per-item `{item_id, quantity}` entries so the backend can price them server-side with current GE prices
- `BankSnapshotService.collectItemIds()` — shared private helper that filters an `Item[]` to tradeable items and coins, used by both `collectInventoryItems()` and `collectGearItems()`

### ♻️ Refactoring
- `FlipSmartApiClient.BankItemId` — new inner data class holding `itemId` + `quantity` (no client-side price); used for inventory and gear entries
- `FlipSmartApiClient.createBankSnapshotAsync` — signature updated to accept `inventoryItems` and `gearItems` lists in place of the old `inventoryValue` long; serialises them as `inventory_items[]` and `gear_items[]` JSON arrays in the POST body alongside the existing `items[]` (bank)

## Backend Dependency

> **Deploy the backend #354 PR before shipping this plugin update.**
>
> The payload now includes `inventory_items[]` and `gear_items[]` fields. The backend PR adds server-side pricing for these arrays and includes backwards-compat handling so existing plugin installs (without the new fields) continue to work during the rollout window.

## Charged Items (AC2)

Charged item re-pricing (e.g. Tumeken's Shadow → uncharged GE price) is handled entirely in the backend. The plugin sends the raw item ID; no client-side mapping is required.

## Plugin Hub Compatibility

- No `Thread.currentThread().interrupt()` calls in any catch blocks — exceptions are logged and handled gracefully, with the executor framework managing thread lifecycle
- No new permissions or API surface beyond what the existing bank snapshot flow already used

## Testing

### Automated Tests
- `./gradlew build` passes (all tasks UP-TO-DATE or successful)
- `./gradlew test` passes

### Manual Testing
- [ ] Log in with items equipped (including high-value gear such as Tumeken's Shadow)
- [ ] Open bank — verify plugin submits snapshot
- [ ] Confirm backend log shows non-zero `gear_value` and a correct `total_wealth` sum (bank + inventory + gear + GE offers)
- [ ] Verify items with no GE price are excluded from gear and inventory arrays

## Deployment Notes

- Requires backend #354 PR to be merged and deployed first
- No environment variables or configuration changes on the plugin side
- No RuneLite permission changes required

## Checklist

- [x] `./gradlew build` passes
- [x] No `Thread.currentThread().interrupt()` in catch blocks
- [x] No hardcoded secrets or internal URLs
- [x] Code follows existing style (Lombok, `@Slf4j`, constructor injection)
- [x] Backwards-compat handled on the backend side

## Related Issues

Closes #354