### PR TITLE
fix(plugin): don't show SELL prompt during active buy + resolve item names via ItemManager

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -1996,9 +1996,10 @@ public class AutoRecommendService
 	}
 
 	/**
-	 * Returns itemId if sellable now (in inventory + has price), else -1.
-	 * In-flight or uncollected buys are skipped so promptCollection() can
-	 * route the correct UI message; truly orphaned entries are queued for cleanup.
+	 * Returns itemId if sellable now, else -1. Items in inventory are sellable.
+	 * Active/completed buys are skipped (promptCollection routes the message).
+	 * Cancelled partial buys (no tracked offer, but collectedQuantity > 0) are
+	 * treated as sellable so the user gets a sell prompt for the partial fill.
 	 */
 	private int evaluateCollectedItem(int itemId, PlayerSession session, List<Integer> staleItems)
 	{
@@ -2010,6 +2011,10 @@ public class AutoRecommendService
 			|| session.hasUncollectedBuyOfferForItem(itemId))
 		{
 			return -1;
+		}
+		if (session.getCollectedQuantity(itemId) > 0)
+		{
+			return hasSellPrice(itemId) ? itemId : -1;
 		}
 		staleItems.add(itemId);
 		return -1;

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -1996,18 +1996,9 @@ public class AutoRecommendService
 	}
 
 	/**
-	 * Evaluate whether a collected item is sellable, stale, or waiting for collection.
-	 * Returns the item ID if sellable now, or -1 to continue searching.
-	 *
-	 * The three non-sellable cases are kept distinct (vs lumped under one
-	 * "hasBuyOffer" check) so the UI can route to the correct prompt:
-	 *   - In-flight buy: stay on the buy / let promptCollection() handle messaging
-	 *   - Completed buy not yet collected: promptCollection() shows "Collect <name>"
-	 *   - Truly stale: queued for cleanup
-	 *
-	 * Critically, an item with an active buy offer that is NOT yet in inventory
-	 * must not be treated as sellable — selling instructions for items still in
-	 * the GE slot are misleading (issue #582).
+	 * Returns itemId if sellable now (in inventory + has price), else -1.
+	 * In-flight or uncollected buys are skipped so promptCollection() can
+	 * route the correct UI message; truly orphaned entries are queued for cleanup.
 	 */
 	private int evaluateCollectedItem(int itemId, PlayerSession session, List<Integer> staleItems)
 	{
@@ -2015,20 +2006,11 @@ public class AutoRecommendService
 		{
 			return hasSellPrice(itemId) ? itemId : -1;
 		}
-
-		// Buy still placing/partially filling — items aren't collectable yet.
-		if (session.hasInFlightBuyOfferForItem(itemId))
+		if (session.hasInFlightBuyOfferForItem(itemId)
+			|| session.hasUncollectedBuyOfferForItem(itemId))
 		{
 			return -1;
 		}
-
-		// Buy completed but items still in the GE slot — user needs to collect first.
-		if (session.hasUncollectedBuyOfferForItem(itemId))
-		{
-			return -1;
-		}
-
-		// Not in inventory and no buy offer of any kind — tracking is stale.
 		staleItems.add(itemId);
 		return -1;
 	}

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -1920,7 +1920,7 @@ public class AutoRecommendService
 
 			if (sellPrice != null && sellPrice > 0)
 			{
-				String itemName = itemNames.getOrDefault(sellableItemId, "Item " + sellableItemId);
+				String itemName = itemNames.getOrDefault(sellableItemId, plugin.getItemName(sellableItemId));
 				int sellQuantity = resolveSellQuantity(sellableItemId);
 
 				int priceOffset = config.priceOffset();
@@ -1997,21 +1997,38 @@ public class AutoRecommendService
 
 	/**
 	 * Evaluate whether a collected item is sellable, stale, or waiting for collection.
-	 * Returns the item ID if sellable, or -1 to continue searching.
+	 * Returns the item ID if sellable now, or -1 to continue searching.
+	 *
+	 * The three non-sellable cases are kept distinct (vs lumped under one
+	 * "hasBuyOffer" check) so the UI can route to the correct prompt:
+	 *   - In-flight buy: stay on the buy / let promptCollection() handle messaging
+	 *   - Completed buy not yet collected: promptCollection() shows "Collect <name>"
+	 *   - Truly stale: queued for cleanup
+	 *
+	 * Critically, an item with an active buy offer that is NOT yet in inventory
+	 * must not be treated as sellable — selling instructions for items still in
+	 * the GE slot are misleading (issue #582).
 	 */
 	private int evaluateCollectedItem(int itemId, PlayerSession session, List<Integer> staleItems)
 	{
-		boolean inInventory = isItemInInventory(itemId);
-		boolean hasBuyOffer = session.hasActiveBuySlotForItem(itemId);
-
-		if (inInventory || hasBuyOffer)
+		if (isItemInInventory(itemId))
 		{
 			return hasSellPrice(itemId) ? itemId : -1;
 		}
 
-		// Not in inventory and no active buy offer — item is no longer accessible.
-		// Even if collectedQuantity > 0, the tracking is stale (item was already
-		// collected and sold/used, or the state got out of sync). Mark for cleanup.
+		// Buy still placing/partially filling — items aren't collectable yet.
+		if (session.hasInFlightBuyOfferForItem(itemId))
+		{
+			return -1;
+		}
+
+		// Buy completed but items still in the GE slot — user needs to collect first.
+		if (session.hasUncollectedBuyOfferForItem(itemId))
+		{
+			return -1;
+		}
+
+		// Not in inventory and no buy offer of any kind — tracking is stale.
 		staleItems.add(itemId);
 		return -1;
 	}

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -331,6 +331,15 @@ public class FlipSmartPlugin extends Plugin
 	}
 
 	/**
+	 * Resolve a human-readable item name via RuneLite's ItemManager.
+	 * Used as a last-resort fallback when caller-side caches don't have the name.
+	 */
+	public String getItemName(int itemId)
+	{
+		return ItemUtils.getItemName(itemManager, itemId);
+	}
+
+	/**
 	 * Store recommended sell price when user views/acts on a flip recommendation
 	 */
 	public void setRecommendedSellPrice(int itemId, int recommendedSellPrice)

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -330,10 +330,6 @@ public class FlipSmartPlugin extends Plugin
 		return activeFlipTracker.getInventoryCountForItem(itemId);
 	}
 
