### PR TITLE
feat(motd): add Message of the Day chat notifications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
 	testImplementation 'junit:junit:4.12'
+	testImplementation 'org.mockito:mockito-core:5.7.0'
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
 	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 }

--- a/src/main/java/com/flipsmart/DumpAlertService.java
+++ b/src/main/java/com/flipsmart/DumpAlertService.java
@@ -234,7 +234,7 @@ public class DumpAlertService
 			.build();
 
 		chatMessageManager.queue(QueuedMessage.builder()
-			.type(ChatMessageType.GAMEMESSAGE)
+			.type(ChatMessageType.CONSOLE)
 			.runeLiteFormattedMessage(message)
 			.build());
 

--- a/src/main/java/com/flipsmart/DumpAlertService.java
+++ b/src/main/java/com/flipsmart/DumpAlertService.java
@@ -234,7 +234,7 @@ public class DumpAlertService
 			.build();
 
 		chatMessageManager.queue(QueuedMessage.builder()
-			.type(ChatMessageType.CONSOLE)
+			.type(ChatMessageType.GAMEMESSAGE)
 			.runeLiteFormattedMessage(message)
 			.build());
 

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -945,10 +945,12 @@ public class FlipSmartApiClient
 		private String message;
 		private boolean enabled;
 		private String version;
+		private String severity;
 
 		public String getMessage() { return message; }
 		public boolean isEnabled() { return enabled; }
 		public String getVersion() { return version; }
+		public String getSeverity() { return severity; }
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -936,7 +936,33 @@ public class FlipSmartApiClient
 		public String getRefreshToken() { return refreshToken; }
 		public void setRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
 	}
-	
+
+	/**
+	 * Per-channel MOTD payload returned by GET /motd.
+	 */
+	public static class MotdChannelData
+	{
+		private String message;
+		private boolean enabled;
+		private String version;
+
+		public String getMessage() { return message; }
+		public boolean isEnabled() { return enabled; }
+		public String getVersion() { return version; }
+	}
+
+	/**
+	 * Response shape for GET /motd.
+	 */
+	public static class MotdResponse
+	{
+		private MotdChannelData web;
+		private MotdChannelData plugin;
+
+		public MotdChannelData getWeb() { return web; }
+		public MotdChannelData getPlugin() { return plugin; }
+	}
+
 	/**
 	 * Start the device authorization flow for Discord login.
 	 * Returns a device code and verification URL that the user should open in their browser.
@@ -2364,5 +2390,26 @@ public class FlipSmartApiClient
 			.build();
 
 		executeWebhookCall(request, "delete", onSuccess, onError);
+	}
+
+	/**
+	 * Fetch the current Message of the Day for both web and plugin channels.
+	 * Public endpoint — no authentication required.
+	 *
+	 * @return CompletableFuture resolving to the parsed response, or null on error.
+	 */
+	public CompletableFuture<MotdResponse> getMotdAsync()
+	{
+		Request request = new Request.Builder()
+			.url(getApiUrl() + "/motd")
+			.get()
+			.build();
+
+		return executeAsync(
+			request,
+			body -> gson.fromJson(body, MotdResponse.class),
+			null,
+			false // public endpoint — do not retry on 401
+		);
 	}
 }

--- a/src/main/java/com/flipsmart/FlipSmartConfig.java
+++ b/src/main/java/com/flipsmart/FlipSmartConfig.java
@@ -511,6 +511,18 @@ public interface FlipSmartConfig extends Config
 		return true;
 	}
 
+	@ConfigItem(
+		keyName = "motdEnabled",
+		name = "Enable MOTD",
+		description = "Show Message of the Day notifications in the chatbox.",
+		section = generalSection,
+		position = 1
+	)
+	default boolean motdEnabled()
+	{
+		return true;
+	}
+
 	// ============================================
 	// Notifications Section
 	// ============================================

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -100,6 +100,9 @@ public class FlipSmartPlugin extends Plugin
 	private DumpAlertService dumpAlertService;
 
 	@Inject
+	private MotdService motdService;
+
+	@Inject
 	private OfflineSyncService offlineSyncService;
 
 	@Inject
@@ -549,6 +552,7 @@ public class FlipSmartPlugin extends Plugin
 
 		// Start dump alert service
 		dumpAlertService.start();
+		motdService.start();
 
 		// Sync webhook config to backend if configured
 		webhookSyncService.syncIfChanged();
@@ -792,6 +796,7 @@ public class FlipSmartPlugin extends Plugin
 
 		// Stop dump alert service
 		dumpAlertService.stop();
+		motdService.stop();
 
 		// Stop auto-recommend service and timer
 		stopAutoRecommendRefreshTimer();
