### PR TITLE
fix(ge-overlay): correct hover-state tax & fix profit-line race condition (#685)

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1542,7 +1542,14 @@ public class FlipFinderPanel extends PluginPanel
 					return;
 				}
 
-				currentActiveFlips.clear();
+				// Build the filtered list locally first, then swap atomically into
+				// currentActiveFlips so cross-thread readers (the GE slot-hover
+				// overlay) never observe an empty/half-populated intermediate
+				// state. Previously the clear+add loop ran inline, allowing the
+				// overlay's render thread to snapshot a transient empty list and
+				// silently hide the profit line. See issue #685 Bug 2.
+				List<ActiveFlip> filtered = new ArrayList<>();
+				int filteredCount = 0;
 				if (response.getActiveFlips() != null)
 				{
 					// Show flips that are either:
@@ -1555,12 +1562,12 @@ public class FlipFinderPanel extends PluginPanel
 					// Note: Using getActiveFlipItemIds() instead of WithInventory() to avoid thread issues
 					java.util.Set<Integer> activeItemIds = plugin.getActiveFlipItemIds();
 					java.time.Instant sevenDaysAgo = java.time.Instant.now().minus(java.time.Duration.ofDays(7));
-					
+
 					for (ActiveFlip flip : response.getActiveFlips())
 					{
 						boolean inGeOrCollected = activeItemIds.contains(flip.getItemId());
 						boolean isRecent = false;
-						
+
 						// Check if flip had activity in the last 7 days
 						// Use lastBuyTime if available (more accurate), fall back to firstBuyTime
 						String timeStr = flip.getLastBuyTime();
@@ -1568,7 +1575,7 @@ public class FlipFinderPanel extends PluginPanel
 						{
 							timeStr = flip.getFirstBuyTime();
 						}
-						
+
 						if (timeStr != null && !timeStr.isEmpty())
 						{
 							try
@@ -1587,11 +1594,11 @@ public class FlipFinderPanel extends PluginPanel
 							// No timestamp, assume recent
 							isRecent = true;
 						}
-						
+
 						if (inGeOrCollected || isRecent)
 						{
-							currentActiveFlips.add(flip);
-							log.debug("Including flip: {} (inGE={}, recent={})", 
+							filtered.add(flip);
+							log.debug("Including flip: {} (inGE={}, recent={})",
 								flip.getItemName(), inGeOrCollected, isRecent);
 						}
 						else
@@ -1599,9 +1606,17 @@ public class FlipFinderPanel extends PluginPanel
 							log.debug("Filtering stale flip: {} (not in GE and older than 7 days)", flip.getItemName());
 						}
 					}
-					log.debug("Loaded {} active flips ({} from backend, {} filtered)", 
-						currentActiveFlips.size(), response.getActiveFlips().size(),
-						response.getActiveFlips().size() - currentActiveFlips.size());
+					filteredCount = response.getActiveFlips().size() - filtered.size();
+				}
+				synchronized (currentActiveFlips)
+				{
+					currentActiveFlips.clear();
+					currentActiveFlips.addAll(filtered);
+				}
+				if (response.getActiveFlips() != null)
+				{
+					log.debug("Loaded {} active flips ({} from backend, {} filtered)",
+						currentActiveFlips.size(), response.getActiveFlips().size(), filteredCount);
 				}
 
 				// Get pending orders from plugin
@@ -3038,13 +3053,25 @@ public class FlipFinderPanel extends PluginPanel
 	}
 	
 	/**
-	 * Get the current active flips
+	 * Get the current active flips.
+	 *
+	 * Returns a synchronized snapshot. The list is mutated on the EDT by
+	 * refreshActiveFlips, but cross-thread callers (e.g. the GE slot-hover
+	 * overlay, which runs on the render thread and reads via
+	 * BuyPriceLookup.findAverageBuyPrice) need to see either the old
+	 * complete list or the new complete list — never a half-populated
+	 * intermediate state. Without this lock the overlay can intermittently
+	 * see an empty list during the clear+addAll swap and silently hide the
+	 * hover-state profit line. See issue #685 Bug 2.
 	 */
 	public List<ActiveFlip> getCurrentActiveFlips()
 	{
-		return new ArrayList<>(currentActiveFlips);
+		synchronized (currentActiveFlips)
+		{
+			return new ArrayList<>(currentActiveFlips);
+		}
 	}
