### PR TITLE
fix(ge-search): player-driven item selection + stop hotkey leak

### DIFF
--- a/src/main/java/com/flipsmart/FlipAssistInputListener.java
+++ b/src/main/java/com/flipsmart/FlipAssistInputListener.java
@@ -39,7 +39,7 @@ public class FlipAssistInputListener implements KeyListener
 
 	// Input type values
 	private static final int INPUT_TYPE_NUMERIC = 7;
-	private static final int INPUT_TYPE_GE_ITEM_SEARCH = 14;
+	static final int INPUT_TYPE_GE_ITEM_SEARCH = 14;
 	
 	// Chat message prefix - cyan color for visibility
 	private static final String CHAT_MESSAGE_PREFIX = "<col=00e5ff>[FlipSmart]</col> ";
@@ -69,13 +69,6 @@ public class FlipAssistInputListener implements KeyListener
 	// Used on EDT to decide whether to consume the hotkey before clientThread runs.
 	private final AtomicInteger currentInputType = new AtomicInteger(0);
 
-	// Cached input text from VarClientStr, updated via event from FlipSmartPlugin.
-	// Used on EDT to gate hotkey consumption in the GE item search dialog: we
-	// only consume when the search box is empty or the user-typed text is a
-	// prefix of the focused item name. Otherwise the player is searching for a
-	// different item and the hotkey character must reach the search field.
-	private final AtomicReference<String> currentInputText = new AtomicReference<>("");
-
 	/**
 	 * Update the cached input type. Called from FlipSmartPlugin on VarClientIntChanged.
 	 */
@@ -84,6 +77,13 @@ public class FlipAssistInputListener implements KeyListener
 		currentInputType.set(inputType);
 	}
 
+	// Cached input text from VarClientStr, updated via event from FlipSmartPlugin.
+	// Used on the EDT to gate hotkey consumption in the GE item-search dialog: we
+	// only consume when the search box is empty or the user-typed text is a prefix
+	// of the focused item name. Otherwise the player is searching for a different
+	// item and the hotkey character must reach the search field (#616).
+	private final AtomicReference<String> currentInputText = new AtomicReference<>("");
+
 	/**
 	 * Update the cached input text. Called from FlipSmartPlugin on VarClientStrChanged.
 	 */
@@ -91,7 +91,36 @@ public class FlipAssistInputListener implements KeyListener
 	{
 		currentInputText.set(inputText == null ? "" : inputText);
 	}
-	
+
+	/**
+	 * EDT-side gate: should the hotkey be consumed in the GE item-search dialog?
+	 * True when the search box is empty or what's typed is a prefix of the focused
+	 * item — i.e. the player is going for the focused item, so the hotkey character
+	 * should be suppressed rather than typed into the box.
+	 */
+	private boolean searchTextMatchesFocusedItem(FocusedFlip focusedFlip)
+	{
+		return searchTextMatchesItem(currentInputText.get(), focusedFlip.getItemName());
+	}
+
+	/**
+	 * Pure prefix check used by {@link #searchTextMatchesFocusedItem}. Empty or null
+	 * search text matches (player hasn't narrowed yet); otherwise the item name must
+	 * start with the typed text, case-insensitively and trimmed.
+	 */
+	static boolean searchTextMatchesItem(String searchText, String itemName)
+	{
+		if (searchText == null || searchText.isEmpty())
+		{
+			return true;
+		}
+		if (itemName == null)
+		{
+			return false;
+		}
+		return itemName.toLowerCase().trim().startsWith(searchText.toLowerCase().trim());
+	}
+
 	@Override
 	public void keyTyped(KeyEvent e)
 	{
@@ -129,63 +158,38 @@ public class FlipAssistInputListener implements KeyListener
 			return;
 		}
 
-		// Only consume the hotkey when a GE input dialog is active.
 		int cachedInputType = currentInputType.get();
-		if (cachedInputType != INPUT_TYPE_NUMERIC && cachedInputType != INPUT_TYPE_GE_ITEM_SEARCH)
+
+		// Numeric (price/quantity) input is hotkey-driven: the plugin fills the
+		// value. Consume eagerly on the EDT — clientThread.invoke() is async, so
+		// consuming inside the callback would be too late to stop the keystroke.
+		if (cachedInputType == INPUT_TYPE_NUMERIC)
 		{
+			handledKeyPressedEvent.set(e);
+			e.consume();
+			clientThread.invoke(() -> handleHotkeyOnClientThread(focusedFlip));
 			return;
 		}
 
