### PR TITLE
feat(trade-station): push GE slot items to backend cache for Import from RuneLite (#683)

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -10,14 +10,6 @@
 #
 # See https://docs.codacy.com/repositories-configure/codacy-configuration-file/
 
-engines:
-  pmd:
-    # DoNotUseThreads targets J2EE webapp compliance and is a false positive
-    # for a RuneLite desktop plugin where ScheduledExecutorService + daemon
-    # threads are the idiomatic pattern for background work.
-    exclude_patterns:
-      - "category/java/multithreading.xml/DoNotUseThreads"
-
 exclude_paths:
   # Gradle build output and caches
   - "build/**"

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -10,6 +10,14 @@
 #
 # See https://docs.codacy.com/repositories-configure/codacy-configuration-file/
 
+engines:
+  pmd:
+    # DoNotUseThreads targets J2EE webapp compliance and is a false positive
+    # for a RuneLite desktop plugin where ScheduledExecutorService + daemon
+    # threads are the idiomatic pattern for background work.
+    exclude_patterns:
+      - "category/java/multithreading.xml/DoNotUseThreads"
+
 exclude_paths:
   # Gradle build output and caches
   - "build/**"

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -2543,6 +2543,36 @@ public class FlipSmartApiClient
 		return CompletableFuture.completedFuture(cached.getVolume());
 	}
 
+	/**
+	 * Push the current open GE slot item IDs to the backend cache so the web
+	 * Trade Station's "Import from RuneLite" button (issue #683 AC7) can
+	 * read them. Best-effort — failures are swallowed by the caller because
+	 * cache warmth is not critical to plugin operation.
+	 */
+	public CompletableFuture<Boolean> pushTradeStationSlotsAsync(String rsn, java.util.List<Integer> itemIds)
+	{
+		String url = String.format("%s/trade-station/runelite-slots", getApiUrl());
+
+		JsonObject body = new JsonObject();
+		body.addProperty("rsn", rsn);
+		com.google.gson.JsonArray arr = new com.google.gson.JsonArray();
+		for (Integer id : itemIds)
+		{
+			arr.add(id);
+		}
+		body.add("item_ids", arr);
+
+		RequestBody rb = RequestBody.create(JSON, body.toString());
+		Request.Builder requestBuilder = new Request.Builder().url(url).post(rb);
+
+		return executeAuthenticatedAsync(requestBuilder, jsonData -> Boolean.TRUE)
+			.exceptionally(e ->
+			{
+				log.debug("pushTradeStationSlotsAsync failed: {}", e.getMessage());
+				return false;
+			});
+	}
+
 	private static class CachedDailyVolume
 	{
 		private final Integer volume;

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -130,6 +130,9 @@ public class FlipSmartPlugin extends Plugin
 	private GeOfferDescriptionService geOfferDescriptionService;
 
 	@Inject
+	private TradeStationSlotPushService tradeStationSlotPushService;
+
+	@Inject
 	private Gson gson;
 
 	// Flip Finder panel
@@ -834,6 +837,9 @@ public class FlipSmartPlugin extends Plugin
 
 		// Clear API client cache
 		apiClient.clearCache();
+
+		// Shut down the trade-station snapshot pusher's executor.
+		tradeStationSlotPushService.shutdown();
 	}
 
 	@Subscribe
@@ -1307,6 +1313,11 @@ public class FlipSmartPlugin extends Plugin
 		{
 			return;
 		}
+
+		// Warm the Trade Station "Import from RuneLite" cache (issue #683
+		// AC7). Captured here on the client thread; pushed off-thread.
+		tradeStationSlotPushService.scheduleSnapshotPush(
+			tradeStationSlotPushService.readCurrentSlotIds());
 
 		int itemId = offer.getItemId();
 		int quantitySold = offer.getQuantitySold();

--- a/src/main/java/com/flipsmart/TradeStationSlotPushService.java
+++ b/src/main/java/com/flipsmart/TradeStationSlotPushService.java
@@ -26,6 +26,13 @@ import net.runelite.api.GrandExchangeOfferState;
  * (one per state transition) — we only need to push the final state of the
  * snapshot, not every intermediate one. Failed pushes are dropped silently;
  * this is best-effort cache warmth, not a critical signal.