-	
+
 	/**
 	 * Check if an item exists in recommendations or active flips
 	 */
@@ -3059,11 +3086,14 @@ public class FlipFinderPanel extends PluginPanel
 			}
 		}
 		// Check active flips
-		for (ActiveFlip flip : currentActiveFlips)
+		synchronized (currentActiveFlips)
 		{
-			if (flip.getItemId() == itemId)
+			for (ActiveFlip flip : currentActiveFlips)
 			{
-				return true;
+				if (flip.getItemId() == itemId)
+				{
+					return true;
+				}
 			}
 		}
 		return false;

--- a/src/main/java/com/flipsmart/GeTax.java
+++ b/src/main/java/com/flipsmart/GeTax.java
@@ -1,0 +1,111 @@
+package com.flipsmart;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Grand Exchange tax helpers.
+ *
+ * Source of truth for the exempt list is the backend at
+ * {@code flip-smart/app/constants.py} (GE_TAX_EXEMPT_ITEM_IDS). The set is
+ * mirrored here so the GE-slot hover overlay can compute the player's true
+ * post-tax profit without a network round-trip. If the backend list changes,
+ * update both.
+ *
+ * Wiki reference:
+ * https://oldschool.runescape.wiki/w/Category:Items_exempt_from_Grand_Exchange_tax
+ */
+public final class GeTax
+{
+	private static final double GE_TAX_RATE = 0.02;
+	private static final int GE_TAX_CAP = 5_000_000;
+	private static final int GE_TAX_EXEMPT_PRICE_THRESHOLD = 50;
+
+	/** Items the GE never taxes regardless of sell price. */
+	public static final Set<Integer> EXEMPT_ITEM_IDS;
+	static
+	{
+		Set<Integer> ids = new HashSet<>();
+		ids.add(233);    // Pestle and mortar
+		ids.add(315);    // Shrimps
+		ids.add(329);    // Salmon
+		ids.add(347);    // Herring
+		ids.add(351);    // Pike
+		ids.add(355);    // Mackerel
+		ids.add(361);    // Tuna
+		ids.add(365);    // Bass
+		ids.add(379);    // Lobster
+		ids.add(558);    // Mind rune
+		ids.add(806);    // Bronze dart
+		ids.add(807);    // Iron dart
+		ids.add(808);    // Steel dart
+		ids.add(882);    // Bronze arrow
+		ids.add(884);    // Iron arrow
+		ids.add(886);    // Steel arrow
+		ids.add(952);    // Spade
+		ids.add(1733);   // Needle
+		ids.add(1735);   // Shears
+		ids.add(1755);   // Chisel
+		ids.add(1785);   // Glassblowing pipe
+		ids.add(1891);   // Cake
+		ids.add(2140);   // Cooked chicken
+		ids.add(2142);   // Cooked meat
+		ids.add(2309);   // Bread
+		ids.add(2327);   // Meat pie
+		ids.add(2347);   // Hammer
+		ids.add(2552);   // Ring of dueling(8)
+		ids.add(3008);   // Energy potion(4)
+		ids.add(3853);   // Games necklace(8)
+		ids.add(5325);   // Gardening trowel
+		ids.add(5329);   // Secateurs
+		ids.add(5331);   // Watering can
+		ids.add(5341);   // Rake
+		ids.add(5343);   // Seed dibber
+		ids.add(8007);   // Varrock teleport (tablet)
+		ids.add(8008);   // Lumbridge teleport (tablet)
+		ids.add(8009);   // Falador teleport (tablet)
+		ids.add(8010);   // Camelot teleport (tablet)
+		ids.add(8011);   // Ardougne teleport (tablet)
+		ids.add(8013);   // Teleport to house (tablet)
+		ids.add(8794);   // Saw
+		ids.add(13190);  // Old school bond
+		ids.add(28790);  // Kourend castle teleport (tablet)
+		ids.add(28824);  // Civitas illa fortis teleport
+		EXEMPT_ITEM_IDS = Collections.unmodifiableSet(ids);
+	}
+
+	private GeTax()
+	{
+		// Utility class - prevent instantiation
+	}
+
+	/**
+	 * Whether the given item id and sell price is exempt from GE tax.
+	 *
+	 * Two reasons an item is exempt: sell price &le; 50gp, or the item id is
+	 * on the GE tax-free list.
+	 */
+	public static boolean isExempt(int itemId, int sellPrice)
+	{
+		if (sellPrice <= GE_TAX_EXEMPT_PRICE_THRESHOLD)
+		{
+			return true;
+		}
+		return EXEMPT_ITEM_IDS.contains(itemId);
+	}
+
+	/**
+	 * Per-item GE tax for a given sell price. Returns 0 for exempt items, and
+	 * caps at 5,000,000gp per item for high-value flips. Matches Jagex's
+	 * floored 2% calc.
+	 */
+	public static int taxFor(int itemId, int sellPrice)
+	{
+		if (isExempt(itemId, sellPrice))
+		{
+			return 0;
+		}
+		return Math.min((int) Math.floor(sellPrice * GE_TAX_RATE), GE_TAX_CAP);
+	}
+}

