### PR TITLE
fix: gate inventory sell highlight to GE window open

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -2081,12 +2081,18 @@ public class AutoRecommendService
 	}
 
 	/**
-	 * Resolve the best sell price for an item.
-	 * Prefers the panel's displayed (smart) sell price over the session's stored price,
-	 * since the panel's price reflects current market conditions and time thresholds.
+	 * Resolve the best sell price for an item. Session is the single source of truth:
+	 * it carries the most recent decision (initial smart-sell, or a manual/auto sell
+	 * adjustment) and is what the Flip Assist prompt reads. The panel's displayed
+	 * price is only a fallback for items the session hasn't seen yet.
 	 */
 	private Integer resolveBestSellPrice(int itemId)
 	{
+		Integer sessionPrice = plugin.getSession().getRecommendedPrice(itemId);
+		if (sessionPrice != null && sessionPrice > 0)
+		{
+			return sessionPrice;
+		}
 		IntFunction<Integer> provider = displayedSellPriceProvider;
 		if (provider != null)
 		{
@@ -2096,7 +2102,7 @@ public class AutoRecommendService
 				return smartPrice;
 			}
 		}
-		return plugin.getSession().getRecommendedPrice(itemId);
+		return null;
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3031,9 +3031,13 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private void setFocus(ActiveFlip flip, JPanel panel)
 	{
-		// Use the cached sell price that's already displayed in the panel
-		// This ensures the Flip Assist shows the same price as the Active Flips tab
-		Integer cachedSellPrice = displayedSellPrices.get(flip.getItemId());
+		// Prefer session — it carries any sell-price adjustments. The displayed
+		// cache is only a fallback when session hasn't been populated yet.
+		PlayerSession session = plugin.getSession();
+		Integer sessionPrice = session != null ? session.getRecommendedPrice(flip.getItemId()) : null;
+		Integer cachedSellPrice = (sessionPrice != null && sessionPrice > 0)
+			? sessionPrice
+			: displayedSellPrices.get(flip.getItemId());
 		int priceOffset = config.priceOffset();
 		
 		if (cachedSellPrice != null && cachedSellPrice > 0)
@@ -3355,13 +3359,22 @@ public class FlipFinderPanel extends PluginPanel
 					}
 				}
 				
-				// Calculate smart sell price based on time, volume, and profitability
-				Integer smartSellPrice = calculateSmartSellPrice(flip, currentMarketPrice);
+				// Session is the source of truth for sell price (initial smart-sell or
+				// any subsequent adjustment writes there). Only fall through to the
+				// freshly-computed smart-sell when the session has nothing yet.
+				PlayerSession session = plugin.getSession();
+				Integer sessionPrice = session != null ? session.getRecommendedPrice(flip.getItemId()) : null;
+				Integer smartSellPrice = (sessionPrice != null && sessionPrice > 0)
+					? sessionPrice
+					: calculateSmartSellPrice(flip, currentMarketPrice);
 				boolean pastThreshold = shouldUseLossMinimizingPrice(flip, dailyVolume);
