### PR TITLE
fix(plugin): lock auto-mode focus while GE offer screen is open (#702)

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -2284,6 +2284,24 @@ public class AutoRecommendService
 		return lockedItemId;
 	}
 
+	/**
+	 * Re-run the next-action router (issue #702). Called by FlipSmartPlugin
+	 * immediately after {@link #releaseOfferLock()} fires from the GameTick
+	 * poll, because any focus updates that happened during the lock (e.g.
+	 * onSellOrderPlaced → focusNextAvailableAction after the player confirmed
+	 * a MODIFY) were dropped by invokeFocusCallback's lock gate. Without this
+	 * replay the overlay stays stuck on the just-handled item. No-op when
+	 * auto-mode is off.
+	 */
+	public synchronized void refreshFocusAfterUnlock()
+	{
+		if (!active)
+		{
+			return;
+		}
+		focusNextAvailableAction();
+	}
+
 	private void invokeQueueAdvancedCallback()
 	{
 		Runnable callback = onQueueAdvanced;

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -64,13 +64,8 @@ public class AutoRecommendService
 	private int currentIndex;
 	private volatile boolean active;
 
-	// Offer-screen lock (issue #702). When the user is on the buy/sell offer setup
-	// screen, auto-mode must not silently re-target the focused flip — that race
-	// causes the import hotkey to write the wrong item's price/qty into the open
-	// offer. While locked, invokeFocusCallback() drops focus changes that don't
-	// match the locked item. Acquired by FlipSmartPlugin on GE_OFFERS_SETUP_BUILD,
-	// released when the offer screen closes (GameTick poll) or the user manually
-	// picks a new item in Flip Finder. null = unlocked.
+	// Offer-screen lock. While set, invokeFocusCallback drops focus changes
+	// for any item other than this one. null = unlocked.
 	private volatile Integer lockedItemId;
 
 	// Timestamp of last queue refresh for staleness checks
@@ -2216,20 +2211,10 @@ public class AutoRecommendService
 
 	private void invokeFocusCallback(FocusedFlip focus)
 	{
-		// Issue #702: while the user is in the buy/sell offer setup screen, the
-		// rec is locked. Drop any auto-mode focus change for a different item so
-		// the overlay and the open offer stay in sync. Manual picks bypass this
-		// because they go through FlipFinderPanel → onFocusChanged directly.
 		Integer locked = lockedItemId;
-		if (locked != null && focus != null && focus.getItemId() != locked)
+		if (locked != null && (focus == null || focus.getItemId() != locked))
 		{
-			log.debug("Auto-recommend: focus change to item {} blocked by offer-screen lock on item {}",
-				focus.getItemId(), locked);
-			return;
-		}
-		if (locked != null && focus == null)
-		{
-			log.debug("Auto-recommend: focus clear blocked by offer-screen lock on item {}", locked);
+			log.debug("Auto-recommend: focus change blocked by offer-screen lock on item {}", locked);
 			return;
 		}
 
@@ -2240,13 +2225,7 @@ public class AutoRecommendService
 		}
 	}
 
-	/**
-	 * Acquire the offer-screen lock for the given item (issue #702). Called when
-	 * the GE buy/sell offer setup widget builds. While locked, auto-mode focus
-	 * mutations targeting a different item are silently dropped. Idempotent —
-	 * re-locking to the same item is a no-op; locking to a new item replaces the
-	 * lock (e.g. user navigates to a different offer screen).
-	 */
+	/** Lock auto-mode focus to the given item until the offer setup screen closes. Idempotent. */
 	public void acquireOfferLock(int itemId)
 	{
 		if (itemId <= 0)
@@ -2262,11 +2241,7 @@ public class AutoRecommendService
 		log.debug("Auto-recommend: offer-screen lock acquired for item {}", itemId);
 	}
 