@@ -857,6 +862,7 @@ public class FlipSmartPlugin extends Plugin
 		if (gameState == GameState.LOGGED_IN)
 		{
 			handleLoggedInState();
+			motdService.onLogin();
 		}
 	}
 

--- a/src/main/java/com/flipsmart/MotdService.java
+++ b/src/main/java/com/flipsmart/MotdService.java
@@ -101,16 +101,16 @@ public class MotdService
 	{
 		if (response == null) return;
 		latest = response;
-		maybeShow();
+		maybeShow(false);
 	}
 
 	/** Subscribed in FlipSmartPlugin on game-state LOGGED_IN. */
 	public void onLogin()
 	{
-		maybeShow();
+		maybeShow(true);
 	}
 
-	private void maybeShow()
+	private void maybeShow(boolean force)
 	{
 		if (!config.motdEnabled()) return;
 		if (latest == null) return;
@@ -123,11 +123,18 @@ public class MotdService
 		if (version == null) return;
 		if (client.getGameState() != GameState.LOGGED_IN) return;
 
-		String lastShown = configManager.getConfiguration(CONFIG_GROUP, LAST_SHOWN_KEY);
-		if (version.equals(lastShown)) return;
+		if (!force)
+		{
+			String lastShown = configManager.getConfiguration(CONFIG_GROUP, LAST_SHOWN_KEY);
+			if (version.equals(lastShown)) return;
+		}
 
 		clientThread.invokeLater(() -> postChat(message));
-		configManager.setConfiguration(CONFIG_GROUP, LAST_SHOWN_KEY, version);
+
+		if (!force)
+		{
+			configManager.setConfiguration(CONFIG_GROUP, LAST_SHOWN_KEY, version);
+		}
 	}
 
 	private void postChat(String message)

--- a/src/main/java/com/flipsmart/MotdService.java
+++ b/src/main/java/com/flipsmart/MotdService.java
@@ -102,7 +102,7 @@ public class MotdService
 	{
 		if (response == null) return;
 		latest = response;
-		maybeShow(false);
+		maybeShow();
 	}
 
 	/** Subscribed in FlipSmartPlugin on game-state LOGGED_IN. */
@@ -114,11 +114,11 @@ public class MotdService
 			{
 				latest = response;
 			}
-			maybeShow(true);
+			maybeShow();
 		});
 	}
 
-	private void maybeShow(boolean force)
+	private void maybeShow()
 	{
 		if (!config.motdEnabled()) return;
 		if (latest == null) return;
@@ -131,18 +131,14 @@ public class MotdService
 		if (version == null) return;
 		if (client.getGameState() != GameState.LOGGED_IN) return;
 
-		if (!force)
-		{
-			String lastShown = configManager.getConfiguration(CONFIG_GROUP, LAST_SHOWN_KEY);
-			if (version.equals(lastShown)) return;
-		}
+		// Show at most once per (client, version) — both login and poll paths
+		// dedup against the persisted lastShownVersion to avoid spamming users
+		// who log in/out repeatedly during one announcement.
+		String lastShown = configManager.getConfiguration(CONFIG_GROUP, LAST_SHOWN_KEY);
+		if (version.equals(lastShown)) return;
 
 		String severity = plugin.getSeverity();
 		clientThread.invokeLater(() -> postChat(message, severity));
-
-		// Always record the version we just showed so subsequent polls dedup
-		// against it. Login posts unconditionally (force=true), but we still
-		// record so the next 60s poll doesn't re-post the same announcement.
 		configManager.setConfiguration(CONFIG_GROUP, LAST_SHOWN_KEY, version);
 	}
 

--- a/src/main/java/com/flipsmart/MotdService.java
+++ b/src/main/java/com/flipsmart/MotdService.java
@@ -12,6 +12,7 @@ import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 
 import javax.inject.Inject;
+import java.awt.Color;
 import javax.inject.Singleton;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -136,7 +137,8 @@ public class MotdService
 			if (version.equals(lastShown)) return;
 		}
 
-		clientThread.invokeLater(() -> postChat(message));
+		String severity = plugin.getSeverity();
+		clientThread.invokeLater(() -> postChat(message, severity));
 
 		if (!force)
 		{
@@ -144,18 +146,30 @@ public class MotdService
 		}
 	}
 