-				
+
 				if (smartSellPrice != null && smartSellPrice > 0)
 				{
-					// Cache the displayed sell price so Flip Assist uses the same value
+					if ((sessionPrice == null || sessionPrice <= 0) && session != null)
+					{
+						session.setRecommendedPrice(flip.getItemId(), smartSellPrice);
+					}
 					displayedSellPrices.put(flip.getItemId(), smartSellPrice);
 					
 					// Apply background color based on price comparison with original recommendation

--- a/src/main/java/com/flipsmart/InventoryHighlightOverlay.java
+++ b/src/main/java/com/flipsmart/InventoryHighlightOverlay.java
@@ -1,6 +1,8 @@
 package com.flipsmart;
 
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
@@ -17,12 +19,18 @@ public class InventoryHighlightOverlay extends WidgetItemOverlay
 {
 	private static final Color COLOR_GLOW = new Color(255, 185, 50);
 
+	private static final int GE_INTERFACE_GROUP = 465;
+	private static final int GE_OFFER_PANEL_CHILD = 26;
+
 	private final Set<Integer> highlightedItemIds = ConcurrentHashMap.newKeySet();
 
 	private final Map<Long, BufferedImage> outlineCache = new ConcurrentHashMap<>();
 
 	@Inject
 	private ItemManager itemManager;
+
+	@Inject
+	private Client client;
 
 	public InventoryHighlightOverlay()
 	{
@@ -50,6 +58,11 @@ public class InventoryHighlightOverlay extends WidgetItemOverlay
 	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem widgetItem)
 	{
 		if (!highlightedItemIds.contains(itemId))
+		{
+			return;
+		}
+
+		if (!isGrandExchangeOpen())
 		{
 			return;
 		}
@@ -132,6 +145,18 @@ public class InventoryHighlightOverlay extends WidgetItemOverlay
 		}
 
 		return outline;
+	}
+
+	private boolean isGrandExchangeOpen()
+	{
+		Widget geWidget = client.getWidget(GE_INTERFACE_GROUP, 0);
+		if (geWidget != null && !geWidget.isHidden())
+		{
+			return true;
+		}
+
+		Widget offerPanel = client.getWidget(GE_INTERFACE_GROUP, GE_OFFER_PANEL_CHILD);
+		return offerPanel != null && !offerPanel.isHidden();
 	}
 
 	private boolean hasOpaqueNeighbor(BufferedImage image, int x, int y, int w, int h)


### PR DESCRIPTION
## Summary

Two flip-assist fixes bundled.

1. **Inventory sell highlights are gated to the Grand Exchange window being open.** Previously the highlight could persist on items being used for unrelated activities (e.g. Anglerfish during PvM). Closes Flip-Smart/flip-smart#585.
2. **One source of truth for the resell price.** Manual sell adjustments are written to `session.recommendedPrice`, but the active-flips panel maintained its own `displayedSellPrices` cache (recomputed every refresh from the active flip's recommendedSellPrice). The Flip Assist focus preferred the panel cache, so an adjustment prompt at e.g. 774gp would still show 902gp in the GE setup, fighting on every tick. Now `session.recommendedPrice` is canonical for sell pricing.

## Changes

### 🐛 Bug fix #1 — sell highlight gated to GE open

- `InventoryHighlightOverlay`: injected `Client` and added `isGrandExchangeOpen()` predicate at the top of `renderItemOverlay`. If widget 465 (GE main interface, child 0) or widget 465:26 (GE offer panel) is not visible, render returns early — no highlight is drawn regardless of what is in `highlightedItemIds`.
- Highlights disappear immediately (next frame) when the GE closes and resume when it reopens, with no explicit clear/restore call needed.

Chose render-time gating over add/remove-time gating: multiple callers (`updateInventoryHighlightForFocus`, `manualAdjustmentTracker.setOnHighlightInventoryItem`) independently manage the highlight set. Gating at render time provides one uniform predicate that covers all paths without GE-state wiring in every caller.

### 🐛 Bug fix #2 — resell price single source of truth

- `AutoRecommendService.resolveBestSellPrice`: reads `session.getRecommendedPrice(itemId)` first; the panel's displayed-price cache is now a fallback for items the session hasn't seen yet. Adjustments win because they explicitly write to session.
- `FlipFinderPanel.refreshActiveFlips` smart-sell loop: when session already has a price for the item, it is used as the displayed value (and not overwritten by a freshly-computed smart-sell). When session has nothing yet, smart-sell is computed and written back to session so subsequent reads stay consistent.
- `FlipFinderPanel.setFocus(ActiveFlip, JPanel)`: prefers session over the displayed-price cache for the same reason.

Net result: whichever price the user sees in the Flip Assist prompt (initial smart-sell, or any subsequent adjustment) is the same price that pre-fills the GE sell setup.

## Testing

### Automated Tests
- ✅ `./gradlew compileJava` — BUILD SUCCESSFUL
- ✅ `./gradlew test` — BUILD SUCCESSFUL

### Manual Testing — sell highlight gating (#585)
- [ ] Start a flip, get to sell step, confirm highlight shows in inventory while at GE
- [ ] Walk away from GE with item still in inventory — highlight disappears immediately
- [ ] Engage in unrelated activity (e.g. PvM with Anglerfish-style consumable) — no highlight
- [ ] Return to GE and open the interface — highlight resumes for the active sell
- [ ] Close the GE window without leaving the area — highlight clears
- [ ] Reopen the GE window — highlight resumes

### Manual Testing — resell price source of truth
- [ ] Place a sell offer that goes stale enough to trigger a manual sell-price adjustment (e.g. basalt scenario from runelite logs).
- [ ] Confirm the prompt shows the adjusted price (e.g. \"Adjust basalt sell price 902 → 774 gp\").
- [ ] Walk to GE, click the highlighted slot, observe pre-filled sell price — it must match the prompt (774, not 902).
- [ ] Verify on subsequent active-flips refreshes the panel UI continues to show 774, not snapping back to 902.
- [ ] If a second adjustment fires later with a different price, that new price flows through to both the prompt and the GE setup consistently.

## Acceptance Criteria Coverage (#585)

| AC | Coverage |
|----|----------|
| AC1: no highlight unless GE open | `renderItemOverlay` returns early if `isGrandExchangeOpen()` is false |
| AC2: cleared immediately on GE close | predicate is checked every frame |
| AC3: resumes on GE reopen | same predicate flips to true when widget 465 becomes visible |
| AC4: real-time, not stale | widget visibility queried per-render, no caching |
| AC5: Anglerfish during PvM not highlighted | GE widget is not visible during PvM, so render returns early |

## API Changes

None — both changes are internal.

## Deployment Notes

- Environment variables added/changed: None
- Dependencies added: None
- Configuration changes: None
- Requires database migration: No

## Related Issues

Closes Flip-Smart/flip-smart#585

The resell-price fix was raised in PR review while testing #585 (basalt re-sell prompt at ~774gp but GE pre-fills 902gp, repeating each tick).

## 🩺 SonarCloud

No open issues found on this branch for `Flip-Smart_flip-smart-runelite-plugin` (public project, verified via anonymous API query).