-	/**
-	 * Resolve a human-readable item name via RuneLite's ItemManager.
-	 * Used as a last-resort fallback when caller-side caches don't have the name.
-	 */
 	public String getItemName(int itemId)
 	{
 		return ItemUtils.getItemName(itemManager, itemId);

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -35,6 +35,17 @@ public class OfflineSyncService
 	private static final String PERSISTED_OFFERS_FALLBACK_KEY = "persistedOffers_lastSession";
 	private static final String COLLECTED_ITEMS_KEY_PREFIX = "collectedItems_";
 	private static final String COLLECTED_QUANTITIES_KEY_PREFIX = "collectedQuantities_";
+	private static final String COLLECTED_ITEMS_SAVED_AT_KEY_PREFIX = "collectedItemsSavedAt_";
+
+	/**
+	 * Persisted collected-item entries older than this are dropped on restore.
+	 * Issue #582: a multi-week absence left orphan entries in the collected-items
+	 * set that no longer matched live GE / inventory state, which the auto-recommend
+	 * focus path then misinterpreted. Seven days is well above any realistic
+	 * "bought but haven't sold yet" gap and well below the multi-week window
+	 * that produced the original bug report.
+	 */
+	static final long MAX_PERSISTED_COLLECTED_AGE_MS = 7L * 24 * 60 * 60 * 1000;
 	private final PlayerSession session;
 	private final FlipSmartApiClient apiClient;
 	private final ConfigManager configManager;
@@ -73,11 +84,23 @@ public class OfflineSyncService
 	/**
 	 * Restore collected item IDs from persisted config.
 	 * These are items that were bought but not yet sold when the player logged out.
+	 * Entries older than {@link #MAX_PERSISTED_COLLECTED_AGE_MS} are dropped to
+	 * avoid resurrecting state that no longer matches live GE/inventory after a
+	 * long absence (issue #582).
 	 */
 	public void restoreCollectedItems()
 	{
 		String key = getCollectedItemsKey();
 		log.debug("Attempting to restore collected items for RSN: {} (key: {})", session.getRsn(), key);
+
+		if (isPersistedCollectedTooOld())
+		{
+			log.debug("Persisted collected items for {} are stale (>{} days) - clearing instead of restoring",
+				session.getRsn(), MAX_PERSISTED_COLLECTED_AGE_MS / (24L * 60 * 60 * 1000));
+			clearPersistedCollectedItems();
+			session.clearCollectedItems();
+			return;
+		}
 
 		Set<Integer> persisted = loadPersistedCollectedItems();
 		if (!persisted.isEmpty())
@@ -93,6 +116,46 @@ public class OfflineSyncService
 			session.clearCollectedItems();
 		}
 
+	}
+
+	/**
+	 * Check whether the savedAt timestamp for the collected-items blob is missing
+	 * or older than the staleness threshold. Missing timestamps (legacy data
+	 * persisted before this guard existed) are treated as stale.
+	 */
+	private boolean isPersistedCollectedTooOld()
+	{
+		String savedAtKey = getCollectedItemsSavedAtKey();
+		String collectedKey = getCollectedItemsKey();
+
+		String collectedJson = configManager.getConfiguration(CONFIG_GROUP, collectedKey);
+		if (collectedJson == null || collectedJson.isEmpty())
+		{
+			return false;
+		}
+
+		String savedAtStr = configManager.getConfiguration(CONFIG_GROUP, savedAtKey);
+		if (savedAtStr == null || savedAtStr.isEmpty())
+		{
+			return true;
+		}
+
+		try
+		{
+			long savedAt = Long.parseLong(savedAtStr);
+			return System.currentTimeMillis() - savedAt > MAX_PERSISTED_COLLECTED_AGE_MS;
+		}
+		catch (NumberFormatException e)
+		{
+			return true;
+		}
+	}
+
+	private void clearPersistedCollectedItems()
+	{
+		configManager.unsetConfiguration(CONFIG_GROUP, getCollectedItemsKey());
+		configManager.unsetConfiguration(CONFIG_GROUP, getCollectedQuantitiesKey());
+		configManager.unsetConfiguration(CONFIG_GROUP, getCollectedItemsSavedAtKey());
 	}
 
 	/**
@@ -129,10 +192,12 @@ public class OfflineSyncService
 		}
 
 		// Persist collected item IDs (items bought but not yet sold)
+		String savedAtKey = getCollectedItemsSavedAtKey();
 		if (session.getCollectedItemIds().isEmpty())
 		{
 			configManager.unsetConfiguration(CONFIG_GROUP, collectedKey);
 			configManager.unsetConfiguration(CONFIG_GROUP, quantitiesKey);
+			configManager.unsetConfiguration(CONFIG_GROUP, savedAtKey);
 			log.debug("No collected items to persist for {}", session.getRsn());
 		}
 		else
@@ -152,6 +217,8 @@ public class OfflineSyncService
 				{
 					configManager.unsetConfiguration(CONFIG_GROUP, quantitiesKey);
 				}
+
+				configManager.setConfiguration(CONFIG_GROUP, savedAtKey, Long.toString(System.currentTimeMillis()));
 
 				log.debug("Persisted {} collected item IDs for {} (active flips)", session.getCollectedItemIds().size(), session.getRsn());
 			}
@@ -552,6 +619,15 @@ public class OfflineSyncService
 			return COLLECTED_QUANTITIES_KEY_PREFIX + UNKNOWN_RSN_FALLBACK;
 		}
 		return COLLECTED_QUANTITIES_KEY_PREFIX + session.getRsn();
+	}
+
+	public String getCollectedItemsSavedAtKey()
+	{
+		if (session.getRsn() == null || session.getRsn().isEmpty())
+		{
+			return COLLECTED_ITEMS_SAVED_AT_KEY_PREFIX + UNKNOWN_RSN_FALLBACK;
+		}
+		return COLLECTED_ITEMS_SAVED_AT_KEY_PREFIX + session.getRsn();
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -37,14 +37,7 @@ public class OfflineSyncService
 	private static final String COLLECTED_QUANTITIES_KEY_PREFIX = "collectedQuantities_";
 	private static final String COLLECTED_ITEMS_SAVED_AT_KEY_PREFIX = "collectedItemsSavedAt_";
 
-	/**
-	 * Persisted collected-item entries older than this are dropped on restore.
-	 * Issue #582: a multi-week absence left orphan entries in the collected-items
-	 * set that no longer matched live GE / inventory state, which the auto-recommend
-	 * focus path then misinterpreted. Seven days is well above any realistic
-	 * "bought but haven't sold yet" gap and well below the multi-week window
-	 * that produced the original bug report.
-	 */
+	/** Persisted collected-item entries older than this are dropped on restore. */
 	static final long MAX_PERSISTED_COLLECTED_AGE_MS = 7L * 24 * 60 * 60 * 1000;
 	private final PlayerSession session;
 	private final FlipSmartApiClient apiClient;