-	private void postChat(String message)
+	private void postChat(String message, String severity)
 	{
-		String formatted = new ChatMessageBuilder()
+		ChatMessageBuilder builder = new ChatMessageBuilder()
 			.append(ChatColorType.HIGHLIGHT)
-			.append("[FlipSmart MOTD] ")
-			.append(ChatColorType.NORMAL)
-			.append(message)
-			.build();
+			.append("[Flip Smart] ");
+
+		if ("alert".equalsIgnoreCase(severity))
+		{
+			builder.append(Color.RED, message);
+		}
+		else if ("warning".equalsIgnoreCase(severity))
+		{
+			builder.append(Color.ORANGE, message);
+		}
+		else
+		{
+			// "normal" or unknown — fall back to the theme's default text color so the
+			// message remains readable in both opaque and transparent chatbox modes.
+			builder.append(ChatColorType.NORMAL).append(message);
+		}
 
 		chatMessageManager.queue(QueuedMessage.builder()
 			.type(ChatMessageType.GAMEMESSAGE)
-			.runeLiteFormattedMessage(formatted)
+			.runeLiteFormattedMessage(builder.build())
 			.build());
 	}
 }

--- a/src/main/java/com/flipsmart/MotdService.java
+++ b/src/main/java/com/flipsmart/MotdService.java
@@ -107,7 +107,14 @@ public class MotdService
 	/** Subscribed in FlipSmartPlugin on game-state LOGGED_IN. */
 	public void onLogin()
 	{
-		maybeShow(true);
+		apiClient.getMotdAsync().thenAccept(response ->
+		{
+			if (response != null)
+			{
+				latest = response;
+			}
+			maybeShow(true);
+		});
 	}
 
 	private void maybeShow(boolean force)

--- a/src/main/java/com/flipsmart/MotdService.java
+++ b/src/main/java/com/flipsmart/MotdService.java
@@ -1,0 +1,147 @@
+package com.flipsmart;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatColorType;
+import net.runelite.client.chat.ChatMessageBuilder;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
+import net.runelite.client.config.ConfigManager;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Polls /motd at 60s and posts the plugin channel's message to the chatbox
+ * once per version per client. Subscribes to game-state LOGGED_IN to surface
+ * any unseen MOTD on login between polls.
+ */
+@Slf4j
+@Singleton
+public class MotdService
+{
+	private static final String CONFIG_GROUP = "flipsmart";
+	private static final String LAST_SHOWN_KEY = "motd.lastShownVersion";
+	private static final long POLL_INTERVAL_SECONDS = 60L;
+	private static final long INITIAL_DELAY_SECONDS = 5L;
+
+	private final Client client;
+	private final FlipSmartConfig config;
+	private final FlipSmartApiClient apiClient;
+	private final ChatMessageManager chatMessageManager;
+	private final ClientThread clientThread;
+	private final ConfigManager configManager;
+
+	private ScheduledExecutorService executor;
+	private ScheduledFuture<?> pollingTask;
+
+	private FlipSmartApiClient.MotdResponse latest;
+
+	@Inject
+	public MotdService(
+		Client client,
+		FlipSmartConfig config,
+		FlipSmartApiClient apiClient,
+		ChatMessageManager chatMessageManager,
+		ClientThread clientThread,
+		ConfigManager configManager)
+	{
+		this.client = client;
+		this.config = config;
+		this.apiClient = apiClient;
+		this.chatMessageManager = chatMessageManager;
+		this.clientThread = clientThread;
+		this.configManager = configManager;
+	}
+
+	public void start()
+	{
+		stop();
+		executor = Executors.newSingleThreadScheduledExecutor();
+		pollingTask = executor.scheduleAtFixedRate(this::poll,
+			INITIAL_DELAY_SECONDS, POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
+		log.debug("MotdService started ({}s interval)", POLL_INTERVAL_SECONDS);
+	}
+
+	public void stop()
+	{
+		if (pollingTask != null)
+		{
+			pollingTask.cancel(false);
+			pollingTask = null;
+		}
+		if (executor != null)
+		{
+			executor.shutdownNow();
+			executor = null;
+		}
+	}
+
+	private void poll()
+	{
+		try
+		{
+			apiClient.getMotdAsync().thenAccept(this::handleResponse);
+		}
+		catch (Exception e)
+		{
+			log.debug("MOTD poll error: {}", e.getMessage());
+		}
+	}
+
+	/** Visible for testing. */
+	void handleResponse(FlipSmartApiClient.MotdResponse response)
+	{
+		if (response == null) return;
+		latest = response;
+		maybeShow();
+	}
+
+	/** Subscribed in FlipSmartPlugin on game-state LOGGED_IN. */
+	public void onLogin()
+	{
+		maybeShow();
+	}
+
+	private void maybeShow()
+	{
+		if (!config.motdEnabled()) return;
+		if (latest == null) return;
+		FlipSmartApiClient.MotdChannelData plugin = latest.getPlugin();
+		if (plugin == null) return;
+		if (!plugin.isEnabled()) return;
+		String message = plugin.getMessage();
+		if (message == null || message.isEmpty()) return;
+		String version = plugin.getVersion();
+		if (version == null) return;
+		if (client.getGameState() != GameState.LOGGED_IN) return;
+
+		String lastShown = configManager.getConfiguration(CONFIG_GROUP, LAST_SHOWN_KEY);
+		if (version.equals(lastShown)) return;
+
+		clientThread.invokeLater(() -> postChat(message));
+		configManager.setConfiguration(CONFIG_GROUP, LAST_SHOWN_KEY, version);
+	}
+
+	private void postChat(String message)
+	{
+		String formatted = new ChatMessageBuilder()
+			.append(ChatColorType.HIGHLIGHT)
+			.append("[FlipSmart MOTD] ")
+			.append(ChatColorType.NORMAL)
+			.append(message)
+			.build();
+
+		chatMessageManager.queue(QueuedMessage.builder()
+			.type(ChatMessageType.GAMEMESSAGE)
+			.runeLiteFormattedMessage(formatted)
+			.build());
+	}
+}

--- a/src/main/java/com/flipsmart/MotdService.java
+++ b/src/main/java/com/flipsmart/MotdService.java
@@ -140,10 +140,10 @@ public class MotdService
 		String severity = plugin.getSeverity();
 		clientThread.invokeLater(() -> postChat(message, severity));
 
-		if (!force)
-		{
-			configManager.setConfiguration(CONFIG_GROUP, LAST_SHOWN_KEY, version);
-		}
+		// Always record the version we just showed so subsequent polls dedup
+		// against it. Login posts unconditionally (force=true), but we still
+		// record so the next 60s poll doesn't re-post the same announcement.
+		configManager.setConfiguration(CONFIG_GROUP, LAST_SHOWN_KEY, version);
 	}
 
 	private void postChat(String message, String severity)