-	/**
-	 * Release the offer-screen lock (issue #702). Called when the offer setup
-	 * widget closes (poll on GameTick) or when the user manually picks a new
-	 * item in Flip Finder. No-op if no lock is held.
-	 */
+	/** Clear the offer-screen lock. No-op if not held. */
 	public void releaseOfferLock()
 	{
 		Integer prior = lockedItemId;
@@ -2278,21 +2253,12 @@ public class AutoRecommendService
 		log.debug("Auto-recommend: offer-screen lock released (was item {})", prior);
 	}
 
-	/** Test-visible accessor for the current lock state. null = unlocked. */
 	public Integer getLockedItemId()
 	{
 		return lockedItemId;
 	}
 
-	/**
-	 * Re-run the next-action router (issue #702). Called by FlipSmartPlugin
-	 * immediately after {@link #releaseOfferLock()} fires from the GameTick
-	 * poll, because any focus updates that happened during the lock (e.g.
-	 * onSellOrderPlaced → focusNextAvailableAction after the player confirmed
-	 * a MODIFY) were dropped by invokeFocusCallback's lock gate. Without this
-	 * replay the overlay stays stuck on the just-handled item. No-op when
-	 * auto-mode is off.
-	 */
+	/** Re-run the next-action router after the lock releases — focus updates that ran while locked were dropped. */
 	public synchronized void refreshFocusAfterUnlock()
 	{
 		if (!active)

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -64,6 +64,15 @@ public class AutoRecommendService
 	private int currentIndex;
 	private volatile boolean active;
 
+	// Offer-screen lock (issue #702). When the user is on the buy/sell offer setup
+	// screen, auto-mode must not silently re-target the focused flip — that race
+	// causes the import hotkey to write the wrong item's price/qty into the open
+	// offer. While locked, invokeFocusCallback() drops focus changes that don't
+	// match the locked item. Acquired by FlipSmartPlugin on GE_OFFERS_SETUP_BUILD,
+	// released when the offer screen closes (GameTick poll) or the user manually
+	// picks a new item in Flip Finder. null = unlocked.
+	private volatile Integer lockedItemId;
+
 	// Timestamp of last queue refresh for staleness checks
 	private volatile long lastQueueRefreshMillis;
 
@@ -2207,11 +2216,72 @@ public class AutoRecommendService
 
 	private void invokeFocusCallback(FocusedFlip focus)
 	{
+		// Issue #702: while the user is in the buy/sell offer setup screen, the
+		// rec is locked. Drop any auto-mode focus change for a different item so
+		// the overlay and the open offer stay in sync. Manual picks bypass this
+		// because they go through FlipFinderPanel → onFocusChanged directly.
+		Integer locked = lockedItemId;
+		if (locked != null && focus != null && focus.getItemId() != locked)
+		{
+			log.debug("Auto-recommend: focus change to item {} blocked by offer-screen lock on item {}",
+				focus.getItemId(), locked);
+			return;
+		}
+		if (locked != null && focus == null)
+		{
+			log.debug("Auto-recommend: focus clear blocked by offer-screen lock on item {}", locked);
+			return;
+		}
+
 		Consumer<FocusedFlip> callback = onFocusChanged;
 		if (callback != null)
 		{
 			javax.swing.SwingUtilities.invokeLater(() -> callback.accept(focus));
 		}
+	}
+
+	/**
+	 * Acquire the offer-screen lock for the given item (issue #702). Called when
+	 * the GE buy/sell offer setup widget builds. While locked, auto-mode focus
+	 * mutations targeting a different item are silently dropped. Idempotent —
+	 * re-locking to the same item is a no-op; locking to a new item replaces the
+	 * lock (e.g. user navigates to a different offer screen).
+	 */
+	public void acquireOfferLock(int itemId)
+	{
+		if (itemId <= 0)
+		{
+			return;
+		}
+		Integer prior = lockedItemId;
+		if (prior != null && prior == itemId)
+		{
+			return;
+		}
+		lockedItemId = itemId;
+		log.debug("Auto-recommend: offer-screen lock acquired for item {}", itemId);
+	}
+
+	/**
+	 * Release the offer-screen lock (issue #702). Called when the offer setup
+	 * widget closes (poll on GameTick) or when the user manually picks a new
+	 * item in Flip Finder. No-op if no lock is held.
+	 */
+	public void releaseOfferLock()
+	{
+		Integer prior = lockedItemId;
+		if (prior == null)
+		{
+			return;
+		}
+		lockedItemId = null;
+		log.debug("Auto-recommend: offer-screen lock released (was item {})", prior);
+	}
+
+	/** Test-visible accessor for the current lock state. null = unlocked. */
+	public Integer getLockedItemId()
+	{
+		return lockedItemId;
 	}
 
 	private void invokeQueueAdvancedCallback()

--- a/src/main/java/com/flipsmart/FlipAssistInputListener.java
+++ b/src/main/java/com/flipsmart/FlipAssistInputListener.java
@@ -209,8 +209,11 @@ public class FlipAssistInputListener implements KeyListener
 		int openOfferItemId = client.getVarpValue(VarPlayerID.TRADINGPOST_SEARCH);
 		if (openOfferItemId > 0 && focusedFlip.getItemId() != openOfferItemId)
 		{
-			log.debug("FlipAssist hotkey: skipped (focused item {} != open offer item {})",
-				focusedFlip.getItemId(), openOfferItemId);
+			if (log.isDebugEnabled())
+			{
+				log.debug("FlipAssist hotkey: skipped (focused item {} != open offer item {})",
+					focusedFlip.getItemId(), openOfferItemId);
+			}
 			return;
 		}
 

--- a/src/main/java/com/flipsmart/FlipAssistInputListener.java
+++ b/src/main/java/com/flipsmart/FlipAssistInputListener.java
@@ -200,12 +200,7 @@ public class FlipAssistInputListener implements KeyListener
 			return;
 		}
 