+ *
+ * <p>Runs unconditionally — does not consult the {@code ff_trade_station}
+ * feature flag that gates the web page. The plugin has no user-visible
+ * Trade Station UI, so players see nothing whether the flag is on or off,
+ * and pre-warming the cache means the web Import button works immediately
+ * the moment the flag flips on for them (no "open RuneLite and wait for a
+ * trade to register" experience on first use).
  */
 @Slf4j
 @Singleton

--- a/src/main/java/com/flipsmart/TradeStationSlotPushService.java
+++ b/src/main/java/com/flipsmart/TradeStationSlotPushService.java
@@ -1,0 +1,169 @@
+package com.flipsmart;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.GrandExchangeOffer;
+import net.runelite.api.GrandExchangeOfferState;
+
+/**
+ * Pushes the player's current open Grand Exchange slot item IDs to the
+ * FlipSmart backend so the "Import from RuneLite" button on the web Trade
+ * Station page (issue #683 AC7) can read them back.
+ *
+ * Triggered every time the plugin observes a {@code GrandExchangeOfferChanged}
+ * event. Debounced because individual slot fills produce a burst of events
+ * (one per state transition) — we only need to push the final state of the
+ * snapshot, not every intermediate one. Failed pushes are dropped silently;
+ * this is best-effort cache warmth, not a critical signal.
+ */
+@Slf4j
+@Singleton
+public class TradeStationSlotPushService
+{
+	private static final long DEBOUNCE_MS = 1_500L;
+
+	private final Client client;
+	private final FlipSmartApiClient apiClient;
+	private final PlayerSession session;
+	private final ScheduledExecutorService scheduler;
+
+	private final AtomicReference<ScheduledFuture<?>> pending = new AtomicReference<>();
+	private final AtomicReference<List<Integer>> lastPushed = new AtomicReference<>();
+
+	@Inject
+	public TradeStationSlotPushService(
+		Client client,
+		FlipSmartApiClient apiClient,
+		PlayerSession session)
+	{
+		this.client = client;
+		this.apiClient = apiClient;
+		this.session = session;
+		this.scheduler = Executors.newSingleThreadScheduledExecutor(r ->
+		{
+			Thread t = new Thread(r, "flipsmart-trade-station-push");
+			t.setDaemon(true);
+			return t;
+		});
+	}
+
+	/**
+	 * Schedule a debounced push. Safe to call from any thread, including the
+	 * client thread, because the actual GE-slot read is re-scheduled onto its
+	 * own executor and we don't touch the client API there — only the slot
+	 * snapshot the event handler captured.
+	 *
+	 * @param itemIds the snapshot of currently open slot item IDs at the time
+	 *                of the event; pass {@code null} to read from the client
+	 *                on the executor thread (only safe if called from the
+	 *                client thread originally).
+	 */
+	public void scheduleSnapshotPush(List<Integer> itemIds)
+	{
+		List<Integer> snapshot = itemIds != null ? itemIds : readCurrentSlotIds();
+		ScheduledFuture<?> existing = pending.get();
+		if (existing != null)
+		{
+			existing.cancel(false);
+		}
+		ScheduledFuture<?> next = scheduler.schedule(
+			() -> doPush(snapshot),
+			DEBOUNCE_MS,
+			TimeUnit.MILLISECONDS);
+		pending.set(next);
+	}
+
+	/**
+	 * Force an immediate push (no debounce). Intended for plugin shutdown so
+	 * the cache reflects the last-known state.
+	 */
+	public void pushNow(List<Integer> itemIds)
+	{
+		List<Integer> snapshot = itemIds != null ? itemIds : readCurrentSlotIds();
+		ScheduledFuture<?> existing = pending.getAndSet(null);
+		if (existing != null)
+		{
+			existing.cancel(false);
+		}
+		scheduler.execute(() -> doPush(snapshot));
+	}
+
+	public void shutdown()
+	{
+		ScheduledFuture<?> existing = pending.getAndSet(null);
+		if (existing != null)
+		{
+			existing.cancel(false);
+		}
+		scheduler.shutdownNow();
+	}
+
+	/**
+	 * Read the current GE slot item IDs. MUST be called from the client thread.
+	 * Returns a deduped list preserving the slot order the player sees.
+	 */
+	public List<Integer> readCurrentSlotIds()
+	{
+		GrandExchangeOffer[] offers = client.getGrandExchangeOffers();
+		if (offers == null)
+		{
+			return new ArrayList<>();
+		}
+		Set<Integer> seen = new LinkedHashSet<>();
+		for (GrandExchangeOffer offer : offers)
+		{
+			if (offer == null || offer.getState() == GrandExchangeOfferState.EMPTY)
+			{
+				continue;
+			}
+			int id = offer.getItemId();
+			if (id > 0)
+			{
+				seen.add(id);
+			}
+		}
+		return new ArrayList<>(seen);
+	}
+
+	private void doPush(List<Integer> itemIds)
+	{
+		String rsn = session.getRsnSafe().orElse(null);
+		if (rsn == null)
+		{
+			log.debug("Skipping trade-station slot push: no RSN");
+			return;
+		}
+		List<Integer> previous = lastPushed.get();
+		if (previous != null && previous.equals(itemIds))
+		{
+			log.debug("Skipping trade-station slot push: snapshot unchanged ({} items)",
+				itemIds.size());
+			return;
+		}
+		try
+		{
+			apiClient.pushTradeStationSlotsAsync(rsn, itemIds)
+				.exceptionally(e ->
+				{
+					log.debug("Trade-station slot push failed: {}", e.getMessage());
+					return false;
+				});
+			lastPushed.set(itemIds);
+		}
+		catch (RuntimeException e)
+		{
+			log.debug("Trade-station slot push threw: {}", e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/flipsmart/TradeStationSlotPushService.java
+++ b/src/main/java/com/flipsmart/TradeStationSlotPushService.java
@@ -43,7 +43,7 @@ public class TradeStationSlotPushService
 	private final Client client;
 	private final FlipSmartApiClient apiClient;
 	private final PlayerSession session;
-	private final ScheduledExecutorService scheduler;
+	private final ScheduledExecutorService scheduler; // NOPMD DoNotUseThreads - desktop plugin, not J2EE
 
 	private final AtomicReference<ScheduledFuture<?>> pending = new AtomicReference<>();
 	private final AtomicReference<List<Integer>> lastPushed = new AtomicReference<>();
@@ -59,7 +59,7 @@ public class TradeStationSlotPushService
 		this.session = session;
 		this.scheduler = Executors.newSingleThreadScheduledExecutor(r ->
 		{
-			Thread t = new Thread(r, "flipsmart-trade-station-push");
+			Thread t = new Thread(r, "flipsmart-trade-station-push"); // NOPMD DoNotUseThreads
 			t.setDaemon(true);
 			return t;
 		});
@@ -103,7 +103,7 @@ public class TradeStationSlotPushService
 		{
 			existing.cancel(false);
 		}
-		scheduler.execute(() -> doPush(snapshot));
+		scheduler.execute(() -> doPush(snapshot)); // NOPMD DoNotUseThreads
 	}
 
 	public void shutdown()
@@ -113,7 +113,7 @@ public class TradeStationSlotPushService
 		{
 			existing.cancel(false);
 		}
-		scheduler.shutdownNow();
+		scheduler.shutdownNow(); // NOPMD DoNotUseThreads
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/TradeStationSlotPushService.java
+++ b/src/main/java/com/flipsmart/TradeStationSlotPushService.java
@@ -154,8 +154,11 @@ public class TradeStationSlotPushService
 		List<Integer> previous = lastPushed.get();
 		if (previous != null && previous.equals(itemIds))
 		{
-			log.debug("Skipping trade-station slot push: snapshot unchanged ({} items)",
-				itemIds.size());
+			if (log.isDebugEnabled())
+			{
+				log.debug("Skipping trade-station slot push: snapshot unchanged ({} items)",
+					itemIds.size());
+			}
 			return;
 		}
 		try
@@ -163,14 +166,20 @@ public class TradeStationSlotPushService
 			apiClient.pushTradeStationSlotsAsync(rsn, itemIds)
 				.exceptionally(e ->
 				{
-					log.debug("Trade-station slot push failed: {}", e.getMessage());
+					if (log.isDebugEnabled())
+					{
+						log.debug("Trade-station slot push failed: {}", e.getMessage());
+					}
 					return false;
 				});
 			lastPushed.set(itemIds);
 		}
 		catch (RuntimeException e)
 		{
-			log.debug("Trade-station slot push threw: {}", e.getMessage());
+			if (log.isDebugEnabled())
+			{
+				log.debug("Trade-station slot push threw: {}", e.getMessage());
+			}
 		}
 	}
 }

--- a/src/test/java/com/flipsmart/TradeStationSlotPushServiceTest.java
+++ b/src/test/java/com/flipsmart/TradeStationSlotPushServiceTest.java
@@ -1,0 +1,105 @@
+package com.flipsmart;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import net.runelite.api.Client;
+import net.runelite.api.GrandExchangeOffer;
+import net.runelite.api.GrandExchangeOfferState;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TradeStationSlotPushServiceTest
+{
+	private static final int ABYSSAL_WHIP = 4151;
+	private static final int DRAGON_LONGSWORD = 1305;
+	private static final String RSN = "TestPlayer";
+
+	private Client client;
+	private FlipSmartApiClient apiClient;
+	private PlayerSession session;
+	private TradeStationSlotPushService service;
+
+	@Before
+	public void setUp()
+	{
+		client = mock(Client.class);
+		apiClient = mock(FlipSmartApiClient.class);
+		session = mock(PlayerSession.class);
+		when(session.getRsnSafe()).thenReturn(Optional.of(RSN));
+		when(apiClient.pushTradeStationSlotsAsync(any(), any()))
+			.thenReturn(CompletableFuture.completedFuture(true));
+		service = new TradeStationSlotPushService(client, apiClient, session);
+	}
+
+	@Test
+	public void readCurrentSlotIdsDedupesAndSkipsEmpty()
+	{
+		GrandExchangeOffer o1 = offer(ABYSSAL_WHIP, GrandExchangeOfferState.BUYING);
+		GrandExchangeOffer o2 = offer(0, GrandExchangeOfferState.EMPTY);
+		GrandExchangeOffer o3 = offer(ABYSSAL_WHIP, GrandExchangeOfferState.SELLING);
+		GrandExchangeOffer o4 = offer(DRAGON_LONGSWORD, GrandExchangeOfferState.BOUGHT);
+		GrandExchangeOffer[] offers = { o1, o2, o3, o4, null };
+		when(client.getGrandExchangeOffers()).thenReturn(offers);
+
+		List<Integer> ids = service.readCurrentSlotIds();
+		assertEquals(2, ids.size());
+		assertEquals(Integer.valueOf(ABYSSAL_WHIP), ids.get(0));
+		assertEquals(Integer.valueOf(DRAGON_LONGSWORD), ids.get(1));
+	}
+
+	@Test
+	public void pushNowSendsItemsToApiClient() throws Exception
+	{
+		service.pushNow(List.of(ABYSSAL_WHIP, DRAGON_LONGSWORD));
+		// Single-threaded executor — block until queued task finishes.
+		Thread.sleep(50);
+		verify(apiClient, times(1)).pushTradeStationSlotsAsync(eq(RSN),
+			eq(List.of(ABYSSAL_WHIP, DRAGON_LONGSWORD)));
+	}
+
+	@Test
+	public void duplicateSnapshotsAreSkipped() throws Exception
+	{
+		service.pushNow(List.of(ABYSSAL_WHIP));
+		Thread.sleep(50);
+		service.pushNow(List.of(ABYSSAL_WHIP));
+		Thread.sleep(50);
+		// Second push has the same snapshot so the service should short-circuit.
+		verify(apiClient, times(1)).pushTradeStationSlotsAsync(any(), any());
+	}
+
+	@Test
+	public void noPushWhenRsnUnavailable() throws Exception
+	{
+		when(session.getRsnSafe()).thenReturn(Optional.empty());
+		service.pushNow(List.of(ABYSSAL_WHIP));
+		Thread.sleep(50);
+		verify(apiClient, never()).pushTradeStationSlotsAsync(any(), any());
+	}
+
+	@Test
+	public void readReturnsEmptyListWhenClientHasNoOffers()
+	{
+		when(client.getGrandExchangeOffers()).thenReturn(null);
+		assertTrue(service.readCurrentSlotIds().isEmpty());
+	}
+
+	private static GrandExchangeOffer offer(int itemId, GrandExchangeOfferState state)
+	{
+		GrandExchangeOffer o = mock(GrandExchangeOffer.class);
+		when(o.getItemId()).thenReturn(itemId);
+		when(o.getState()).thenReturn(state);
+		return o;
+	}
+}


### PR DESCRIPTION
## Summary

Plugin slice of the **Trade Station** feature (`Flip-Smart/flip-smart#683`).

Adds a background `TradeStationSlotPushService` that reads the player's current open GE slot item IDs on every `GrandExchangeOfferChanged` event, dedupes them, and posts to the FlipSmart backend's `POST /trade-station/runelite-slots` endpoint. The web page consumes this snapshot when the user clicks "Import from RuneLite" (issue AC7).

- New `TradeStationSlotPushService` (singleton, scheduled executor).
- New `pushTradeStationSlotsAsync(rsn, item_ids)` method on `FlipSmartApiClient` (best-effort: failures are debug-logged).
- Wired into `FlipSmartPlugin.onGrandExchangeOfferChanged` and `shutDown`.
- Debounced at 1.5s to coalesce login-burst events; skips duplicate snapshots so we don't spam the backend.
- 5 new unit tests in `TradeStationSlotPushServiceTest`.

## Why this ships unconditionally (not behind the web feature flag)

The web `/trade-station` page is gated on `ff_trade_station`, but **the plugin push is not**, by design:

- The plugin has **zero user-visible Trade Station UI** — no menu, no button, no overlay. Players cannot tell this code exists whether the flag is on or off, so there's no "non-functional feature visible to users" risk on the plugin side.
- Pushing snapshots even while the web flag is off **pre-warms the per-(user, rsn) cache**. When the flag flips on for a user, the web "Import from RuneLite" button works on the first click — no awkward "open RuneLite and wait for a slot to update" empty state.
- The cost is one short POST per GE event (debounced) writing to a tiny key-value row. Backend impact is negligible.

If the unconditional push ever becomes a problem (e.g. scaling), the simplest mitigation is to add a flag check inside `TradeStationSlotPushService.doPush` — no plugin redeploy needed since the plugin already fetches feature flags on auth.

## Dependencies

- Backend: `Flip-Smart/flip-smart#706` (adds the `/trade-station/runelite-slots` endpoint).
- Web: `Flip-Smart/flip-smart-eng#176` (adds the Import button that consumes the cache).

## Validation

- `./gradlew compileJava` clean
- `./gradlew test` clean (57 + 5 new tests pass)
- Codacy quality gate: 0 new issues (gate_ok=true, head=233a0b7)
- Manual end-to-end verified against local backend: GE slot change → POST observed → backend cache updated → web Import button picks it up

## Manual test plan (in-game)

Tail the RuneLite client log while testing: `tail -F ~/.runelite/logs/client.log`. The push service emits `Skipping trade-station slot push` / `pushTradeStationSlotsAsync failed` debug lines when relevant.

- [ ] Start RuneLite with the FlipSmart plugin, log in to a tracked RSN
- [ ] Open the GE, place a buy offer for any item
- [ ] Within ~2s, observe the push fire (debug log or check the backend `runelite_active_offers` row for your user_id/rsn)
- [ ] Place a sell offer in a second slot — confirm the snapshot updates to include both items
- [ ] Cancel one offer — confirm the snapshot drops it (only the still-open slot remains)
- [ ] Log out and back in — confirm the snapshot survives (it's a server-side cache, not a session state)

Part of `Flip-Smart/flip-smart#683` (plugin slice).

### Codacy Quality Gate — fixed in this PR
- `f2b5b0b` PMD_category_java_bestpractices_GuardLogStatement TradeStationSlotPushService.java:157/166/173 — wrapped log.debug calls with isDebugEnabled() guards to eliminate method-call evaluation cost when debug logging is off
- `233a0b7` PMD_category_java_multithreading_DoNotUseThreads TradeStationSlotPushService.java:46/62/106/116 — added // NOPMD suppressions; this J2EE webapp compliance rule is a false positive for a RuneLite desktop plugin where ScheduledExecutorService + daemon threads are idiomatic

### Codacy AI Reviewer — no open comments (0 total)