### PR TITLE
fix(auto-mode): prioritize collecting completed GE offers before new actions

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -378,8 +378,10 @@ public class AutoRecommendService
 
 	/**
 	 * Called when a buy order completes (fully bought).
-	 * Prompts user to collect items. Sell price is already stored in session
-	 * via setRecommendedSellPrice() when the buy order was placed.
+	 * Routes through focusNextAvailableAction so the collect prompt is surfaced
+	 * immediately regardless of slot availability. Sell price is already stored
+	 * in session via setRecommendedSellPrice() when the buy order was placed.
+	 * onOfferCollected will transition to sell when user actually collects.
 	 */
 	public synchronized void onBuyOrderCompleted(int itemId, String itemName)
 	{
@@ -389,17 +391,8 @@ public class AutoRecommendService
 		}
 
 		clearAdjustmentTimer(itemId);
-		log.debug("Auto-recommend: Buy complete for {} - collect from GE to sell", itemName);
-		updateStatus("Auto: Collect " + itemName + " from GE");
-
-		// When no GE slots are available, clear the buy focus and show collect overlay.
-		// The hint box only displays when focusedFlip is null.
-		// onOfferCollected will transition to sell when user actually collects.
-		if (!hasAvailableGESlots())
-		{
-			invokeFocusCallback(null);
-			invokeOverlayMessageCallback(itemName, itemId);
-		}
+		log.debug("Auto-recommend: Buy complete for {} - routing for collect", itemName);
+		focusNextAvailableAction();
 	}
 
 	/**
@@ -668,11 +661,26 @@ public class AutoRecommendService
 
 	/**
 	 * Determine the next action based on current state.
-	 * Priority: sell collected items > buy next from queue > wait.
+	 * Priority: collect completed GE offers > sell collected items > resolve
+	 * stale offers > buy next from queue > wait.
 	 */
 	private void focusNextAvailableAction()
 	{
 		focusedCollectedItemId = -1;
+
+		// Highest priority: any GE slot with a completed (BOUGHT/SOLD) offer
+		// awaiting collection must be surfaced before anything else. Otherwise
+		// auto-mode could advance to a new buy on a different slot while the
+		// completed slot sits uncollected — and may even recommend a flip for
+		// an item the user has already sold, because the slot has not been
+		// freed. See issue #621.
+		PlayerSession session = plugin.getSession();
+		if (session != null && !session.getCompletedOffers().isEmpty())
+		{
+			promptCollection();
+			return;
+		}
+
 		if (hasCollectedItemsToSell())
 		{
 			focusNextCollectedItemSell();


### PR DESCRIPTION
## Summary

Auto mode was advancing to a new buy on a free slot even when another slot held a completed (BOUGHT/SOLD) offer awaiting collection. In some cases this surfaced a flip recommendation for an item the player had just sold, because the slot hadn't been freed. Two surgical edits to `AutoRecommendService` add a top-priority collect check so the plugin always prompts collection before any other action.

## Changes

### 🐛 Bug Fixes

- `focusNextAvailableAction()` — inserted a top-priority branch that calls `promptCollection()` when `session.getCompletedOffers()` is non-empty. The existing `promptCollection()` already iterates completed offers and surfaces the "Collect X from GE" overlay; it was previously demoted to a fallback branch.
- `onBuyOrderCompleted()` — replaced the conditional overlay-message block (which only ran when slots were full) with a call to `focusNextAvailableAction()`. Mirrors what `onSellOrderCompleted()` already did and lets the new top-priority check surface the collect prompt regardless of slot availability.

### Updated action priority order

```
collect completed GE offers  ← new top priority
  > sell collected items
  > resolve stale offers
  > buy next from queue
  > wait
```

## Files Changed

- `src/main/java/com/flipsmart/AutoRecommendService.java` — two edits as described above (22 insertions, 14 deletions)

## Acceptance Criteria Coverage

| AC | Status | How |
|----|--------|-----|
| AC1: Immediate collect prompt on completion | ✅ | `onBuyOrderCompleted` now routes through `focusNextAvailableAction`, which detects the completed offer first |
| AC2: Collect priority over new flips / re-listing / price checks | ✅ | New top branch in `focusNextAvailableAction` is checked before sell-collected / stale-offer / new-buy branches |
| AC3: Resume normal sequence after collection | ✅ | Existing `onOfferCollected → focusNextAvailableAction` path re-evaluates; falls through to existing branches when no uncollected completed offers remain |
| AC4: Multi-slot completions queue in order | ✅ | Each completion fires `onBuyOrderCompleted`/`onSellOrderCompleted → focusNextAvailableAction`; user collects one, re-eval finds the next; FIFO via existing slot iteration |

## Testing Instructions

Build the plugin locally (`./gradlew clean shadowJar`) and load it in RuneLite.

1. Enable auto mode (Flip Assist).
2. Set up a small buy flip with a tight margin so it completes quickly.
3. Wait for the buy to fully complete (slot transitions to BOUGHT). **Expected:** the overlay/hint immediately prompts "Collect [item] from GE" — NOT a new flip recommendation.
4. Set up a second flip in parallel; let both buys complete near-simultaneously. **Expected:** plugin prompts to collect one at a time; after collecting the first, the second is surfaced (AC4).
5. With a completed (BOUGHT) slot uncollected AND a free slot available, verify the plugin does NOT recommend a new buy until you collect the completed one (AC2).
6. After all completed offers are collected, verify auto mode resumes its normal sequence — surfaces next buy from the queue (AC3).
7. Verify the "Auto: Collect X from GE" status text appears at the bottom of the plugin panel/overlay.

**Automated test results:**
- [x] `./gradlew compileJava` — clean
- [x] `./gradlew test` — clean (no auto-recommend priority tests existed pre-fix; nothing regressed)
- [x] SonarCloud branch scan — 0 new issues

## Related Issues

Closes Flip-Smart/flip-smart#621

### Codacy Quality Gate — no new issues
Gate status: PASS (0 new findings against head 1183068f)

### Codacy AI Reviewer — no open signals
Total comments: 0