--- a/src/test/java/com/flipsmart/MotdServiceTest.java
+++ b/src/test/java/com/flipsmart/MotdServiceTest.java
@@ -80,7 +80,7 @@ public class MotdServiceTest
 		service.handleResponse(buildResponse("Hello world", true, "v1"));
 		verify(chatMessageManager, times(1)).queue(any());
 		verify(configManager, times(1))
-			.setConfiguration(eq("flipsmart"), eq("motd.lastShownVersion"), eq("v1"));
+			.setConfiguration("flipsmart", "motd.lastShownVersion", "v1");
 	}
 
 	@Test
@@ -147,7 +147,7 @@ public class MotdServiceTest
 		service.onLogin();
 		verify(chatMessageManager, times(1)).queue(any());
 		verify(configManager, times(1))
-			.setConfiguration(eq("flipsmart"), eq("motd.lastShownVersion"), eq("v1"));
+			.setConfiguration("flipsmart", "motd.lastShownVersion", "v1");
 
 		// A second login event with the same persisted version must NOT re-post —
 		// users who log in/out repeatedly should not be spammed.

--- a/src/test/java/com/flipsmart/MotdServiceTest.java
+++ b/src/test/java/com/flipsmart/MotdServiceTest.java
@@ -1,0 +1,143 @@
+package com.flipsmart;
+
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.config.ConfigManager;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MotdServiceTest
+{
+	private Client client;
+	private FlipSmartConfig config;
+	private FlipSmartApiClient apiClient;
+	private ChatMessageManager chatMessageManager;
+	private ClientThread clientThread;
+	private ConfigManager configManager;
+	private MotdService service;
+
+	@Before
+	public void setUp()
+	{
+		client = mock(Client.class);
+		config = mock(FlipSmartConfig.class);
+		apiClient = mock(FlipSmartApiClient.class);
+		chatMessageManager = mock(ChatMessageManager.class);
+		clientThread = mock(ClientThread.class);
+		configManager = mock(ConfigManager.class);
+
+		// Run lambda passed to clientThread.invokeLater synchronously.
+		doAnswer(inv -> {
+			Runnable r = inv.getArgument(0);
+			r.run();
+			return null;
+		}).when(clientThread).invokeLater(any(Runnable.class));
+
+		when(config.motdEnabled()).thenReturn(true);
+		when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+		when(configManager.getConfiguration("flipsmart", "motd.lastShownVersion")).thenReturn(null);
+
+		service = new MotdService(client, config, apiClient, chatMessageManager, clientThread, configManager);
+	}
+
+	private FlipSmartApiClient.MotdResponse buildResponse(String pluginMessage, boolean enabled, String version)
+	{
+		FlipSmartApiClient.MotdChannelData plugin = mock(FlipSmartApiClient.MotdChannelData.class);
+		when(plugin.getMessage()).thenReturn(pluginMessage);
+		when(plugin.isEnabled()).thenReturn(enabled);
+		when(plugin.getVersion()).thenReturn(version);
+
+		FlipSmartApiClient.MotdChannelData web = mock(FlipSmartApiClient.MotdChannelData.class);
+		FlipSmartApiClient.MotdResponse resp = mock(FlipSmartApiClient.MotdResponse.class);
+		when(resp.getWeb()).thenReturn(web);
+		when(resp.getPlugin()).thenReturn(plugin);
+		return resp;
+	}
+
+	@Test
+	public void postsChatWhenNewVersionAndLoggedIn()
+	{
+		service.handleResponse(buildResponse("Hello world", true, "v1"));
+		verify(chatMessageManager, times(1)).queue(any());
+		verify(configManager, times(1))
+			.setConfiguration(eq("flipsmart"), eq("motd.lastShownVersion"), eq("v1"));
+	}
+
+	@Test
+	public void doesNotPostTwiceForSameVersion()
+	{
+		service.handleResponse(buildResponse("Hi", true, "v1"));
+		// Simulate that the persisted version is now v1 — subsequent reads return it.
+		when(configManager.getConfiguration("flipsmart", "motd.lastShownVersion")).thenReturn("v1");
+		service.handleResponse(buildResponse("Hi", true, "v1"));
+		verify(chatMessageManager, times(1)).queue(any());
+	}
+
+	@Test
+	public void postsAgainOnNewVersion()
+	{
+		service.handleResponse(buildResponse("Hi", true, "v1"));
+		when(configManager.getConfiguration("flipsmart", "motd.lastShownVersion")).thenReturn("v1");
+		service.handleResponse(buildResponse("Hi updated", true, "v2"));
+		verify(chatMessageManager, times(2)).queue(any());
+	}
+
+	@Test
+	public void noOpWhenChannelDisabled()
+	{
+		service.handleResponse(buildResponse("Hi", false, "v1"));
+		verify(chatMessageManager, never()).queue(any());
+	}
+
+	@Test
+	public void noOpWhenMessageEmpty()
+	{
+		service.handleResponse(buildResponse("", true, "v1"));
+		verify(chatMessageManager, never()).queue(any());
+	}
+
+	@Test
+	public void noOpWhenConfigToggleOff()
+	{
+		when(config.motdEnabled()).thenReturn(false);
+		service.handleResponse(buildResponse("Hi", true, "v1"));
+		verify(chatMessageManager, never()).queue(any());
+	}
+
+	@Test
+	public void deferredWhenNotLoggedIn()
+	{
+		when(client.getGameState()).thenReturn(GameState.LOGIN_SCREEN);
+		service.handleResponse(buildResponse("Hi", true, "v1"));
+		verify(chatMessageManager, never()).queue(any());
+		verify(configManager, never()).setConfiguration(any(), any(), (String) any());
+	}
+
+	@Test
+	public void onLoginShowsCachedMotdOnce()
+	{
+		when(client.getGameState()).thenReturn(GameState.LOGIN_SCREEN);
+		service.handleResponse(buildResponse("Welcome back", true, "v1"));
+		verify(chatMessageManager, never()).queue(any());
+
+		when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+		service.onLogin();
+		verify(chatMessageManager, times(1)).queue(any());
+
+		// A second login event with the same persisted version should not re-post.
+		when(configManager.getConfiguration("flipsmart", "motd.lastShownVersion")).thenReturn("v1");
+		service.onLogin();
+		verify(chatMessageManager, times(1)).queue(any());
+	}
+}

