### PR TITLE
fix(ge): widget-op select + negative-cache volume backoff

### DIFF
--- a/src/main/java/com/flipsmart/FlipAssistInputListener.java
+++ b/src/main/java/com/flipsmart/FlipAssistInputListener.java
@@ -10,8 +10,6 @@ import net.runelite.client.config.Keybind;
 import net.runelite.client.input.KeyListener;
 
 import javax.inject.Inject;
-import java.awt.Canvas;
-import java.awt.KeyboardFocusManager;
 import java.awt.event.KeyEvent;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -467,26 +465,53 @@ public class FlipAssistInputListener implements KeyListener
 	}
 
 	/**
-	 * Select the first item in the GE search results by dispatching Enter key.
+	 * Select the first item in the GE search results by invoking the result
+	 * widget's own click listener via a script event.
+	 *
+	 * <p>This replaces an earlier approach that synthesised AWT Enter key events
+	 * and pushed them through {@link java.awt.KeyboardFocusManager}, which the
+	 * RuneLite Plugin Hub disallows. Instead we locate the first search-result
+	 * widget that carries an "op" listener and run it exactly as a left-click
+	 * would (menu op 1, the default "select" action), which selects the top
+	 * result — the same outcome as pressing Enter in the search box.
+	 *
 	 * MUST be called on client thread.
 	 */
 	private void selectFirstSearchResult()
 	{
-		Canvas canvas = client.getCanvas();
-		if (canvas == null)
+		Widget searchResults = client.getWidget(InterfaceID.Chatbox.MES_LAYER_SCROLLCONTENTS);
+		if (searchResults == null || searchResults.isHidden())
 		{
 			return;
 		}
 
-		long now = System.currentTimeMillis();
-		KeyEvent enterPressed = new KeyEvent(canvas, KeyEvent.KEY_PRESSED, now, 0, KeyEvent.VK_ENTER, KeyEvent.CHAR_UNDEFINED);
-		KeyEvent enterTyped = new KeyEvent(canvas, KeyEvent.KEY_TYPED, now, 0, KeyEvent.VK_UNDEFINED, '\n');
-		KeyEvent enterReleased = new KeyEvent(canvas, KeyEvent.KEY_RELEASED, now, 0, KeyEvent.VK_ENTER, KeyEvent.CHAR_UNDEFINED);
+		Widget[] children = searchResults.getDynamicChildren();
+		if (children == null)
+		{
+			return;
+		}
 
-		KeyboardFocusManager focusManager = KeyboardFocusManager.getCurrentKeyboardFocusManager();
-		focusManager.dispatchKeyEvent(enterPressed);
-		focusManager.dispatchKeyEvent(enterTyped);
-		focusManager.dispatchKeyEvent(enterReleased);
+		// Result rows are laid out in document order; the first row that carries
+		// an onOp listener is the top match. Running its listener mirrors a
+		// left-click on that row without dispatching synthetic input events.
+		for (Widget child : children)
+		{
+			if (child == null)
+			{
+				continue;
+			}
+
+			Object[] opListener = child.getOnOpListener();
+			if (opListener != null)
+			{
+				client.createScriptEventBuilder(opListener)
+					.setSource(child)
+					.setOp(1)
+					.build()
+					.run();
+				return;
+			}
+		}
 	}
 }
 

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -2475,14 +2475,21 @@ public class FlipSmartApiClient
 	// are picked up the next time the user opens a buy window, but long enough to
 	// avoid hitting the API on every offer-screen rebuild as the player adjusts qty.
 	private static final long DAILY_VOLUME_CACHE_TTL_MS = 300_000;  // 5 minutes