@@ -84,9 +77,7 @@ public class OfflineSyncService
 	/**
 	 * Restore collected item IDs from persisted config.
 	 * These are items that were bought but not yet sold when the player logged out.
-	 * Entries older than {@link #MAX_PERSISTED_COLLECTED_AGE_MS} are dropped to
-	 * avoid resurrecting state that no longer matches live GE/inventory after a
-	 * long absence (issue #582).
+	 * Entries older than {@link #MAX_PERSISTED_COLLECTED_AGE_MS} are dropped.
 	 */
 	public void restoreCollectedItems()
 	{
@@ -95,8 +86,7 @@ public class OfflineSyncService
 
 		if (isPersistedCollectedTooOld())
 		{
-			log.debug("Persisted collected items for {} are stale (>{} days) - clearing instead of restoring",
-				session.getRsn(), MAX_PERSISTED_COLLECTED_AGE_MS / (24L * 60 * 60 * 1000));
+			log.debug("Persisted collected items for {} are stale - clearing", session.getRsn());
 			clearPersistedCollectedItems();
 			session.clearCollectedItems();
 			return;
@@ -118,11 +108,7 @@ public class OfflineSyncService
 
 	}
 
-	/**
-	 * Check whether the savedAt timestamp for the collected-items blob is missing
-	 * or older than the staleness threshold. Missing timestamps (legacy data
-	 * persisted before this guard existed) are treated as stale.
-	 */
+	/** Missing timestamps (legacy data) are treated as stale. */
 	private boolean isPersistedCollectedTooOld()
 	{
 		String savedAtKey = getCollectedItemsSavedAtKey();

--- a/src/main/java/com/flipsmart/PlayerSession.java
+++ b/src/main/java/com/flipsmart/PlayerSession.java
@@ -408,10 +408,7 @@ public class PlayerSession
 		return false;
 	}
 
-	/**
-	 * Check if an item has a buy offer that is still in flight
-	 * (placed but not yet completed/cancelled — items not yet collectable).
-	 */
+	/** Buy offer placed but not yet completed (items not collectable yet). */
 	public boolean hasInFlightBuyOfferForItem(int itemId)
 	{
 		for (TrackedOffer offer : trackedOffers.values())
@@ -424,10 +421,7 @@ public class PlayerSession
 		return false;
 	}
 
-	/**
-	 * Check if an item has a completed buy offer that hasn't been collected yet
-	 * (BOUGHT state — items waiting in the GE slot for the user to collect).
-	 */
+	/** Buy offer completed but items still in the GE slot awaiting collection. */
 	public boolean hasUncollectedBuyOfferForItem(int itemId)
 	{
 		for (TrackedOffer offer : trackedOffers.values())

--- a/src/main/java/com/flipsmart/PlayerSession.java
+++ b/src/main/java/com/flipsmart/PlayerSession.java
@@ -409,6 +409,38 @@ public class PlayerSession
 	}
 
 	/**
+	 * Check if an item has a buy offer that is still in flight
+	 * (placed but not yet completed/cancelled — items not yet collectable).
+	 */
+	public boolean hasInFlightBuyOfferForItem(int itemId)
+	{
+		for (TrackedOffer offer : trackedOffers.values())
+		{
+			if (offer.getItemId() == itemId && offer.isBuy() && !offer.isCompleted())
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Check if an item has a completed buy offer that hasn't been collected yet
+	 * (BOUGHT state — items waiting in the GE slot for the user to collect).
+	 */
+	public boolean hasUncollectedBuyOfferForItem(int itemId)
+	{
+		for (TrackedOffer offer : trackedOffers.values())
+		{
+			if (offer.getItemId() == itemId && offer.isBuy() && offer.isCompleted())
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Check if there are available GE slots for new offers.
 	 */
 	public boolean hasAvailableGESlots(int slotLimit)

--- a/src/test/java/com/flipsmart/PlayerSessionTest.java
+++ b/src/test/java/com/flipsmart/PlayerSessionTest.java
@@ -64,10 +64,6 @@ public class PlayerSessionTest
 		assertEquals("Foo", session.getRsnSafe().orElse(null));
 	}
 
-	// --- Buy-state classification (issue #582) ---
-	// The plugin must distinguish in-flight buys from completed-but-uncollected
-	// buys so the SELL prompt doesn't fire while items are still in the GE slot.
-
 	private static TrackedOffer inFlightBuy(int itemId)
 	{
 		return new TrackedOffer(itemId, "x", true, 100, 1, 5);

--- a/src/test/java/com/flipsmart/PlayerSessionTest.java
+++ b/src/test/java/com/flipsmart/PlayerSessionTest.java
@@ -63,4 +63,60 @@ public class PlayerSessionTest
 		session.setRsn("Foo");
 		assertEquals("Foo", session.getRsnSafe().orElse(null));
 	}
+
+	// --- Buy-state classification (issue #582) ---
+	// The plugin must distinguish in-flight buys from completed-but-uncollected
+	// buys so the SELL prompt doesn't fire while items are still in the GE slot.
+
+	private static TrackedOffer inFlightBuy(int itemId)
+	{
+		return new TrackedOffer(itemId, "x", true, 100, 1, 5);
+	}
+
+	private static TrackedOffer completedBuy(int itemId)
+	{
+		TrackedOffer offer = new TrackedOffer(itemId, "x", true, 100, 1, 100);
+		offer.setCompletedAtMillis(System.currentTimeMillis());
+		return offer;
+	}
+
+	@Test
+	public void hasInFlightBuyOffer_trueForBuyingPartialFill()
+	{
+		PlayerSession session = new PlayerSession();
+		session.putTrackedOffer(0, inFlightBuy(3827));
+
+		assertTrue(session.hasInFlightBuyOfferForItem(3827));
+		assertFalse(session.hasUncollectedBuyOfferForItem(3827));
+	}
+
+	@Test
+	public void hasUncollectedBuyOffer_trueForCompletedNotYetCollected()
+	{
+		PlayerSession session = new PlayerSession();
+		session.putTrackedOffer(0, completedBuy(3827));
+
+		assertTrue(session.hasUncollectedBuyOfferForItem(3827));
+		assertFalse(session.hasInFlightBuyOfferForItem(3827));
+	}
+
+	@Test
+	public void noBuyOfferState_bothHelpersFalse()
+	{
+		PlayerSession session = new PlayerSession();
+
+		assertFalse(session.hasInFlightBuyOfferForItem(3827));
+		assertFalse(session.hasUncollectedBuyOfferForItem(3827));
+	}
+
+	@Test
+	public void sellOffer_doesNotCountAsBuyState()
+	{
+		PlayerSession session = new PlayerSession();
+		TrackedOffer sellOffer = new TrackedOffer(3827, "x", false, 100, 1, 5);
+		session.putTrackedOffer(0, sellOffer);
+
+		assertFalse(session.hasInFlightBuyOfferForItem(3827));
+		assertFalse(session.hasUncollectedBuyOfferForItem(3827));
+	}
 }


### PR DESCRIPTION
## Summary

- Plugin was jumping to SELL state while a GE buy offer was still in-flight (partial fill, orange progress bar), incorrectly prompting the user to sell items not yet received
- Item names were rendering as \`Item 3827\` instead of \`Saradomin page 1\` because the fallback used a raw ID string rather than resolving through RuneLite's ItemManager
- Three bugs from the same live screenshot; all fixed in the first commit
- Long-absence logins were restoring stale collected-items state (the root trigger for the screenshot bug) — persisted collected items older than 7 days are now dropped on restore

## What's changed

**\`PlayerSession.java\`**
- Added \`hasInFlightBuyOfferForItem(int itemId)\` — returns \`true\` when there is an active buy offer that is not yet completed (\`!TrackedOffer.isCompleted()\`)
- Added \`hasUncollectedBuyOfferForItem(int itemId)\` — returns \`true\` when a buy offer is completed but the items have not been pulled from the GE slot yet

**\`AutoRecommendService.java\`**
- Rewrote \`evaluateCollectedItem\` so an item is only considered sellable when it is actually present in inventory
- In-flight buy offers now return \`-1\` and fall through to \`promptCollection()\`, which shows the correct "Collect \`<name>\`" or waiting message instead of a premature SELL prompt
- Fixed the item name fallback: replaced \`"Item " + id\` with \`plugin.getItemName(id)\` (resolves through ItemManager)

**\`FlipSmartPlugin.java\`**
- Added public \`getItemName(int itemId)\` helper wrapping \`ItemUtils.getItemName(itemManager, id)\` so services can resolve names without holding a direct ItemManager reference

**\`PlayerSessionTest.java\`**
- 4 new unit tests covering the buy-state classification helpers (\`hasInFlightBuyOfferForItem\`, \`hasUncollectedBuyOfferForItem\`)

**\`OfflineSyncService.java\`**
- New constant \`MAX_PERSISTED_COLLECTED_AGE_MS\` (7 days, package-private \`static final\` so tests can reference it)
- New constant \`COLLECTED_ITEMS_SAVED_AT_KEY_PREFIX\` for the RuneLite config key that stores the savedAt timestamp
- New public accessor \`getCollectedItemsSavedAtKey()\` (mirrors the existing \`getCollectedItemsKey\` / \`getCollectedQuantitiesKey\` pattern)
- \`persistOfferState\`: writes \`System.currentTimeMillis()\` as a string under the savedAt key whenever collected items are persisted; unsets the savedAt key when there are no items to persist
- \`restoreCollectedItems\`: calls \`isPersistedCollectedTooOld()\` first — if savedAt is missing (legacy data) or older than 7 days, the persisted blob and savedAt key are cleared and the session's collected items are reset instead of restored
- New private helpers: \`isPersistedCollectedTooOld()\` and \`clearPersistedCollectedItems()\`

## Test plan

- [x] Place a long-running buy order (e.g. a slow-moving item) with a large enough quantity that it partially fills and stays active for 20+ seconds
- [x] While the buy offer is still in the orange progress state, open the FlipSmart panel — confirm it does NOT show "Click SELL on collected items"; it should show a waiting/collect prompt instead
- [x] Let the buy complete; before collecting, verify the panel shows "Collect \`<ItemName>\`" with the correct resolved name (not \`Item <id>\`)
- [x] Collect the items into inventory; confirm the panel now transitions to the SELL state correctly
- [x] Trigger a queue refresh mid-buy; confirm item name still resolves correctly after refresh (was the original reproduction case)
- [x] Verify that after a multi-week absence (or simulated by setting \`MAX_PERSISTED_COLLECTED_AGE_MS\` to a small value and waiting), \`restoreCollectedItems\` clears the persisted blob and the session starts with an empty collected-items set instead of restoring stale entries
- [x] Run \`./gradlew test\` — all tests pass

## Linked issue

Closes Flip-Smart/flip-smart#582