### PR TITLE
fix: keep subscribe banner aligned with stored premium status

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1279,8 +1279,10 @@ public class FlipFinderPanel extends PluginPanel
 	}
 
 	/**
-	 * Update the premium status display (subscribe label visibility).
-	 * Called when entitlements are fetched on game login.
+	 * Sync the subscribe banner's text and visibility with the locally-stored
+	 * premium / RSN-entitlement state. Safe to call from any UI-transition path
+	 * (login, logout, away-from-GE, empty/failed responses, entitlements fetch);
+	 * it never depends on a fresh API response.
 	 */
 	public void updatePremiumStatus()
 	{
@@ -1395,6 +1397,8 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				refreshButton.setEnabled(true);
 				showErrorInRecommended(ERROR_PREFIX + throwable.getMessage());
+				// Failed call — banner should reflect stored premium state.
+				updatePremiumStatus();
 				restoreScrollPosition(recommendedScrollPane, scrollPos);
 			});
 			return null;
@@ -1419,6 +1423,9 @@ public class FlipFinderPanel extends PluginPanel
 				else
 				{
 					showErrorInRecommended("Failed to fetch recommendations. Check your API settings.");
+					// API call failed — derive banner from stored premium status
+					// rather than leaving it stuck on the previous response.
+					updatePremiumStatus();
 				}
 				restoreScrollPosition(recommendedScrollPane, scrollPos);
 				return;
@@ -1428,6 +1435,9 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				currentRecommendations.clear();
 				showErrorInRecommended("No flip recommendations found matching your criteria.");
+				// Empty result — banner must still reflect current premium status,
+				// not whatever it happened to be set to last.
+				updatePremiumStatus();
 				restoreScrollPosition(recommendedScrollPane, scrollPos);
 				return;
 			}
@@ -1888,6 +1898,11 @@ public class FlipFinderPanel extends PluginPanel
 		showErrorInContainer(recommendedListContainer, "Flip Finder", "You must be in the Grand Exchange to load suggestions.");
 		statusLabel.setText("Visit the Grand Exchange");
 		refreshButton.setEnabled(true);