-		// In the GE item search dialog, only consume the hotkey when the search
-		// box is empty or the user is on track to find the focused item. If the
-		// player is typing a different item name, let the character through to
-		// the search field — this is the fix for #616.
+		// GE item search: selection happens via the injected "FlipSmart item" row
+		// (player click or the game's native Enter), NOT the hotkey — the Plugin
+		// Hub forbids selecting on the player's behalf. We still consume the hotkey
+		// here so its character doesn't leak into the search box, but only when the
+		// player is clearly going for the focused item (empty box or a prefix of the
+		// item name). If they're typing a different item, let the character through
+		// so search still works (#616).
 		if (cachedInputType == INPUT_TYPE_GE_ITEM_SEARCH
-			&& !searchTextMatchesFocusedItem(focusedFlip))
+			&& searchTextMatchesFocusedItem(focusedFlip))
 		{
-			return;
+			handledKeyPressedEvent.set(e);
+			e.consume();
+			// Intentionally no action — the player selects via the injected row.
 		}
-
-		// Consume the event eagerly on the EDT to prevent the hotkey character
-		// from being typed into the GE search/input. clientThread.invoke() is
-		// asynchronous from the EDT, so consuming inside the callback is too late.
-		handledKeyPressedEvent.set(e);
-		e.consume();
-
-		clientThread.invoke(() -> handleHotkeyOnClientThread(focusedFlip));
-	}
-
-	/**
-	 * Decide on the EDT whether the cached search text indicates the player is
-	 * still searching for the focused item (empty box or a prefix of the item
-	 * name). Returns false when the player has typed something the focused item
-	 * does not start with — in that case the hotkey must not consume the key.
-	 */
-	private boolean searchTextMatchesFocusedItem(FocusedFlip focusedFlip)
-	{
-		String searchText = currentInputText.get();
-		if (searchText.isEmpty())
-		{
-			// Empty search box — the focused item will be auto-populated by
-			// the GE_LAST_SEARCHED varp, so the hotkey can confirm it.
-			return true;
-		}
-
-		String itemName = focusedFlip.getItemName();
-		if (itemName == null)
-		{
-			return false;
-		}
-
-		String normalizedSearch = searchText.toLowerCase().trim();
-		String normalizedItem = itemName.toLowerCase().trim();
-
-		return normalizedItem.startsWith(normalizedSearch);
 	}
 
 	/**
 	 * Handle the hotkey action on the client thread.
-	 * Validates GE state and dispatches to the appropriate handler.
+	 * Validates GE state and fills the numeric price/quantity input.
 	 * MUST be called on client thread.
 	 */
 	private void handleHotkeyOnClientThread(FocusedFlip focusedFlip)
@@ -195,22 +199,9 @@ public class FlipAssistInputListener implements KeyListener
 			return;
 		}
 
-		int inputType = client.getVarcIntValue(VARCLIENT_INPUT_TYPE);
-
-		// Handle GE item search — fill the search box with the focused item's
-		// name and let the game's own search populate the results. The EDT guard
-		// already verified the search text matches the focused item (or is
-		// empty). The player clicks the result themselves; the plugin never
-		// selects/clicks an item on their behalf.
-		if (inputType == INPUT_TYPE_GE_ITEM_SEARCH)
-		{
-			fillSearchWithFocusedItem(focusedFlip);
-			flipAssistOverlay.updateStep();
-			return;
-		}
-
-		// Handle numeric input (price/quantity)
-		if (inputType == INPUT_TYPE_NUMERIC)
+		// Only numeric (price/quantity) input is hotkey-driven. Item selection is
+		// handled by the injected "FlipSmart item" shortcut row the player clicks.
+		if (client.getVarcIntValue(VARCLIENT_INPUT_TYPE) == INPUT_TYPE_NUMERIC)
 		{
 			handleFlipAssistAction(focusedFlip);
 			flipAssistOverlay.updateStep();
@@ -443,35 +434,6 @@ public class FlipAssistInputListener implements KeyListener
 			CHAT_MESSAGE_PREFIX + message,
 			null
 		);
