### PR TITLE
feat(assist): trade activity log under idle Flip Assist states

### DIFF
--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -86,6 +86,7 @@ public class FlipAssistOverlay extends Overlay
 	private final ClientThread clientThread;
 	private final FlipSmartConfig config;
 	private final ItemManager itemManager;
+	private final TradeActivityLog tradeActivityLog;
 	
 	@Getter
 	private FocusedFlip focusedFlip;
@@ -147,13 +148,14 @@ public class FlipAssistOverlay extends Overlay
 	}
 
 	@Inject
-	private FlipAssistOverlay(FlipSmartPlugin flipSmartPlugin, Client client, ClientThread clientThread, FlipSmartConfig config, ItemManager itemManager)
+	private FlipAssistOverlay(FlipSmartPlugin flipSmartPlugin, Client client, ClientThread clientThread, FlipSmartConfig config, ItemManager itemManager, TradeActivityLog tradeActivityLog)
 	{
 		this.flipSmartPlugin = flipSmartPlugin;
 		this.client = client;
 		this.clientThread = clientThread;
 		this.config = config;
 		this.itemManager = itemManager;
+		this.tradeActivityLog = tradeActivityLog;
 		
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_WIDGETS);
@@ -357,6 +359,11 @@ public class FlipAssistOverlay extends Overlay
 		int maxTextWidth = HINT_PANEL_WIDTH - textPadding * 2;
 		java.util.List<String> wrappedLines = null;
 
+		// Activity log: shown in idle assist states (waiting/monitoring) (AC4)
+		java.util.List<TradeActivityLog.Entry> activityEntries =
+			isIdleAssistMessage(message) ? tradeActivityLog.snapshot() : java.util.Collections.emptyList();
+		int activityLogHeight = computeActivityLogHeight(activityEntries, smallMetrics);
+
 		int panelHeight;
 		if (hasIcon)
 		{
@@ -376,6 +383,7 @@ public class FlipAssistOverlay extends Overlay
 			panelHeight = 20 + 8 + lineHeight * wrappedLines.size() + 8;
 			panelHeight = Math.max(panelHeight, HINT_PANEL_HEIGHT);
 		}
+		panelHeight += activityLogHeight;
 
 		// Calculate pulse animation
 		long elapsed = System.currentTimeMillis() - animationStartTime;
@@ -459,7 +467,66 @@ public class FlipAssistOverlay extends Overlay
 			}
 		}
 
+		if (!activityEntries.isEmpty())
+		{
+			int activityTop = panelHeight - activityLogHeight;
+			renderActivityLog(graphics, activityEntries, activityTop, smallMetrics);
+		}
+
 		return new Dimension(HINT_PANEL_WIDTH, panelHeight);
+	}
+
+	private boolean isIdleAssistMessage(String message)
+	{
+		if (message == null)
+		{
+			return false;
+		}
+		return message.startsWith("Waiting for flips")
+			|| message.startsWith("Monitoring active offers");
+	}
+
+	private int computeActivityLogHeight(java.util.List<TradeActivityLog.Entry> entries, FontMetrics fm)
+	{
+		if (entries.isEmpty())
+		{
+			return 0;
+		}
+		// gap above divider (4) + divider line (1) + gap below (4) + entries + bottom padding (4)
+		return 4 + 1 + 4 + fm.getHeight() * entries.size() + 4;
+	}
+
+	private void renderActivityLog(Graphics2D graphics, java.util.List<TradeActivityLog.Entry> entries, int top, FontMetrics fm)
+	{
+		int dividerY = top + 4;
+		graphics.setColor(COLOR_STEP_PENDING);
+		graphics.setStroke(new BasicStroke(1f));
+		graphics.drawLine(10, dividerY, HINT_PANEL_WIDTH - 10, dividerY);
+
+		graphics.setFont(FontManager.getRunescapeSmallFont());
+		int lineHeight = fm.getHeight();
+		int textY = dividerY + 4 + fm.getAscent();
+		int leftX = 10;
+		int rightEdge = HINT_PANEL_WIDTH - 10;
+		for (TradeActivityLog.Entry entry : entries)
+		{
+			String ago = TimeUtils.formatRelativeAgo(entry.getTimestampMs());
+			int agoWidth = fm.stringWidth(ago);
+			int agoX = rightEdge - agoWidth;
+
+			String prefix = entry.isBuy() ? "Buy" : "Sell";
+			String head = String.format("%s %dx ", prefix, entry.getQuantity());
+			int nameMaxWidth = agoX - leftX - fm.stringWidth(head) - 4;
+			String name = truncateString(entry.getItemName(), Math.max(0, nameMaxWidth), fm);
+
+			graphics.setColor(entry.isBuy() ? COLOR_BUY : COLOR_SELL);
+			graphics.drawString(head + name, leftX, textY);
+
+			graphics.setColor(COLOR_TEXT_DIM);
+			graphics.drawString(ago, agoX, textY);
+
+			textY += lineHeight;
+		}
 	}
 
 	private Color getHintLineColor(String line)

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -29,6 +29,7 @@ public class GrandExchangeTracker
 	private final FlipSmartApiClient apiClient;
 	private final ActiveFlipTracker activeFlipTracker;
 	private final ItemManager itemManager;
