### PR TITLE
Clear stale RSN on account switch to prevent cross-account flip contamination

### DIFF
--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -145,6 +145,11 @@ public class FlipSmartPlugin extends Plugin
 	// when session.getRsn() may already be null
 	private volatile String lastKnownRsn;
 
+	// True when handleLoggedInState ran but the local player was not yet
+	// populated, so syncRSN couldn't capture the current account's name. The
+	// onGameTick handler retries until it succeeds. Issue #556.
+	private volatile boolean rsnSyncPending;
+
 	// Cached world-type flag — updated on the client thread (WorldChanged, login) and read
 	// from any thread (Swing EDT, scheduler). Defaults to true so unlinked callers see more items.
 	private volatile boolean membersWorld = true;
@@ -865,6 +870,15 @@ public class FlipSmartPlugin extends Plugin
 	{
 		Player localPlayer = client.getLocalPlayer();
 		atGrandExchange = localPlayer != null && localPlayer.getWorldLocation().getRegionID() == GE_REGION_ID;
+
+		// On the first LOGGED_IN tick the local player is sometimes not yet
+		// populated, so syncRSN()'s early-return fires and we'd be stuck with
+		// either no RSN or (worse) the previous account's name. Retry here on
+		// each tick until the live name is captured. Issue #556.
+		if (rsnSyncPending && localPlayer != null && localPlayer.getName() != null && !localPlayer.getName().isEmpty())
+		{
+			syncRSN();
+		}
 	}
 
 	private void handleLogoutState()
@@ -902,6 +916,23 @@ public class FlipSmartPlugin extends Plugin
 		updateMembersWorldCache();
 		session.onLoggedIn();
 		syncRSN();
+
+		// If syncRSN couldn't capture the live name yet (player object not
+		// populated on the first LOGGED_IN tick), fall back to the persisted
+		// last-known RSN so offer preloading and the entitlements call below
+		// have *something* to work with. onGameTick will refresh to the live
+		// name as soon as it's available. Issue #556.
+		if (session.getRsn() == null || session.getRsn().isEmpty())
+		{
+			String persistedRsn = configManager.getConfiguration(CONFIG_GROUP, LAST_KNOWN_RSN_KEY);
+			if (persistedRsn != null && !persistedRsn.isEmpty())
+			{
+				session.setRsn(persistedRsn);
+				lastKnownRsn = persistedRsn;
+				log.info("Using persisted RSN fallback: {}", persistedRsn);
+			}
+		}
+
 		updateCashStack();
 
 		apiClient.fetchWikiPrices();
@@ -916,20 +947,6 @@ public class FlipSmartPlugin extends Plugin
 			// Pull webhook config after auth is confirmed
 			webhookSyncService.pullFromBackend();
 		});
-
-		// If RSN isn't available yet from the client (common on cold starts),
-		// fall back to the last known RSN persisted in config so offer preloading
-		// can find the correct config key (e.g. persistedOffers_dumbridge3 vs _unknown)
-		if (session.getRsn() == null || session.getRsn().isEmpty())
-		{
-			String persistedRsn = configManager.getConfiguration(CONFIG_GROUP, LAST_KNOWN_RSN_KEY);
-			if (persistedRsn != null && !persistedRsn.isEmpty())
-			{
-				session.setRsn(persistedRsn);
-				lastKnownRsn = persistedRsn;
-				log.info("Using persisted RSN fallback: {}", persistedRsn);
-			}
-		}
 
 		// Restore collected items from config (items bought but not yet sold)
 		// Must be after syncRSN() so we have the correct RSN for the config key
@@ -1102,54 +1119,83 @@ public class FlipSmartPlugin extends Plugin
 
 	
 	/**
-	 * Sync the player's RSN with the API and store locally
+	 * Sync the player's RSN with the API and store locally.
+	 *
+	 * On the first LOGGED_IN tick the local player can still be null or
+	 * unnamed; in that case we set rsnSyncPending so onGameTick retries
+	 * until the live name is captured. Issue #556.
 	 */
 	private void syncRSN()
 	{
-		if (client.getLocalPlayer() == null)
+		Player localPlayer = client.getLocalPlayer();
+		if (localPlayer == null)
 		{
-			log.warn("syncRSN called but getLocalPlayer() is null");
+			log.debug("syncRSN: getLocalPlayer() is null, will retry on next tick");
+			rsnSyncPending = true;
 			return;
 		}
-		
-		String rsn = client.getLocalPlayer().getName();
-		if (rsn != null && !rsn.isEmpty())
+
+		String rsn = localPlayer.getName();
+		if (rsn == null || rsn.isEmpty())
 		{
-			session.setRsn(rsn);
-			lastKnownRsn = rsn;
-			configManager.setConfiguration(CONFIG_GROUP, LAST_KNOWN_RSN_KEY, rsn);
-			log.info("RSN synced: {}", rsn);
-			apiClient.updateRSN(rsn);
+			log.debug("syncRSN: player name is null or empty, will retry on next tick");
+			rsnSyncPending = true;
+			return;
+		}
+
+		rsnSyncPending = false;
+		String previous = session.getRsn();
+		session.setRsn(rsn);
+		lastKnownRsn = rsn;
+		configManager.setConfiguration(CONFIG_GROUP, LAST_KNOWN_RSN_KEY, rsn);
+		if (previous != null && !previous.equals(rsn))
+		{
+			log.info("RSN switched: {} -> {}", previous, rsn);
 		}
 		else
 		{
-			log.warn("syncRSN: player name is null or empty");
+			log.info("RSN synced: {}", rsn);
 		}
+		apiClient.updateRSN(rsn);
 	}