-	}
-
-	/**
-	 * Populate the GE item-search box with the focused item's name and run the
-	 * game's own search script so the matching results appear. The player then
-	 * clicks the result themselves.
-	 *
-	 * <p>This replaces an earlier approach that selected the first result for the
-	 * player — first by synthesising AWT Enter key events, then by invoking the
-	 * result widget's "op" listener via a script event. The RuneLite Plugin Hub
-	 * does not permit plugins to click/select on the player's behalf. Writing the
-	 * search text and letting the player pick the result is the supported pattern
-	 * (VarClientStr.INPUT_TEXT / 359 + ScriptID.GE_ITEM_SEARCH).
-	 *
-	 * MUST be called on client thread.
-	 */
-	private void fillSearchWithFocusedItem(FocusedFlip focusedFlip)
-	{
-		String itemName = focusedFlip.getItemName();
-		if (itemName == null || itemName.isEmpty())
-		{
-			return;
-		}
-
-		// Set the GE search input text, then run the vanilla GE item-search
-		// script so the result list rebuilds for the typed name — exactly as if
-		// the player had typed it themselves. They still click the item.
-		client.setVarcStrValue(VARCLIENT_INPUT_TEXT, itemName);
-		client.runScript(ScriptID.GE_ITEM_SEARCH);
 	}
 }
 

--- a/src/main/java/com/flipsmart/FlipAssistInputListener.java
+++ b/src/main/java/com/flipsmart/FlipAssistInputListener.java
@@ -3,7 +3,6 @@ package com.flipsmart;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.ScriptID;
-import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.Keybind;
@@ -198,16 +197,15 @@ public class FlipAssistInputListener implements KeyListener
 
 		int inputType = client.getVarcIntValue(VARCLIENT_INPUT_TYPE);
 
-		// Handle GE item search — press hotkey to select the first result.
-		// The EDT guard already verified the search text matches the focused
-		// item (or is empty), so the player expects auto-selection here.
+		// Handle GE item search — fill the search box with the focused item's
+		// name and let the game's own search populate the results. The EDT guard
+		// already verified the search text matches the focused item (or is
+		// empty). The player clicks the result themselves; the plugin never
+		// selects/clicks an item on their behalf.
 		if (inputType == INPUT_TYPE_GE_ITEM_SEARCH)
 		{
-			if (hasSearchResults())
-			{
-				selectFirstSearchResult();
-				flipAssistOverlay.updateStep();
-			}
+			fillSearchWithFocusedItem(focusedFlip);
+			flipAssistOverlay.updateStep();
 			return;
 		}
 
@@ -448,70 +446,32 @@ public class FlipAssistInputListener implements KeyListener
 	}
 
 	/**
-	 * Check if there are GE search results displayed.
-	 * MUST be called on client thread.
-	 */
-	private boolean hasSearchResults()
-	{
-		Widget searchResults = client.getWidget(InterfaceID.Chatbox.MES_LAYER_SCROLLCONTENTS);
-		if (searchResults == null || searchResults.isHidden())
-		{
-			return false;
-		}
-
-		Widget[] children = searchResults.getDynamicChildren();
-		// Each search result has 3 children (icon, name, ?)
-		return children != null && children.length >= 3;
-	}
-
-	/**
-	 * Select the first item in the GE search results by invoking the result
-	 * widget's own click listener via a script event.
+	 * Populate the GE item-search box with the focused item's name and run the
+	 * game's own search script so the matching results appear. The player then
+	 * clicks the result themselves.
 	 *
-	 * <p>This replaces an earlier approach that synthesised AWT Enter key events
-	 * and pushed them through {@link java.awt.KeyboardFocusManager}, which the
-	 * RuneLite Plugin Hub disallows. Instead we locate the first search-result
-	 * widget that carries an "op" listener and run it exactly as a left-click
-	 * would (menu op 1, the default "select" action), which selects the top
-	 * result — the same outcome as pressing Enter in the search box.
+	 * <p>This replaces an earlier approach that selected the first result for the
+	 * player — first by synthesising AWT Enter key events, then by invoking the
+	 * result widget's "op" listener via a script event. The RuneLite Plugin Hub
+	 * does not permit plugins to click/select on the player's behalf. Writing the
+	 * search text and letting the player pick the result is the supported pattern
+	 * (VarClientStr.INPUT_TEXT / 359 + ScriptID.GE_ITEM_SEARCH).
 	 *
 	 * MUST be called on client thread.
 	 */
