### PR TITLE
fix(plugin): reset offer timer baseline when player relists at new price (#608)

### DIFF
--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -639,8 +639,16 @@ public class GrandExchangeTracker
 
 	private void handleNewOfferNoFills(OfferContext ctx, TrackedOffer previousOffer)
 	{
-		// Preserve timestamps from existing offer if same item (avoids timer reset on re-sent events)
-		if (previousOffer != null && previousOffer.getItemId() == ctx.itemId && previousOffer.getCreatedAtMillis() > 0)
+		// Preserve timestamps only when this looks like a re-sent event for
+		// the SAME offer (same item, same price). A different price means the
+		// player cancelled and relisted — that's a fresh timer baseline (per
+		// issue #608 AC6/AC7: timeout timer restarts when a new sell price is
+		// set after the player acts on an adjustment recommendation).
+		boolean isSameOfferReSend = previousOffer != null
+			&& previousOffer.getItemId() == ctx.itemId
+			&& previousOffer.getPrice() == ctx.price
+			&& previousOffer.getCreatedAtMillis() > 0;
+		if (isSameOfferReSend)
 		{
 			TrackedOffer preserved = new TrackedOffer(ctx.itemId, ctx.itemName, ctx.isBuy,
 				ctx.totalQuantity, ctx.price, 0, previousOffer.getCreatedAtMillis());


### PR DESCRIPTION
## Summary

In `handleNewOfferNoFills`, the predicate that preserves a prior `TrackedOffer`'s `createdAtMillis` / `lastActivityAtMillis` was tightened to require both the same item **and** the same price. Previously, any same-item event in the slot would carry forward the old timestamps. This meant that when a player cancelled a stale sell and relisted at a new price — exactly the workflow triggered by a sell-price adjustment recommendation — the slot retained the stale `lastActivityAtMillis`. The backend would then compute a large `minutes_since_offer` from that baseline, potentially treating the new offer as already inside the 12-hour timeout window and firing the "sell at market" recommendation before the player had time to let the adjusted price work.

A different price unambiguously indicates a cancel + relist (a fresh offer). A same-price re-event is a RuneLite re-send of an unchanged offer and still correctly preserves timestamps.

## Changes

### Bug Fixes
- Tighten same-offer detection in `handleNewOfferNoFills` to require `price` match in addition to `itemId` match, so a cancel+relist at a new price resets the timer baseline instead of inheriting stale timestamps.

## Testing

### Automated Tests
- `./gradlew clean compileJava` — BUILD SUCCESSFUL
- `./gradlew test` — BUILD SUCCESSFUL (all existing tests pass: `ExamplePluginTest`, `MotdServiceTest`, `PlayerSessionTest`)

### Manual Testing
- [ ] Place a sell offer at price X, let it partially fill, then cancel and relist at price Y. Confirm the in-game timer overlay resets rather than continuing from the prior offer's start time.
- [ ] Place a sell offer; observe the same GE event re-delivered without a price change — confirm the timer does NOT reset (regression check for the original same-event deduplication guard).

## Companion PR

Companion backend PR: Flip-Smart/flip-smart#<!-- fill in once backend PR is open -->

Refs Flip-Smart/flip-smart#608

## Deployment Notes

- No configuration changes required.
- No new dependencies.
- Plugin update will be delivered through the standard RuneLite Plugin Hub release process.

## Checklist

- [x] Build passes (`./gradlew clean compileJava`)
- [x] Tests pass (`./gradlew test`)
- [x] Change is behavior-preserving for the same-price re-send case
- [x] No `Thread.currentThread().interrupt()` calls on unowned threads
- [x] No debug logging left in

---

🤖 Generated with [Claude Code](https://claude.ai/code)

---

### Codacy: no open signals at f9e4437