### PR TITLE
fix(plugin): exclude already-listed items from auto-mode recommendations

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -828,7 +828,11 @@ public class AutoRecommendService
 	{
 		recommendationQueue.clear();
 		currentIndex = 0;
-		if (currentRec == null)
+		// If currentRec is now on the GE, don't preserve it across the refresh —
+		// otherwise it would survive the filter and resurface at index 0.
+		boolean currentRecActive = currentRec != null
+			&& plugin.getActiveFlipItemIds().contains(currentRec.getItemId());
+		if (currentRec == null || currentRecActive)
 		{
 			recommendationQueue.addAll(filtered);
 			return;
@@ -1852,6 +1856,18 @@ public class AutoRecommendService
 		FlipRecommendation rec = getCurrentRecommendation();
 		if (rec == null)
 		{
+			return;
+		}
+
+		// Re-validate against active GE state. The queue can carry an already-listed
+		// item into focus via paths that bypass advanceToNext()'s skip-loop:
+		// rebuildQueue() preserving currentRec across a refresh, restoreState() on
+		// relogin, or focusCurrent() callers when slots free up. Catch them all here
+		// so we never recommend an item the player already has on the GE.
+		if (plugin.getActiveFlipItemIds().contains(rec.getItemId()))
+		{
+			log.debug("Auto-recommend: Current rec {} is already on GE - advancing", rec.getItemName());
+			advanceToNext();
 			return;
 		}
 


### PR DESCRIPTION
## Summary

Auto-mode could surface a flip recommendation for an item the player already had listed on the Grand Exchange. The plugin has an exclusion filter via `PlayerSession.getActiveFlipItemIds()` that runs in `start()`, `filterAndSortRecommendations()`, and `advanceToNext()`'s skip-loop — but three paths reached `focusCurrent()` without going through that skip-loop:

- **`rebuildQueue()`** (2-min panel refresh) preserved `currentRec` at index 0, so an item the player listed *between* refreshes survived the filter and remained the focused recommendation.
- **`restoreState()`** (relogin) restored the persisted queue and called `focusCurrent()` directly, with no validation against offers placed during the offline window.
- **Various `focusCurrent()` callers** that fire when a slot frees up after collection did not re-validate the focused item against active offers.

The fix adds a single re-validation gate at the `focusCurrent()` choke point: if the focused item is already in `getActiveFlipItemIds()`, route to `advanceToNext()` instead of displaying. Additionally, `rebuildQueue()` now drops `currentRec` from the preserved slot when it has become active, preventing the queue from being repopulated with a stale entry.

**Single file changed**: `AutoRecommendService.java` (+17 / -1). No API changes.

## Changes

### Bug Fixes
- `focusCurrent()`: added re-validation guard — if the item to display is in `getActiveFlipItemIds()`, call `advanceToNext()` and log `Auto-recommend: Current rec <name> is already on GE - advancing`
- `rebuildQueue()`: stops re-inserting `currentRec` at index 0 when that item is currently active on the GE

## Acceptance Criteria Coverage

| AC | Description | Fix |
|----|-------------|-----|
| AC1 | Never recommend an already-listed item | `focusCurrent()` re-validation on every focus call |
| AC2 | Item becomes re-eligible once cleared | Naturally inherited — `getActiveFlipItemIds()` drops the item the moment its `TrackedOffer` is removed by the existing `GrandExchangeTracker` flow |
| AC3 | Real-time exclusion mid-session | Every `focusCurrent()` call re-checks live state |
| AC4 | No re-insertion while listed | `rebuildQueue()` skips active `currentRec` when rebuilding index 0 |

## Testing

### Automated Tests
- Build: `./gradlew clean build` — passing

### Manual Testing (in-game)
- [ ] List 1–2 items manually before clicking Auto Recommend → those items never surface as the focused recommendation
- [ ] Auto recommends Item X, place buy via the overlay → queue advances past X; X does not re-surface while still on GE
- [ ] While focused on Item X, list a different Item Y from elsewhere → when the queue reaches Y it is skipped
- [ ] List the focused item near the 2-min panel auto-refresh boundary → after refresh, the just-listed item does NOT survive at index 0 (log: `Auto-recommend: Current rec <name> is already on GE - advancing`)
- [ ] Collect/cancel an offer for Item X → X becomes recommendable again in the same auto session
- [ ] Relog mid-auto with at least one offer placed → restored queue does not show the just-listed item; relevant log line fires if it would have

## Deployment Notes

- No environment variables changed
- No new dependencies
- No database migrations
- Plugin-only change; no backend or frontend impact

## Checklist

- [x] Build passes (`./gradlew clean build`)
- [x] No debug code or extra logging left in
- [x] Single-responsibility fix at the correct choke point
- [x] Follows Plugin Hub thread-management rules (no `Thread.currentThread().interrupt()`)
- [ ] Manual in-game QA by maintainer

## Related Issues

Closes Flip-Smart/flip-smart#619