### PR TITLE
Lower log.info calls to log.debug

### DIFF
--- a/src/main/java/com/flipsmart/ActiveFlipTracker.java
+++ b/src/main/java/com/flipsmart/ActiveFlipTracker.java
@@ -92,7 +92,7 @@ public class ActiveFlipTracker
 		{
 			if (Boolean.TRUE.equals(success))
 			{
-				log.info("Dismissed active flip for item {}", itemId);
+				log.debug("Dismissed active flip for item {}", itemId);
 				if (onPanelRefreshNeeded != null)
 				{
 					javax.swing.SwingUtilities.invokeLater(onPanelRefreshNeeded);
@@ -112,12 +112,12 @@ public class ActiveFlipTracker
 			return;
 		}
 
-		log.info("Inventory empty and no active sell slot for item {}, auto-closing active flip", itemId);
+		log.debug("Inventory empty and no active sell slot for item {}, auto-closing active flip", itemId);
 		apiClient.dismissActiveFlipAsync(itemId, getRsnSafe().orElse(null)).thenAccept(success ->
 		{
 			if (Boolean.TRUE.equals(success))
 			{
-				log.info("Successfully auto-closed active flip for item {} (no items remaining)", itemId);
+				log.debug("Successfully auto-closed active flip for item {} (no items remaining)", itemId);
 				if (onPanelRefreshNeeded != null)
 				{
 					javax.swing.SwingUtilities.invokeLater(onPanelRefreshNeeded);
@@ -166,7 +166,7 @@ public class ActiveFlipTracker
 	{
 		Set<Integer> activeItemIds = collectAllActiveItemIds();
 
-		log.info("Cleaning up stale flips - {} item IDs are truly active", activeItemIds.size());
+		log.debug("Cleaning up stale flips - {} item IDs are truly active", activeItemIds.size());
 
 		apiClient.cleanupStaleFlipsAsync(activeItemIds, getRsnSafe().orElse(null))
 			.thenAccept(this::handleCleanupResult);
@@ -189,7 +189,7 @@ public class ActiveFlipTracker
 					&& itemIds.add(offer.getItemId()))
 				{
 					addedFromClient++;
-					log.info("Cleanup safety: item {} found in GE client state but not in tracked offers",
+					log.debug("Cleanup safety: item {} found in GE client state but not in tracked offers",
 						offer.getItemId());
 				}
 			}
@@ -207,7 +207,7 @@ public class ActiveFlipTracker
 	{
 		if (Boolean.TRUE.equals(success))
 		{
-			log.info("Stale flip cleanup completed successfully");
+			log.debug("Stale flip cleanup completed successfully");
 			if (onActiveFlipsRefreshNeeded != null)
 			{
 				javax.swing.SwingUtilities.invokeLater(onActiveFlipsRefreshNeeded);
@@ -273,7 +273,7 @@ public class ActiveFlipTracker
 
 		if (actualQty == 0)
 		{
-			log.info("No items found for {} during validation - dismissing active flip", flip.getItemName());
+			log.debug("No items found for {} during validation - dismissing active flip", flip.getItemName());
 			dismissFlip(itemId);
 			return;
 		}
@@ -288,7 +288,7 @@ public class ActiveFlipTracker
 		}
 
 		String direction = actualQty > activeFlipQty ? "up" : "down";
-		log.info("Inventory quantity mismatch for {} - active flip shows {} but have {} (inv + sell slots). Syncing {}.",
+		log.debug("Inventory quantity mismatch for {} - active flip shows {} but have {} (inv + sell slots). Syncing {}.",
 			flip.getItemName(), activeFlipQty, actualQty, direction);
 
 		int orderQty = flip.getOrderQuantity() > 0 ? flip.getOrderQuantity() : Math.max(activeFlipQty, actualQty);

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -245,7 +245,7 @@ public class AutoRecommendService
 
 		active = true;
 		lastQueueRefreshMillis = System.currentTimeMillis();
-		log.info("Auto-recommend started with {} items in queue (sorted by volume asc)", recommendationQueue.size());
+		log.debug("Auto-recommend started with {} items in queue (sorted by volume asc)", recommendationQueue.size());
 		focusCurrent();
 
 		// Schedule adjustment timers
@@ -287,7 +287,7 @@ public class AutoRecommendService
 
 		invokeFocusCallback(null);
 
-		log.info("Auto-recommend stopped");
+		log.debug("Auto-recommend stopped");
 	}
 
 	// =====================
@@ -310,7 +310,7 @@ public class AutoRecommendService
 			return false;
 		}
 
-		log.info("Auto-recommend: Re-evaluating after login");
+		log.debug("Auto-recommend: Re-evaluating after login");
 		focusNextAvailableAction();
 
 		// Reschedule adjustment timers from persisted offer timestamps
@@ -355,13 +355,13 @@ public class AutoRecommendService
 				plugin.setRecommendedSellPrice(itemId, rec.getRecommendedSellPrice());
 				buyPrices.put(itemId, rec.getRecommendedBuyPrice());
 				scheduleAdjustmentTimer(itemId, rec.getRecommendedBuyPrice());
-				log.info("Auto-recommend: Non-focused buy for item {} - stored sell price {} from queue",
+				log.debug("Auto-recommend: Non-focused buy for item {} - stored sell price {} from queue",
 					itemId, rec.getRecommendedSellPrice());
 			}
 
 			if (!hasAvailableGESlots())
 			{
-				log.info("Auto-recommend: Non-focused buy filled last GE slot - clearing focus");
+				log.debug("Auto-recommend: Non-focused buy filled last GE slot - clearing focus");
 				promptCollection();
 			}
 			return;
@@ -372,7 +372,7 @@ public class AutoRecommendService
 
 		scheduleAdjustmentTimer(itemId, current.getRecommendedBuyPrice());
 
-		log.info("Auto-recommend: Buy order placed for {} - advancing to next", current.getItemName());
+		log.debug("Auto-recommend: Buy order placed for {} - advancing to next", current.getItemName());
 		advanceToNext();
 	}
 
@@ -389,7 +389,7 @@ public class AutoRecommendService
 		}
 
 		clearAdjustmentTimer(itemId);
-		log.info("Auto-recommend: Buy complete for {} - collect from GE to sell", itemName);
+		log.debug("Auto-recommend: Buy complete for {} - collect from GE to sell", itemName);
 		updateStatus("Auto: Collect " + itemName + " from GE");
 
 		// When no GE slots are available, clear the buy focus and show collect overlay.
@@ -440,11 +440,11 @@ public class AutoRecommendService
 			{
 				sellPrice = rec.getRecommendedSellPrice();
 				plugin.setRecommendedSellPrice(itemId, sellPrice);
-				log.info("Auto-recommend: Recovered sell price for {} from queue ({})", itemName, sellPrice);
+				log.debug("Auto-recommend: Recovered sell price for {} from queue ({})", itemName, sellPrice);
 			}
 			else
 			{
-				log.info("Auto-recommend: No local sell price for {} - falling through to API lookup", itemName);
+				log.debug("Auto-recommend: No local sell price for {} - falling through to API lookup", itemName);
 				return false;
 			}
 		}
@@ -463,7 +463,7 @@ public class AutoRecommendService
 		invokeFocusCallback(focus);
 		updateStatus(String.format(MSG_SELL_FORMAT, itemName, GpUtils.formatGPWithSuffix(sellPrice)));
 
-		log.info("Auto-recommend: Override focus for sell {} x{} @ {} gp", itemName, collectedQty, sellPrice);
+		log.debug("Auto-recommend: Override focus for sell {} x{} @ {} gp", itemName, collectedQty, sellPrice);
 		return true;
 	}
 
@@ -477,7 +477,7 @@ public class AutoRecommendService
 			return;
 		}
 
-		log.info("Auto-recommend: Sell order placed for item {} - checking next action", itemId);
+		log.debug("Auto-recommend: Sell order placed for item {} - checking next action", itemId);
 
 		// Schedule sell adjustment timer
 		scheduleSellAdjustmentTimer(itemId);
@@ -499,7 +499,7 @@ public class AutoRecommendService
 
 		clearSellAdjustmentTimer(itemId);
 		buyPrices.remove(itemId);
-		log.info("Auto-recommend: Sell completed for item {} - checking next action", itemId);
+		log.debug("Auto-recommend: Sell completed for item {} - checking next action", itemId);
 		focusNextAvailableAction();
 	}
 
@@ -539,7 +539,7 @@ public class AutoRecommendService
 		}
 		else
 		{
-			log.info("Auto-recommend: Offer cancelled (wasBuy={}, filled={}/{}) - re-evaluating",
+			log.debug("Auto-recommend: Offer cancelled (wasBuy={}, filled={}/{}) - re-evaluating",
 				wasBuy, filledQuantity, totalQuantity);
 		}
 
@@ -558,7 +558,7 @@ public class AutoRecommendService
 		ensureSellPriceAvailable(itemId);
 		ensureSellPriceFallback(itemId);
 
-		log.info("Auto-recommend: Partial buy cancelled for item {} ({}/{} filled) - tracked for sell",
+		log.debug("Auto-recommend: Partial buy cancelled for item {} ({}/{} filled) - tracked for sell",
 			itemId, filledQuantity, totalQuantity);
 	}
 
@@ -578,7 +578,7 @@ public class AutoRecommendService
 
 		session.addCollectedItem(itemId, remainingQuantity);
 		updateSellPriceFromQueueOrFallback(itemId);
-		log.info("Auto-recommend: Sell cancelled for item {} ({}/{} sold) - tracked {} for re-sell",
+		log.debug("Auto-recommend: Sell cancelled for item {} ({}/{} sold) - tracked {} for re-sell",
 			itemId, filledQuantity, totalQuantity, remainingQuantity);
 	}
 
@@ -598,7 +598,7 @@ public class AutoRecommendService
 		if (wikiPrice != null && wikiPrice.instaBuy > 0)
 		{
 			plugin.setRecommendedSellPrice(itemId, wikiPrice.instaBuy);
-			log.info("Auto-recommend: Using wiki insta-buy {} as sell price fallback for item {}",
+			log.debug("Auto-recommend: Using wiki insta-buy {} as sell price fallback for item {}",
 				wikiPrice.instaBuy, itemId);
 		}
 	}
@@ -631,7 +631,7 @@ public class AutoRecommendService
 		{
 			clearSellAdjustmentTimer(itemId);
 			buyPrices.remove(itemId);
-			log.info("Auto-recommend: Sell collected for {} - advancing", itemName);
+			log.debug("Auto-recommend: Sell collected for {} - advancing", itemName);
 			focusNextAvailableAction();
 		}
 	}