-	private void selectFirstSearchResult()
+	private void fillSearchWithFocusedItem(FocusedFlip focusedFlip)
 	{
-		Widget searchResults = client.getWidget(InterfaceID.Chatbox.MES_LAYER_SCROLLCONTENTS);
-		if (searchResults == null || searchResults.isHidden())
+		String itemName = focusedFlip.getItemName();
+		if (itemName == null || itemName.isEmpty())
 		{
 			return;
 		}
 
-		Widget[] children = searchResults.getDynamicChildren();
-		if (children == null)
-		{
-			return;
-		}
-
-		// Result rows are laid out in document order; the first row that carries
-		// an onOp listener is the top match. Running its listener mirrors a
-		// left-click on that row without dispatching synthetic input events.
-		for (Widget child : children)
-		{
-			if (child == null)
-			{
-				continue;
-			}
-
-			Object[] opListener = child.getOnOpListener();
-			if (opListener != null)
-			{
-				client.createScriptEventBuilder(opListener)
-					.setSource(child)
-					.setOp(1)
-					.build()
-					.run();
-				return;
-			}
-		}
+		// Set the GE search input text, then run the vanilla GE item-search
+		// script so the result list rebuilds for the typed name — exactly as if
+		// the player had typed it themselves. They still click the item.
+		client.setVarcStrValue(VARCLIENT_INPUT_TEXT, itemName);
+		client.runScript(ScriptID.GE_ITEM_SEARCH);
 	}
 }
 