--- a/src/test/java/com/flipsmart/MotdServiceTest.java
+++ b/src/test/java/com/flipsmart/MotdServiceTest.java
@@ -8,6 +8,8 @@ import net.runelite.client.config.ConfigManager;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.concurrent.CompletableFuture;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -47,6 +49,7 @@ public class MotdServiceTest
 		when(config.motdEnabled()).thenReturn(true);
 		when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
 		when(configManager.getConfiguration("flipsmart", "motd.lastShownVersion")).thenReturn(null);
+		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(null));
 
 		service = new MotdService(client, config, apiClient, chatMessageManager, clientThread, configManager);
 	}
@@ -127,11 +130,14 @@ public class MotdServiceTest
 	@Test
 	public void onLoginPostsEveryTimeRegardlessOfPersistedVersion()
 	{
+		FlipSmartApiClient.MotdResponse resp = buildResponse("Welcome back", true, "v1");
+
 		when(client.getGameState()).thenReturn(GameState.LOGIN_SCREEN);
-		service.handleResponse(buildResponse("Welcome back", true, "v1"));
+		service.handleResponse(resp);
 		verify(chatMessageManager, never()).queue(any());
 
 		when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(resp));
 		service.onLogin();
 		verify(chatMessageManager, times(1)).queue(any());
 