+	private final TradeActivityLog tradeActivityLog;
 
 	// Set after construction (created in plugin startUp)
 	private AutoRecommendService autoRecommendService;
@@ -73,12 +74,14 @@ public class GrandExchangeTracker
 		PlayerSession session,
 		FlipSmartApiClient apiClient,
 		ActiveFlipTracker activeFlipTracker,
-		ItemManager itemManager)
+		ItemManager itemManager,
+		TradeActivityLog tradeActivityLog)
 	{
 		this.session = session;
 		this.apiClient = apiClient;
 		this.activeFlipTracker = activeFlipTracker;
 		this.itemManager = itemManager;
+		this.tradeActivityLog = tradeActivityLog;
 	}
 
 	// =====================
@@ -579,6 +582,8 @@ public class GrandExchangeTracker
 			.rsn(getRsn().orElse(null))
 			.totalQuantity(ctx.totalQuantity)
 			.build());
+
+		tradeActivityLog.record(ctx.itemId, ctx.itemName, ctx.isBuy, newQuantity);
 
 		if (!ctx.isBuy)
 		{

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -583,7 +583,7 @@ public class GrandExchangeTracker
 			.totalQuantity(ctx.totalQuantity)
 			.build());
 
-		tradeActivityLog.record(ctx.itemId, ctx.itemName, ctx.isBuy, newQuantity);
+		tradeActivityLog.addEntry(ctx.itemId, ctx.itemName, ctx.isBuy, newQuantity);
 
 		if (!ctx.isBuy)
 		{

--- a/src/main/java/com/flipsmart/TimeUtils.java
+++ b/src/main/java/com/flipsmart/TimeUtils.java
@@ -99,4 +99,34 @@ public final class TimeUtils
 		}
 		return minutes + "m";
 	}
+
+	/**
+	 * Format elapsed time as a relative "ago" string (e.g., "just now", "5m ago", "2h 15m ago").
+	 */
+	public static String formatRelativeAgo(long pastMillis)
+	{
+		long elapsed = Math.max(0, System.currentTimeMillis() - pastMillis);
+		long seconds = elapsed / 1000;
+		long minutes = elapsed / 60000;
+		long hours = elapsed / 3600000;
+
+		if (seconds < 5)
+		{
+			return "just now";
+		}
+		if (minutes < 1)
+		{
+			return seconds + "s ago";
+		}
+		if (hours < 1)
+		{
+			return minutes + "m ago";
+		}
+		long remMinutes = minutes - hours * 60;
+		if (remMinutes == 0)
+		{
+			return hours + "h ago";
+		}
+		return hours + "h " + remMinutes + "m ago";
+	}
 }

--- a/src/main/java/com/flipsmart/TradeActivityLog.java
+++ b/src/main/java/com/flipsmart/TradeActivityLog.java
@@ -35,7 +35,7 @@ public class TradeActivityLog
 
 	private final Deque<Entry> entries = new ConcurrentLinkedDeque<>();
 