+		// Banner visibility must reflect stored premium status, not be left stale
+		// from the last API response. Without this, premium users who walk away
+		// from the GE see a "Subscribe to Premium" banner because no /flip-finder
+		// call ever runs to refresh it.
+		updatePremiumStatus();
 	}
 
 	/**
@@ -2035,6 +2050,10 @@ public class FlipFinderPanel extends PluginPanel
 		completedFlipsListContainer.add(createEmptyStatePanel(MSG_LOGIN_TO_RUNESCAPE, MSG_LOGIN_INSTRUCTION, 80));
 		completedFlipsListContainer.revalidate();
 		completedFlipsListContainer.repaint();
+
+		// Keep subscribe banner aligned with stored premium status while logged out
+		// of RuneScape (no API calls run, so the banner would otherwise stay stale).
+		updatePremiumStatus();
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1397,7 +1397,6 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				refreshButton.setEnabled(true);
 				showErrorInRecommended(ERROR_PREFIX + throwable.getMessage());
-				// Failed call — banner should reflect stored premium state.
 				updatePremiumStatus();
 				restoreScrollPosition(recommendedScrollPane, scrollPos);
 			});
@@ -1423,8 +1422,6 @@ public class FlipFinderPanel extends PluginPanel
 				else
 				{
 					showErrorInRecommended("Failed to fetch recommendations. Check your API settings.");
-					// API call failed — derive banner from stored premium status
-					// rather than leaving it stuck on the previous response.
 					updatePremiumStatus();
 				}
 				restoreScrollPosition(recommendedScrollPane, scrollPos);
@@ -1435,8 +1432,6 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				currentRecommendations.clear();
 				showErrorInRecommended("No flip recommendations found matching your criteria.");
-				// Empty result — banner must still reflect current premium status,
-				// not whatever it happened to be set to last.
 				updatePremiumStatus();
 				restoreScrollPosition(recommendedScrollPane, scrollPos);
 				return;
@@ -1898,10 +1893,6 @@ public class FlipFinderPanel extends PluginPanel
 		showErrorInContainer(recommendedListContainer, "Flip Finder", "You must be in the Grand Exchange to load suggestions.");
 		statusLabel.setText("Visit the Grand Exchange");
 		refreshButton.setEnabled(true);
-		// Banner visibility must reflect stored premium status, not be left stale
-		// from the last API response. Without this, premium users who walk away
-		// from the GE see a "Subscribe to Premium" banner because no /flip-finder
-		// call ever runs to refresh it.
 		updatePremiumStatus();
 	}
 
@@ -2051,8 +2042,6 @@ public class FlipFinderPanel extends PluginPanel
 		completedFlipsListContainer.revalidate();
 		completedFlipsListContainer.repaint();
 
-		// Keep subscribe banner aligned with stored premium status while logged out
-		// of RuneScape (no API calls run, so the banner would otherwise stay stale).
 		updatePremiumStatus();
 	}
 


### PR DESCRIPTION
## Summary

When a player walks away from the Grand Exchange, `FlipFinderPanel.refreshRecommendations()` returns early without making an API call. Because `subscribeLabel` visibility was only updated inside `handleRecommendationsResponse()`, premium users who left the GE would continue to see a \"Subscribe to Premium\" banner — the UI was stuck on whatever state the last response had set. This PR ensures the subscribe banner always reflects the locally-stored premium entitlement state, regardless of whether an API call has run recently.

## Root Cause

PR #113 (_Gate flip suggestions to Grand Exchange only_) introduced an early return in `refreshRecommendations()` for non-GE contexts. Before that change, every UI refresh produced a fresh API response that updated the banner. After it, the only code path that updated banner visibility was `handleRecommendationsResponse()` — which was now skipped entirely when the player was not at the GE. The same gap existed for the async exception path, empty-results branch, null-response branch, and `showLoggedOutOfGameState()`.

## Changes

- **`showNotAtGeMessage()`** — calls `updatePremiumStatus()` after rendering the \"visit the Grand Exchange\" message. This is the primary fix for the reported regression.
- **`showLoggedOutOfGameState()`** — calls `updatePremiumStatus()` so the banner is correct while the player is logged out of RuneScape (no API calls run during this state).
- **`handleRecommendationsResponse()` — empty-results branch** — calls `updatePremiumStatus()` so a \"no flips found\" screen does not leave the banner stale.
- **`handleRecommendationsResponse()` — null/failed-response branch** — calls `updatePremiumStatus()` for the same reason.
- **`.exceptionally(...)` handler in `refreshRecommendations()`** — calls `updatePremiumStatus()` after logging the async failure, so a network error does not freeze the banner state.
- **`updatePremiumStatus()` JavaDoc** — updated to document its expanded role: safe to call from any UI-transition path; never depends on a fresh API response.

`updatePremiumStatus()` derives text and visibility entirely from `apiClient.isPremium()` and `apiClient.isRsnBlocked()` — locally-stored state that is valid at all times.

## Acceptance Criteria

| AC | How it is satisfied |
|---|---|
| Premium status is stored and accessible client-side, independent of active API calls or GE proximity | Already true via `apiClient.isPremium()`; this PR ensures every UI-transition path actually reads it. |
| "Subscribe to Premium" banner is never displayed for premium users regardless of in-game location | `showNotAtGeMessage()` now calls `updatePremiumStatus()`, which hides the banner when `apiClient.isPremium()` is true. |
| "Subscribe to Premium" banner is displayed for non-premium users in all locations | All non-response paths now call `updatePremiumStatus()`, which shows the banner when `apiClient.isPremium()` is false. |
| Plugin does not fall back to a non-premium UI state when the API is idle or returning no suggestions | Empty-result and failed-response branches now call `updatePremiumStatus()` instead of leaving the banner unchanged. |
| Premium status check does not depend on a successful API response | `updatePremiumStatus()` reads local state only; no network call is involved. |
| Manually verified at GE, away from GE, and immediately after login | Covered by the manual test plan below. |

## Manual Test Plan

A reviewer should verify the following scenarios with a premium account and a free account in-game:

- [x] **Premium account — at the Grand Exchange** → \"Subscribe to Premium\" banner is not visible.
- [x] **Premium account — walking away from the Grand Exchange** → banner remains hidden (this is the regression scenario; was broken before this fix).
- [x] **Premium account — immediately after game login, before any API call has resolved** → banner is not visible once entitlements are stored by the initial login flow.
- [x] **Free account — at the Grand Exchange** → banner is visible.
- [x] **Free account — away from the Grand Exchange** → banner remains visible.
- [x] **Free account — fresh login, before any API call resolves** → banner becomes visible once entitlements resolve.
- [x] **RSN-blocked account** → subscribe label shows the \"Subscribe to Premium for this account\" RSN-specific text rather than the generic label.

## SonarCloud

Branch analysis shows zero new issues introduced by this change.

## Non-Goals

- Not changing the `apiClient.isPremium = false` initial default.
- Not refactoring the existing inline `subscribeLabel.setVisible(!response.isPremium())` in `handleRecommendationsResponse()` (line ~1459) — that path still updates the banner on a successful response, which is correct.
- Not adding periodic background re-fetching of entitlements.

---

Closes Flip-Smart/flip-smart#575