-	
+
 	/**
-	 * Get the current RSN, attempting to fetch from client if not cached.
-	 * Returns Optional.empty() if RSN cannot be determined.
-	 * This ensures callers explicitly handle the case where RSN is unavailable.
+	 * Get the current RSN.
+	 *
+	 * When the player is logged in, the live client is authoritative — the
+	 * cache may still hold the previous account's name from a quick character
+	 * switch (issue #556). When offline, fall back to the cached or persisted
+	 * value so background work (offer persistence, config keys) still resolves.
 	 */
 	public Optional<String> getCurrentRsnSafe()
 	{
-		if (session.getRsn() != null && !session.getRsn().isEmpty())
+		if (client.getGameState() == GameState.LOGGED_IN)
 		{
-			return Optional.of(session.getRsn());
+			Player localPlayer = client.getLocalPlayer();
+			if (localPlayer != null && localPlayer.getName() != null && !localPlayer.getName().isEmpty())
+			{
+				String liveRsn = localPlayer.getName();
+				String cached = session.getRsn();
+				if (!liveRsn.equals(cached))
+				{
+					log.info("RSN refreshed from client: {} -> {}", cached, liveRsn);
+					session.setRsn(liveRsn);
+					lastKnownRsn = liveRsn;
+					configManager.setConfiguration(CONFIG_GROUP, LAST_KNOWN_RSN_KEY, liveRsn);
+				}
+				return Optional.of(liveRsn);
+			}
+			// Logged in but the player object isn't ready yet — fall through
+			// to the cache so the request still has *some* RSN. onGameTick
+			// will refresh once the live name is available.
 		}
-		
-		// Try to get RSN from client if not cached
-		if (client.getLocalPlayer() != null && client.getLocalPlayer().getName() != null)
+
+		String cached = session.getRsn();
+		if (cached != null && !cached.isEmpty())
 		{
-			String rsn = client.getLocalPlayer().getName();
-			session.setRsn(rsn);
-			lastKnownRsn = rsn;
-			configManager.setConfiguration(CONFIG_GROUP, LAST_KNOWN_RSN_KEY, rsn);
-			log.info("RSN fetched from client on-demand: {}", rsn);
-			return Optional.of(rsn);
+			return Optional.of(cached);
 		}
-		
+
 		log.warn("Unable to determine RSN - transactions will be recorded without RSN");
 		return Optional.empty();
 	}

--- a/src/main/java/com/flipsmart/PlayerSession.java
+++ b/src/main/java/com/flipsmart/PlayerSession.java
@@ -293,10 +293,16 @@ public class PlayerSession
 
 	/**
 	 * Handle logout state change (LOGIN_SCREEN).
+	 *
+	 * Clears the cached RSN so a subsequent login as a different account does
+	 * not reuse the previous account's name. Issue #549 / #556 — without this,
+	 * an outgoing API call between logout and the next syncRSN() would still
+	 * carry the previous account's RSN.
 	 */
 	public void onLogout()
 	{
 		this.loggedIntoRunescape = false;
+		this.rsn = null;
 	}
 
 	/**

--- a/src/test/java/com/flipsmart/PlayerSessionTest.java
+++ b/src/test/java/com/flipsmart/PlayerSessionTest.java
@@ -1,0 +1,66 @@
+package com.flipsmart;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link PlayerSession}. Focused on the RSN lifecycle that
+ * underpins the multi-account contamination fix (issue #549 / #556).
+ */
+public class PlayerSessionTest
+{
+	@Test
+	public void onLogout_clearsCachedRsnSoNextLoginCannotReuseIt()
+	{
+		PlayerSession session = new PlayerSession();
+		session.setRsn("AccountA");
+		assertEquals("AccountA", session.getRsnSafe().orElse(null));
+
+		session.onLogout();
+
+		assertFalse(
+			"onLogout must drop the cached RSN; otherwise a subsequent login as a different "
+				+ "account reuses the previous account's name (issue #549).",
+			session.getRsnSafe().isPresent()
+		);
+	}
+
+	@Test
+	public void onLogout_alsoFlipsLoggedIntoRunescapeBackToFalse()
+	{
+		PlayerSession session = new PlayerSession();
+		session.onLoggedIn();
+		assertTrue(session.isLoggedIntoRunescape());
+
+		session.onLogout();
+
+		assertFalse(session.isLoggedIntoRunescape());
+	}
+
+	@Test
+	public void clear_alsoNullsRsn()
+	{
+		PlayerSession session = new PlayerSession();
+		session.setRsn("AccountA");
+
+		session.clear();
+
+		assertFalse(session.getRsnSafe().isPresent());
+	}
+
+	@Test
+	public void getRsnSafe_returnsEmptyForNullOrBlank()
+	{
+		PlayerSession session = new PlayerSession();
+		assertFalse(session.getRsnSafe().isPresent());
+
+		session.setRsn("");
+		assertFalse(session.getRsnSafe().isPresent());
+
+		session.setRsn("Foo");
+		assertEquals("Foo", session.getRsnSafe().orElse(null));
+	}
+}


