### PR TITLE
chore: set build=standard in runelite-plugin.properties

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=Flip Smart
 author=Flip-Smart
-build=gradle
+build=standard
 description=Provides a comprehensive tool for flipping items in the Grand Exchange
 tags=grand exchange,flipping,trading,money making,profit,flip finder
 plugins=com.flipsmart.FlipSmartPlugin


### PR DESCRIPTION
## Summary

Sets `build=standard` in `runelite-plugin.properties` as requested by a reviewer on plugin-hub PR [#11928](https://github.com/runelite/plugin-hub/pull/11928). The plugin-hub AI reviewer requires this property to be set to `standard` in order to evaluate plugin submissions. Without it, the automated review cannot run.

## Changes

### ♻️ Refactoring
- `runelite-plugin.properties`: flip `build` property from `gradle` to `standard`

## Testing

### Automated Tests
- N/A — metadata-only change, no code paths affected

### Manual Testing
- [ ] Confirm plugin-hub PR #11928 AI reviewer picks up the change after this merges to master and the plugin-hub PR is updated

## API Changes

None.

## Database Migrations

None.

## Deployment Notes

- No environment variables changed
- No dependencies added
- **Impact**: metadata-only — does not affect plugin runtime behavior, compilation output, or any in-game functionality. This property tells the plugin-hub build system how to classify the artifact; changing it from `gradle` to `standard` has no effect on the built JAR.

## Checklist

- [x] Change is limited to exactly one line in `runelite-plugin.properties`
- [x] No runtime code modified
- [x] Requested by plugin-hub reviewer — see https://github.com/runelite/plugin-hub/pull/11928

## Related Issues

Requested by reviewer on plugin-hub PR https://github.com/runelite/plugin-hub/pull/11928

---

🤖 Generated with [Claude Code](https://claude.ai/code)