### PR TITLE
chore: add Codacy analysis config for evaluation

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,22 @@
+# Codacy analysis configuration for the FlipSmart RuneLite plugin.
+#
+# Scope: ignore Gradle build output, vendored wrappers, generated class
+# files, and any image/asset directories so the issue list reflects
+# handwritten Java under src/main and src/test.
+#
+# See https://docs.codacy.com/repositories-configure/codacy-configuration-file/
+
+exclude_paths:
+  # Gradle build output and caches
+  - "build/**"
+  - ".gradle/**"
+  # Compiled artifacts
+  - "**/*.class"
+  - "**/*.jar"
+  # Vendored Gradle wrapper scripts (upstream-maintained)
+  - "gradlew"
+  - "gradlew.bat"
+  - "gradle/wrapper/**"
+  # Static assets — image/icon directories carry no code
+  - "images/**"
+  - "src/main/resources/**"

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -4,6 +4,10 @@
 # files, and any image/asset directories so the issue list reflects
 # handwritten Java under src/main and src/test.
 #
+# Note: src/main/resources is intentionally NOT excluded so secret-detection
+# scans .properties/.xml/.fxml. Image files there are already covered by
+# the **/*.png and **/*.jpg patterns below.
+#
 # See https://docs.codacy.com/repositories-configure/codacy-configuration-file/
 
 exclude_paths:
@@ -17,6 +21,11 @@ exclude_paths:
   - "gradlew"
   - "gradlew.bat"
   - "gradle/wrapper/**"
-  # Static assets — image/icon directories carry no code
+  # Static assets — image/icon files carry no code
   - "images/**"
-  - "src/main/resources/**"
+  - "**/*.png"
+  - "**/*.jpg"
+  - "**/*.jpeg"
+  - "**/*.gif"
+  - "**/*.ico"
+  - "**/*.svg"


### PR DESCRIPTION
## Summary

Adds `.codacy.yaml` so Codacy scans are scoped to handwritten Java under `src/main` and `src/test`, ignoring Gradle output (`build/`, `.gradle/`), compiled artifacts, vendored gradlew scripts, and static asset directories.

This is config-only — no code changes.

## Context

Part of the Codacy-vs-SonarCloud tooling evaluation. Sister PRs landing the same `.codacy.yaml` shape in the other three primary repos:
- `Flip-Smart/flip-smart#633` (backend)
- `Flip-Smart/flip-smart-eng#170` (frontend)
- `Flip-Smart/flip-smart-discord-bot` PR (in flight)

## Test plan

- [ ] Codacy posts a check-run + PR comment within ~2 minutes of branch push
- [ ] Excluded paths (`build/`, `src/main/resources/**`) are not enumerated in Codacy's issue list post-merge
- [ ] Existing CI (Gradle build / lint) continues to pass — no change in build inputs

## Non-goals

- Not removing or altering the existing SonarCloud/PMD configuration.
- Not changing any plugin functionality.