### PR TITLE
fix: standardize product name to FlipSmart (no space)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Flip Smart RuneLite Plugin
+# FlipSmart RuneLite Plugin
 
 A RuneLite plugin that helps you find profitable items to flip in the Grand Exchange and automatically tracks your flipping progress.
 
 ## 🔐 Authentication Required
 
-This plugin requires a **Flip Smart account** to use. You'll need to:
+This plugin requires a **FlipSmart account** to use. You'll need to:
 
-1. Create an account on [Flip Smart](https://flipsmart.net)
+1. Create an account on [FlipSmart](https://flipsmart.net)
 2. Log in through the plugin's **Flip Finder panel** in the RuneLite sidebar
 3. Your credentials are securely stored after login
 
@@ -119,7 +119,7 @@ All prices and calculations are based on live market data:
 
 ## ⚙️ Configuration
 
-Access settings via the RuneLite configuration panel (wrench icon) → "Flip Smart":
+Access settings via the RuneLite configuration panel (wrench icon) → "FlipSmart":
 
 ### Flip Finder
 - **Enable Flip Finder**: Toggle the sidebar panel on/off
@@ -149,7 +149,7 @@ Access settings via the RuneLite configuration panel (wrench icon) → "Flip Sma
 
 1. **Install the plugin** in RuneLite
 2. **Open the Flip Finder panel** from the RuneLite sidebar
-3. **Log in** with your Flip Smart account
+3. **Log in** with your FlipSmart account
 4. **Browse recommended flips** and choose items that fit your cash stack
 5. **Buy items in the GE** - they'll automatically appear in the "Active Flips" tab
 6. **Sell when ready** - completed flips move to the "Completed" tab
@@ -185,7 +185,7 @@ Access settings via the RuneLite configuration panel (wrench icon) → "Flip Sma
 ## 🛠️ Troubleshooting
 
 **Plugin shows "Failed to fetch recommendations"**
-- Check that you're logged in to Flip Smart
+- Check that you're logged in to FlipSmart
 - Ensure you're logged into RuneLite and OSRS
 - Try clicking the Refresh button
 

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,4 +1,4 @@
-displayName=Flip Smart
+displayName=FlipSmart
 author=Flip-Smart
 build=standard
 description=Provides a comprehensive tool for flipping items in the Grand Exchange

--- a/src/main/java/com/flipsmart/BankSnapshotService.java
+++ b/src/main/java/com/flipsmart/BankSnapshotService.java
@@ -179,7 +179,7 @@ public class BankSnapshotService
 	{
 		ChatMessageBuilder builder = new ChatMessageBuilder()
 			.append(ChatColorType.HIGHLIGHT)
-			.append("[Flip Smart] ")
+			.append("[FlipSmart] ")
 			.append(isError ? ChatColorType.HIGHLIGHT : ChatColorType.NORMAL)
 			.append(message);
 

--- a/src/main/java/com/flipsmart/DumpAlertService.java
+++ b/src/main/java/com/flipsmart/DumpAlertService.java
@@ -228,7 +228,7 @@ public class DumpAlertService
 	{
 		String message = new ChatMessageBuilder()
 			.append(ChatColorType.HIGHLIGHT)
-			.append("[Flip Smart] ")
+			.append("[FlipSmart] ")
 			.append(ChatColorType.NORMAL)
 			.append(dump.toChatMessage())
 			.build();

--- a/src/main/java/com/flipsmart/DumpEvent.java
+++ b/src/main/java/com/flipsmart/DumpEvent.java
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 
 /**
- * Represents a market dump event from the Flip Smart API.
+ * Represents a market dump event from the FlipSmart API.
  * A dump is a sudden price drop (≥5%) with high trading volume.
  */
 @Data

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -282,7 +282,7 @@ public class FlipFinderPanel extends PluginPanel
 		contentPanel.setBorder(new EmptyBorder(40, 20, 40, 20));
 
 		// Title
-		JLabel titleLabel = new JLabel("Flip Smart");
+		JLabel titleLabel = new JLabel("FlipSmart");
 		titleLabel.setForeground(Color.WHITE);
 		titleLabel.setFont(new Font(FONT_ARIAL, Font.BOLD, 24));
 		titleLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
@@ -2564,7 +2564,7 @@ public class FlipFinderPanel extends PluginPanel
 		java.awt.image.BufferedImage chartIcon = drawChartIcon(new Color(100, 180, 255), new Color(150, 150, 150));
 
 		JLabel chartLabel = new JLabel(new ImageIcon(chartIcon));
-		chartLabel.setToolTipText("View price history on Flip Smart website");
+		chartLabel.setToolTipText("View price history on FlipSmart website");
 		chartLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
 		chartLabel.setBorder(BorderFactory.createEmptyBorder(0, 4, 0, 0));
 		chartLabel.setOpaque(false);

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -51,7 +51,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 @Slf4j
 @PluginDescriptor(
-	name = "Flip Smart",
+	name = "FlipSmart",
 	description = "A tool to help with item flipping in the Grand Exchange",
 	tags = {"grand exchange", "flipping", "trading", "money making"}
 )
@@ -543,7 +543,7 @@ public class FlipSmartPlugin extends Plugin
 	@Override
 	protected void startUp() throws Exception
 	{
-		log.debug("Flip Smart started!");
+		log.debug("FlipSmart started!");
 		overlayManager.add(geOverlay);
 		overlayManager.add(geSlotOverlay);
 		overlayManager.add(flipAssistOverlay);
@@ -761,7 +761,7 @@ public class FlipSmartPlugin extends Plugin
 	@Override
 	protected void shutDown() throws Exception
 	{
-		log.debug("Flip Smart stopped!");
+		log.debug("FlipSmart stopped!");
 
 		// Persist refresh token on shutdown to prevent session loss
 		String currentRefreshToken = apiClient.getRefreshToken();

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -127,7 +127,7 @@ public class GEHistoryService
 		chatPromptSent = true;
 		String msg = new ChatMessageBuilder()
 			.append(ChatColorType.HIGHLIGHT)
-			.append("[Flip Smart] ")
+			.append("[FlipSmart] ")
 			.append(ChatColorType.NORMAL)
 			.append("Offline trades detected. Open the Grand Exchange and click the ")
 			.append(ChatColorType.HIGHLIGHT)

--- a/src/main/java/com/flipsmart/MotdService.java
+++ b/src/main/java/com/flipsmart/MotdService.java
@@ -146,7 +146,7 @@ public class MotdService
 	{
 		ChatMessageBuilder builder = new ChatMessageBuilder()
 			.append(ChatColorType.HIGHLIGHT)
-			.append("[Flip Smart] ");
+			.append("[FlipSmart] ");
 
 		if ("alert".equalsIgnoreCase(severity))
 		{


### PR DESCRIPTION
## Summary

Standardizes the product name from "Flip Smart" (with space) to "FlipSmart" (no space) across all plugin-facing strings. This covers the Plugin Hub listing display name, the RuneLite sidebar/config panel title, chat message prefixes, and README brand mentions. No functional code changes — pure in-place string replacements.

This is AC2 of Flip-Smart/flip-smart#709. AC1 (website title tag) is handled in a separate frontend PR.

## Changes

### 🐛 Bug Fixes
- `runelite-plugin.properties`: `displayName=Flip Smart` → `displayName=FlipSmart` (drives the Plugin Hub listing card)
- `FlipSmartPlugin.java`: `@PluginDescriptor(name = "Flip Smart")` → `name = "FlipSmart"` (RuneLite sidebar + config panel title)
- `BankSnapshotService.java`, `DumpAlertService.java`, `GEHistoryService.java`, `MotdService.java`: chat prefix `[Flip Smart]` → `[FlipSmart]`
- `FlipFinderPanel.java`: panel title label and tooltip text updated
- `DumpEvent.java`: javadoc brand reference updated
- `README.md`: brand mentions updated (shown on Plugin Hub listing page)

## Files Changed

- `runelite-plugin.properties` — display name for Plugin Hub listing
- `src/main/java/com/flipsmart/FlipSmartPlugin.java` — plugin descriptor name + debug log strings
- `src/main/java/com/flipsmart/FlipFinderPanel.java` — panel title label + tooltip
- `src/main/java/com/flipsmart/BankSnapshotService.java` — chat prefix
- `src/main/java/com/flipsmart/DumpAlertService.java` — chat prefix
- `src/main/java/com/flipsmart/GEHistoryService.java` — chat prefix
- `src/main/java/com/flipsmart/MotdService.java` — chat prefix
- `src/main/java/com/flipsmart/DumpEvent.java` — javadoc
- `README.md` — brand mentions

## Testing Instructions

1. Build the plugin locally and sideload into RuneLite
2. Open the plugin list — the entry reads "FlipSmart" (no space)
3. Open the config panel (wrench icon) — the panel title reads "FlipSmart"
4. Trigger a chat-printing path (e.g., a price alert or MOTD) — the chat prefix reads `[FlipSmart]`
5. After plugin-hub re-publishes, the website listing card displays "FlipSmart"

**Test Results:**
- [x] `./gradlew test --no-daemon` — BUILD SUCCESSFUL, all tests passed
- [ ] Manual sideload testing (in-game verification)

Closes Flip-Smart/flip-smart#709