--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -107,7 +107,7 @@ public class FlipAssistOverlay extends Overlay
 	public enum FlipAssistStep
 	{
 		SELECT_ITEM("Select Item", "Click BUY on an empty slot"),
-		SEARCH_ITEM("Search Item", "Item auto-selected, press Enter"),
+		SEARCH_ITEM("Search Item", "Press [%s] to search, then click item"),
 		SET_QUANTITY("Set Quantity", "Press [%s] to set qty: %s"),
 		SET_PRICE("Set Price", "Press [%s] to set price: %s"),
 		CONFIRM_OFFER("Confirm", "Click the confirm button"),
@@ -798,6 +798,9 @@ public class FlipAssistOverlay extends Overlay
 		
 		switch (currentStep)
 		{
+			case SEARCH_ITEM:
+				// Press the hotkey to fill the search box, then click the result.
+				return String.format(currentStep.getDescription(), hotkeyName);
 			case SET_QUANTITY:
 				int targetQty = focusedFlip.getCurrentStepQuantity();
 				// Just show the target quantity with hotkey

--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -107,7 +107,7 @@ public class FlipAssistOverlay extends Overlay
 	public enum FlipAssistStep
 	{
 		SELECT_ITEM("Select Item", "Click BUY on an empty slot"),
-		SEARCH_ITEM("Search Item", "Press [%s] to search, then click item"),
+		SEARCH_ITEM("Search Item", "Press Enter or click the item"),
 		SET_QUANTITY("Set Quantity", "Press [%s] to set qty: %s"),
 		SET_PRICE("Set Price", "Press [%s] to set price: %s"),
 		CONFIRM_OFFER("Confirm", "Click the confirm button"),
@@ -798,9 +798,6 @@ public class FlipAssistOverlay extends Overlay
 		
 		switch (currentStep)
 		{
-			case SEARCH_ITEM:
-				// Press the hotkey to fill the search box, then click the result.
-				return String.format(currentStep.getDescription(), hotkeyName);
 			case SET_QUANTITY:
 				int targetQty = focusedFlip.getCurrentStepQuantity();
 				// Just show the target quantity with hotkey

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -187,6 +187,9 @@ public class FlipSmartPlugin extends Plugin
 	// Flip Assist input listener for hotkey handling
 	private FlipAssistInputListener flipAssistInputListener;
 
+	// Injects the clickable "FlipSmart item" shortcut into GE search results
+	private GeSearchSuggestion geSearchSuggestion;
+
 	// Timer delay constants (in milliseconds)
 	/** Delay before syncing offline fills after login */
 	private static final int OFFLINE_SYNC_DELAY_MS = 2000;
@@ -547,6 +550,9 @@ public class FlipSmartPlugin extends Plugin
 		flipAssistInputListener = new FlipAssistInputListener(client, clientThread, config, flipAssistOverlay);
 		keyManager.registerKeyListener(flipAssistInputListener);
 
+		// GE search suggestion injector (clickable "FlipSmart item" shortcut row)
+		geSearchSuggestion = new GeSearchSuggestion(client, config, flipAssistOverlay);
+
 		// Initialize Flip Finder panel
 		if (config.showFlipFinder())
 		{
@@ -794,6 +800,7 @@ public class FlipSmartPlugin extends Plugin
 			keyManager.unregisterKeyListener(flipAssistInputListener);
 			flipAssistInputListener = null;
 		}
+		geSearchSuggestion = null;
 		
 		// Remove flip finder panel
 		if (flipFinderNavButton != null)
@@ -1336,13 +1343,25 @@ public class FlipSmartPlugin extends Plugin
 	{
 		if (event.getIndex() == FlipAssistInputListener.VARCLIENT_INPUT_TYPE && flipAssistInputListener != null)
 		{
-			flipAssistInputListener.updateInputType(client.getVarcIntValue(FlipAssistInputListener.VARCLIENT_INPUT_TYPE));
+			int inputType = client.getVarcIntValue(FlipAssistInputListener.VARCLIENT_INPUT_TYPE);
+			flipAssistInputListener.updateInputType(inputType);
+
+			// When the GE item-search dialog opens, inject the clickable
+			// "FlipSmart item" shortcut row. Deferred so the search-results
+			// widget is built before we add children to it.
+			if (inputType == FlipAssistInputListener.INPUT_TYPE_GE_ITEM_SEARCH && geSearchSuggestion != null)
+			{
+				clientThread.invokeLater(geSearchSuggestion::showSuggestedItemInSearch);
+			}
 		}
 	}
 
 	@Subscribe
 	public void onVarClientStrChanged(VarClientStrChanged event)
 	{
+		// Keep the listener's cached search text fresh so its EDT-side consume
+		// gate (suppressing the stray hotkey char in GE item search) can compare
+		// what's typed against the focused item name.
 		if (event.getIndex() == FlipAssistInputListener.VARCLIENT_INPUT_TEXT && flipAssistInputListener != null)
 		{
 			flipAssistInputListener.updateInputText(client.getVarcStrValue(FlipAssistInputListener.VARCLIENT_INPUT_TEXT));

--- a/src/main/java/com/flipsmart/GeSearchSuggestion.java
+++ b/src/main/java/com/flipsmart/GeSearchSuggestion.java
@@ -1,0 +1,202 @@
+package com.flipsmart;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.gameval.VarPlayerID;
+import net.runelite.api.gameval.VarbitID;
+import net.runelite.api.widgets.JavaScriptCallback;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetTextAlignment;
+import net.runelite.api.widgets.WidgetType;
+
+/**
+ * Injects a clickable "FlipSmart item" shortcut row at the top of the Grand
+ * Exchange item-search results, pointing at the focused buy recommendation.
+ *
+ * <p>The plugin attaches the game's own search-select listener to the row and
+ * gives it a "Select" action, but never invokes it — <strong>the player clicks
+ * the row</strong> to select the item. This mirrors the vanilla "previous
+ * search" shortcut and the mechanism used by the approved Flipping Copilot
+ * plugin ({@code GePreviousSearch}). The RuneLite Plugin Hub forbids selecting
+ * or clicking an item on the player's behalf, so we only set up the shortcut
+ * and let the player trigger it.
+ */
+@Slf4j
+class GeSearchSuggestion
+{
+	// GE search-results container == InterfaceID.Chatbox.MES_LAYER_SCROLLCONTENTS
+	// == ComponentID.CHATBOX_GE_SEARCH_RESULTS.
+	private static final int CHATBOX_GE_SEARCH_RESULTS = 10616884;
+
+	// The vanilla GE "select search result" client script and the op/key trigger
+	// args the game attaches to each real result row. We attach the same listener
+	// to our row so a player click runs the game's own selection logic — we never
+	// run it ourselves.
+	private static final int GE_SELECT_SCRIPT = 754;
+	private static final int GE_SELECT_OP = 84;
+	private static final int GE_SELECT_KEY = -2147483640;
+
+	// Orange used by the vanilla "previous search" item name.
+	private static final String NAME_COLOR = "ff9040";
+
+	// Result-row child indices in the search-results container.
+	private static final int ROW_CHILD = 0;
+	private static final int LABEL_CHILD = 1;
+	private static final int NAME_CHILD = 2;
+	private static final int ICON_CHILD = 3;
+
+	private static final int FONT_ID = 495;
+
+	private final Client client;
+	private final FlipSmartConfig config;
+	private final FlipAssistOverlay flipAssistOverlay;
+
+	GeSearchSuggestion(Client client, FlipSmartConfig config, FlipAssistOverlay flipAssistOverlay)
+	{
+		this.client = client;
+		this.config = config;
+		this.flipAssistOverlay = flipAssistOverlay;
+	}
+
+	/**
+	 * Inject or refresh the suggested-item shortcut row for the focused buy.
+	 * No-op unless Flip Assist is enabled, a buy is focused, and the GE search
+	 * results widget is present. MUST be called on the client thread.
+	 */
+	void showSuggestedItemInSearch()
+	{
+		if (!config.enableFlipAssistant())
+		{
+			return;
+		}
+
+		FocusedFlip focusedFlip = flipAssistOverlay.getFocusedFlip();
+		if (focusedFlip == null || !focusedFlip.isBuying())
+		{
+			log.debug("GE search opened but no focused buy — skipping row injection (focus={})", focusedFlip);
+			return;
+		}
+
+		String itemName = focusedFlip.getItemName();
+		if (itemName == null || itemName.isEmpty())
+		{
+			return;
+		}
+
+		Widget searchResults = client.getWidget(CHATBOX_GE_SEARCH_RESULTS);
+		if (searchResults == null)
+		{
+			log.debug("GE search opened but results widget not present yet — skipping row injection");
+			return;
+		}
+
+		int itemId = focusedFlip.getItemId();
+
+		// When the game already shows a "previous search" shortcut row, repurpose
+		// its existing children; otherwise build our own. Mirrors Flipping Copilot.
+		if (previousSearchRowVisible())
+		{
+			log.debug("Injecting FlipSmart search row (repurpose previous-search) for {} (id {})", itemName, itemId);
+			repurposePreviousSearchRow(searchResults, itemId, itemName);
+		}
+		else
+		{
+			log.debug("Injecting FlipSmart search row (create new) for {} (id {})", itemName, itemId);
+			createSuggestionRow(searchResults, itemId, itemName);
+		}
+	}
+
+	private boolean previousSearchRowVisible()
+	{
+		return client.getVarpValue(VarPlayerID.GE_LAST_SEARCHED) != -1
+			&& client.getVarbitValue(VarbitID.DISABLE_LAST_SEARCHED) == 0;
+	}
+
+	private void repurposePreviousSearchRow(Widget searchResults, int itemId, String itemName)
+	{
+		Widget row = searchResults.getChild(ROW_CHILD);
+		Widget label = searchResults.getChild(LABEL_CHILD);
+		Widget nameWidget = searchResults.getChild(NAME_CHILD);
+		Widget icon = searchResults.getChild(ICON_CHILD);
+		if (row == null || label == null || nameWidget == null || icon == null)
+		{
+			return;
+		}
+
+		applySelectListener(row, itemId, itemName);
+
+		label.setText("FlipSmart item:");
+		label.setOriginalWidth(95);
+		label.setXTextAlignment(WidgetTextAlignment.LEFT);
+		label.revalidate();
+
+		nameWidget.setText(itemName);
+		nameWidget.revalidate();
+
+		icon.setItemId(itemId);
+		icon.revalidate();
+	}
+
+	private void createSuggestionRow(Widget searchResults, int itemId, String itemName)
+	{
+		Widget row = searchResults.createChild(ROW_CHILD, WidgetType.RECTANGLE);
+		row.setTextColor(0xFFFFFF);
+		row.setOpacity(255);
+		row.setFilled(true);
+		row.setOriginalX(114);
+		row.setOriginalY(0);
+		row.setOriginalWidth(256);
+		row.setOriginalHeight(32);
+		applySelectListener(row, itemId, itemName);
+		// Subtle hover feedback so it reads as clickable.
+		row.setOnMouseOverListener((JavaScriptCallback) ev -> row.setOpacity(200));
+		row.setOnMouseLeaveListener((JavaScriptCallback) ev -> row.setOpacity(255));
+		row.revalidate();
+
+		Widget label = searchResults.createChild(LABEL_CHILD, WidgetType.TEXT);
+		label.setText("FlipSmart item:");
+		label.setFontId(FONT_ID);
+		label.setOriginalX(114);
+		label.setOriginalY(0);
+		label.setOriginalWidth(95);
+		label.setOriginalHeight(32);
+		label.setYTextAlignment(WidgetTextAlignment.CENTER);
+		label.revalidate();
+
+		Widget nameWidget = searchResults.createChild(NAME_CHILD, WidgetType.TEXT);
+		nameWidget.setText(itemName);
+		nameWidget.setFontId(FONT_ID);
+		nameWidget.setOriginalX(254);
+		nameWidget.setOriginalY(0);
+		nameWidget.setOriginalWidth(116);
+		nameWidget.setOriginalHeight(32);
+		nameWidget.setYTextAlignment(WidgetTextAlignment.CENTER);
+		nameWidget.revalidate();
+
+		Widget icon = searchResults.createChild(ICON_CHILD, WidgetType.GRAPHIC);
+		icon.setItemId(itemId);
+		icon.setItemQuantity(1);
+		icon.setItemQuantityMode(0);
+		icon.setRotationX(550);
+		icon.setModelZoom(1031);
+		icon.setBorderType(1);
+		icon.setOriginalX(214);
+		icon.setOriginalY(0);
+		icon.setOriginalWidth(36);
+		icon.setOriginalHeight(32);
+		icon.revalidate();
+	}
+
+	/**
+	 * Attach the game's native select listener and a "Select" right-click action.
+	 * The plugin never invokes this — only the player's click does.
+	 */
+	private void applySelectListener(Widget row, int itemId, String itemName)
+	{
+		row.setHasListener(true);
+		row.setName("<col=" + NAME_COLOR + ">" + itemName + "</col>");
+		row.setOnOpListener(GE_SELECT_SCRIPT, itemId, GE_SELECT_OP);
+		row.setOnKeyListener(GE_SELECT_SCRIPT, itemId, GE_SELECT_KEY);
+		row.setAction(0, "Select");
+	}
+}


### PR DESCRIPTION
## Summary

Reworks how Flip Assist helps the player pick the suggested item in the Grand Exchange search, and fixes a bug where the hotkey character ("e" by default) leaked into the search box.

- **Selection is player-driven (Plugin Hub compliant).** A clickable "FlipSmart item" row is injected into the GE search results (mirroring the approved Flipping Copilot `GePreviousSearch` pattern). The player selects by **clicking the row or pressing the game's native Enter** — the plugin never selects on their behalf. This replaces earlier approaches (synthesising Enter / invoking the result widget's op listener) that aren't permitted.
- **Hotkey no longer leaks into the search box.** The Flip Assist hotkey doesn't drive item selection anymore, but pressing it in the search dialog used to type its character into the box. It's now consumed while the search box is empty or what's typed is a prefix of the focused item. If the player is typing a *different* item, the character still passes through to search (preserves #616).
- **Hotkey still drives the numeric step.** Price/quantity filling on the hotkey is unchanged.
- **Overlay hint updated.** The Flip Assist "Search Item" step now reads "Press Enter or click the item" so the supported gesture is clear.

## Files

- `FlipAssistInputListener` — prefix-gated consume for GE item search; restores the EDT-side `currentInputText` cache the gate relies on
- `FlipSmartPlugin` — restores `onVarClientStrChanged` to feed that cache
- `GeSearchSuggestion` — injects the clickable suggestion row (selection triggered only by player click / native Enter)
- `FlipAssistOverlay` — SEARCH_ITEM step text → "Press Enter or click the item"

## Test plan

- [x] `./gradlew compileJava test` passes
- [x] In-game: hotkey in GE search no longer types "e"; Enter or clicking the "FlipSmart item" row selects the focused buy; typing a different item still works
- [x] Numeric price/quantity hotkey fill still works

## Compliance note

Item selection is never performed by the plugin — only by the player's click or the game's native Enter. This is the same boundary the approved Flipping Copilot plugin respects (its hotkeys fill price/quantity but never select an item in search).

### Codacy — no open signals at bb7154f
- Quality Gate: passed (0 new issues)
- AI Reviewer: 0 comments