### PR TITLE
fix(auto-recommend): drop stale queued item on Flip Finder refresh

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -814,7 +814,9 @@ public class AutoRecommendService
 		plugin.getSession().clearStaleNotifications();
 
 		log.debug("Auto-recommend: Queue refreshed with {} items", recommendationQueue.size());
-		updateOverlayAfterRefresh(currentRec);
+		// Reflect the item actually focused after the rebuild — currentRec may have
+		// been dropped from the queue if Flip Finder no longer recommends it.
+		updateOverlayAfterRefresh(getCurrentRecommendation());
 	}
 
 	private List<FlipRecommendation> filterAndSortRecommendations(List<FlipRecommendation> newRecommendations)
@@ -839,24 +841,44 @@ public class AutoRecommendService
 	private void rebuildQueue(List<FlipRecommendation> filtered, FlipRecommendation currentRec)
 	{
 		recommendationQueue.clear();
+		recommendationQueue.addAll(buildRefreshedQueue(filtered, currentRec, plugin.getActiveFlipItemIds()));
 		currentIndex = 0;
+	}
+
+	/**
+	 * Decide the ordered queue after a Flip Finder refresh. {@code filtered} is the
+	 * refreshed, actionable pool (already excludes GE-active and below-min-profit items).
+	 * The currently focused item is kept at index 0 only when it is still in that pool,
+	 * so churn is avoided when nothing changed but stale items are dropped when Flip
+	 * Finder no longer recommends them.
+	 */
+	static List<FlipRecommendation> buildRefreshedQueue(
+		List<FlipRecommendation> filtered,
+		FlipRecommendation currentRec,
+		Set<Integer> activeItemIds)
+	{
 		// If currentRec is now on the GE, don't preserve it across the refresh —
 		// otherwise it would survive the filter and resurface at index 0.
 		boolean currentRecActive = currentRec != null
-			&& plugin.getActiveFlipItemIds().contains(currentRec.getItemId());
-		if (currentRec == null || currentRecActive)
+			&& activeItemIds.contains(currentRec.getItemId());
+		// If Flip Finder dropped currentRec from the actionable pool, don't keep it
+		// queued — fall through to the refreshed order so the next pull is current.
+		boolean currentRecStillRecommended = currentRec != null
+			&& filtered.stream().anyMatch(r -> r.getItemId() == currentRec.getItemId());
+		if (currentRec == null || currentRecActive || !currentRecStillRecommended)
 		{
-			recommendationQueue.addAll(filtered);
-			return;
+			return new ArrayList<>(filtered);
 		}
-		recommendationQueue.add(currentRec);
+		List<FlipRecommendation> queue = new ArrayList<>();
+		queue.add(currentRec);
 		for (FlipRecommendation rec : filtered)
 		{
 			if (rec.getItemId() != currentRec.getItemId())
 			{
-				recommendationQueue.add(rec);
+				queue.add(rec);
 			}
 		}
+		return queue;
 	}
 
 	private void updateOverlayAfterRefresh(FlipRecommendation currentRec)

