### PR TITLE
fix(recommendations): bypass minimumProfit filter for curated-pool fallback items

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1854,9 +1854,19 @@ public class FlipFinderPanel extends PluginPanel
 		}
 	}
 
-	/** Returns true if a recommendation passes the current profit filter. */
+	/** Returns true if a recommendation passes the current profit filter.
+	 *
+	 * Curated-pool fallback items (sub-25M cashstack / F2P "always-fill" picks
+	 * from API issue #617) bypass the user's minimumProfit threshold — they're
+	 * force-recommended slot fillers, and hiding them would re-introduce the
+	 * "API only returned 5 recommendations" complaint we just fixed.
+	 */
 	private boolean shouldDisplay(FlipRecommendation rec)
 	{
+		if (rec.isCuratedPoolFallback())
+		{
+			return true;
+		}
 		return FocusedFlip.calculateAdjustedProfit(rec, config.priceOffset()) >= config.minimumProfit();
 	}
 

--- a/src/main/java/com/flipsmart/FlipRecommendation.java
+++ b/src/main/java/com/flipsmart/FlipRecommendation.java
@@ -78,6 +78,15 @@ public class FlipRecommendation
 	@SerializedName("total_cost")
 	private int totalCost;
 
+	/**
+	 * True when this recommendation came from the API's curated-pool random
+	 * fallback (issue #617). These items are "force-recommend" picks that fill
+	 * empty slots regardless of margin, so the plugin's local minimumProfit
+	 * filter must not hide them.
+	 */
+	@SerializedName("is_curated_pool_fallback")
+	private boolean curatedPoolFallback;
+
 	// Deprecated fields (kept for backwards compatibility)
 	@SerializedName("buy_price")
 	private Integer buyPrice;


### PR DESCRIPTION
## Summary

Plugin was hiding the API's "always-fill" sub-25M / F2P curated-pool fallback items because their margins fall below the user's local `minimumProfit` filter (default 10K GP). Result: users saw fewer than the 8 recommendations the API was returning.

Adds the `is_curated_pool_fallback` field to `FlipRecommendation` and bypasses `shouldDisplay()`'s profit floor when that flag is set.

Pairs with API PR #624 (https://github.com/Flip-Smart/flip-smart/pull/624) — this PR depends on that API change being deployed first.

## Changes

### 🐛 Bug Fixes
- `FlipRecommendation.java` — adds `private boolean curatedPoolFallback` mapped to the API's new `is_curated_pool_fallback` JSON field. Lombok `@Data` generates the `isCuratedPoolFallback()` accessor automatically.
- `FlipFinderPanel.java` — `shouldDisplay(rec)` now short-circuits to `true` when `rec.isCuratedPoolFallback()`. Normal scoring-pipeline recs continue to respect the user's `minimumProfit` setting unchanged.

### ♻️ Refactoring
- Expanded the Javadoc on `shouldDisplay` to explain the bypass rationale, linking back to the API issue context so future reviewers understand why curated-pool items are exempt from the profit floor.

## Why client-side and not API-side

The API doesn't know the user's `minimumProfit` setting — it's a plugin-only config field. Pushing the threshold to the API would require a new query parameter and would complicate the always-fill contract. The cleaner fix is for the plugin to recognise the "force-recommend" marker and skip its local filter for those items.

## Testing

### Automated Tests
- `./gradlew compileJava` — clean, no warnings
- `./gradlew test` — all passing

### Manual Testing
- [ ] Pull this branch, run the plugin from RuneLite source.
- [ ] Point at a local API on the `feature/curated-pool-filtering` branch with `ff_sub_25m_pool_filter=true` and `ff_curated_pool_only_mode=true` enabled (Miles already has these set in his dev DB).
- [ ] Sign in with a sub-25M cashstack account and refresh the Recommended tab. Expect: status label reads "Conservative | 8 suggestions" (or whatever your `flipFinderLimit` is set to). Previously read "5 suggestions" or fewer.
- [ ] Drop `ff_curated_pool_only_mode` to false but keep `ff_sub_25m_pool_filter` on. Expect: scored recs come first, curated fallbacks fill remaining slots, none filtered out by `minimumProfit`.
- [ ] Verify normal recs (above the user's `minimumProfit`) still display, and that recs with profit BELOW threshold AND no `is_curated_pool_fallback` flag are still hidden as before.

## API Changes

No plugin-facing API contract changes. This PR consumes the new `is_curated_pool_fallback` boolean field added in API PR #624. The field deserialises cleanly as `false` on older API versions that don't emit it, so the plugin remains backwards-compatible.

## Deployment Notes

- [ ] API PR #624 must be deployed before this plugin release becomes useful — without it, `is_curated_pool_fallback` will always deserialise as `false` and `shouldDisplay` behaviour is unchanged.
- [ ] No new config fields, no environment changes, no migrations.

## Checklist

- [x] `./gradlew compileJava` clean
- [x] `./gradlew test` passing
- [x] No debug logging left in
- [x] Backwards-compatible (field defaults to `false` if API doesn't emit it)
- [x] `shouldDisplay` logic for non-curated recs is untouched

## SonarCloud

- SonarCloud branch analysis: 0 open issues on `fix/curated-pool-bypass-profit-filter`.

## Related Issues

Closes #617

Related to API PR: https://github.com/Flip-Smart/flip-smart/pull/624