--- a/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
@@ -459,7 +459,7 @@ public class GrandExchangeSlotOverlay extends Overlay
 		graphics.setFont(new Font("Arial", Font.PLAIN, 11));
 		FontMetrics fm = graphics.getFontMetrics();
 
-		java.util.List<String> lines = buildTooltipLines(wikiPrice, offerPrice, buyPrice, isBuy, offer.getTotalQuantity());
+		java.util.List<String> lines = buildTooltipLines(wikiPrice, offerPrice, buyPrice, isBuy, offer.getTotalQuantity(), offer.getItemId());
 		Color yourPriceColor = determineYourPriceColor(wikiPrice, offerPrice, isBuy);
 
 		drawTooltipBackground(graphics, x, y, lines, fm);
@@ -480,7 +480,7 @@ public class GrandExchangeSlotOverlay extends Overlay
 	 * Build tooltip text lines based on wiki price data
 	 */
 	private java.util.List<String> buildTooltipLines(FlipSmartApiClient.WikiPrice wikiPrice, int offerPrice,
-													  Integer buyPrice, boolean isBuy, int totalQuantity)
+													  Integer buyPrice, boolean isBuy, int totalQuantity, int itemId)
 	{
 		java.util.List<String> lines = new java.util.ArrayList<>();
 
@@ -489,7 +489,7 @@ public class GrandExchangeSlotOverlay extends Overlay
 
 		if (!isBuy && buyPrice != null && buyPrice > 0 && totalQuantity > 0)
 		{
-			addProfitLossLine(lines, offerPrice, buyPrice, totalQuantity);
+			addProfitLossLine(lines, offerPrice, buyPrice, totalQuantity, itemId);
 		}
 
 		return lines;
@@ -512,9 +512,12 @@ public class GrandExchangeSlotOverlay extends Overlay
 		}
 	}
 
