### PR TITLE
fix: dedup in-flight daily-volume fetches to stop per-frame request storm

### DIFF
--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 @Slf4j
 @Singleton
@@ -2481,6 +2482,10 @@ public class FlipSmartApiClient
 	// fires one request per frame. We back off for a minute, then retry.
 	private static final long DAILY_VOLUME_ERROR_CACHE_TTL_MS = 60_000;  // 1 minute
 	private final Map<Integer, CachedDailyVolume> dailyVolumeCache = new ConcurrentHashMap<>();
+	// In-flight fetches keyed by item id. onBeforeRender rebuilds the GE offer
+	// description every render frame, so without deduping a cold cache opens one
+	// connection per frame for the same item until the first response lands.
+	private final Map<Integer, CompletableFuture<Integer>> inFlightDailyVolume = new ConcurrentHashMap<>();
 
 	/**
 	 * Fetch the 24h daily trading volume for a single item.
@@ -2499,6 +2504,11 @@ public class FlipSmartApiClient
 			return CompletableFuture.completedFuture(cached.getVolume());
 		}
 
+		return dedupeInFlight(inFlightDailyVolume, itemId, () -> fetchDailyVolume(itemId));
+	}
+
+	private CompletableFuture<Integer> fetchDailyVolume(int itemId)
+	{
 		String url = String.format("%s/items/%d/daily-volume", getApiUrl(), itemId);
 		Request.Builder requestBuilder = new Request.Builder()
 			.url(url)
@@ -2525,6 +2535,28 @@ public class FlipSmartApiClient
 			}
 		});
 
+		return future;
+	}
+
+	/**
+	 * Share a single in-flight fetch per key. Callers arriving while a fetch is
+	 * running get the same future instead of starting their own; the entry is
+	 * cleared on completion so a later (post-TTL) call can fetch again. Callers
+	 * are serialized on the client thread, so a plain get-then-put is safe here.
+	 */
+	static CompletableFuture<Integer> dedupeInFlight(
+		Map<Integer, CompletableFuture<Integer>> inFlight,
+		int itemId,
+		Supplier<CompletableFuture<Integer>> fetcher)
+	{
+		CompletableFuture<Integer> existing = inFlight.get(itemId);
+		if (existing != null)
+		{
+			return existing;
+		}
+		CompletableFuture<Integer> future = fetcher.get();
+		inFlight.put(itemId, future);
+		future.whenComplete((v, ex) -> inFlight.remove(itemId, future));
 		return future;
 	}
 