--- a/src/test/java/com/flipsmart/AutoRecommendRefreshQueueTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendRefreshQueueTest.java
@@ -1,0 +1,116 @@
+package com.flipsmart;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Covers {@link AutoRecommendService#buildRefreshedQueue} — the ordering decision
+ * applied when Flip Finder refreshes its pool in auto mode (issue #722). The
+ * focused item must be dropped when it leaves the refreshed pool and retained
+ * (without churn) when it is still present.
+ */
+public class AutoRecommendRefreshQueueTest
+{
+	private static FlipRecommendation rec(int itemId, String name, double volumePerHour)
+	{
+		FlipRecommendation r = new FlipRecommendation();
+		r.setItemId(itemId);
+		r.setItemName(name);
+		r.setVolumePerHour(volumePerHour);
+		return r;
+	}
+
+	private static List<Integer> itemIds(List<FlipRecommendation> queue)
+	{
+		return queue.stream().map(FlipRecommendation::getItemId).collect(Collectors.toList());
+	}
+
+	private static final Set<Integer> NONE_ACTIVE = Collections.emptySet();
+
+	// AC2 — focused item removed from the refreshed pool is dropped from the queue.
+	@Test
+	public void dropsFocusedItemWhenNoLongerRecommended()
+	{
+		FlipRecommendation stale = rec(1001, "Demonic Hood", 50);
+		List<FlipRecommendation> refreshedPool = Arrays.asList(
+			rec(2002, "Raw Shark", 100),
+			rec(3003, "Magic Logs", 200));
+
+		List<FlipRecommendation> queue = AutoRecommendService.buildRefreshedQueue(
+			refreshedPool, stale, NONE_ACTIVE);
+
+		assertFalse("stale item must be dropped", itemIds(queue).contains(1001));
+		assertEquals(Arrays.asList(2002, 3003), itemIds(queue));
+	}
+
+	// AC3 — focused item still in the refreshed pool is kept at index 0 (no churn).
+	@Test
+	public void retainsFocusedItemAtFrontWhenStillRecommended()
+	{
+		FlipRecommendation focused = rec(2002, "Raw Shark", 100);
+		List<FlipRecommendation> refreshedPool = Arrays.asList(
+			rec(3003, "Magic Logs", 200),
+			rec(2002, "Raw Shark", 100),
+			rec(4004, "Yew Logs", 300));
+
+		List<FlipRecommendation> queue = AutoRecommendService.buildRefreshedQueue(
+			refreshedPool, focused, NONE_ACTIVE);
+
+		assertEquals("focused item stays at index 0", 2002, queue.get(0).getItemId());
+		assertEquals("no duplication of the focused item", 3, queue.size());
+		assertTrue(itemIds(queue).containsAll(Arrays.asList(2002, 3003, 4004)));
+	}
+
+	// AC5 — focused item now live on the GE is excluded from the refreshed (filtered)
+	// pool and must not be re-prepended; the offer is left untouched.
+	@Test
+	public void doesNotPrependFocusedItemThatIsLiveOnTheGe()
+	{
+		FlipRecommendation onGe = rec(2002, "Raw Shark", 100);
+		// filtered pool already excludes GE-active items, so onGe is absent here.
+		List<FlipRecommendation> refreshedPool = Arrays.asList(
+			rec(3003, "Magic Logs", 200));
+		Set<Integer> active = new HashSet<>(Collections.singletonList(2002));
+
+		List<FlipRecommendation> queue = AutoRecommendService.buildRefreshedQueue(
+			refreshedPool, onGe, active);
+
+		assertFalse("GE-active item not re-queued", itemIds(queue).contains(2002));
+		assertEquals(Arrays.asList(3003), itemIds(queue));
+	}
+
+	// AC6 — empty refreshed pool clears the queue without error.
+	@Test
+	public void clearsQueueWhenRefreshedPoolIsEmpty()
+	{
+		FlipRecommendation stale = rec(1001, "Demonic Hood", 50);
+
+		List<FlipRecommendation> queue = AutoRecommendService.buildRefreshedQueue(
+			Collections.emptyList(), stale, NONE_ACTIVE);
+
+		assertTrue("queue cleared when nothing recommended", queue.isEmpty());
+	}
+
+	// Nothing focused yet — queue mirrors the refreshed pool.
+	@Test
+	public void mirrorsPoolWhenNothingFocused()
+	{
+		List<FlipRecommendation> refreshedPool = Arrays.asList(
+			rec(2002, "Raw Shark", 100),
+			rec(3003, "Magic Logs", 200));
+
+		List<FlipRecommendation> queue = AutoRecommendService.buildRefreshedQueue(
+			refreshedPool, null, NONE_ACTIVE);
+
+		assertEquals(Arrays.asList(2002, 3003), itemIds(queue));
+	}
+}

--- a/src/test/java/com/flipsmart/AutoRecommendRefreshQueueTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendRefreshQueueTest.java
@@ -35,15 +35,19 @@ public class AutoRecommendRefreshQueueTest
 	}
 
 	private static final Set<Integer> NONE_ACTIVE = Collections.emptySet();
+	private static final String RAW_SHARK = "Raw Shark";
+	private static final String MAGIC_LOGS = "Magic Logs";
+	private static final String DEMONIC_HOOD = "Demonic Hood";
+	private static final String YEW_LOGS = "Yew Logs";
 
 	// AC2 — focused item removed from the refreshed pool is dropped from the queue.
 	@Test
 	public void dropsFocusedItemWhenNoLongerRecommended()
 	{
-		FlipRecommendation stale = rec(1001, "Demonic Hood", 50);
+		FlipRecommendation stale = rec(1001, DEMONIC_HOOD, 50);
 		List<FlipRecommendation> refreshedPool = Arrays.asList(
-			rec(2002, "Raw Shark", 100),
-			rec(3003, "Magic Logs", 200));
+			rec(2002, RAW_SHARK, 100),
+			rec(3003, MAGIC_LOGS, 200));
 
 		List<FlipRecommendation> queue = AutoRecommendService.buildRefreshedQueue(
 			refreshedPool, stale, NONE_ACTIVE);
@@ -56,11 +60,11 @@ public class AutoRecommendRefreshQueueTest
 	@Test
 	public void retainsFocusedItemAtFrontWhenStillRecommended()
 	{
-		FlipRecommendation focused = rec(2002, "Raw Shark", 100);
+		FlipRecommendation focused = rec(2002, RAW_SHARK, 100);
 		List<FlipRecommendation> refreshedPool = Arrays.asList(
-			rec(3003, "Magic Logs", 200),
-			rec(2002, "Raw Shark", 100),
-			rec(4004, "Yew Logs", 300));
+			rec(3003, MAGIC_LOGS, 200),
+			rec(2002, RAW_SHARK, 100),
+			rec(4004, YEW_LOGS, 300));
 
 		List<FlipRecommendation> queue = AutoRecommendService.buildRefreshedQueue(
 			refreshedPool, focused, NONE_ACTIVE);
@@ -75,10 +79,9 @@ public class AutoRecommendRefreshQueueTest
 	@Test
 	public void doesNotPrependFocusedItemThatIsLiveOnTheGe()
 	{
-		FlipRecommendation onGe = rec(2002, "Raw Shark", 100);
-		// filtered pool already excludes GE-active items, so onGe is absent here.
+		FlipRecommendation onGe = rec(2002, RAW_SHARK, 100);
 		List<FlipRecommendation> refreshedPool = Arrays.asList(
-			rec(3003, "Magic Logs", 200));
+			rec(3003, MAGIC_LOGS, 200));
 		Set<Integer> active = new HashSet<>(Collections.singletonList(2002));
 
 		List<FlipRecommendation> queue = AutoRecommendService.buildRefreshedQueue(
@@ -92,7 +95,7 @@ public class AutoRecommendRefreshQueueTest
 	@Test
 	public void clearsQueueWhenRefreshedPoolIsEmpty()
 	{
-		FlipRecommendation stale = rec(1001, "Demonic Hood", 50);
+		FlipRecommendation stale = rec(1001, DEMONIC_HOOD, 50);
 
 		List<FlipRecommendation> queue = AutoRecommendService.buildRefreshedQueue(
 			Collections.emptyList(), stale, NONE_ACTIVE);
@@ -105,8 +108,8 @@ public class AutoRecommendRefreshQueueTest
 	public void mirrorsPoolWhenNothingFocused()
 	{
 		List<FlipRecommendation> refreshedPool = Arrays.asList(
-			rec(2002, "Raw Shark", 100),
-			rec(3003, "Magic Logs", 200));
+			rec(2002, RAW_SHARK, 100),
+			rec(3003, MAGIC_LOGS, 200));
 
 		List<FlipRecommendation> queue = AutoRecommendService.buildRefreshedQueue(
 			refreshedPool, null, NONE_ACTIVE);


### PR DESCRIPTION
## Summary

In auto mode, when Flip Finder refreshed its recommendation pool and dropped a previously recommended item, Flip Assist kept that stale item queued at index 0 indefinitely. The root cause was that `rebuildQueue()` unconditionally prepended the currently focused item to the rebuilt queue whenever it was not live on the GE — without checking whether it still existed in the refreshed pool.

This fix adds the missing staleness guard and extracts the queue-ordering decision into a testable static helper.

Implements Flip-Smart/flip-smart#722.

## Changes

### Bug Fixes

- `AutoRecommendService.rebuildQueue()`: the currently focused item is now kept at index 0 only when it is still present in the refreshed actionable pool; otherwise it is dropped and the queue is rebuilt from the current pool order.
- Overlay after refresh now calls `getCurrentRecommendation()` rather than passing the pre-rebuild `currentRec`, so the display reflects the item actually focused after the rebuild (matters for the empty-pool case).

### Refactoring

- Extracted `buildRefreshedQueue(filtered, currentRec, activeItemIds)` as a package-visible static helper so the ordering logic is pure and unit-testable without a full plugin context.

## Acceptance Criteria Coverage

| AC | Description | How satisfied |
|----|-------------|---------------|
| AC1 | Queue rebuilds from the fresh pool on every Flip Finder refresh | `rebuildQueue` is called on every `onNewRecommendations` event; now delegates to `buildRefreshedQueue` which always starts from `filtered` |
| AC2 | Stale focused item is dropped when Flip Finder no longer recommends it | `currentRecStillRecommended` guard added; covered by `dropsFocusedItemWhenNoLongerRecommended` test |
| AC3 | Focused item still in the pool is retained at index 0 (no churn) | Guard only drops when absent; covered by `retainsFocusedItemAtFrontWhenStillRecommended` test |
| AC4 | Active GE offers are never cancelled by the rebuild | `filtered` pool already excludes GE-active items before reaching `buildRefreshedQueue`; the helper cannot touch live offers |
| AC5 | Focused item with a live GE offer is not re-prepended | `currentRecActive` check precedes all logic; covered by `doesNotPrependFocusedItemThatIsLiveOnTheGe` test |
| AC6 | Empty refreshed pool clears the queue cleanly | Returns empty list when `filtered` is empty; covered by `clearsQueueWhenRefreshedPoolIsEmpty` test |

## Testing

### Automated Tests

- New `AutoRecommendRefreshQueueTest` covers AC2, AC3, AC5, AC6, and the no-focus mirror case (5 tests).
- Full plugin suite passes: `./gradlew clean test` — BUILD SUCCESSFUL.

### Manual Testing

- [x] Start client in auto mode with at least one item queued
- [x] Trigger a Flip Finder refresh (wait for the auto-refresh interval or force-refresh)
- [x] Confirm that if the previously focused item has left the pool, the overlay shows the next recommended item instead of keeping the stale one
- [x] Confirm that if the focused item is still in the refreshed pool, it stays at the front without flickering
- [x] Confirm that items with an active GE offer are not re-queued or cancelled by a refresh

## Deployment Notes

- No config changes, no new dependencies, no schema changes.
- Drop-in fix; no migration or environment variable changes required.

---

### Codacy Quality Gate — fixed in this PR
- `1d67d74` PMD_category_java_errorprone_AvoidDuplicateLiterals AutoRecommendRefreshQueueTest.java:45,46 — extracted repeated item-name string literals (Raw Shark x5, Magic Logs x4) into private static final constants

### Codacy AI Reviewer — no open comments