### PR TITLE
fix(plugin): show neutral empty-state when no flip recommendations match

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1431,7 +1431,7 @@ public class FlipFinderPanel extends PluginPanel
 			if (response.getRecommendations() == null || response.getRecommendations().isEmpty())
 			{
 				currentRecommendations.clear();
-				showErrorInRecommended("No flip recommendations found matching your criteria.");
+				showNoRecommendationsAvailable();
 				updatePremiumStatus();
 				restoreScrollPosition(recommendedScrollPane, scrollPos);
 				return;
@@ -1881,6 +1881,13 @@ public class FlipFinderPanel extends PluginPanel
 	{
 		statusLabel.setText(ERROR_DIALOG_TITLE);
 		showErrorInContainer(recommendedListContainer, "Flip Finder", message);
+	}
+
+	private void showNoRecommendationsAvailable()
+	{
+		statusLabel.setText("No available trades");
+		showErrorInContainer(recommendedListContainer, "Flip Finder",
+			"There are currently no available trades for your cash stack amount and flip style.");
 	}
 
 	/**


### PR DESCRIPTION
## Summary

When the Flip Finder panel receives an empty recommendations list from the API (e.g. the user's cash stack is too small for any current opportunity, or their flip style filters out all candidates), the panel was rendering a red **"Error"** header with **"Auto: All recommendations listed"** beneath it — making a normal, expected condition look like an API failure. This PR splits the empty-results case from the true error path so users see a neutral, informative message instead.

## Changes

### Bug Fixes
- `handleRecommendationsResponse`: empty-array branch no longer calls `showErrorInRecommended(...)`, which sets the status label to `"Error"`. It now calls the new `showNoRecommendationsAvailable()` helper.
- Added `showNoRecommendationsAvailable()`: sets `statusLabel` to `"No available trades"` and renders the friendly body text **"There are currently no available trades for your cash stack amount and flip style."**
- True API failures (null response, network/HTTP errors) continue to route through the existing `showErrorInRecommended` path — behavior unchanged.

### Files Changed
- `src/main/java/com/flipsmart/FlipFinderPanel.java` — 8 lines changed (1 call-site change + 7-line new helper method)

## Testing

### Build
```bash
./gradlew shadowJar
```

### Manual Test Plan
- [x] Sideload the built plugin via the RuneLite developer mode
- [x] Log in; set your cash stack absurdly low (e.g. 100 000 gp) so the backend returns an empty recommendations list
- [x] Open Flip Finder — confirm the panel shows **"No available trades"** as the status header and **"There are currently no available trades for your cash stack amount and flip style."** in the body
- [x] Confirm there is **no** red "Error" badge above the auto-recommend status line
- [x] Sanity check: simulate a real API failure (e.g. point the plugin at an unreachable host, or temporarily kill the API) — confirm the panel **still** shows **"Error"** and **"Failed to fetch recommendations. Check your API settings."** (existing error path unchanged)

### Automated Tests
- `./gradlew test` — all 3 test classes pass (PlayerSessionTest, ExamplePluginTest, MotdServiceTest)

## Non-Goals

- No backend changes — the API response shape is unchanged
- No changes to the auto-recommend status line logic
- No visual styling changes to the empty-state panel (font, colour, layout)
- No changes to the GE-gating or RSN-blocked message paths