+	// Shorter TTL applied when a fetch fails (404/5xx/connection error). The GE
+	// offer description is rebuilt every render frame, so without a negative
+	// cache a persistent error (e.g. the endpoint missing on a stale API build)
+	// fires one request per frame. We back off for a minute, then retry.
+	private static final long DAILY_VOLUME_ERROR_CACHE_TTL_MS = 60_000;  // 1 minute
 	private final Map<Integer, CachedDailyVolume> dailyVolumeCache = new ConcurrentHashMap<>();
 
 	/**
 	 * Fetch the 24h daily trading volume for a single item.
-	 * Cached in-memory for {@link #DAILY_VOLUME_CACHE_TTL_MS}; cached value may
-	 * be null (the API returned no data for the item).
+	 * Cached in-memory for {@link #DAILY_VOLUME_CACHE_TTL_MS} on success (the
+	 * value may be null — the API returned no data for the item) and for
+	 * {@link #DAILY_VOLUME_ERROR_CACHE_TTL_MS} on failure, so the per-frame GE
+	 * render loop cannot spam the API when a request keeps failing.
 	 *
-	 * @return CompletableFuture resolving to the daily volume, or null when no data exists.
+	 * @return CompletableFuture resolving to the daily volume, or null when no data exists / the fetch failed.
 	 */
 	public CompletableFuture<Integer> getDailyVolumeAsync(int itemId)
 	{
@@ -2497,15 +2504,28 @@ public class FlipSmartApiClient
 			.url(url)
 			.get();
 
-		return executeAuthenticatedAsync(requestBuilder, jsonData ->
+		CompletableFuture<Integer> future = executeAuthenticatedAsync(requestBuilder, jsonData ->
 		{
 			JsonObject obj = gson.fromJson(jsonData, JsonObject.class);
 			Integer volume = (obj != null && obj.has("daily_volume") && !obj.get("daily_volume").isJsonNull())
 				? obj.get("daily_volume").getAsInt()
 				: null;
-			dailyVolumeCache.put(itemId, new CachedDailyVolume(volume));
+			dailyVolumeCache.put(itemId, new CachedDailyVolume(volume, DAILY_VOLUME_CACHE_TTL_MS));
 			return volume;
 		});
+
+		// On any non-2xx response executeAsync completes the future with null
+		// WITHOUT running the handler above, so nothing gets cached. Record a
+		// short-lived negative entry in that case to throttle the render loop.
+		future.whenComplete((volume, ex) ->
+		{
+			if (!dailyVolumeCache.containsKey(itemId))
+			{
+				dailyVolumeCache.put(itemId, new CachedDailyVolume(null, DAILY_VOLUME_ERROR_CACHE_TTL_MS));
+			}
+		});
+
+		return future;
 	}
 
 	/**
@@ -2527,14 +2547,16 @@ public class FlipSmartApiClient
 	{
 		private final Integer volume;
 		private final long fetchedAt;
+		private final long ttlMs;
 
-		CachedDailyVolume(Integer volume)
+		CachedDailyVolume(Integer volume, long ttlMs)
 		{
 			this.volume = volume;
 			this.fetchedAt = System.currentTimeMillis();
+			this.ttlMs = ttlMs;
 		}
 
 		Integer getVolume() { return volume; }
-		boolean isExpired() { return System.currentTimeMillis() - fetchedAt > DAILY_VOLUME_CACHE_TTL_MS; }
+		boolean isExpired() { return System.currentTimeMillis() - fetchedAt > ttlMs; }
 	}
 }


### PR DESCRIPTION
## Summary

Two bug fixes in the GE offer flow. The first removes use of `KeyboardFocusManager.dispatchKeyEvent()` to confirm a GE search result — flagged by the Plugin Hub reviewer on runelite/plugin-hub#12204 — replacing it with a `ScriptEvent`-based widget op invocation. The second adds negative caching for failed daily-volume fetches to prevent a persistent API error from generating one HTTP request per render frame.

## Changes

### Bug Fixes

- **fix(ge): select GE search result via widget op listener, not synthetic key events** — `FlipAssistInputListener.selectFirstSearchResult()` previously synthesised three AWT `KeyEvent`s (PRESSED / TYPED / RELEASED for Enter) and pushed them through `KeyboardFocusManager.dispatchKeyEvent()`. The Plugin Hub disallows synthetic input dispatch. The method now walks the `Chatbox.MES_LAYER_SCROLLCONTENTS` widget's dynamic children, finds the first row carrying an `onOp` listener, and invokes it via `client.createScriptEventBuilder(...).setSource(child).setOp(1).build().run()`. This selects the top search result without any synthetic input. Runs on the client thread as required. Removed unused `java.awt.Canvas` and `java.awt.KeyboardFocusManager` imports.

- **fix(api): negative-cache failed daily-volume fetches to stop render-loop spam** — `GeOfferDescriptionService.onBeforeRender()` rebuilds the GE offer description every frame and re-fires `getDailyVolumeAsync()` whenever the cache entry is absent. `executeAsync` completes the future with `null` (not exceptionally) on any non-2xx, skipping the success handler that writes the cache, so errors were never cached. A persistent failure (404 from a stale API build, 503 during an outage) produced one request per frame — observed locally as ~3,600 404s. Fix: added `DAILY_VOLUME_ERROR_CACHE_TTL_MS = 60_000` and a `whenComplete` hook that writes a negative cache entry (null volume, 1-min TTL) if no success entry was written. Successful responses keep the existing 5-min TTL. `CachedDailyVolume` now carries a per-entry `ttlMs` field.

### Refactoring

- `CachedDailyVolume` constructor now takes an explicit `ttlMs` parameter instead of reading the class-level constant, making per-entry TTL variation possible without additional wrapper types.

## Testing

### Automated Tests

- Build: `./gradlew compileJava test` — exits 0, all tasks UP-TO-DATE / passing.
- No new test cases were added; the changed paths are not currently covered by unit tests.

### Manual Testing

The `dispatchKeyEvent` replacement must be verified in-game — Playwright cannot drive the RuneLite client.

- [ ] Open the Grand Exchange, begin a buy order, type a partial item name to trigger the search dropdown.
- [ ] Press the Flip Assist hotkey that auto-selects the top result.
- [ ] Confirm the top result is selected and the item-buy flow advances (price input opens) without error.
- [ ] Verify no `ERROR` or `WARN` entries appear in `~/.runelite/logs/client.log` from `FlipAssistInputListener` after the selection.

For the volume backoff fix, reproduce with a deliberate 404:

- [ ] Temporarily point the plugin at a local API build missing the `/items/{id}/daily-volume` endpoint.
- [ ] Open a GE offer panel. Observe the log — confirm at most one 404 per minute (not per frame).
- [ ] Restore the correct API URL; confirm volume data resumes loading within 1 minute.

## API Changes

None — plugin-side only.

## Deployment Notes

- No new config keys or Doppler secrets required.
- No database migrations.
- No changes to public API endpoints.

## Checklist

- [x] Follows Plugin Hub coding standards (no synthetic input dispatch, no owned-thread interruption)
- [x] `./gradlew compileJava test` exits 0
- [x] No debug logging left in
- [x] Commit messages are descriptive
- [ ] In-game manual QA for the widget-op select path

## Related Issues

Addresses Plugin Hub review feedback: runelite/plugin-hub#12204

### Codacy Quality Gate — no new issues
- Static analysis clean at head `236ccb3`: `gate_ok=true`, `new=0`. No fixes or config changes needed.

### Codacy AI Reviewer — no comments
- Zero AI Reviewer review comments on this PR. No threads to triage.