@@ -642,7 +642,7 @@ public class AutoRecommendService
 	 */
 	private void handleBuyCollected(int itemId, String itemName, int quantity)
 	{
-		log.info("Auto-recommend: Buy collected for {} x{} - checking sell", itemName, quantity);
+		log.debug("Auto-recommend: Buy collected for {} x{} - checking sell", itemName, quantity);
 
 		PlayerSession session = plugin.getSession();
 		if (session == null)
@@ -653,12 +653,12 @@ public class AutoRecommendService
 		ensureSellPriceAvailable(itemId);
 		boolean isCollected = session.getCollectedItemIds().contains(itemId);
 		Integer sellPrice = session.getRecommendedPrice(itemId);
-		log.info("Auto-recommend: Buy collected check - itemId={}, isCollected={}, sellPrice={}",
+		log.debug("Auto-recommend: Buy collected check - itemId={}, isCollected={}, sellPrice={}",
 			itemId, isCollected, sellPrice);
 
 		if (isCollected && sellPrice != null)
 		{
-			log.info("Auto-recommend: Focusing sell for {} x{}", itemName, quantity);
+			log.debug("Auto-recommend: Focusing sell for {} x{}", itemName, quantity);
 			focusSellForItem(itemId, itemName, quantity);
 			return;
 		}
@@ -723,7 +723,7 @@ public class AutoRecommendService
 		{
 			int count = deferredActions.size();
 			deferredActions.clear();
-			log.info("Auto-recommend: Draining {} deferred actions after step change to {}", count, newStep);
+			log.debug("Auto-recommend: Draining {} deferred actions after step change to {}", count, newStep);
 			focusNextAvailableAction();
 		}
 	}
@@ -749,7 +749,7 @@ public class AutoRecommendService
 		FlipRecommendation rec = findRecommendationForItem(itemId);
 		if (rec != null && rec.getRecommendedSellPrice() > 0)
 		{
-			log.info("Auto-recommend: Recovering sell price for item {} from queue ({})",
+			log.debug("Auto-recommend: Recovering sell price for item {} from queue ({})",
 				itemId, rec.getRecommendedSellPrice());
 			plugin.setRecommendedSellPrice(itemId, rec.getRecommendedSellPrice());
 		}
@@ -761,7 +761,7 @@ public class AutoRecommendService
 		if (rec != null && rec.getRecommendedSellPrice() > 0)
 		{
 			plugin.setRecommendedSellPrice(itemId, rec.getRecommendedSellPrice());
-			log.info("Auto-recommend: Updated re-sell price for item {} from queue ({})",
+			log.debug("Auto-recommend: Updated re-sell price for item {} from queue ({})",
 				itemId, rec.getRecommendedSellPrice());
 			return;
 		}
@@ -770,7 +770,7 @@ public class AutoRecommendService
 		PlayerSession session = plugin.getSession();
 		if (session != null && session.getRecommendedPrice(itemId) != null)
 		{
-			log.info("Auto-recommend: Keeping existing sell price for item {} ({})",
+			log.debug("Auto-recommend: Keeping existing sell price for item {} ({})",
 				itemId, session.getRecommendedPrice(itemId));
 		}
 		else
@@ -801,7 +801,7 @@ public class AutoRecommendService
 		lastQueueRefreshMillis = System.currentTimeMillis();
 		plugin.getSession().clearStaleNotifications();
 
-		log.info("Auto-recommend: Queue refreshed with {} items", recommendationQueue.size());
+		log.debug("Auto-recommend: Queue refreshed with {} items", recommendationQueue.size());
 		updateOverlayAfterRefresh(currentRec);
 	}
 
@@ -913,7 +913,7 @@ public class AutoRecommendService
 		}
 
 		long age = now - staleOffer.getEffectiveLastActivityAtMillis();
-		log.info("Auto-recommend: Stale & uncompetitive offer for {} (age: {}m)",
+		log.debug("Auto-recommend: Stale & uncompetitive offer for {} (age: {}m)",
 			staleOffer.getItemName(), age / 60000);
 
 		addToStaleQueue(staleOffer);
@@ -957,7 +957,7 @@ public class AutoRecommendService
 		long delay = AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS;
 		long deadline = System.currentTimeMillis() + delay;
 		adjustmentDeadlines.put(itemId, deadline);
-		log.info("Auto-recommend: Adjustment timer scheduled for item {} in {}m", itemId, delay / 60000);
+		log.debug("Auto-recommend: Adjustment timer scheduled for item {} in {}m", itemId, delay / 60000);
 	}
 
 	/**
@@ -973,7 +973,7 @@ public class AutoRecommendService
 		long delay = AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS;
 		long deadline = System.currentTimeMillis() + delay;
 		adjustmentDeadlines.put(itemId, deadline);
-		log.info("Auto-recommend: Adjustment timer reset for item {} ({}m)", itemId, delay / 60000);
+		log.debug("Auto-recommend: Adjustment timer reset for item {} ({}m)", itemId, delay / 60000);
 
 		// Clear stale-notified flag so the 15-minute inactivity check can fire again
 		// if the offer goes quiet after this fill
@@ -1007,13 +1007,13 @@ public class AutoRecommendService
 	{
 		if (!active || adjustmentDeadlines.isEmpty() || trackedOffers == null)
 		{
-			log.info("Auto-recommend: checkAdjustmentTimers skipped (active={}, deadlines={}, offers={})",
+			log.debug("Auto-recommend: checkAdjustmentTimers skipped (active={}, deadlines={}, offers={})",
 				active, adjustmentDeadlines.size(), trackedOffers != null ? trackedOffers.size() : "null");
 			return;
 		}
 
 		long now = System.currentTimeMillis();
-		log.info("Auto-recommend: Checking {} adjustment timers (recommendations={})",
+		log.debug("Auto-recommend: Checking {} adjustment timers (recommendations={})",
 			adjustmentDeadlines.size(),
 			currentRecommendations != null ? currentRecommendations.size() : "null");
 
@@ -1026,7 +1026,7 @@ public class AutoRecommendService
 			String itemName = itemNames.getOrDefault(entry.getKey(), "id=" + entry.getKey());
 			if (now >= deadline)
 			{
-				log.info("Auto-recommend: Timer expired for {} (overdue by {}s)",
+				log.debug("Auto-recommend: Timer expired for {} (overdue by {}s)",
 					itemName, (now - deadline) / 1000);
 				processExpiredAdjustmentTimer(entry, trackedOffers, currentRecommendations, iter, now);
 			}
@@ -1068,7 +1068,7 @@ public class AutoRecommendService
 		// Get buy price (cost basis) for breakeven calculation
 		Integer costBasis = buyPrices.getOrDefault(itemId, offer.getPrice());
 
-		log.info("Auto-recommend: Checking buy adjustment for {} (price={}, {}min elapsed)",
+		log.debug("Auto-recommend: Checking buy adjustment for {} (price={}, {}min elapsed)",
 			itemName, offer.getPrice(), minutesSince);
 
 		plugin.getApiClient().getFlipAdjustmentAsync(FlipSmartApiClient.FlipAdjustmentRequest.builder()
@@ -1135,14 +1135,14 @@ public class AutoRecommendService
 
 		if (response.isReadjustBuy() && response.getRecommendedPrice() != null)
 		{
-			log.info("Auto-recommend: API recommends adjust {} buy {} → {} gp",
+			log.debug("Auto-recommend: API recommends adjust {} buy {} → {} gp",
 				offer.getItemName(), offer.getPrice(), response.getRecommendedPrice());
 			addToStaleQueue(offer);
 			adjustmentDeadlines.remove(itemId);
 		}
 		else if (response.isCancelAndSell())
 		{
-			log.info("Auto-recommend: API says cancel {} — margin gone", offer.getItemName());
+			log.debug("Auto-recommend: API says cancel {} — margin gone", offer.getItemName());
 			addToStaleQueue(offer);
 			adjustmentDeadlines.remove(itemId);
 		}
@@ -1184,13 +1184,13 @@ public class AutoRecommendService
 			{
 				adjustmentDeadlines.put(offer.getItemId(), now - 1);
 				anyAlreadyStale = true;
-				log.info("Auto-recommend: {} already stale (age={}m, threshold={}m) — will check immediately",
+				log.debug("Auto-recommend: {} already stale (age={}m, threshold={}m) — will check immediately",
 					offer.getItemName(), offerAgeMs / 60000, delayMs / 60000);
 			}
 			else
 			{
 				adjustmentDeadlines.put(offer.getItemId(), now + remainingMs);
-				log.info("Auto-recommend: Rescheduled adjustment timer for {} in {}m (age={}m, threshold={}m)",
+				log.debug("Auto-recommend: Rescheduled adjustment timer for {} in {}m (age={}m, threshold={}m)",
 					offer.getItemName(), remainingMs / 60000, offerAgeMs / 60000, delayMs / 60000);
 			}
 		}
@@ -1235,7 +1235,7 @@ public class AutoRecommendService
 		long deadline = offerAgeMs >= AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS
 			? now - 1 : now + (AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS - offerAgeMs);
 		adjustmentDeadlines.put(offer.getItemId(), deadline);
-		log.info("Auto-recommend: Scheduled missing buy timer for {} (age={}m)",
+		log.debug("Auto-recommend: Scheduled missing buy timer for {} (age={}m)",
 			offer.getItemName(), offerAgeMs / 60000);
 	}
 
@@ -1248,7 +1248,7 @@ public class AutoRecommendService
 		SellAdjustmentState state = new SellAdjustmentState(
 			offer.getItemId(), offer.getItemName(), buyPrice, deadline);
 		sellAdjustmentStates.put(offer.getItemId(), state);
-		log.info("Auto-recommend: Scheduled missing sell timer for {} (age={}m)",
+		log.debug("Auto-recommend: Scheduled missing sell timer for {} (age={}m)",
 			offer.getItemName(), offerAgeMs / 60000);
 	}
 
@@ -1338,7 +1338,7 @@ public class AutoRecommendService
 		boolean wasEmpty = staleOfferQueue.isEmpty();
 		staleOfferQueue.add(offer);
 		promptedStaleItems.add(offer.getItemId());
-		log.info("Auto-recommend: Added {} to stale queue (queue size: {})",
+		log.debug("Auto-recommend: Added {} to stale queue (queue size: {})",
 			offer.getItemName(), staleOfferQueue.size());
 
 		if (wasEmpty)
@@ -1394,7 +1394,7 @@ public class AutoRecommendService
 			itemId, sellOffer.getItemName(), buyPrice, deadline);
 		sellAdjustmentStates.put(itemId, state);
 
-		log.info("Auto-recommend: Sell adjustment timer scheduled for {} in {}m (buyPrice={})",
+		log.debug("Auto-recommend: Sell adjustment timer scheduled for {} in {}m (buyPrice={})",
 			sellOffer.getItemName(), delay / 60000, buyPrice);
 	}
 
@@ -1426,7 +1426,7 @@ public class AutoRecommendService
 		}
 
 		state.deadline = System.currentTimeMillis() + AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS;
-		log.info("Auto-recommend: Sell adjustment timer reset for item {} ({}m)", itemId,
+		log.debug("Auto-recommend: Sell adjustment timer reset for item {} ({}m)", itemId,
 			AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS / 60000);
 
 		// Clear stale-notified flag so the inactivity check can fire again
@@ -1489,7 +1489,7 @@ public class AutoRecommendService
 	{
 		String timeframe = config.flipTimeframe().getApiValue();
 
-		log.info("Auto-recommend: Checking sell adjustment for {} (price={}, buyPrice={}, {}min elapsed, adj#{})",
+		log.debug("Auto-recommend: Checking sell adjustment for {} (price={}, buyPrice={}, {}min elapsed, adj#{})",
 			state.itemName, offer.getPrice(), state.averageBuyPrice, minutesSince, state.adjustmentCount);
 
 		PlayerSession session = plugin.getSession();
@@ -1546,7 +1546,7 @@ public class AutoRecommendService
 			int newPrice = response.getRecommendedPrice();
 			state.adjustmentCount++;
 
-			log.info("Auto-recommend: Sell adjustment for {} — {} → {} gp (adj#{})",
+			log.debug("Auto-recommend: Sell adjustment for {} — {} → {} gp (adj#{})",
 				state.itemName, offer.getPrice(), newPrice, state.adjustmentCount);
 
 			// The API already determined this sell is overpriced — always queue the prompt.
@@ -1569,7 +1569,7 @@ public class AutoRecommendService
 		else
 		{
 			// Unexpected action — log and reschedule
-			log.info("Auto-recommend: Sell adjustment response for {}: action={}, message={}",
+			log.debug("Auto-recommend: Sell adjustment response for {}: action={}, message={}",
 				state.itemName, response.getAction(), response.getMessage());
 			state.deadline = System.currentTimeMillis()
 				+ AdjustmentTimerUtils.nextCheckDelayMs(response.getNextCheckMinutes());
@@ -1613,13 +1613,13 @@ public class AutoRecommendService
 			if (remainingMs <= 0)
 			{
 				deadline = now - 1;
-				log.info("Auto-recommend: Sell {} already stale (age={}m, threshold={}m) — will check immediately",
+				log.debug("Auto-recommend: Sell {} already stale (age={}m, threshold={}m) — will check immediately",
 					offer.getItemName(), offerAgeMs / 60000, delayMs / 60000);
 			}
 			else
 			{
 				deadline = now + remainingMs;
-				log.info("Auto-recommend: Rescheduled sell adjustment timer for {} in {}m (age={}m, threshold={}m)",
+				log.debug("Auto-recommend: Rescheduled sell adjustment timer for {} in {}m (age={}m, threshold={}m)",
 					offer.getItemName(), remainingMs / 60000, offerAgeMs / 60000, delayMs / 60000);
 			}
 
@@ -1719,7 +1719,7 @@ public class AutoRecommendService
 		long age = System.currentTimeMillis() - state.savedAtMillis;
 		if (age > maxAgeMs)
 		{
-			log.info("Auto-recommend: Persisted state is stale ({}m old), not restoring", age / 60000);
+			log.debug("Auto-recommend: Persisted state is stale ({}m old), not restoring", age / 60000);
 			return false;
 		}
 
@@ -1747,10 +1747,10 @@ public class AutoRecommendService
 		if (state.buyPrices != null)
 		{
 			buyPrices.putAll(state.buyPrices);
-			log.info("Auto-recommend: Restored {} buy prices from persisted state", state.buyPrices.size());
+			log.debug("Auto-recommend: Restored {} buy prices from persisted state", state.buyPrices.size());
 		}
 
-		log.info("Auto-recommend: Restored state with {} items in queue, index {}",
+		log.debug("Auto-recommend: Restored state with {} items in queue, index {}",
 			recommendationQueue.size(), currentIndex);
 
 		focusCurrent();
@@ -1776,7 +1776,7 @@ public class AutoRecommendService
 		{
 			TrackedOffer skipped = staleOfferQueue.remove(0);
 			staleResellPrices.remove(skipped.getItemId());
-			log.info("Auto-recommend: User skipped stale offer prompt for {}", skipped.getItemName());
+			log.debug("Auto-recommend: User skipped stale offer prompt for {}", skipped.getItemName());
 			focusNextAvailableAction();
 			return;
 		}
@@ -1786,14 +1786,14 @@ public class AutoRecommendService
 		if (collectedId >= 0)
 		{
 			PlayerSession session = plugin.getSession();
-			log.info("Auto-recommend: User skipped collected item sell prompt for item {}", collectedId);
+			log.debug("Auto-recommend: User skipped collected item sell prompt for item {}", collectedId);
 			session.removeCollectedItem(collectedId);
 			focusedCollectedItemId = -1;
 			focusNextAvailableAction();
 			return;
 		}
 
-		log.info("Auto-recommend: User skipped current recommendation");
+		log.debug("Auto-recommend: User skipped current recommendation");
 		advanceToNext();
 	}
 
@@ -1839,7 +1839,7 @@ public class AutoRecommendService
 
 		if (!hasAvailableGESlots())
 		{
-			log.info("Auto-recommend: All GE slots full - waiting for collection");
+			log.debug("Auto-recommend: All GE slots full - waiting for collection");
 			promptCollection();
 			return;
 		}
@@ -1988,7 +1988,7 @@ public class AutoRecommendService
 
 		for (int staleId : staleItems)
 		{
-			log.info("Auto-recommend: Cleaning up stale collected item {} (not in inventory or GE)", staleId);
+			log.debug("Auto-recommend: Cleaning up stale collected item {} (not in inventory or GE)", staleId);
 			session.removeCollectedItem(staleId);
 		}
 

--- a/src/main/java/com/flipsmart/BankSnapshotService.java
+++ b/src/main/java/com/flipsmart/BankSnapshotService.java
@@ -135,7 +135,7 @@ public class BankSnapshotService
 			List<FlipSmartApiClient.BankItemId> gearItems = collectGearItems();
 			long geOffersValue = calculateGEOffersValue();
 
-			log.info("Capturing bank snapshot: {} bank items, {} inv items, {} gear items, ge={} for RSN {}",
+			log.debug("Capturing bank snapshot: {} bank items, {} inv items, {} gear items, ge={} for RSN {}",
 				items.size(), inventoryItems.size(), gearItems.size(), geOffersValue, rsn);
 
 			apiClient.createBankSnapshotAsync(rsn, items, inventoryItems, gearItems, geOffersValue).thenAccept(response ->
@@ -143,7 +143,7 @@ public class BankSnapshotService
 				if (response != null)
 				{
 					String wealthStr = String.format("%,d", response.getTotalWealth());
-					log.info("Bank snapshot captured: {} items, {} GP total wealth",
+					log.debug("Bank snapshot captured: {} items, {} GP total wealth",
 						response.getItemCount(), wealthStr);
 					postBankSnapshotMessage(
 						String.format("Bank snapshot saved: %s GP total wealth", wealthStr),

--- a/src/main/java/com/flipsmart/DumpAlertService.java
+++ b/src/main/java/com/flipsmart/DumpAlertService.java
@@ -66,7 +66,7 @@ public class DumpAlertService
 
 		int intervalSeconds = Math.max(30, Math.min(300, config.dumpAlertInterval()));
 
-		log.info("Starting dump alert service with {}s interval", intervalSeconds);
+		log.debug("Starting dump alert service with {}s interval", intervalSeconds);
 
 		if (executor == null || executor.isShutdown())
 		{
@@ -93,7 +93,7 @@ public class DumpAlertService
 	{
 		if (pollingTask != null)
 		{
-			log.info("Stopping dump alert service");
+			log.debug("Stopping dump alert service");
 			pollingTask.cancel(false);
 			pollingTask = null;
 		}
@@ -238,7 +238,7 @@ public class DumpAlertService
 			.runeLiteFormattedMessage(message)
 			.build());
 
-		log.info("Posted dump alert: {} ({}% drop, {} profit)",
+		log.debug("Posted dump alert: {} ({}% drop, {} profit)",
 			dump.getItemName(),
 			String.format("%.1f", dump.getPriceDropPercent()),
 			dump.getEstimatedProfit() != null ? dump.getEstimatedProfit() + "gp" : "unknown");

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -830,13 +830,13 @@ public class FlipFinderPanel extends PluginPanel
 						}
 						else
 						{
-							log.info("Refresh token auth failed (transient) - keeping token for next attempt");
+							log.debug("Refresh token auth failed (transient) - keeping token for next attempt");
 						}
 						tryLegacyPasswordAuth();
 					}
 				})
 			).exceptionally(e -> {
-				log.info("Refresh token auth failed: {}", e.getMessage());
+				log.debug("Refresh token auth failed: {}", e.getMessage());
 				SwingUtilities.invokeLater(this::tryLegacyPasswordAuth);
 				return null;
 			});
@@ -3150,7 +3150,7 @@ public class FlipFinderPanel extends PluginPanel
 			}
 		}
 		
-		log.info("Set Flip Assist focus: {} - {} at {} gp x{}", 
+		log.debug("Set Flip Assist focus: {} - {} at {} gp x{}", 
 			newFocus.getStep(), 
 			newFocus.getItemName(), 
 			newFocus.getCurrentStepPrice(),
@@ -4063,7 +4063,7 @@ public class FlipFinderPanel extends PluginPanel
 			autoRecommendButton.setForeground(Color.WHITE);
 			autoRecommendButton.setText("Auto");
 			skipButton.setVisible(true);
-			log.info("Auto-recommend enabled with {} recommendations", currentRecommendations.size());
+			log.debug("Auto-recommend enabled with {} recommendations", currentRecommendations.size());
 		}
 		else
 		{
@@ -4080,7 +4080,7 @@ public class FlipFinderPanel extends PluginPanel
 			// Repaint recommendations to remove highlight
 			populateRecommendations(new ArrayList<>(currentRecommendations));
 
-			log.info("Auto-recommend disabled");
+			log.debug("Auto-recommend disabled");
 		}
 	}
 

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -409,7 +409,7 @@ public class FlipSmartApiClient
 			}
 
 			processSuccessfulLogin(response);
-			log.info("Successfully authenticated with API (premium: {})", isPremium());
+			log.debug("Successfully authenticated with API (premium: {})", isPremium());
 			return new AuthResult(true, "Login successful!");
 		}
 		catch (Exception e)
@@ -566,7 +566,7 @@ public class FlipSmartApiClient
 
 					processTokenResponse(tokenResponse);
 
-					log.info("Successfully refreshed access token (premium: {})", isPremium());
+					log.debug("Successfully refreshed access token (premium: {})", isPremium());
 					future.complete(true);
 				}
 				catch (Exception e)
@@ -682,7 +682,7 @@ public class FlipSmartApiClient
 						tokenExpiry = System.currentTimeMillis() + (6 * 24 * 60 * 60 * 1000L);
 					}
 					
-					log.info("Successfully signed up and authenticated with API");
+					log.debug("Successfully signed up and authenticated with API");
 					future.complete(new AuthResult(true, "Account created successfully!"));
 				}
 				catch (Exception e)
@@ -866,7 +866,7 @@ public class FlipSmartApiClient
 					isRsnBlocked = rsnBlocked;
 				}
 
-				log.info("Fetched entitlements - premium: {}, rsnBlocked: {}", premium, rsnBlocked);
+				log.debug("Fetched entitlements - premium: {}, rsnBlocked: {}", premium, rsnBlocked);
 				return premium;
 			}
 			catch (Exception e)
@@ -987,7 +987,7 @@ public class FlipSmartApiClient
 					authResponse.expiresIn = json.get("expires_in").getAsInt();
 					authResponse.pollInterval = json.get("poll_interval").getAsInt();
 					
-					log.info("Device auth started, verification URL: {}", authResponse.verificationUrl);
+					log.debug("Device auth started, verification URL: {}", authResponse.verificationUrl);
 					future.complete(authResponse);
 				}
 				catch (Exception e)
@@ -1092,7 +1092,7 @@ public class FlipSmartApiClient
 			// JWT tokens from this API expire in 7 days, but we'll check earlier
 			this.tokenExpiry = System.currentTimeMillis() + (6 * 24 * 60 * 60 * 1000L);
 		}
-		log.info("Successfully authenticated via Discord");
+		log.debug("Successfully authenticated via Discord");
 	}
 	
 	/**
@@ -1114,7 +1114,7 @@ public class FlipSmartApiClient
 		
 		executeAuthenticatedAsync(requestBuilder, jsonData ->
 		{
-			log.info("Successfully updated RSN to: {}", rsn);
+			log.debug("Successfully updated RSN to: {}", rsn);
 			return true;
 		}).exceptionally(e ->
 		{
@@ -1380,7 +1380,7 @@ public class FlipSmartApiClient
 		return executeAuthenticatedAsync(requestBuilder, jsonData ->
 		{
 			JsonObject responseObj = gson.fromJson(jsonData, JsonObject.class);
-			log.info("Transaction recorded for {}: {}", request.rsn, responseObj.get("message").getAsString());
+			log.debug("Transaction recorded for {}: {}", request.rsn, responseObj.get("message").getAsString());
 			return null;
 		}).thenApply(v -> null);
 	}
@@ -1473,7 +1473,7 @@ public class FlipSmartApiClient
 		
 		return executeAuthenticatedAsync(requestBuilder, jsonData ->
 		{
-			log.info("Successfully dismissed active flip for item {}", itemId);
+			log.debug("Successfully dismissed active flip for item {}", itemId);
 			return true;
 		}).exceptionally(e ->
 		{
@@ -1525,7 +1525,7 @@ public class FlipSmartApiClient
 			int itemsCleaned = responseObj.has("items_cleaned") ? responseObj.get("items_cleaned").getAsInt() : 0;
 			if (itemsCleaned > 0)
 			{
-				log.info("Cleaned up {} stale active flips", itemsCleaned);
+				log.debug("Cleaned up {} stale active flips", itemsCleaned);
 			}
 			else
 			{
@@ -1577,7 +1577,7 @@ public class FlipSmartApiClient
 			int newQty = responseObj.has("new_quantity") ? responseObj.get("new_quantity").getAsInt() : 0;
 			if (previousQty != newQty)
 			{
-				log.info("Synced active flip for {} ({}): {} -> {} items", 
+				log.debug("Synced active flip for {} ({}): {} -> {} items", 
 					itemName, itemId, previousQty, newQty);
 			}
 			return true;
@@ -1607,7 +1607,7 @@ public class FlipSmartApiClient
 
 		return executeAuthenticatedAsync(requestBuilder, jsonData ->
 		{
-			log.info("Marked active flip for item {} as selling", itemId);
+			log.debug("Marked active flip for item {} as selling", itemId);
 			return true;
 		}).exceptionally(e ->
 		{
@@ -2156,7 +2156,7 @@ public class FlipSmartApiClient
 		return executeAuthenticatedAsync(requestBuilder, jsonData ->
 		{
 			// If we got here, the request succeeded
-			log.info("Added item {} to blocklist {}", itemId, blocklistId);
+			log.debug("Added item {} to blocklist {}", itemId, blocklistId);
 			return true;
 		}).exceptionally(e ->
 		{

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -516,7 +516,7 @@ public class FlipSmartPlugin extends Plugin
 	@Override
 	protected void startUp() throws Exception
 	{
-		log.info("Flip Smart started!");
+		log.debug("Flip Smart started!");
 		overlayManager.add(geOverlay);
 		overlayManager.add(geSlotOverlay);
 		overlayManager.add(flipAssistOverlay);
@@ -648,7 +648,7 @@ public class FlipSmartPlugin extends Plugin
 		if (focus != null)
 		{
 			geSlotOverlay.clearAllAdjustmentHighlights();
-			log.info("Auto-recommend focus set: {} {} @ {} gp",
+			log.debug("Auto-recommend focus set: {} {} @ {} gp",
 				focus.getStep(), focus.getItemName(), focus.getCurrentStepPrice());
 			// Keep panel focus in sync so the active flip refresh cycle doesn't
 			// re-create a stale sell overlay for a previously focused item
@@ -709,7 +709,7 @@ public class FlipSmartPlugin extends Plugin
 		boolean stepMatches = (isBuy && focusedFlip.isBuying()) || (!isBuy && focusedFlip.isSelling());
 		if (stepMatches)
 		{
-			log.info("Clearing Flip Assist focus - order submitted for {} ({})",
+			log.debug("Clearing Flip Assist focus - order submitted for {} ({})",
 				focusedFlip.getItemName(), isBuy ? "BUY" : "SELL");
 			flipAssistOverlay.clearFocus();
 			updateInventoryHighlightForFocus(null);
@@ -723,7 +723,7 @@ public class FlipSmartPlugin extends Plugin
 	@Override
 	protected void shutDown() throws Exception
 	{
-		log.info("Flip Smart stopped!");
+		log.debug("Flip Smart stopped!");
 
 		// Persist refresh token on shutdown to prevent session loss
 		String currentRefreshToken = apiClient.getRefreshToken();
@@ -751,7 +751,7 @@ public class FlipSmartPlugin extends Plugin
 		if (!session.getTrackedOffers().isEmpty())
 		{
 			offlineSyncService.persistOfferState();
-			log.info("Persisted offer state on shutdown for {}", rsnForPersistence);
+			log.debug("Persisted offer state on shutdown for {}", rsnForPersistence);
 		}
 		
 		overlayManager.remove(geOverlay);
@@ -912,7 +912,7 @@ public class FlipSmartPlugin extends Plugin
 
 	private void handleLoggedInState()
 	{
-		log.info("Player logged in");
+		log.debug("Player logged in");
 		updateMembersWorldCache();
 		session.onLoggedIn();
 		syncRSN();
@@ -929,7 +929,7 @@ public class FlipSmartPlugin extends Plugin
 			{
 				session.setRsn(persistedRsn);
 				lastKnownRsn = persistedRsn;
-				log.info("Using persisted RSN fallback: {}", persistedRsn);
+				log.debug("Using persisted RSN fallback: {}", persistedRsn);
 			}
 		}
 
@@ -938,7 +938,7 @@ public class FlipSmartPlugin extends Plugin
 		apiClient.fetchWikiPrices();
 
 		apiClient.fetchEntitlementsAsync(getCurrentRsnSafe().orElse(null)).thenAccept(isPremium -> {
-			log.info("User premium status: {}", isPremium);
+			log.debug("User premium status: {}", isPremium);
 			if (flipFinderPanel != null)
 			{
 				javax.swing.SwingUtilities.invokeLater(() -> flipFinderPanel.updatePremiumStatus());
@@ -1039,7 +1039,7 @@ public class FlipSmartPlugin extends Plugin
 
 			if (corrected > 0)
 			{
-				log.info("Corrected {} offer timestamps from backend active flips", corrected);
+				log.debug("Corrected {} offer timestamps from backend active flips", corrected);
 			}
 		}).exceptionally(e ->
 		{
@@ -1073,7 +1073,7 @@ public class FlipSmartPlugin extends Plugin
 
 		if (backendMs > 0)
 		{
-			log.info("Backfilled missing timestamp for {} from backend ({}m ago)",
+			log.debug("Backfilled missing timestamp for {} from backend ({}m ago)",
 				offer.getItemName(), (System.currentTimeMillis() - backendMs) / 60000);
 			offer.setCreatedAtMillis(backendMs);
 			return true;
@@ -1091,7 +1091,7 @@ public class FlipSmartPlugin extends Plugin
 		}
 		else
 		{
-			log.info("Skipping cleanup - no GE offers or collected items detected, may not be safe");
+			log.debug("Skipping cleanup - no GE offers or collected items detected, may not be safe");
 		}
 	}
 
@@ -1150,11 +1150,11 @@ public class FlipSmartPlugin extends Plugin
 		configManager.setConfiguration(CONFIG_GROUP, LAST_KNOWN_RSN_KEY, rsn);
 		if (previous != null && !previous.equals(rsn))
 		{
-			log.info("RSN switched: {} -> {}", previous, rsn);
+			log.debug("RSN switched: {} -> {}", previous, rsn);
 		}
 		else
 		{
-			log.info("RSN synced: {}", rsn);
+			log.debug("RSN synced: {}", rsn);
 		}
 		apiClient.updateRSN(rsn);
 	}
@@ -1178,7 +1178,7 @@ public class FlipSmartPlugin extends Plugin
 				String cached = session.getRsn();
 				if (!liveRsn.equals(cached))
 				{
-					log.info("RSN refreshed from client: {} -> {}", cached, liveRsn);
+					log.debug("RSN refreshed from client: {} -> {}", cached, liveRsn);
 					session.setRsn(liveRsn);
 					lastKnownRsn = liveRsn;
 					configManager.setConfiguration(CONFIG_GROUP, LAST_KNOWN_RSN_KEY, liveRsn);
@@ -1324,7 +1324,7 @@ public class FlipSmartPlugin extends Plugin
 			flipAssistOverlay.setFocusedFlip(focus);
 			if (focus != null)
 			{
-				log.info("Flip Assist focus set: {} {} - {} @ {} gp", 
+				log.debug("Flip Assist focus set: {} {} - {} @ {} gp", 
 					focus.getStep(),
 					focus.getItemName(),
 					focus.getCurrentStepQuantity(),
@@ -1332,7 +1332,7 @@ public class FlipSmartPlugin extends Plugin
 			}
 			else
 			{
-				log.info("Flip Assist focus cleared");
+				log.debug("Flip Assist focus cleared");
 				flipAssistOverlay.clearFocus();
 			}
 		});
@@ -1342,7 +1342,7 @@ public class FlipSmartPlugin extends Plugin
 			// Sync RSN to API if we have one (player is logged in)
 			if (session.getRsn() != null && !session.getRsn().isEmpty())
 			{
-				log.info("Auth success callback - syncing RSN: {}", session.getRsn());
+				log.debug("Auth success callback - syncing RSN: {}", session.getRsn());
 				apiClient.updateRSN(session.getRsn());
 			}
 			else
@@ -1377,7 +1377,7 @@ public class FlipSmartPlugin extends Plugin
 			.build();
 
 		clientToolbar.addNavigation(flipFinderNavButton);
-		log.info("Flip Finder panel initialized");
+		log.debug("Flip Finder panel initialized");
 	}
 
 	/**
@@ -1491,7 +1491,7 @@ public class FlipSmartPlugin extends Plugin
 			}
 		}, refreshIntervalMs, refreshIntervalMs);
 
-		log.info("Flip Finder auto-refresh started (every {} minutes)", refreshMinutes);
+		log.debug("Flip Finder auto-refresh started (every {} minutes)", refreshMinutes);
 	}
 
 	/**
@@ -1503,7 +1503,7 @@ public class FlipSmartPlugin extends Plugin
 		{
 			flipFinderRefreshTimer.cancel();
 			flipFinderRefreshTimer = null;
-			log.info("Flip Finder auto-refresh stopped");
+			log.debug("Flip Finder auto-refresh stopped");
 		}
 	}
 
@@ -1565,7 +1565,7 @@ public class FlipSmartPlugin extends Plugin
 			}
 		}, AUTO_RECOMMEND_REFRESH_INTERVAL_MS, AUTO_RECOMMEND_REFRESH_INTERVAL_MS);
 
-		log.info("Auto-recommend refresh timer started (every 2 minutes)");
+		log.debug("Auto-recommend refresh timer started (every 2 minutes)");
 	}
 
 	private void runRefreshCycle()
@@ -1638,7 +1638,7 @@ public class FlipSmartPlugin extends Plugin
 		AutoRecommendService.PersistedState state = autoRecommendService.getStateForPersistence();
 		String json = gson.toJson(state);
 		configManager.setConfiguration(CONFIG_GROUP, getAutoRecommendStateKey(), json);
-		log.info("Persisted auto-recommend state ({} items in queue)", state.queue != null ? state.queue.size() : 0);
+		log.debug("Persisted auto-recommend state ({} items in queue)", state.queue != null ? state.queue.size() : 0);
 	}
 
 	/**
@@ -1657,7 +1657,7 @@ public class FlipSmartPlugin extends Plugin
 			AutoRecommendService.PersistedState state = gson.fromJson(json, AutoRecommendService.PersistedState.class);
 			if (autoRecommendService.restoreState(state, AutoRecommendService.MAX_PERSISTED_AGE_MS))
 			{
-				log.info("Restored auto-recommend state from previous session");
+				log.debug("Restored auto-recommend state from previous session");
 
 				// Update the panel button
 				if (flipFinderPanel != null)

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -237,7 +237,7 @@ public class GrandExchangeTracker
 		if (remaining > 0)
 		{
 			session.addCollectedItem(ctx.itemId, remaining);
-			log.info("Sell cancelled for {} - re-added {} unsold items to collected",
+			log.debug("Sell cancelled for {} - re-added {} unsold items to collected",
 				ctx.itemName, remaining);
 		}
 	}
@@ -253,7 +253,7 @@ public class GrandExchangeTracker
 			long incrementalSpent = ctx.spent - previousSpent;
 			int pricePerItem = (newQuantity > 0) ? (int)(incrementalSpent / newQuantity) : 0;
 
-			log.info("Recording final transaction before cancellation: {} {} x{}/{} @ {} gp each",
+			log.debug("Recording final transaction before cancellation: {} {} x{}/{} @ {} gp each",
 				ctx.isBuy ? "BUY" : "SELL",
 				ctx.itemName,
 				newQuantity,
@@ -271,7 +271,7 @@ public class GrandExchangeTracker
 				.build());
 		}
 
-		log.info("Order cancelled: {} {} - {} items filled out of {}",
+		log.debug("Order cancelled: {} {} - {} items filled out of {}",
 			ctx.isBuy ? "BUY" : "SELL",
 			ctx.itemName,
 			ctx.quantitySold,
@@ -281,13 +281,13 @@ public class GrandExchangeTracker
 	private void handleZeroFillCancellation(OfferContext ctx)
 	{
 		TrackedOffer previousOffer = session.getTrackedOffer(ctx.slot);
-		log.info("Order cancelled with no fills: {} {}",
+		log.debug("Order cancelled with no fills: {} {}",
 			ctx.isBuy ? "BUY" : "SELL",
 			ctx.itemName);
 
 		if (ctx.isBuy)
 		{
-			log.info("Dismissing active flip for {} - buy order cancelled with 0 fills", ctx.itemName);
+			log.debug("Dismissing active flip for {} - buy order cancelled with 0 fills", ctx.itemName);
 			apiClient.dismissActiveFlipAsync(ctx.itemId, getRsn().orElse(null));
 			fireActiveFlipsRefresh();
 		}
@@ -296,7 +296,7 @@ public class GrandExchangeTracker
 	private void syncCancelledPartialBuy(OfferContext ctx)
 	{
 		TrackedOffer cancelledOffer = session.getTrackedOffer(ctx.slot);
-		log.info("Cancelled buy order had {} items filled (ordered {}) - syncing actual quantity and tracking until sold",
+		log.debug("Cancelled buy order had {} items filled (ordered {}) - syncing actual quantity and tracking until sold",
 			ctx.quantitySold, cancelledOffer != null ? cancelledOffer.getTotalQuantity() : "?");
 		session.addCollectedItem(ctx.itemId, ctx.quantitySold);
 
@@ -304,7 +304,7 @@ public class GrandExchangeTracker
 		if (rsn != null && cancelledOffer != null)
 		{
 			int pricePerItem = (ctx.quantitySold > 0) ? (int)((long) ctx.spent / ctx.quantitySold) : 0;
-			log.info("Syncing cancelled order quantity to backend: {} x{} (was {})",
+			log.debug("Syncing cancelled order quantity to backend: {} x{} (was {})",
 				ctx.itemName, ctx.quantitySold, cancelledOffer.getTotalQuantity());
 			apiClient.syncActiveFlipAsync(
 				ctx.itemId,
@@ -359,7 +359,7 @@ public class GrandExchangeTracker
 		if (inventoryCount > trackedFills)
 		{
 			collectedQty = Math.min(inventoryCount, collectedOffer.getTotalQuantity());
-			log.info("Order for {} may have completed offline - tracked {} fills but have {} in inventory. Using {} as collected quantity.",
+			log.debug("Order for {} may have completed offline - tracked {} fills but have {} in inventory. Using {} as collected quantity.",
 				collectedOffer.getItemName(), trackedFills, inventoryCount, collectedQty);
 
 			String rsn = getRsn().orElse(null);
@@ -378,7 +378,7 @@ public class GrandExchangeTracker
 			}
 		}
 
-		log.info("Buy offer collected from GE: {} x{} - tracking until sold",
+		log.debug("Buy offer collected from GE: {} x{} - tracking until sold",
 			collectedOffer.getItemName(), collectedQty);
 		session.addCollectedItem(collectedOffer.getItemId(), collectedQty);
 	}
@@ -388,13 +388,13 @@ public class GrandExchangeTracker
 		int inventoryCount = activeFlipTracker.getInventoryCountForItem(collectedOffer.getItemId());
 		if (inventoryCount > 0)
 		{
-			log.info("Sell offer collected/modified for {}: {} items returned to inventory - keeping active flip tracking",
+			log.debug("Sell offer collected/modified for {}: {} items returned to inventory - keeping active flip tracking",
 				collectedOffer.getItemName(), inventoryCount);
 			session.addCollectedItem(collectedOffer.getItemId(), inventoryCount);
 		}
 		else
 		{
-			log.info("Sell offer for {} went empty with no items in inventory - dismissing active flip",
+			log.debug("Sell offer for {} went empty with no items in inventory - dismissing active flip",
 				collectedOffer.getItemName());
 			activeFlipTracker.dismissFlip(collectedOffer.getItemId());
 		}
@@ -405,7 +405,7 @@ public class GrandExchangeTracker
 		int inventoryCount = activeFlipTracker.getInventoryCountForItem(collectedOffer.getItemId());
 		if (inventoryCount > 0)
 		{
-			log.info("Buy order for {} went empty but found {} items in inventory - may have filled offline",
+			log.debug("Buy order for {} went empty but found {} items in inventory - may have filled offline",
 				collectedOffer.getItemName(), inventoryCount);
 			session.addCollectedItem(collectedOffer.getItemId(), inventoryCount);
 		}
@@ -421,7 +421,7 @@ public class GrandExchangeTracker
 				: collectedOffer.getPrice();
 			int fallbackSellPrice = (int) Math.ceil((buyPrice + 1) / 0.98);
 			session.setRecommendedPrice(collectedOffer.getItemId(), fallbackSellPrice);
-			log.info("No recommended sell price for {} - using fallback {} gp (bought at {} gp)",
+			log.debug("No recommended sell price for {} - using fallback {} gp (bought at {} gp)",
 				collectedOffer.getItemName(), fallbackSellPrice, buyPrice);
 		}
 	}
@@ -550,7 +550,7 @@ public class GrandExchangeTracker
 		FlipRecommendation currentRec = autoRecommendService.getCurrentRecommendation();
 		if (currentRec != null && currentRec.getItemId() == ctx.itemId && currentRec.getRecommendedSellPrice() > 0)
 		{
-			log.info("Immediate-fill buy for {} - pre-storing recommended sell price {}", ctx.itemName, currentRec.getRecommendedSellPrice());
+			log.debug("Immediate-fill buy for {} - pre-storing recommended sell price {}", ctx.itemName, currentRec.getRecommendedSellPrice());
 			session.setRecommendedPrice(ctx.itemId, currentRec.getRecommendedSellPrice());
 		}
 	}
@@ -561,7 +561,7 @@ public class GrandExchangeTracker
 		long incrementalSpent = ctx.spent - previousSpent;
 		int pricePerItem = (newQuantity > 0) ? (int)(incrementalSpent / newQuantity) : 0;
 
-		log.info("Recording transaction: {} {} x{} @ {} gp each (slot {}, {}/{} filled)",
+		log.debug("Recording transaction: {} {} x{} @ {} gp each (slot {}, {}/{} filled)",
 			ctx.isBuy ? "BUY" : "SELL",
 			ctx.itemName,
 			newQuantity,
@@ -609,7 +609,7 @@ public class GrandExchangeTracker
 	{
 		if (isBuy && isAutoRecommendActive())
 		{
-			log.info("Immediate-fill buy for {} - advancing auto-recommend queue", itemName);
+			log.debug("Immediate-fill buy for {} - advancing auto-recommend queue", itemName);
 			autoRecommendService.onBuyOrderPlaced(itemId);
 		}
 		else if (!isBuy)
@@ -620,7 +620,7 @@ public class GrandExchangeTracker
 
 	private void handleImmediateFillSell(int itemId, String itemName)
 	{
-		log.info("Immediate-fill sell for {} - performing sell bookkeeping", itemName);
+		log.debug("Immediate-fill sell for {} - performing sell bookkeeping", itemName);
 		String rsn = getRsn().orElse(null);
 		if (rsn != null)
 		{
@@ -696,7 +696,7 @@ public class GrandExchangeTracker
 
 	private void recordNewSellOrder(OfferContext ctx)
 	{
-		log.info("Sell order placed for {} x{} - marking active flip as selling", ctx.itemName, ctx.totalQuantity);
+		log.debug("Sell order placed for {} x{} - marking active flip as selling", ctx.itemName, ctx.totalQuantity);
 		String rsn = getRsn().orElse(null);
 		if (rsn != null)
 		{
@@ -794,7 +794,7 @@ public class GrandExchangeTracker
 		{
 			int orderQty = matchingFlip.getOrderQuantity() > 0
 				? matchingFlip.getOrderQuantity() : inventoryCount;
-			log.info("Syncing inventory-corrected quantity for {} to API: {} items",
+			log.debug("Syncing inventory-corrected quantity for {} to API: {} items",
 				matchingFlip.getItemName(), inventoryCount);
 			apiClient.syncActiveFlipAsync(
 				matchingFlip.getItemId(),
@@ -860,7 +860,7 @@ public class GrandExchangeTracker
 		{
 			javax.swing.SwingUtilities.invokeLater(() -> onFocusChanged.accept(focus));
 		}
-		log.info("Auto-focused on active flip for sell: {} @ {} gp (qty: api={}, inv={}, using={})",
+		log.debug("Auto-focused on active flip for sell: {} @ {} gp (qty: api={}, inv={}, using={})",
 			flip.getItemName(), sellPrice, apiQuantity, inventoryFallbackCount, sellQuantity);
 	}
 

--- a/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
+++ b/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
@@ -156,7 +156,7 @@ public class ManualAdjustmentTracker
 		OfferAdjustmentState state = new OfferAdjustmentState(
 			itemId, itemName, true, geSlot, deadline, offerPrice);
 		trackedOffers.put(geSlot, state);
-		log.info("Manual adjustment timer scheduled for {} (slot {}) in {}m",
+		log.debug("Manual adjustment timer scheduled for {} (slot {}) in {}m",
 			itemName, geSlot, delay / 60000);
 	}
 
@@ -177,7 +177,7 @@ public class ManualAdjustmentTracker
 		OfferAdjustmentState state = new OfferAdjustmentState(
 			itemId, itemName, false, geSlot, deadline, averageBuyPrice);
 		trackedOffers.put(geSlot, state);
-		log.info("Manual sell adjustment timer scheduled for {} (slot {}) in {}m",
+		log.debug("Manual sell adjustment timer scheduled for {} (slot {}) in {}m",
 			itemName, geSlot, delay / 60000);
 	}
 
@@ -338,7 +338,7 @@ public class ManualAdjustmentTracker
 		}
 		else if (response.isCancelAndSell())
 		{
-			log.info("Manual adjustment: Margin gone on {} — fetching replacement", state.itemName);
+			log.debug("Manual adjustment: Margin gone on {} — fetching replacement", state.itemName);
 			fetchReplacementRecommendation(state);
 		}
 	}
@@ -351,7 +351,7 @@ public class ManualAdjustmentTracker
 			GpUtils.formatGPWithSuffix(offer.getPrice()),
 			GpUtils.formatGPWithSuffix(response.getRecommendedPrice()));
 
-		log.info("Manual adjustment: {}", msg);
+		log.debug("Manual adjustment: {}", msg);
 
 		BiConsumer<FocusedFlip, String> focusCallback = onFocusFlip;
 		if (focusCallback != null)
@@ -381,7 +381,7 @@ public class ManualAdjustmentTracker
 			GpUtils.formatGPWithSuffix(offer.getPrice()),
 			GpUtils.formatGPWithSuffix(response.getRecommendedPrice()));
 
-		log.info("Manual adjustment: {}", msg);
+		log.debug("Manual adjustment: {}", msg);
 		notifyPrompt(msg, state.itemId);
 		notifyHighlight(state.geSlot, response.getRecommendedPrice());
 		notifyInventoryHighlight(state.itemId);
@@ -474,7 +474,7 @@ public class ManualAdjustmentTracker
 			replacement.getItemName(),
 			GpUtils.formatGPWithSuffix(replacement.getPotentialProfit()));
 
-		log.info("Ditch recommendation: {}", msg);
+		log.debug("Ditch recommendation: {}", msg);
 
 		BiConsumer<FocusedFlip, String> focusCallback = onFocusFlip;
 		if (focusCallback != null)

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -77,19 +77,19 @@ public class OfflineSyncService
 	public void restoreCollectedItems()
 	{
 		String key = getCollectedItemsKey();
-		log.info("Attempting to restore collected items for RSN: {} (key: {})", session.getRsn(), key);
+		log.debug("Attempting to restore collected items for RSN: {} (key: {})", session.getRsn(), key);
 
 		Set<Integer> persisted = loadPersistedCollectedItems();
 		if (!persisted.isEmpty())
 		{
 			Map<Integer, Integer> quantities = loadPersistedCollectedQuantities();
 			session.restoreCollectedItems(persisted, quantities);
-			log.info("Restored {} collected items from previous session: {} (with {} quantities)",
+			log.debug("Restored {} collected items from previous session: {} (with {} quantities)",
 				persisted.size(), persisted, quantities.size());
 		}
 		else
 		{
-			log.info("No collected items found in config for RSN: {}", session.getRsn());
+			log.debug("No collected items found in config for RSN: {}", session.getRsn());
 			session.clearCollectedItems();
 		}
 
@@ -120,7 +120,7 @@ public class OfflineSyncService
 				String json = gson.toJson(offersToSave);
 				configManager.setConfiguration(CONFIG_GROUP, offersKey, json);
 				configManager.setConfiguration(CONFIG_GROUP, PERSISTED_OFFERS_FALLBACK_KEY, json);
-				log.info("Persisted {} tracked offers for {} (offline sync)", offersToSave.size(), session.getRsn());
+				log.debug("Persisted {} tracked offers for {} (offline sync)", offersToSave.size(), session.getRsn());
 			}
 			catch (Exception e)
 			{
@@ -153,7 +153,7 @@ public class OfflineSyncService
 					configManager.unsetConfiguration(CONFIG_GROUP, quantitiesKey);
 				}
 
-				log.info("Persisted {} collected item IDs for {} (active flips)", session.getCollectedItemIds().size(), session.getRsn());
+				log.debug("Persisted {} collected item IDs for {} (active flips)", session.getCollectedItemIds().size(), session.getRsn());
 			}
 			catch (Exception e)
 			{
@@ -192,7 +192,7 @@ public class OfflineSyncService
 			}
 		}
 
-		log.info("Preloaded {} persisted offers into session for timestamp preservation",
+		log.debug("Preloaded {} persisted offers into session for timestamp preservation",
 			persisted.size());
 	}
 
@@ -229,7 +229,7 @@ public class OfflineSyncService
 		// (e.g., client crash, force close where shutDown() doesn't run)
 		persistOfferState();
 
-		log.info("Offline sync completed for {}", session.getRsn());
+		log.debug("Offline sync completed for {}", session.getRsn());
 
 		if (onSyncComplete != null)
 		{
@@ -360,7 +360,7 @@ public class OfflineSyncService
 				continue;
 			}
 
-			log.info("Slot {} is now empty (was tracking {} x{}). Checking for offline completions.",
+			log.debug("Slot {} is now empty (was tracking {} x{}). Checking for offline completions.",
 				slot, persistedOffer.getItemName(), persistedOffer.getTotalQuantity());
 
 			if (persistedOffer.isBuy())
@@ -387,7 +387,7 @@ public class OfflineSyncService
 		// If the order was fully sold before logout, only collection happened offline — don't re-record.
 		if (persistedSoldQty >= totalQty && totalQty > 0)
 		{
-			log.info("Sell order for {} was complete before logout ({}/{}). Collection happened offline — no offline sells to record.",
+			log.debug("Sell order for {} was complete before logout ({}/{}). Collection happened offline — no offline sells to record.",
 				persistedOffer.getItemName(), persistedSoldQty, totalQty);
 		}
 		else
@@ -395,13 +395,13 @@ public class OfflineSyncService
 			int offlineSells = totalQty - persistedSoldQty;
 			if (offlineSells > 0)
 			{
-				log.info("Detected {} {} sold offline (total: {}, tracked before logout: {}). Recording SELL transaction.",
+				log.debug("Detected {} {} sold offline (total: {}, tracked before logout: {}). Recording SELL transaction.",
 					offlineSells, persistedOffer.getItemName(), totalQty, persistedSoldQty);
 				recordOfflineSellTransaction(persistedOffer, offlineSells);
 			}
 			else
 			{
-				log.info("Sell order for {} was cancelled or no items sold.", persistedOffer.getItemName());
+				log.debug("Sell order for {} was cancelled or no items sold.", persistedOffer.getItemName());
 			}
 		}
 
@@ -411,7 +411,7 @@ public class OfflineSyncService
 			int inventoryCount = getInventoryCountForItem(persistedOffer.getItemId());
 			if (inventoryCount == 0)
 			{
-				log.info("No {} in inventory after offline sell - dismissing active flip", persistedOffer.getItemName());
+				log.debug("No {} in inventory after offline sell - dismissing active flip", persistedOffer.getItemName());
 				activeFlipTracker.dismissFlip(persistedOffer.getItemId());
 			}
 		});
@@ -456,7 +456,7 @@ public class OfflineSyncService
 			}
 			else if (trackedFills > 0)
 			{
-				log.info("No {} found in inventory (had {} fills tracked). Items may have been sold/used offline.",
+				log.debug("No {} found in inventory (had {} fills tracked). Items may have been sold/used offline.",
 					persistedOffer.getItemName(), trackedFills);
 			}
 		});
@@ -476,7 +476,7 @@ public class OfflineSyncService
 		}
 		else
 		{
-			log.info("Adding {} to collected tracking (had {} items filled before going offline)",
+			log.debug("Adding {} to collected tracking (had {} items filled before going offline)",
 				persistedOffer.getItemName(), trackedFills);
 		}
 	}
@@ -501,7 +501,7 @@ public class OfflineSyncService
 	 */
 	private void syncOfflineCompletedOrder(TrackedOffer persistedOffer, int inventoryCount, int trackedFills, int actualFills)
 	{
-		log.info("Detected offline completion for {} - tracked {} fills but have {} in inventory. Syncing {} items with backend.",
+		log.debug("Detected offline completion for {} - tracked {} fills but have {} in inventory. Syncing {} items with backend.",
 			persistedOffer.getItemName(), trackedFills, inventoryCount, actualFills);
 
 		String rsn = getRsnSafe().orElse(null);
@@ -626,7 +626,7 @@ public class OfflineSyncService
 
 			Type type = new TypeToken<Map<Integer, TrackedOffer>>(){}.getType();
 			Map<Integer, TrackedOffer> offers = gson.fromJson(json, type);
-			log.info("Loaded {} persisted offers for {}", offers != null ? offers.size() : 0, session.getRsn());
+			log.debug("Loaded {} persisted offers for {}", offers != null ? offers.size() : 0, session.getRsn());
 			return offers != null ? offers : new HashMap<>();
 		}
 		catch (Exception e)
@@ -647,7 +647,7 @@ public class OfflineSyncService
 			Map<Integer, TrackedOffer> result = tryLoadOffersFromKey(PERSISTED_OFFERS_FALLBACK_KEY);
 			if (!result.isEmpty())
 			{
-				log.info("Loaded {} offers from fallback key", result.size());
+				log.debug("Loaded {} offers from fallback key", result.size());
 				return result;
 			}
 
@@ -663,7 +663,7 @@ public class OfflineSyncService
 				result = tryLoadOffersFromKey(keyPart);
 				if (!result.isEmpty())
 				{
-					log.info("Loaded {} offers via key scan (key: {})", result.size(), keyPart);
+					log.debug("Loaded {} offers via key scan (key: {})", result.size(), keyPart);
 					return result;
 				}
 			}

--- a/src/main/java/com/flipsmart/WebhookSyncService.java
+++ b/src/main/java/com/flipsmart/WebhookSyncService.java
@@ -131,7 +131,7 @@ public class WebhookSyncService
 		// If webhook URL is empty, delete webhook from backend
 		if (webhookUrl == null || webhookUrl.trim().isEmpty())
 		{
-			log.info("Webhook URL cleared in plugin config (lastSynced={})", lastSyncedWebhookUrl);
+			log.debug("Webhook URL cleared in plugin config (lastSynced={})", lastSyncedWebhookUrl);
 			if (lastSyncedWebhookUrl != null && !lastSyncedWebhookUrl.trim().isEmpty())
 			{
 				deleteWebhook();
@@ -151,7 +151,7 @@ public class WebhookSyncService
 			notifySale,
 			notifySuggestion,
 			() -> {
-				log.info("Webhook config synced to backend successfully");
+				log.debug("Webhook config synced to backend successfully");
 				lastSyncedWebhookUrl = webhookUrl;
 				lastSyncedNotifySale = notifySale;
 				lastSyncedNotifySuggestion = notifySuggestion;
@@ -166,7 +166,7 @@ public class WebhookSyncService
 
 		apiClient.deleteWebhookAsync(
 			() -> {
-				log.info("Webhook deleted from backend successfully");
+				log.debug("Webhook deleted from backend successfully");
 				lastSyncedWebhookUrl = null;
 				lastSyncedNotifySale = false;
 				lastSyncedNotifySuggestion = false;


### PR DESCRIPTION
Plugin Hub review feedback (PR runelite/plugin-hub#11581): plugins should not emit info-level logs by default. Demoted all 155 log.info() calls to log.debug() across the codebase.