-	public void record(int itemId, String itemName, boolean isBuy, int quantity)
+	public void addEntry(int itemId, String itemName, boolean isBuy, int quantity)
 	{
 		if (quantity <= 0 || itemName == null)
 		{

--- a/src/main/java/com/flipsmart/TradeActivityLog.java
+++ b/src/main/java/com/flipsmart/TradeActivityLog.java
@@ -1,0 +1,60 @@
+package com.flipsmart;
+
+import lombok.Value;
+
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+/**
+ * Bounded, in-memory log of recent fulfilled GE trade events used by the Flip
+ * Assist "waiting for flips" hint. Newest entries are at the front; older
+ * entries beyond {@link #MAX_ENTRIES} are dropped.
+ *
+ * <p>Each entry represents a single fill event ("Bought 28x Bow string"); a
+ * partially filled offer that fills again later produces two separate entries
+ * because the user perceives them as distinct activity beats.
+ */
+@Singleton
+public class TradeActivityLog
+{
+	public static final int MAX_ENTRIES = 4;
+
+	@Value
+	public static class Entry
+	{
+		int itemId;
+		String itemName;
+		boolean buy;
+		int quantity;
+		long timestampMs;
+	}
+
+	private final Deque<Entry> entries = new ConcurrentLinkedDeque<>();
+
+	public void record(int itemId, String itemName, boolean isBuy, int quantity)
+	{
+		if (quantity <= 0 || itemName == null)
+		{
+			return;
+		}
+		entries.addFirst(new Entry(itemId, itemName, isBuy, quantity, System.currentTimeMillis()));
+		while (entries.size() > MAX_ENTRIES)
+		{
+			entries.pollLast();
+		}
+	}
+
+	public List<Entry> snapshot()
+	{
+		return Collections.unmodifiableList(new ArrayList<>(entries));
+	}
+
+	public void clear()
+	{
+		entries.clear();
+	}
+}


### PR DESCRIPTION
## Summary

Implements the Flip Assist trade activity log (Flip-Smart/flip-smart#374). A bounded ring buffer of the 4 most-recent fulfilled GE fill events is now displayed below the Flip Assist hint box whenever the assistant is in an idle state ("Waiting for flips" or "Monitoring active offers"). Each entry shows transaction type, quantity, item name, and a relative timestamp; the log disappears as soon as the assistant transitions out of an idle state.

## Changes

### Features
- `TradeActivityLog` — thread-safe `@Singleton` backed by a `ConcurrentLinkedDeque`; holds up to 4 entries newest-first; partial fills surface as separate entries.
- `FlipAssistOverlay` — extends the hint box panel height to accommodate the log section; renders a divider, colored Buy/Sell prefix, quantity, truncated item name, and right-aligned dim relative timestamp; predicate-driven visibility means no state caching is needed.
- `TimeUtils.formatRelativeAgo` — new shared helper returning "just now" / "Xs ago" / "Xm ago" / "Xh ago" / "Xh Ym ago".

### Refactoring
- `GrandExchangeTracker` — receives `TradeActivityLog` via constructor injection; calls `tradeActivityLog.record(...)` inside `recordFillTransaction` so every fulfilled-qty event is captured automatically.

## Testing

### Automated Tests
- `./gradlew compileJava` — PASS
- `./gradlew test` — PASS

### Manual Testing
- [ ] (a) Trigger a buy fill while in "Monitoring active offers" state — log entry appears with "Buy", correct qty, item name, and "just now" timestamp.
- [ ] (b) Trigger 5+ fills in sequence — only the 4 most recent remain, newest at the top.
- [ ] (c) Wait several minutes — timestamps progress to "Xm ago"; wait longer — timestamps show "Xh Ym ago".
- [ ] (d) Let the assistant transition to an active-flip state (e.g. focused flip) — log panel hides completely.
- [ ] (e) Reach "Waiting for flips" state with prior fill history — log appears there too, same entries.

## API Changes

None — plugin-only change, no backend endpoints affected.

## Database Migrations

None.

## Deployment Notes

- No environment variables added or changed.
- No new dependencies.
- No configuration changes.
- No backend deployment required.

## SonarCloud

SonarCloud analysis for `Flip-Smart_flip-smart-runelite-plugin` (public project): **0 open issues** on this branch.

## Checklist

- [x] Automated tests pass (`./gradlew test`)
- [x] Build compiles cleanly (`./gradlew compileJava`)
- [x] SonarCloud: 0 new issues
- [x] `Thread.currentThread().interrupt()` not called on executor-owned threads
- [x] No hardcoded secrets or debug logging left
- [x] Acceptance criteria AC1–AC4 all addressed

## Related Issues

Closes Flip-Smart/flip-smart#374