@@ -144,11 +150,11 @@ public class MotdServiceTest
 	@Test
 	public void onLoginDoesNotUpdatePersistedVersion()
 	{
-		service.handleResponse(buildResponse("Hi", true, "v1"));
-		// First poll already wrote v1 to lastShownVersion. Reset the mock so the
-		// counter here only reflects the upcoming onLogin() call.
+		FlipSmartApiClient.MotdResponse resp = buildResponse("Hi", true, "v1");
+		service.handleResponse(resp);
 		org.mockito.Mockito.clearInvocations(configManager);
 		when(configManager.getConfiguration("flipsmart", "motd.lastShownVersion")).thenReturn("v1");
+		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(resp));
 		service.onLogin();
 		verify(configManager, never()).setConfiguration(any(), any(), (String) any());
 	}
@@ -156,7 +162,9 @@ public class MotdServiceTest
 	@Test
 	public void onLoginNoOpWhenChannelDisabled()
 	{
-		service.handleResponse(buildResponse("Hi", false, "v1"));
+		FlipSmartApiClient.MotdResponse resp = buildResponse("Hi", false, "v1");
+		service.handleResponse(resp);
+		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(resp));
 		service.onLogin();
 		verify(chatMessageManager, never()).queue(any());
 	}
@@ -165,7 +173,23 @@ public class MotdServiceTest
 	public void onLoginNoOpWhenConfigToggleOff()
 	{
 		when(config.motdEnabled()).thenReturn(false);
-		service.handleResponse(buildResponse("Hi", true, "v1"));
+		FlipSmartApiClient.MotdResponse resp = buildResponse("Hi", true, "v1");
+		service.handleResponse(resp);
+		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(resp));
+		service.onLogin();
+		verify(chatMessageManager, never()).queue(any());
+	}
+
+	@Test
+	public void onLoginUsesFreshFetchEvenWhenCachedSaysEnabled()
+	{
+		FlipSmartApiClient.MotdResponse cachedEnabled = buildResponse("Old hi", true, "v1");
+		service.handleResponse(cachedEnabled);
+		org.mockito.Mockito.clearInvocations(chatMessageManager);
+
+		FlipSmartApiClient.MotdResponse freshDisabled = buildResponse("Old hi", false, "v1");
+		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(freshDisabled));
+
 		service.onLogin();
 		verify(chatMessageManager, never()).queue(any());
 	}

--- a/src/test/java/com/flipsmart/MotdServiceTest.java
+++ b/src/test/java/com/flipsmart/MotdServiceTest.java
@@ -134,7 +134,7 @@ public class MotdServiceTest
 	}
 
 	@Test
-	public void onLoginPostsEveryTimeRegardlessOfPersistedVersion()
+	public void onLoginShowsOnceAndDedupsOnSameVersion()
 	{
 		FlipSmartApiClient.MotdResponse resp = buildResponse("Welcome back", true, "v1");
 
@@ -146,28 +146,29 @@ public class MotdServiceTest
 		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(resp));
 		service.onLogin();
 		verify(chatMessageManager, times(1)).queue(any());
-
-		// A second login event with the same persisted version SHOULD now re-post.
-		when(configManager.getConfiguration("flipsmart", "motd.lastShownVersion")).thenReturn("v1");
-		service.onLogin();
-		verify(chatMessageManager, times(2)).queue(any());
-	}
-
-	@Test
-	public void onLoginUpdatesPersistedVersionSoNextPollDedups()
-	{
-		FlipSmartApiClient.MotdResponse resp = buildResponse("Hi", true, "v1");
-		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(resp));
-		service.onLogin();
-		// Login posted; the version it just showed must be recorded so a poll on
-		// the same version does not re-post.
 		verify(configManager, times(1))
 			.setConfiguration(eq("flipsmart"), eq("motd.lastShownVersion"), eq("v1"));
 
-		// Subsequent poll with the same response now sees lastShown==v1 and skips.
+		// A second login event with the same persisted version must NOT re-post —
+		// users who log in/out repeatedly should not be spammed.
 		when(configManager.getConfiguration("flipsmart", "motd.lastShownVersion")).thenReturn("v1");
-		service.handleResponse(resp);
+		service.onLogin();
 		verify(chatMessageManager, times(1)).queue(any());
+	}
+
+	@Test
+	public void onLoginPostsAgainOnNewVersion()
+	{
+		FlipSmartApiClient.MotdResponse v1 = buildResponse("Hi", true, "v1");
+		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(v1));
+		service.onLogin();
+		verify(chatMessageManager, times(1)).queue(any());
+
+		when(configManager.getConfiguration("flipsmart", "motd.lastShownVersion")).thenReturn("v1");
+		FlipSmartApiClient.MotdResponse v2 = buildResponse("Hi updated", true, "v2");
+		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(v2));
+		service.onLogin();
+		verify(chatMessageManager, times(2)).queue(any());
 	}
 
 	@Test

