### PR TITLE
fix(plugin): reset adjustment timer when user relists at a new price (#608)

### DIFF
--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -639,8 +639,14 @@ public class GrandExchangeTracker
 
 	private void handleNewOfferNoFills(OfferContext ctx, TrackedOffer previousOffer)
 	{
-		// Preserve timestamps from existing offer if same item (avoids timer reset on re-sent events)
-		if (previousOffer != null && previousOffer.getItemId() == ctx.itemId && previousOffer.getCreatedAtMillis() > 0)
+		// Preserve timestamps from existing offer if same item AND same price.
+		// Same price = re-sent state event for an unchanged offer, so the timer
+		// must NOT restart. Different price = user relisted at a new price, so
+		// the offer is effectively brand new and the timer should reset (fall
+		// through to the else branch, which creates a fresh TrackedOffer).
+		if (previousOffer != null && previousOffer.getItemId() == ctx.itemId
+			&& previousOffer.getCreatedAtMillis() > 0
+			&& previousOffer.getPrice() == ctx.price)
 		{
 			TrackedOffer preserved = new TrackedOffer(ctx.itemId, ctx.itemName, ctx.isBuy,
 				ctx.totalQuantity, ctx.price, 0, previousOffer.getCreatedAtMillis());


### PR DESCRIPTION
## Summary

- **Bug**: `handleNewOfferNoFills` preserved `createdAt`/`lastActivityAtMillis` from the previous `TrackedOffer` whenever any state event arrived for the same `itemId`. This meant a cancel-and-relist at a different price silently reused the original offer's timestamp, causing the 4H/12H AC8 timeout brackets to fire immediately on the relisted offer.
- **Fix**: Tightens the preserve-timestamps predicate to also require `previousOffer.getPrice() == ctx.price`. Same item + same price is a re-sent state event for an unchanged offer (preserve). Same item + different price is a genuine relist (fall through to the `else` branch, which constructs a fresh `TrackedOffer` with the current timestamp).
- **Scope**: Single-method, single-file change — `handleNewOfferNoFills` in `GrandExchangeTracker.java`. No other event handlers touched.
- **Companion PR**: The API-side relist guard lives in [Flip-Smart/flip-smart#667](https://github.com/Flip-Smart/flip-smart/pull/667). That PR adds a server-side check as a belt-and-suspenders guard; this plugin PR is the durable fix.

## What's New

`handleNewOfferNoFills` now checks `previousOffer.getPrice() == ctx.price` before deciding to preserve timestamps:

```java
// Before
if (previousOffer != null && previousOffer.getItemId() == ctx.itemId
    && previousOffer.getCreatedAtMillis() > 0)

// After
if (previousOffer != null && previousOffer.getItemId() == ctx.itemId
    && previousOffer.getCreatedAtMillis() > 0
    && previousOffer.getPrice() == ctx.price)
```

When the condition is not met (price changed), execution falls through to the `else` branch, which allocates a new `TrackedOffer` and timestamps it at the current wall-clock time — giving the relisted offer a clean 4H/12H window.

## Test Plan

Manual in-game QA (no existing unit tests cover this handler):

- [ ] Place a sell (or buy) offer on an item that qualifies for a 4H/12H flip recommendation
- [ ] Let the offer sit for at least 10 minutes without any fills
- [ ] Cancel the offer, then relist the same item at a **different** price
- [ ] Verify the plugin does **not** immediately emit an AC8 adjustment suggestion on the relisted offer — the full `timeframe / 2` window should restart from the relist time
- [ ] Place a sell offer, cancel it, and relist at the **same** price — verify the timer is preserved (no spurious reset)
- [ ] Check that normal partial-fill offers (handled by `handleOfferWithFills`) are unaffected

## Non-Goals

- No changes to `handleOfferWithFills` or `handleCancelledOffer` — those event paths are not involved in this bug
- No new threads, executors, or shared mutable state introduced
- No changes to any public-facing API, serialization format, or network calls

## Plugin-Hub Safety

- Single-file behavioral change; no new dependencies, no new threads, no reflection
- Does not call any RuneLite API that is on the restricted list
- Compile and `./gradlew test` both pass on the branch

## Related Issues

References [Flip-Smart/flip-smart#608](https://github.com/Flip-Smart/flip-smart/issues/608) (4H/12H trade timeout & price adjustment logic)
Pairs with [Flip-Smart/flip-smart#667](https://github.com/Flip-Smart/flip-smart/pull/667) (API-side companion fix)