### PR TITLE
chore(plugin): remove dead is_estimated handling from CompletedFlip + FlipFinderPanel

### DIFF
--- a/src/main/java/com/flipsmart/CompletedFlip.java
+++ b/src/main/java/com/flipsmart/CompletedFlip.java
@@ -56,8 +56,5 @@ public class CompletedFlip
 
 	@SerializedName("is_successful")
 	private boolean isSuccessful;
-
-	@SerializedName("is_estimated")
-	private boolean isEstimated;
 }
 

--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -66,7 +66,7 @@ public class FlipAssistOverlay extends Overlay
 	private static final String HINT_MESSAGE = "Click on a flip suggestion to start";
 	private static final String UPGRADE_MESSAGE = "Upgrade to Premium for more flip slots";
 	private static final String LOGIN_MESSAGE = "Log in to use Flip Assist";
-	private static final String HISTORY_PROMPT_MESSAGE = "Open GE History tab to improve offline fill accuracy";
+	private static final String HISTORY_PROMPT_MESSAGE = "Open GE History tab to backfill recent trades";
 	
 	// GE Interface IDs
 	private static final int GE_INTERFACE_GROUP = 465;

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3731,31 +3731,6 @@ public class FlipFinderPanel extends PluginPanel
 		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(), backgroundColor);
 		JPanel topPanel = header.topPanel;
 
-		// If this flip's data may be incomplete (offline fills), add a warning icon to the header
-		if (flip.isEstimated())
-		{
-			JLabel warningLabel = new JLabel("\u26A0");
-			warningLabel.setForeground(new Color(255, 200, 0)); // yellow
-			warningLabel.setFont(FONT_BOLD_13);
-			warningLabel.setToolTipText(
-				"<html>Profit may be approximate.<br>"
-				+ "Some fills for this flip were recorded from offline sync<br>"
-				+ "(e.g. trades completed on OSRS Mobile).</html>");
-			warningLabel.setBorder(new EmptyBorder(0, 0, 0, 4));
-
-			// Insert warning into the EAST icons panel of the top header
-			Component eastComponent = ((BorderLayout) header.topPanel.getLayout()).getLayoutComponent(BorderLayout.EAST);
-			if (eastComponent instanceof JPanel)
-			{
-				((JPanel) eastComponent).add(warningLabel, 0);  // add at index 0 = leftmost in the icons row
-			}
-			else
-			{
-				// Fallback: add to topPanel directly
-				header.topPanel.add(warningLabel, BorderLayout.EAST);
-			}
-		}
-
 		// Details section with profit/loss info - use GridBagLayout for tighter column spacing
 		JPanel detailsPanel = new JPanel(new GridBagLayout());
 		detailsPanel.setBackground(backgroundColor);


### PR DESCRIPTION
## Summary

Cleans up the dead `is_estimated` field and its unreachable UI branch after the backend retired the offline-fill mechanism in two phases: PR #597 (2026-04-30) rejected new estimated rows, and PR #639 (2026-05-12) dropped the `flips.is_estimated` and `ge_transactions.is_offline_fill` columns entirely. Gson was silently defaulting the deserialized field to `false` after #639, making the warning-icon branch permanently unreachable. Removes the dead code and updates one stale string constant.

Closes Flip-Smart/flip-smart#640

## Changes

### ♻️ Refactoring
- `CompletedFlip.java` — dropped the `is_estimated` field and its Lombok-generated `isEstimated()` accessor
- `FlipFinderPanel.java` — removed the dead `if (flip.isEstimated()) { ... }` branch that conditionally rendered a yellow warning icon for estimated flips; this branch was unreachable post-#639
- `FlipAssistOverlay.java` — reworded `HISTORY_PROMPT_MESSAGE` constant from "improve offline fill accuracy" → "backfill recent trades", replacing stale offline-fill framing with the active GE History backfill mechanism

## Testing

### Automated Tests
- `./gradlew compileJava` — clean
- `./gradlew test` — clean (no unit tests covered the removed branch, so nothing regressed)

### Manual Testing (in-game, by Miles)
- [ ] Build plugin (`./gradlew clean shadowJar`), load in RuneLite
- [ ] Open the FlipSmart panel and navigate to Completed Flips list
- [ ] Confirm rendering is unchanged versus master — no missing fields, no broken layout, profit/ROI rows render correctly
- [ ] Confirm no yellow warning icon appears (dead branch removed; was unreachable post-#639 anyway)
- [ ] Verify the history-prompt hint still appears under the conditions that triggered it before, with updated wording "Open GE History tab to backfill recent trades"

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: None
- [ ] Requires database migration: No

## Out of Scope

The following were intentionally left unchanged (tracked in Flip-Smart/flip-smart#640):
- `OfflineSyncService.java` and `GrandExchangeTracker.java` offline-fill detection paths remain intentionally inert. Removing them is a larger refactor requiring metric confirmation that no clients still rely on local offline-detect for UX state.
- The active GE History backfill (`GEHistoryService`, `FlipSmartApiClient.recordHistoryBackfillBatchAsync`) is untouched.

## Checklist

- [x] Tests added/updated (n/a — removed dead code)
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct

## Related Issues

Closes Flip-Smart/flip-smart#640

---

**Backend context:**
- PR #597 — backend started rejecting `is_offline_fill=true` requests with 400 and hard-deleted estimated rows
- PR #639 — dropped `flips.is_estimated` and `ge_transactions.is_offline_fill` columns; `GET /flips/completed` no longer returns `is_estimated` in the payload

---

### Codacy Quality Gate — no new issues
Analyzed head `48032a3`. Gate: PASS. New issues: 0. Fixed issues: 0.

### Codacy AI Reviewer — no open comments
No `@codacy-production[bot]` review comments on this PR at head `48032a3`.