-		// Issue #702 — defense-in-depth against the auto-advance race. The
-		// AutoRecommendService offer-screen lock should already keep focusedFlip
-		// in sync with the open offer, but the brief window between the player
-		// opening an offer and GE_OFFERS_SETUP_BUILD firing leaves room for a
-		// mismatch. If they don't match, silently skip — the hotkey is for the
-		// slot you're on, so we never write a different item's price/qty.
+		// Defense-in-depth against the auto-advance race window before the offer-screen lock acquires.
 		int openOfferItemId = client.getVarpValue(VarPlayerID.TRADINGPOST_SEARCH);
 		if (openOfferItemId > 0 && focusedFlip.getItemId() != openOfferItemId)
 		{

--- a/src/main/java/com/flipsmart/FlipAssistInputListener.java
+++ b/src/main/java/com/flipsmart/FlipAssistInputListener.java
@@ -3,6 +3,7 @@ package com.flipsmart;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.ScriptID;
+import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.Keybind;
@@ -196,6 +197,20 @@ public class FlipAssistInputListener implements KeyListener
 	{
 		if (!isGrandExchangeOpen())
 		{
+			return;
+		}
+
+		// Issue #702 — defense-in-depth against the auto-advance race. The
+		// AutoRecommendService offer-screen lock should already keep focusedFlip
+		// in sync with the open offer, but the brief window between the player
+		// opening an offer and GE_OFFERS_SETUP_BUILD firing leaves room for a
+		// mismatch. If they don't match, silently skip — the hotkey is for the
+		// slot you're on, so we never write a different item's price/qty.
+		int openOfferItemId = client.getVarpValue(VarPlayerID.TRADINGPOST_SEARCH);
+		if (openOfferItemId > 0 && focusedFlip.getItemId() != openOfferItemId)
+		{
+			log.debug("FlipAssist hotkey: skipped (focused item {} != open offer item {})",
+				focusedFlip.getItemId(), openOfferItemId);
 			return;
 		}
 

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3263,10 +3263,7 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private void updateFocus(FocusedFlip newFocus, JPanel panel)
 	{
-		// Issue #702 — manual pick is the user's explicit override of the
-		// offer-screen lock. Release here so auto-mode can resume; the lock
-		// re-acquires on the next GE_OFFERS_SETUP_BUILD if they open another
-		// offer screen.
+		// Manual pick overrides the auto-mode offer-screen lock.
 		AutoRecommendService autoService = plugin.getAutoRecommendService();
 		if (autoService != null)
 		{

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3263,6 +3263,16 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private void updateFocus(FocusedFlip newFocus, JPanel panel)
 	{
+		// Issue #702 — manual pick is the user's explicit override of the
+		// offer-screen lock. Release here so auto-mode can resume; the lock
+		// re-acquires on the next GE_OFFERS_SETUP_BUILD if they open another
+		// offer screen.
+		AutoRecommendService autoService = plugin.getAutoRecommendService();
+		if (autoService != null)
+		{
+			autoService.releaseOfferLock();
+		}
+
 		// Reset previous focused panel
 		if (currentFocusedPanel != null)
 		{

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -25,6 +25,7 @@ import net.runelite.api.events.BeforeRender;
 import net.runelite.api.events.VarClientIntChanged;
 import net.runelite.api.events.VarClientStrChanged;
 import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.widgets.Widget;
 import net.runelite.api.ScriptID;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.VarbitID;
@@ -931,6 +932,30 @@ public class FlipSmartPlugin extends Plugin
 		}
 
 		geHistoryService.onGameTick();
+
+		// Issue #702 — release the offer-screen lock once the setup widget is
+		// gone (player confirmed, cancelled, or navigated back to the standard
+		// GE). We can't trust a single close event because the script-build hook
+		// only fires on open. Poll cheaply: short-circuit when no lock is held.
+		releaseOfferLockIfSetupClosed();
+	}
+
+	/**
+	 * If the auto-recommend offer-screen lock is held and the GE offer setup
+	 * widget is no longer visible, release the lock and surface the current
+	 * recommendation (which may have advanced in the background while locked).
+	 */
+	private void releaseOfferLockIfSetupClosed()
+	{
+		if (autoRecommendService == null || autoRecommendService.getLockedItemId() == null)
+		{
+			return;
+		}
+		Widget setupDesc = client.getWidget(InterfaceID.GeOffers.SETUP_DESC);
+		if (setupDesc == null || setupDesc.isHidden())
+		{
+			autoRecommendService.releaseOfferLock();
+		}
 	}
 
 	private void handleLogoutState()
@@ -1288,19 +1313,28 @@ public class FlipSmartPlugin extends Plugin
 			geOfferDescriptionService.onSetupBuildScriptPostFired();
 		}
 
+		// Issue #702 — lock auto-mode to the open offer's item the moment the
+		// setup screen builds. Applies to BOTH buy and sell so the user can't be
+		// raced into the wrong values on either side. Released in onGameTick
+		// when the setup widget closes, or by FlipFinderPanel on manual pick.
+		int openItemId = client.getVarpValue(VarPlayerID.TRADINGPOST_SEARCH);
+		if (openItemId > 0 && autoRecommendService != null)
+		{
+			autoRecommendService.acquireOfferLock(openItemId);
+		}
+
 		int offerType = client.getVarbitValue(VarbitID.GE_NEWOFFER_TYPE);
 		if (offerType != 1)
 		{
 			return;
 		}
 
-		int itemId = client.getVarpValue(VarPlayerID.TRADINGPOST_SEARCH);
-		if (itemId <= 0)
+		if (openItemId <= 0)
 		{
 			return;
 		}
 
-		grandExchangeTracker.autoFocusOnActiveFlip(itemId);
+		grandExchangeTracker.autoFocusOnActiveFlip(openItemId);
 	}
 
 	@Subscribe

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -933,21 +933,9 @@ public class FlipSmartPlugin extends Plugin
 
 		geHistoryService.onGameTick();
 
-		// Issue #702 — release the offer-screen lock once the setup widget is
-		// gone (player confirmed, cancelled, or navigated back to the standard
-		// GE). We can't trust a single close event because the script-build hook
-		// only fires on open. Poll cheaply: short-circuit when no lock is held.
 		releaseOfferLockIfSetupClosed();
 	}
 
-	/**
-	 * If the auto-recommend offer-screen lock is held and the GE offer setup
-	 * widget is no longer visible, release the lock and surface the current
-	 * recommendation. The refresh is critical: any focusNextAvailableAction
-	 * routes that ran during the lock (e.g. onSellOrderPlaced after the player
-	 * confirmed a MODIFY) had their invokeFocusCallback dropped by the lock
-	 * gate, so without the replay the overlay stays on the just-handled item.
-	 */
 	private void releaseOfferLockIfSetupClosed()
 	{
 		if (autoRecommendService == null || autoRecommendService.getLockedItemId() == null)
@@ -1317,10 +1305,6 @@ public class FlipSmartPlugin extends Plugin
 			geOfferDescriptionService.onSetupBuildScriptPostFired();
 		}
 
-		// Issue #702 — lock auto-mode to the open offer's item the moment the
-		// setup screen builds. Applies to BOTH buy and sell so the user can't be
-		// raced into the wrong values on either side. Released in onGameTick
-		// when the setup widget closes, or by FlipFinderPanel on manual pick.
 		int openItemId = client.getVarpValue(VarPlayerID.TRADINGPOST_SEARCH);
 		if (openItemId > 0 && autoRecommendService != null)
 		{

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -943,7 +943,10 @@ public class FlipSmartPlugin extends Plugin
 	/**
 	 * If the auto-recommend offer-screen lock is held and the GE offer setup
 	 * widget is no longer visible, release the lock and surface the current
-	 * recommendation (which may have advanced in the background while locked).
+	 * recommendation. The refresh is critical: any focusNextAvailableAction
+	 * routes that ran during the lock (e.g. onSellOrderPlaced after the player
+	 * confirmed a MODIFY) had their invokeFocusCallback dropped by the lock
+	 * gate, so without the replay the overlay stays on the just-handled item.
 	 */
 	private void releaseOfferLockIfSetupClosed()
 	{
@@ -955,6 +958,7 @@ public class FlipSmartPlugin extends Plugin
 		if (setupDesc == null || setupDesc.isHidden())
 		{
 			autoRecommendService.releaseOfferLock();
+			autoRecommendService.refreshFocusAfterUnlock();
 		}
 	}
 

--- a/src/test/java/com/flipsmart/AutoRecommendServiceLockTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendServiceLockTest.java
@@ -1,0 +1,85 @@
+package com.flipsmart;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Issue #702 — verifies the offer-screen lock state machine on
+ * {@link AutoRecommendService}. The lock guards against the auto-advance race
+ * where focus could silently switch to a different item while the user is
+ * mid-input on a GE offer screen.
+ *
+ * <p>These tests cover the lock's public state contract only. The
+ * {@code invokeFocusCallback} gate is exercised indirectly through manual QA
+ * (the offer-screen reproduction) because it requires a fully-wired queue.
+ */
+public class AutoRecommendServiceLockTest
+{
+	private AutoRecommendService service;
+
+	@Before
+	public void setUp()
+	{
+		FlipSmartConfig config = mock(FlipSmartConfig.class);
+		FlipSmartPlugin plugin = mock(FlipSmartPlugin.class);
+		service = new AutoRecommendService(config, plugin);
+	}
+
+	@Test
+	public void lockStartsCleared()
+	{
+		assertNull(service.getLockedItemId());
+	}
+
+	@Test
+	public void acquireOfferLockStoresItemId()
+	{
+		service.acquireOfferLock(1234);
+		assertEquals(Integer.valueOf(1234), service.getLockedItemId());
+	}
+
+	@Test
+	public void acquireOfferLockIgnoresNonPositiveItemId()
+	{
+		service.acquireOfferLock(0);
+		assertNull(service.getLockedItemId());
+
+		service.acquireOfferLock(-1);
+		assertNull(service.getLockedItemId());
+	}
+
+	@Test
+	public void acquireOfferLockReplacesExistingLock()
+	{
+		service.acquireOfferLock(1111);
+		service.acquireOfferLock(2222);
+		assertEquals(Integer.valueOf(2222), service.getLockedItemId());
+	}
+
+	@Test
+	public void acquireOfferLockIsIdempotentForSameItem()
+	{
+		service.acquireOfferLock(4444);
+		service.acquireOfferLock(4444);
+		assertEquals(Integer.valueOf(4444), service.getLockedItemId());
+	}
+
+	@Test
+	public void releaseOfferLockClearsState()
+	{
+		service.acquireOfferLock(5555);
+		service.releaseOfferLock();
+		assertNull(service.getLockedItemId());
+	}
+
+	@Test
+	public void releaseOfferLockIsSafeWhenAlreadyCleared()
+	{
+		service.releaseOfferLock();
+		assertNull(service.getLockedItemId());
+	}
+}

--- a/src/test/java/com/flipsmart/AutoRecommendServiceLockTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendServiceLockTest.java
@@ -8,14 +8,9 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
 /**
- * Issue #702 — verifies the offer-screen lock state machine on
- * {@link AutoRecommendService}. The lock guards against the auto-advance race
- * where focus could silently switch to a different item while the user is
- * mid-input on a GE offer screen.
- *
- * <p>These tests cover the lock's public state contract only. The
- * {@code invokeFocusCallback} gate is exercised indirectly through manual QA
- * (the offer-screen reproduction) because it requires a fully-wired queue.
+ * Verifies the offer-screen lock state machine on {@link AutoRecommendService}.
+ * Covers the public state contract only; the {@code invokeFocusCallback} gate
+ * is exercised via manual QA because it requires a fully-wired queue.
  */
 public class AutoRecommendServiceLockTest
 {


### PR DESCRIPTION
## Summary

In Auto mode, the plugin could silently re-target the focused recommendation while the player had a GE buy/sell offer setup screen open for a _different_ item. Pressing the import hotkey (`E`) would then write the new recommendation's price/qty into the wrong offer — a confirmed real-money bug (~1.5M GP loss: user bought green dragonhide instead of sapphire dragon bolts (e)). This PR adds a two-layer defense: an offer-screen lock that freezes auto-mode focus for the duration of the open screen, and a silent pre-write guard in the hotkey listener that drops any mismatched write on the narrow lock-acquire race window.

## Changes

### 🐛 Bug Fixes
- Auto-mode no longer re-targets the focused recommendation while the player has a GE offer setup screen open (`AutoRecommendService.lockedItemId` lock)
- Import hotkey (`E`) silently no-ops if `focusedFlip.itemId` does not match `VarPlayerID.TRADINGPOST_SEARCH` at the moment of write — covers the micro-window before the lock acquires
- After the lock releases (offer screen closed), the next-action router is replayed so focus updates dropped during the lock are surfaced (otherwise the overlay would stay pinned to the just-handled item, e.g. "MODIFY Cannon furnace" after the player confirmed the modify)

### ✨ New Features / Design
- `AutoRecommendService` gains a `lockedItemId` field; `invokeFocusCallback` drops and clears focus changes for any item other than the locked item while the lock is held
- Lock acquires on `GE_OFFERS_SETUP_BUILD` (script post-fired) for both buy and sell offer screens
- Lock releases on the next `GameTick` when the GE offer setup widget is gone, OR when the player explicitly picks a different item in Flip Finder's Recommended tab (`FlipFinderPanel.updateFocus` — user's explicit intent overrides)
- `refreshFocusAfterUnlock()` re-runs `focusNextAvailableAction()` immediately after `releaseOfferLock()` on the GameTick path. Manual-pick releases don't need it because `FlipFinderPanel.updateFocus` already pushes its own focus via `onFocusChanged`.

### ✅ Tests
- `AutoRecommendServiceLockTest.java` (new, 7 tests): acquire stores item ID, non-positive item ID ignored, re-acquire replaces, idempotent same-item lock, release clears, release-when-already-cleared is safe

### ♻️ Refactoring
- No structural refactoring — intentionally minimal diff to reduce review surface

## Testing

### Automated Tests
- ✅ `./gradlew clean build` → BUILD SUCCESSFUL
- ✅ All 7 new `AutoRecommendServiceLockTest` cases pass
- ✅ All pre-existing tests pass

### Manual Testing

> ⚠️ RuneLite cannot be driven by browser automation (Playwright is browser-only). All items below require a human running the in-game client. Check `~/.runelite/logs/client.log` — FlipSmart log lines are tagged `com.flipsmart.*`; lock state messages use `AutoRecommendService` and `FlipAssistInputListener`.

- [x] **Happy path — lock holds**: Verified via live QA on `dumbridge3`. Opening sell offer setup for Cannon furnace (item 12) → `offer-screen lock acquired for item 12` → background `focusCurrent` to Camphor hull parts (item 32053) → `focus change to item 32053 blocked by offer-screen lock on item 12`. Overlay stayed on the open item.
- [x] **Lock releases on close + dropped focus replayed**: After confirming the sell → `offer-screen lock released (was item 12)` → `Auto-recommend focus set: BUY Camphor hull parts @ 9302 gp`. Reproduced cleanly on a second item (Shattered relics void ornament kit) within the same session.
- [x] **Sell offers also lock**: Confirmed during QA — lock acquired on `SELL` offer setup screens, not just buys.
- [ ] **Hotkey fills correct item**: Numeric import on the open offer — verify price and qty match the open offer's item. Inspect logs; on mismatch you should see `FlipAssist hotkey: skipped (focused item X != open offer item Y)`.
- [ ] **Manual pick releases lock**: While locked (offer screen open), click a different item in the Recommended tab of Flip Finder. Verify lock releases (`offer-screen lock released`), the overlay switches to the clicked item, and if you then open THAT item's offer screen the lock re-acquires to it.
- [ ] **Non-rec item offer (edge case)**: Open an offer screen for an item that is NOT the current auto-rec. Lock should acquire to that item; import hotkey should silently no-op (mismatch between focused rec and open offer item).

## API Changes

None — plugin-only change, no backend API interaction modified.

## Database Migrations

None.

## Deployment Notes

- [ ] No new environment variables
- [ ] No new dependencies
- [ ] No configuration changes
- [ ] No database migration required
- Plugin Hub compliance:
  - No synthetic input or op-spoofing — the lock and guard only DROP unsafe writes, never click/select/submit on the player's behalf ✅
  - `Thread.currentThread().interrupt()` is not used in this diff ✅
  - No `.claude/`, `CLAUDE.md`, or Claude config files in this repo ✅

## Checklist

- [x] 7 new tests added covering lock state semantics
- [x] `./gradlew clean build` passes (BUILD SUCCESSFUL)
- [x] No debug code left (log levels are `debug`/`info` appropriate)
- [x] No synthetic input, no op-spoofing — Plugin Hub compliant
- [x] No `Thread.currentThread().interrupt()` usage
- [x] Commit message uses conventional format; no AI attribution
- [x] Manual QA reproducing the lock + release + replay chain on a live in-game client (Cannon furnace, Shattered relics ornament kit)

## AC Variance Note

The issue's third AC item — "User feedback when import is no-op'd (e.g. toast/banner)" — is **intentionally omitted**. With the lock in place the mismatch case is essentially unreachable during normal play. The original reporter explicitly requested: _"we should just make sure the hotkey data and item is focused on the slot we are on. If the offer screen is open for a specific item that is what the hotkey should fill, no focus on other items."_ A silent no-op + lock is the agreed implementation. This is documented here so reviewers understand the AC delta.

## Related Issues

Closes Flip-Smart/flip-smart#702

---

**Note:** This issue is tracked on the private `Flip-Smart/flip-smart` repo (not this public plugin repo) per workspace policy — plugin issues filed publicly would expose product roadmap to competitors.

---

### Codacy Quality Gate — fixed in this PR
- `738ffcc` PMD_category_java_bestpractices_GuardLogStatement src/main/java/com/flipsmart/FlipAssistInputListener.java:212 — wrapped debug log call in isDebugEnabled() guard

### Codacy AI Reviewer — no open signals
- 0 AI Reviewer comments on this PR
