### PR TITLE
Add build=gradle to runelite-plugin.properties

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,5 +1,6 @@
 displayName=Flip Smart
 author=Flip-Smart
+build=gradle
 description=Provides a comprehensive tool for flipping items in the Grand Exchange
 tags=grand exchange,flipping,trading,money making,profit,flip finder
 plugins=com.flipsmart.FlipSmartPlugin


### PR DESCRIPTION
## Summary

Adds the required `build=gradle` property to `runelite-plugin.properties` so the RuneLite plugin-hub packager can successfully complete the package step. Without this entry the packager fails with: `"build" must be set`.

We use `build=gradle` rather than `build=standard` because the plugin uses Lombok's `annotationProcessor` in `build.gradle`, which requires running the full Gradle build rather than the standard classpath-based approach.

## Changes

### 🐛 Bug Fixes
- Added `build=gradle` to `runelite-plugin.properties` between the `author` and `description` lines — fixes the plugin-hub CI pipeline failure

## Testing

### Automated Tests
- N/A — config-only change, no code logic affected

### Manual Testing
- [ ] Verify plugin-hub packager no longer errors with `"build" must be set`
- [ ] Confirm Gradle build still compiles and passes (`./gradlew build`)

## Deployment Notes

- No environment variables changed
- No dependencies added
- Config-only change to `runelite-plugin.properties`
- No database migration required

## Checklist

- [x] Change is minimal and targeted
- [x] No debug code added
- [x] Follows plugin-hub property file conventions