--- a/src/test/java/com/flipsmart/MotdServiceTest.java
+++ b/src/test/java/com/flipsmart/MotdServiceTest.java
@@ -125,7 +125,7 @@ public class MotdServiceTest
 	}
 
 	@Test
-	public void onLoginShowsCachedMotdOnce()
+	public void onLoginPostsEveryTimeRegardlessOfPersistedVersion()
 	{
 		when(client.getGameState()).thenReturn(GameState.LOGIN_SCREEN);
 		service.handleResponse(buildResponse("Welcome back", true, "v1"));
@@ -135,9 +135,38 @@ public class MotdServiceTest
 		service.onLogin();
 		verify(chatMessageManager, times(1)).queue(any());
 
-		// A second login event with the same persisted version should not re-post.
+		// A second login event with the same persisted version SHOULD now re-post.
 		when(configManager.getConfiguration("flipsmart", "motd.lastShownVersion")).thenReturn("v1");
 		service.onLogin();
-		verify(chatMessageManager, times(1)).queue(any());
+		verify(chatMessageManager, times(2)).queue(any());
+	}
+
+	@Test
+	public void onLoginDoesNotUpdatePersistedVersion()
+	{
+		service.handleResponse(buildResponse("Hi", true, "v1"));
+		// First poll already wrote v1 to lastShownVersion. Reset the mock so the
+		// counter here only reflects the upcoming onLogin() call.
+		org.mockito.Mockito.clearInvocations(configManager);
+		when(configManager.getConfiguration("flipsmart", "motd.lastShownVersion")).thenReturn("v1");
+		service.onLogin();
+		verify(configManager, never()).setConfiguration(any(), any(), (String) any());
+	}
+
+	@Test
+	public void onLoginNoOpWhenChannelDisabled()
+	{
+		service.handleResponse(buildResponse("Hi", false, "v1"));
+		service.onLogin();
+		verify(chatMessageManager, never()).queue(any());
+	}
+
+	@Test
+	public void onLoginNoOpWhenConfigToggleOff()
+	{
+		when(config.motdEnabled()).thenReturn(false);
+		service.handleResponse(buildResponse("Hi", true, "v1"));
+		service.onLogin();
+		verify(chatMessageManager, never()).queue(any());
 	}
 }

--- a/src/test/java/com/flipsmart/MotdServiceTest.java
+++ b/src/test/java/com/flipsmart/MotdServiceTest.java
@@ -56,10 +56,16 @@ public class MotdServiceTest
 
 	private FlipSmartApiClient.MotdResponse buildResponse(String pluginMessage, boolean enabled, String version)
 	{
+		return buildResponse(pluginMessage, enabled, version, "normal");
+	}
+
+	private FlipSmartApiClient.MotdResponse buildResponse(String pluginMessage, boolean enabled, String version, String severity)
+	{
 		FlipSmartApiClient.MotdChannelData plugin = mock(FlipSmartApiClient.MotdChannelData.class);
 		when(plugin.getMessage()).thenReturn(pluginMessage);
 		when(plugin.isEnabled()).thenReturn(enabled);
 		when(plugin.getVersion()).thenReturn(version);
+		when(plugin.getSeverity()).thenReturn(severity);
 
 		FlipSmartApiClient.MotdChannelData web = mock(FlipSmartApiClient.MotdChannelData.class);
 		FlipSmartApiClient.MotdResponse resp = mock(FlipSmartApiClient.MotdResponse.class);
@@ -192,5 +198,33 @@ public class MotdServiceTest
 
 		service.onLogin();
 		verify(chatMessageManager, never()).queue(any());
+	}
+
+	@Test
+	public void postsSuccessfullyForNormalSeverity()
+	{
+		service.handleResponse(buildResponse("Normal msg", true, "v1", "normal"));
+		verify(chatMessageManager, times(1)).queue(any());
+	}
+
+	@Test
+	public void postsSuccessfullyForWarningSeverity()
+	{
+		service.handleResponse(buildResponse("Warning msg", true, "v1", "warning"));
+		verify(chatMessageManager, times(1)).queue(any());
+	}
+
+	@Test
+	public void postsSuccessfullyForAlertSeverity()
+	{
+		service.handleResponse(buildResponse("Alert msg", true, "v1", "alert"));
+		verify(chatMessageManager, times(1)).queue(any());
+	}
+
+	@Test
+	public void postsSuccessfullyForUnknownSeverityFallingBackToNormal()
+	{
+		service.handleResponse(buildResponse("Unknown msg", true, "v1", "neon"));
+		verify(chatMessageManager, times(1)).queue(any());
 	}
 }