### PR DESCRIPTION
## Summary

After switching OSRS accounts within the same RuneLite session, the plugin was sending the previous account's RSN to `/flip-finder`. The root cause was twofold: `PlayerSession.onLogout()` never cleared the cached RSN, and `getCurrentRsnSafe()` always preferred the cached value over the live `client.getLocalPlayer()` name. This meant recommendation tiers and active-flip exclusions were scoped to the wrong account until the game was fully restarted.

A server-side defence-in-depth hot-fix shipped in Flip-Smart/flip-smart#555. This PR is the plugin-side fix that eliminates the root cause.

Closes Flip-Smart/flip-smart#556

## Changes

### Bug Fixes
- `PlayerSession.onLogout()` now clears the cached `rsn` field so a subsequent login as a different character cannot reuse the previous account's name.
- `getCurrentRsnSafe()` reads `client.getLocalPlayer().getName()` directly whenever the client state is `LOGGED_IN`, refreshing the cache if the live name differs from the stored one. The cached value is used only as a fallback when the player is offline or on the login screen.
- `syncRSN()` sets a `rsnSyncPending` flag instead of silently giving up when the local player object is not yet ready on the first `LOGGED_IN` tick. `onGameTick` retries until the live name is captured, guaranteeing the cache settles to the current account within one or two ticks of login.
- `handleLoggedInState` reordered so the persisted-RSN fallback runs before the entitlements call, preserving existing behaviour where background work resolves while the live name is still loading.

### Tests
- New `PlayerSessionTest` (4 tests, all passing) covers the RSN lifecycle: `onLogout` clears the cached RSN, `clear()` nulls it, `getRsnSafe` returns empty for null/blank values.

## Testing

### Automated Tests
- All unit tests passing (`./gradlew build` — `BUILD SUCCESSFUL`)
- `PlayerSessionTest` covers: logout clears RSN, clear nulls RSN, getRsnSafe returns empty string on null, getRsnSafe returns empty string on blank

### Manual Testing Checklist
- [ ] Log in to Account A, open the flip-finder panel, verify suggestions match Account A's cash stack and active flips
- [ ] Log out, log in to Account B, refresh the panel — verify suggestions immediately reflect Account B (not Account A)
- [ ] Hop worlds while logged in as Account B — verify RSN is not mistakenly cleared mid-session
- [ ] After production deployment, confirm the server-side `flipsmart_flip_finder_rsn_validation_total{outcome=mismatch}` counter trends toward zero

## Non-Goals

- Per-account cash-stack overrides on the FlipSmart UI side — this is tracked separately as a UX enhancement.
- Hardening other endpoints (`/transactions`, `/bank`, `/dismiss-flip`) against the same RSN bug class — the server-side validator in Flip-Smart/flip-smart#555 only covers `/flip-finder` for now; the remaining endpoints are a follow-up.

## Deployment Notes

- No new dependencies or configuration changes.
- Server-side metric `flipsmart_flip_finder_rsn_validation_total{outcome=mismatch}` (from Flip-Smart/flip-smart#555) can be used post-deploy to verify the mismatch rate drops as clients update.

## Checklist

- [x] Tests added for new behaviour (`PlayerSessionTest`)
- [x] Build passes (`./gradlew build`)
- [x] No `Thread.currentThread().interrupt()` called on threads we do not own
- [x] No debug logging left behind
- [x] Commits are clean and descriptive