--- a/src/test/java/com/flipsmart/DailyVolumeDedupTest.java
+++ b/src/test/java/com/flipsmart/DailyVolumeDedupTest.java
@@ -1,0 +1,88 @@
+package com.flipsmart;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Covers {@link FlipSmartApiClient#dedupeInFlight} — the in-flight dedup that stops
+ * the per-render-frame GE offer loop from opening one daily-volume connection per
+ * frame for the same uncached item (issue #727).
+ */
+public class DailyVolumeDedupTest
+{
+	// AC1 — repeated calls while a fetch is in flight share a single underlying fetch.
+	@Test
+	public void sharesSingleFetchWhileInFlight()
+	{
+		Map<Integer, CompletableFuture<Integer>> inFlight = new ConcurrentHashMap<>();
+		AtomicInteger fetches = new AtomicInteger();
+		Supplier<CompletableFuture<Integer>> fetcher = () ->
+		{
+			fetches.incrementAndGet();
+			return new CompletableFuture<>(); // never completes during this test
+		};
+
+		CompletableFuture<Integer> first = FlipSmartApiClient.dedupeInFlight(inFlight, 1747, fetcher);
+		for (int i = 0; i < 10; i++)
+		{
+			CompletableFuture<Integer> again = FlipSmartApiClient.dedupeInFlight(inFlight, 1747, fetcher);
+			assertSame("repeat callers get the same in-flight future", first, again);
+		}
+
+		assertEquals("only one underlying fetch is issued", 1, fetches.get());
+	}
+
+	// AC2 — once the in-flight fetch completes, the entry clears and a later call refetches.
+	@Test
+	public void clearsInFlightOnCompletionAndAllowsRefetch()
+	{
+		Map<Integer, CompletableFuture<Integer>> inFlight = new ConcurrentHashMap<>();
+		AtomicInteger fetches = new AtomicInteger();
+		CompletableFuture<Integer> backing = new CompletableFuture<>();
+		Supplier<CompletableFuture<Integer>> fetcher = () ->
+		{
+			fetches.incrementAndGet();
+			return backing.thenApply(v -> v); // a fresh dependent future per call
+		};
+
+		FlipSmartApiClient.dedupeInFlight(inFlight, 1747, fetcher);
+		assertTrue("entry registered while in flight", inFlight.containsKey(1747));
+
+		backing.complete(42);
+
+		assertFalse("entry cleared after completion", inFlight.containsKey(1747));
+
+		FlipSmartApiClient.dedupeInFlight(inFlight, 1747, fetcher);
+		assertEquals("a post-completion call refetches", 2, fetches.get());
+	}
+
+	// AC3 — different item ids fetch independently.
+	@Test
+	public void differentItemsFetchIndependently()
+	{
+		Map<Integer, CompletableFuture<Integer>> inFlight = new ConcurrentHashMap<>();
+		AtomicInteger fetches = new AtomicInteger();
+		Supplier<CompletableFuture<Integer>> fetcher = () ->
+		{
+			fetches.incrementAndGet();
+			return new CompletableFuture<>();
+		};
+
+		CompletableFuture<Integer> a = FlipSmartApiClient.dedupeInFlight(inFlight, 1747, fetcher);
+		CompletableFuture<Integer> b = FlipSmartApiClient.dedupeInFlight(inFlight, 27641, fetcher);
+
+		assertEquals("each distinct item issues its own fetch", 2, fetches.get());
+		org.junit.Assert.assertNotSame("distinct items get distinct futures", a, b);
+		assertTrue(inFlight.containsKey(1747));
+		assertTrue(inFlight.containsKey(27641));
+	}
+}


### PR DESCRIPTION
## Summary

While a GE offer window is open, `GeOfferDescriptionService.onBeforeRender()` rebuilds the offer description every render frame (~50/s) and calls `getDailyVolumeAsync(itemId)`. The endpoint had a 5-minute value-cache but no in-flight dedup, so during the window before the first response arrived every frame opened a new HTTP connection to `/items/{id}/daily-volume` — observed as dozens of concurrent connections per item, doubled on windows showing both a buy and a sell offer.

Implements Flip-Smart/flip-smart#727.

## Changes

- **`FlipSmartApiClient`**: added `inFlightDailyVolume` (`ConcurrentHashMap<Integer, CompletableFuture<Integer>>`) and a package-visible static helper `dedupeInFlight(inFlight, itemId, fetcher)`. Concurrent callers for the same item now share one in-flight future; the map entry clears on completion so a later post-TTL refresh can fetch again.
- Extracted `fetchDailyVolume(int itemId)` as a private method so `getDailyVolumeAsync` stays readable: cache check → dedup → fetch.
- The existing success and negative-TTL value-cache is unchanged.
- **`DailyVolumeDedupTest`**: three tests covering the dedup contract directly via the static helper.

## Acceptance Criteria

| AC | Status |
|----|--------|
| AC1 — concurrent in-flight calls for the same item share one fetch | Covered by `sharesSingleFetchWhileInFlight` |
| AC2 — in-flight entry clears on completion; later call refetches | Covered by `clearsInFlightOnCompletionAndAllowsRefetch` |
| AC3 — distinct items fetch independently | Covered by `differentItemsFetchIndependently` |
| AC4 — existing value-cache (success + negative TTL) still short-circuits | Preserved by construction — cache check runs before `dedupeInFlight` |
| AC5 — no new blocking calls on the client thread | `dedupeInFlight` is non-blocking; does a map get/put and returns an existing or new `CompletableFuture` |

**Out of scope (noted on the issue):** the `getCachedDailyVolume` null-ambiguity smell (cached-null value vs uncached) is a separate follow-up.

## Testing

- `./gradlew clean test` — BUILD SUCCESSFUL, all tests pass including `DailyVolumeDedupTest`.
- Manual: open GE offer window while connected to the API; confirm a single `/items/{id}/daily-volume` request is issued per item per cache window rather than one per frame.

### 🩺 Codacy Quality Gate

No new issues at head `6db38706df` — gate green on entry, no action needed.

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)

- `FlipSmartApiClient.java:2560` — `computeIfAbsent` suggestion: get-then-put is intentional and safe; callers are serialized on the client thread (documented in Javadoc). `computeIfAbsent` also prohibits recursive map modifications from its lambda — a constraint the current pattern avoids.
- `DailyVolumeDedupTest.java:31` — test setup "duplication": each method uses a structurally distinct setup to exercise a different AC scenario (never-completing future vs. thenApply completion vs. independent item IDs). A shared helper would obscure the per-AC variation.