-	private void addProfitLossLine(java.util.List<String> lines, int sellPrice, int buyPrice, int totalQuantity)
+	private void addProfitLossLine(java.util.List<String> lines, int sellPrice, int buyPrice, int totalQuantity, int itemId)
 	{
-		int geTaxPerItem = Math.min((int)(sellPrice * 0.02), 5_000_000);
+		// Honor the GE tax-exempt list and the <=50gp threshold (issue #685 Bugs 3 & 4).
+		// ROI uses netPnlPerItem so it automatically becomes pre-tax for exempt items
+		// and post-tax for taxable ones, matching AC2 of Bug 4.
+		int geTaxPerItem = GeTax.taxFor(itemId, sellPrice);
 		int netPnlPerItem = sellPrice - buyPrice - geTaxPerItem;
 		int totalPnl = netPnlPerItem * totalQuantity;
 		double roiPercent = (netPnlPerItem / (double) buyPrice) * 100.0;

--- a/src/test/java/com/flipsmart/GeTaxTest.java
+++ b/src/test/java/com/flipsmart/GeTaxTest.java
@@ -1,0 +1,57 @@
+package com.flipsmart;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GeTaxTest
+{
+	private static final int ABYSSAL_WHIP_ID = 4151;       // not exempt
+	private static final int OLD_SCHOOL_BOND_ID = 13190;   // exempt
+	private static final int COOKED_LOBSTER_ID = 379;      // exempt
+
+	@Test
+	public void exemptWhenSellPriceIsFiftyOrLess()
+	{
+		assertTrue(GeTax.isExempt(ABYSSAL_WHIP_ID, 50));
+		assertTrue(GeTax.isExempt(ABYSSAL_WHIP_ID, 49));
+		assertTrue(GeTax.isExempt(ABYSSAL_WHIP_ID, 1));
+	}
+
+	@Test
+	public void exemptWhenItemIsOnList()
+	{
+		assertTrue(GeTax.isExempt(OLD_SCHOOL_BOND_ID, 8_000_000));
+		assertTrue(GeTax.isExempt(COOKED_LOBSTER_ID, 250));
+	}
+
+	@Test
+	public void notExemptForArbitraryItemAboveThreshold()
+	{
+		assertFalse(GeTax.isExempt(ABYSSAL_WHIP_ID, 51));
+	}
+
+	@Test
+	public void taxIsZeroForExempt()
+	{
+		assertEquals(0, GeTax.taxFor(OLD_SCHOOL_BOND_ID, 8_000_000));
+		assertEquals(0, GeTax.taxFor(ABYSSAL_WHIP_ID, 50));
+	}
+
+	@Test
+	public void taxFloorsTwoPercent()
+	{
+		assertEquals(1, GeTax.taxFor(ABYSSAL_WHIP_ID, 99));      // floor(1.98) = 1
+		assertEquals(30_000, GeTax.taxFor(ABYSSAL_WHIP_ID, 1_500_000));
+		assertEquals(582_000, GeTax.taxFor(ABYSSAL_WHIP_ID, 29_100_000));
+	}
+
+	@Test
+	public void taxCapsAtFiveMillion()
+	{
+		assertEquals(5_000_000, GeTax.taxFor(ABYSSAL_WHIP_ID, 500_000_000));
+		assertEquals(5_000_000, GeTax.taxFor(ABYSSAL_WHIP_ID, Integer.MAX_VALUE));
+	}
+}


### PR DESCRIPTION
## Summary

Addresses Bugs 2, 3, and 4 from issue Flip-Smart/flip-smart#685 («FlipSmart Misc. Plugin Bugs: Flip Finder Qty Logic, Hover State Profit & Hover State Tax Calculations»). Bug 1 (quantity cap in Flip Finder recommendations) ships separately on the backend repo (`flip-smart`) and is not part of this PR. Once both PRs merge the issue can be fully closed.

## Changes

### 🐛 Bug Fixes

**Bug 3 — Hover state applies tax to exempt items (AC1-3)**
- New `GeTax.java` utility: mirrors `app/constants.py` `GE_TAX_EXEMPT_ITEM_IDS` and the frontend's `ge-tax.ts` rules — 2% floor, 5 M gp cap, price-threshold exemption (≤50 gp), and a named exempt-item set. Single source of tax logic in the plugin so it cannot drift from the backend/frontend again.
- `GrandExchangeSlotOverlay.addProfitLossLine` now calls `GeTax.taxFor(itemId, sellPrice)` instead of the unconditional inline `Math.min((int)(sellPrice * 0.02), 5_000_000)`.
- `itemId` threaded through `buildTooltipLines` so the call has the context it needs.
- Scope is strictly the hover tooltip — Flip Finder recommendations, completed-flip tallies, and the adjustment flow are untouched (satisfies AC3).

**Bug 4 — Hover state ROI should include tax (AC1-3)**
- ROI already used `netPnlPerItem`, which is now correctly post-tax for taxable items and the raw spread for exempt ones. No separate code change needed; the fix falls out of the `GeTax` integration.
- AC2 (exempt items show ROI without tax deducted) and AC3 (Flip Finder untouched) satisfied automatically.

**Bug 2 — Hover state Profit value intermittently disappears (AC1-4)**
- Root cause: `FlipFinderPanel.refreshActiveFlips` mutated `currentActiveFlips` inline on the EDT — `clear()` then a populate loop — while the render thread called `BuyPriceLookup.findAverageBuyPrice` against the same list. An empty or partially-populated list caused `buyPrice` to come back `null`, which silently hid the profit line.
- Fix: build the filtered list locally first, then atomically swap under `synchronized (currentActiveFlips)`. Added `synchronized` to `getCurrentActiveFlips()` and `hasFlipForItem()` so all reads observe a consistent state.
- Covers all three symptom scenarios: manual price adjust, logout/login, and extended-session staleness — each triggers the refresh path.

### ✅ Tests

- 6 new unit tests in `GeTaxTest.java`:
  - `exemptWhenSellPriceIsFiftyOrLess`
  - `exemptWhenItemIsOnList`
  - `notExemptForArbitraryItemAboveThreshold`
  - `taxIsZeroForExempt`
  - `taxFloorsTwoPercent`
  - `taxCapsAtFiveMillion`

## Acceptance Criteria Mapping

| Bug | AC | Satisfied by |
|-----|----|-------------|
| Bug 2 | AC1 — Profit line present after manual price adjust | Atomic swap in `refreshActiveFlips` removes window where list is empty mid-update |
| Bug 2 | AC2 — Profit line repopulates after logout/login | Same fix: refresh rebuilds list atomically |
| Bug 2 | AC3 — Profit line stable over long session | Synchronized reads eliminate stale-list races |
| Bug 2 | AC4 — Flip Finder recommendations unaffected | Refresh logic isolated to active-flips list |
| Bug 3 | AC1 — Exempt items show raw spread, no tax deducted | `GeTax.isExempt` returns `true` → `taxFor` returns 0 |
| Bug 3 | AC2 — ≤50 gp items exempt from tax | Price-threshold branch in `GeTax.isExempt` |
| Bug 3 | AC3 — Flip Finder and completed-flip tallies untouched | Change scoped to `addProfitLossLine` in hover overlay only |
| Bug 4 | AC1 — ROI uses post-tax profit for taxable items | `netPnlPerItem = sell - buy - GeTax.taxFor(...)` |
| Bug 4 | AC2 — ROI uses raw spread for exempt items | `GeTax.taxFor` returns 0 → same formula gives raw ROI |
| Bug 4 | AC3 — Flip Finder ROI untouched | Change scoped to hover overlay only |

## Testing

### Automated Tests
- ✅ `./gradlew clean build test` passes (7 tasks, 0 failures)
- ✅ 6 new `GeTaxTest` cases cover all tax rule branches

### Manual Testing Checklist

**Bug 3 & 4 — Tax correctness**
- [ ] Hover on a sell offer for an exempt item (e.g. Old school bond ID 13190, Cooked lobster ID 379) — Profit line shows raw spread (sell − buy), no tax deducted; ROI matches raw spread ÷ buy price
- [ ] Hover on a sell offer for any item priced at ≤50 gp (e.g. Mind rune at market price) — same behaviour: raw spread, no tax
- [ ] Hover on a sell offer for a taxable item (e.g. Abyssal whip ~2 M gp) — Profit reflects sell − buy − 2% tax (capped at 5 M); ROI uses that post-tax figure
- [ ] Hover on a very high-value taxable item (sell price > 250 M gp) — tax shows as exactly 5,000,000 gp deducted

**Bug 2 — Profit line stability**
- [ ] Place a sell offer, then immediately manually adjust the price via the GE interface — Profit line stays present after the adjustment completes (does not disappear)
- [ ] Log out of the game, then log back in — Profit line repopulates within a few seconds on a matching sell offer and remains present
- [ ] Extended session (15–30 min of normal play with GE offers open) — Profit line does not intermittently disappear; note in the test plan that this cannot be rapidly simulated but should be monitored post-merge

## 🩺 SonarCloud

- Branch analysis returned **0 open issues** (`Flip-Smart_flip-smart-runelite-plugin` — public project). No fixes or deferrals needed.

## 🤖 Codacy AI Reviewer — no open signals at 2558efa

- Total AI Reviewer comments: 0 — no action needed.

## 🩺 Codacy Quality Gate — no open signals at 2558efa

- Gate status: PASS (isUpToStandards=true, new=0)
- No new issues to fix, configure, or defer.

## Deployment Notes

- [ ] No environment variables added or changed
- [ ] No new dependencies — `GeTax.java` uses only `java.util` standard library
- [ ] No database migrations
- [ ] No configuration changes
- [ ] `GeTax.EXEMPT_ITEM_IDS` must be kept in sync with `flip-smart/app/constants.py:GE_TAX_EXEMPT_ITEM_IDS` and `flip-smart-eng/src/lib/utils/ge-tax.ts` if that list changes in future

## Checklist

- [x] Tests added (6 new `GeTaxTest` cases)
- [x] No `.claude/`, `CLAUDE.md`, or Claude Code configuration added to this public repo
- [x] No `Thread.currentThread().interrupt()` on framework-managed threads
- [x] No synthetic input / op-spoofing
- [x] No AI attribution in commits or PR body
- [x] Commits are scoped and descriptive
- [x] Gradle build passes cleanly

## Related Issues

Closes Flip-Smart/flip-smart#685 (together with the companion backend PR for Bug 1 — once both merge the issue is fully resolved)