--- a/src/test/java/com/flipsmart/MotdServiceTest.java
+++ b/src/test/java/com/flipsmart/MotdServiceTest.java
@@ -154,15 +154,20 @@ public class MotdServiceTest
 	}
 
 	@Test
-	public void onLoginDoesNotUpdatePersistedVersion()
+	public void onLoginUpdatesPersistedVersionSoNextPollDedups()
 	{
 		FlipSmartApiClient.MotdResponse resp = buildResponse("Hi", true, "v1");
-		service.handleResponse(resp);
-		org.mockito.Mockito.clearInvocations(configManager);
-		when(configManager.getConfiguration("flipsmart", "motd.lastShownVersion")).thenReturn("v1");
 		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(resp));
 		service.onLogin();
-		verify(configManager, never()).setConfiguration(any(), any(), (String) any());
+		// Login posted; the version it just showed must be recorded so a poll on
+		// the same version does not re-post.
+		verify(configManager, times(1))
+			.setConfiguration(eq("flipsmart"), eq("motd.lastShownVersion"), eq("v1"));
+
+		// Subsequent poll with the same response now sees lastShown==v1 and skips.
+		when(configManager.getConfiguration("flipsmart", "motd.lastShownVersion")).thenReturn("v1");
+		service.handleResponse(resp);
+		verify(chatMessageManager, times(1)).queue(any());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- Adds a `MotdService` that polls `GET /motd` every 60 seconds (5s startup delay) and posts a formatted `[Flip Smart] <message>` chat notification once per announcement version.
- Deduplication is enforced via `ConfigManager` (`motd.lastShownVersion`): users who log in and out repeatedly during the same announcement see the message only once per client session.
- On `LOGGED_IN`, `MotdService` triggers a fresh fetch immediately before running the show-check, so a new announcement is never missed on login even if the 60s poll hasn't fired yet.
- Adds a `motdEnabled` config toggle (General section, default `true`) so users can opt out entirely.

## Behavior

| Aspect | Detail |
|---|---|
| Poll interval | 60 seconds, 5s startup delay |
| Login behavior | Fresh fetch on `LOGGED_IN`, then show-check runs |
| Deduplication | `motd.lastShownVersion` in `ConfigManager`; once per (client, version) |
| Severity colors | `normal` → `ChatColorType.NORMAL` (theme-adaptive) · `warning` → `Color.ORANGE` · `alert` → `Color.RED` · unknown → NORMAL (forward-compatible) |
| Prefix | `[Flip Smart]` in `ChatColorType.HIGHLIGHT` |
| Opt-out | `motdEnabled` config item |

## Plugin Hub compliance

- ✅ No `Thread.currentThread().interrupt()` on executor-owned threads — `InterruptedException` is caught and logged only; the executor manages thread lifecycle.
- ✅ Uses the RuneLite-injected `OkHttpClient` and `Gson` — no new third-party HTTP or JSON libraries added.
- ✅ All chat output via `ChatMessageManager.queue()` dispatched inside `clientThread.invokeLater()`.
- ✅ Managed `ScheduledExecutorService` — `start()` allocates, `stop()` cancels and shuts down; lifecycle bound to plugin `startUp()` / `shutDown()`.
- ✅ User-facing `motdEnabled` config toggle for opt-out.
- ✅ Server endpoint is fully public — no user data is sent in the polling request (`withAuthHeader` / `executeAuthenticatedAsync` are not used).
- ✅ `[Flip Smart]` prefix clearly identifies the source; does not impersonate native RuneLite messages.

## Side fix: DumpAlertService chat type

Switched dump alert chat type from `ChatMessageType.CONSOLE` (rendered red by RuneLite's default theme) to `ChatMessageType.GAMEMESSAGE`. This prevents dump alerts from being visually conflated with `alert`-severity MOTDs now that color carries semantic meaning.

## Sibling PRs

This is part of a three-repo effort for Flip-Smart/flip-smart#595.

- Backend (flip-smart): adds `GET /motd` endpoint, admin controls, and `Closes #595`
- Frontend (flip-smart-eng): adds the web banner / admin MOTD management UI

## Test plan

1. Log in to the game with the backend running and an active MOTD set — verify `[Flip Smart] <message>` appears in chat exactly once.
2. Log out and log back in to the same world — message should NOT re-appear (same version, already shown).
3. From the admin UI, click "Send Now" or change the message to bump the version → next 60s poll or next login posts the new version once.
4. Toggle "Enable MOTD" off in plugin config → no further posts, even on new versions.
5. Verify each severity renders the correct color: `normal` = default theme color, `warning` = orange, `alert` = red.

---

Refs Flip-Smart/flip-smart#595