### PR TITLE
fix(auto-recommend): surface a buy on freed GE slot after collect/cancel

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -726,10 +726,7 @@ public class AutoRecommendService
 			{
 				int idx = firstAvailableBuyIndex(recommendationQueue,
 					plugin.getActiveFlipItemIds(), excludeItemId, config.priceOffset(), config.minimumProfit());
-				if (idx >= 0)
-				{
-					currentIndex = idx;
-				}
+				currentIndex = (idx >= 0) ? idx : recommendationQueue.size();
 			}
 			if (currentIndex < recommendationQueue.size())
 			{

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -540,8 +540,9 @@ public class AutoRecommendService
 				wasBuy, filledQuantity, totalQuantity);
 		}
 
-		// A cancel frees a slot — rewind so a new recommendation surfaces immediately.
-		focusNextAvailableAction(true);
+		// A cancel frees a slot — rewind so a new recommendation surfaces immediately,
+		// but skip the just-cancelled item so we don't re-recommend what was dropped.
+		focusNextAvailableAction(true, itemId);
 	}
 
 	private void trackPartialBuyCancel(int itemId, int filledQuantity, int totalQuantity)
@@ -673,7 +674,12 @@ public class AutoRecommendService
 	 */
 	private void focusNextAvailableAction()
 	{
-		focusNextAvailableAction(false);
+		focusNextAvailableAction(false, -1);
+	}
+
+	private void focusNextAvailableAction(boolean rewindToFirstAvailableBuy)
+	{
+		focusNextAvailableAction(rewindToFirstAvailableBuy, -1);
 	}
 
 	/**
@@ -681,8 +687,10 @@ public class AutoRecommendService
 	 * {@code currentIndex} to the first still-valid queue item instead of relying on
 	 * its monotonically-advanced position. Set on slot-freeing events (collect /
 	 * cancel) so a freed slot always recovers a recommendation.
+	 * @param excludeItemId item id to skip when rewinding — set to the just-cancelled
+	 * item so a cancel surfaces a different flip rather than re-recommending the same one.
 	 */
-	private void focusNextAvailableAction(boolean rewindToFirstAvailableBuy)
+	private void focusNextAvailableAction(boolean rewindToFirstAvailableBuy, int excludeItemId)
 	{
 		focusedCollectedItemId = -1;
 
@@ -717,7 +725,7 @@ public class AutoRecommendService
 			if (rewindToFirstAvailableBuy)
 			{
 				int idx = firstAvailableBuyIndex(recommendationQueue,
-					plugin.getActiveFlipItemIds(), config.priceOffset(), config.minimumProfit());
+					plugin.getActiveFlipItemIds(), excludeItemId, config.priceOffset(), config.minimumProfit());
 				if (idx >= 0)
 				{
 					currentIndex = idx;
@@ -750,13 +758,15 @@ public class AutoRecommendService
 	static int firstAvailableBuyIndex(
 		List<FlipRecommendation> queue,
 		Set<Integer> activeItemIds,
+		int excludeItemId,
 		int priceOffset,
 		int minProfit)
 	{
 		for (int i = 0; i < queue.size(); i++)
 		{
 			FlipRecommendation rec = queue.get(i);
-			if (!activeItemIds.contains(rec.getItemId())
+			if (rec.getItemId() != excludeItemId
+				&& !activeItemIds.contains(rec.getItemId())
 				&& FocusedFlip.calculateAdjustedProfit(rec, priceOffset) >= minProfit)
 			{
 				return i;

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -540,7 +540,8 @@ public class AutoRecommendService
 				wasBuy, filledQuantity, totalQuantity);
 		}
 
-		focusNextAvailableAction();
+		// A cancel frees a slot — rewind so a new recommendation surfaces immediately.
+		focusNextAvailableAction(true);
 	}
 
 	private void trackPartialBuyCancel(int itemId, int filledQuantity, int totalQuantity)
@@ -629,7 +630,8 @@ public class AutoRecommendService
 			clearSellAdjustmentTimer(itemId);
 			buyPrices.remove(itemId);
 			log.debug("Auto-recommend: Sell collected for {} - advancing", itemName);
-			focusNextAvailableAction();
+			// Collecting a sell frees the slot — rewind so a new buy surfaces.
+			focusNextAvailableAction(true);
 		}
 	}
 
@@ -660,7 +662,8 @@ public class AutoRecommendService
 			return;
 		}
 
-		focusNextAvailableAction();
+		// Nothing to sell for this collected buy — the slot is free, so rewind to a buy.
+		focusNextAvailableAction(true);
 	}
 
 	/**
@@ -669,6 +672,17 @@ public class AutoRecommendService
 	 * stale offers > buy next from queue > wait.
 	 */
 	private void focusNextAvailableAction()
+	{
+		focusNextAvailableAction(false);
+	}
+
+	/**
+	 * @param rewindToFirstAvailableBuy when a buy is the next action, rewind
+	 * {@code currentIndex} to the first still-valid queue item instead of relying on
+	 * its monotonically-advanced position. Set on slot-freeing events (collect /
+	 * cancel) so a freed slot always recovers a recommendation. See issue #725.
+	 */
+	private void focusNextAvailableAction(boolean rewindToFirstAvailableBuy)
 	{
 		focusedCollectedItemId = -1;
 
@@ -694,9 +708,29 @@ public class AutoRecommendService
 			// Guide user through stale offers one at a time before new recommendations
 			focusNextStaleOffer();
 		}
-		else if (hasAvailableGESlots() && currentIndex < recommendationQueue.size())
+		else if (hasAvailableGESlots())
 		{
-			focusCurrent();
+			// currentIndex only ever moves forward, so a freed slot can leave it
+			// parked past every still-valid item (including the one just freed).
+			// Rewind to the first surfaceable buy in that case so the slot is never
+			// left empty until the next full queue refresh.
+			if (rewindToFirstAvailableBuy)
+			{
+				int idx = firstAvailableBuyIndex(recommendationQueue,
+					plugin.getActiveFlipItemIds(), config.priceOffset(), config.minimumProfit());
+				if (idx >= 0)
+				{
+					currentIndex = idx;
+				}
+			}
+			if (currentIndex < recommendationQueue.size())
+			{
+				focusCurrent();
+			}
+			else
+			{
+				promptCollection();
+			}
 		}
 		else
 		{
@@ -704,6 +738,31 @@ public class AutoRecommendService
 			// completed offers, otherwise show "Waiting for flips"
 			promptCollection();
 		}
+	}
+
+	/**
+	 * First queue index that can be surfaced as a buy right now: not already on the
+	 * GE and at or above the minimum adjusted profit. Scans from the front (lowest
+	 * volume first), independent of {@code currentIndex}, so a freed slot can recover
+	 * an item the monotonic {@code currentIndex} has already advanced past. Returns
+	 * -1 when nothing is currently surfaceable.
+	 */
+	static int firstAvailableBuyIndex(
+		List<FlipRecommendation> queue,
+		Set<Integer> activeItemIds,
+		int priceOffset,
+		int minProfit)
+	{
+		for (int i = 0; i < queue.size(); i++)
+		{
+			FlipRecommendation rec = queue.get(i);
+			if (!activeItemIds.contains(rec.getItemId())
+				&& FocusedFlip.calculateAdjustedProfit(rec, priceOffset) >= minProfit)
+			{
+				return i;
+			}
+		}
+		return -1;
 	}
 
 	private boolean isUserBusy()

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -680,7 +680,7 @@ public class AutoRecommendService
 	 * @param rewindToFirstAvailableBuy when a buy is the next action, rewind
 	 * {@code currentIndex} to the first still-valid queue item instead of relying on
 	 * its monotonically-advanced position. Set on slot-freeing events (collect /
-	 * cancel) so a freed slot always recovers a recommendation. See issue #725.
+	 * cancel) so a freed slot always recovers a recommendation.
 	 */
 	private void focusNextAvailableAction(boolean rewindToFirstAvailableBuy)
 	{

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -214,15 +214,18 @@ public class GrandExchangeTracker
 		TrackedOffer cancelledOffer = session.getTrackedOffer(ctx.slot);
 		int totalQuantity = cancelledOffer != null ? cancelledOffer.getTotalQuantity() : ctx.totalQuantity;
 
+		// A cancel that leaves items in the GE collection box must stay collectable so
+		// the items route through the normal collect -> (re)sell flow instead of being
+		// orphaned. Removing the offer here would leave the later collect (EMPTY) event
+		// with no tracked offer, so no (re)sell prompt would ever surface proactively.
+		//  - partial BUY cancel: the bought items still need selling
+		//  - SELL cancel with unsold items: the returned items need re-listing
 		boolean partialBuyCancel = ctx.isBuy && ctx.quantitySold > 0;
-		if (partialBuyCancel && cancelledOffer != null)
+		boolean sellCancelWithRemaining = !ctx.isBuy && (totalQuantity - ctx.quantitySold) > 0;
+		if ((partialBuyCancel || sellCancelWithRemaining) && cancelledOffer != null)
 		{
-			// Keep the partially-bought offer as a collectable completed buy. The bought
-			// items sit in the GE collection box, so removing the offer here would orphan
-			// them — the later collect (EMPTY) event would find no tracked offer and never
-			// surface a sell. Marking it completed routes it through the normal
-			// collect -> sell flow: a Collect prompt now (the slot still counts as
-			// occupied), then a Sell prompt once the player collects the items.
+			// Mark it completed: a Collect prompt now (the slot still counts as occupied),
+			// then a (re)sell prompt once the player collects the items.
 			cancelledOffer.setPreviousQuantitySold(ctx.quantitySold);
 			cancelledOffer.setCompletedAtMillis(System.currentTimeMillis());
 		}

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -214,9 +214,24 @@ public class GrandExchangeTracker
 		TrackedOffer cancelledOffer = session.getTrackedOffer(ctx.slot);
 		int totalQuantity = cancelledOffer != null ? cancelledOffer.getTotalQuantity() : ctx.totalQuantity;
 
-		// Remove tracked offer BEFORE notifying auto-recommend so hasActiveSellSlotForItem
-		// returns false and findNextSellableCollectedItem can find the re-added items
-		session.removeTrackedOffer(ctx.slot);
+		boolean partialBuyCancel = ctx.isBuy && ctx.quantitySold > 0;
+		if (partialBuyCancel && cancelledOffer != null)
+		{
+			// Keep the partially-bought offer as a collectable completed buy. The bought
+			// items sit in the GE collection box, so removing the offer here would orphan
+			// them — the later collect (EMPTY) event would find no tracked offer and never
+			// surface a sell. Marking it completed routes it through the normal
+			// collect -> sell flow: a Collect prompt now (the slot still counts as
+			// occupied), then a Sell prompt once the player collects the items.
+			cancelledOffer.setPreviousQuantitySold(ctx.quantitySold);
+			cancelledOffer.setCompletedAtMillis(System.currentTimeMillis());
+		}
+		else
+		{
+			// Remove tracked offer BEFORE notifying auto-recommend so hasActiveSellSlotForItem
+			// returns false and findNextSellableCollectedItem can find the re-added items
+			session.removeTrackedOffer(ctx.slot);
+		}
 
 		// Only remove recommended price for zero-fill buy cancels — partial fills need the
 		// sell price preserved so the user can be prompted to sell the collected items

--- a/src/test/java/com/flipsmart/AutoRecommendFreeSlotBuyTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendFreeSlotBuyTest.java
@@ -43,6 +43,7 @@ public class AutoRecommendFreeSlotBuyTest
 	}
 
 	private static final Set<Integer> NONE_ACTIVE = Collections.emptySet();
+	private static final int NO_EXCLUDE = -1;
 
 	// The freed slot must find an available item even when it sits at index 0 and
 	// the (monotonic) currentIndex has run off the end — the scan ignores currentIndex.
@@ -52,7 +53,7 @@ public class AutoRecommendFreeSlotBuyTest
 		List<FlipRecommendation> queue = Arrays.asList(
 			profitable(1001), profitable(2002), profitable(3003));
 
-		int idx = AutoRecommendService.firstAvailableBuyIndex(queue, NONE_ACTIVE, 0, 1);
+		int idx = AutoRecommendService.firstAvailableBuyIndex(queue, NONE_ACTIVE, NO_EXCLUDE, 0, 1);
 
 		assertEquals(0, idx);
 	}
@@ -65,9 +66,22 @@ public class AutoRecommendFreeSlotBuyTest
 			profitable(1001), profitable(2002), profitable(3003));
 		Set<Integer> active = new HashSet<>(Arrays.asList(1001, 2002));
 
-		int idx = AutoRecommendService.firstAvailableBuyIndex(queue, active, 0, 1);
+		int idx = AutoRecommendService.firstAvailableBuyIndex(queue, active, NO_EXCLUDE, 0, 1);
 
 		assertEquals("first non-GE item", 2, idx);
+	}
+
+	// The just-cancelled item is skipped so a cancel surfaces a different flip
+	// instead of immediately re-recommending the one the player just dropped (#725).
+	@Test
+	public void skipsExcludedJustCancelledItem()
+	{
+		List<FlipRecommendation> queue = Arrays.asList(
+			profitable(1001), profitable(2002), profitable(3003));
+
+		int idx = AutoRecommendService.firstAvailableBuyIndex(queue, NONE_ACTIVE, 1001, 0, 1);
+
+		assertEquals("skips the excluded item, picks the next", 1, idx);
 	}
 
 	// Items below the minimum-profit threshold are skipped.
@@ -77,7 +91,7 @@ public class AutoRecommendFreeSlotBuyTest
 		List<FlipRecommendation> queue = Arrays.asList(
 			unprofitable(1001), profitable(2002));
 
-		int idx = AutoRecommendService.firstAvailableBuyIndex(queue, NONE_ACTIVE, 0, 1);
+		int idx = AutoRecommendService.firstAvailableBuyIndex(queue, NONE_ACTIVE, NO_EXCLUDE, 0, 1);
 
 		assertEquals(1, idx);
 	}
@@ -90,7 +104,7 @@ public class AutoRecommendFreeSlotBuyTest
 			profitable(1001), profitable(2002));
 		Set<Integer> active = new HashSet<>(Arrays.asList(1001, 2002));
 
-		int idx = AutoRecommendService.firstAvailableBuyIndex(queue, active, 0, 1);
+		int idx = AutoRecommendService.firstAvailableBuyIndex(queue, active, NO_EXCLUDE, 0, 1);
 
 		assertEquals(-1, idx);
 	}
@@ -99,7 +113,7 @@ public class AutoRecommendFreeSlotBuyTest
 	public void returnsMinusOneForEmptyQueue()
 	{
 		int idx = AutoRecommendService.firstAvailableBuyIndex(
-			Collections.emptyList(), NONE_ACTIVE, 0, 1);
+			Collections.emptyList(), NONE_ACTIVE, NO_EXCLUDE, 0, 1);
 
 		assertEquals(-1, idx);
 	}

--- a/src/test/java/com/flipsmart/AutoRecommendFreeSlotBuyTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendFreeSlotBuyTest.java
@@ -1,0 +1,106 @@
+package com.flipsmart;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Covers {@link AutoRecommendService#firstAvailableBuyIndex} — the scan that lets a
+ * freed GE slot (collect / unfilled-cancel) surface a buy even when {@code currentIndex}
+ * has advanced past every still-valid item. Monotonic {@code currentIndex} was the
+ * root cause of issue #725: once it reached the end, a freed slot found nothing to
+ * focus until the next full queue refresh.
+ */
+public class AutoRecommendFreeSlotBuyTest
+{
+	// recommendedBuyPrice/SellPrice/quantity chosen so adjusted profit is clearly
+	// positive (profitable) or negative (below threshold) under priceOffset 0.
+	private static FlipRecommendation profitable(int itemId)
+	{
+		FlipRecommendation r = new FlipRecommendation();
+		r.setItemId(itemId);
+		r.setItemName("item-" + itemId);
+		r.setRecommendedBuyPrice(100);
+		r.setRecommendedSellPrice(200);
+		r.setRecommendedQuantity(10);
+		return r;
+	}
+
+	private static FlipRecommendation unprofitable(int itemId)
+	{
+		FlipRecommendation r = new FlipRecommendation();
+		r.setItemId(itemId);
+		r.setItemName("item-" + itemId);
+		r.setRecommendedBuyPrice(200);
+		r.setRecommendedSellPrice(100);
+		r.setRecommendedQuantity(10);
+		return r;
+	}
+
+	private static final Set<Integer> NONE_ACTIVE = Collections.emptySet();
+
+	// The freed slot must find an available item even when it sits at index 0 and
+	// the (monotonic) currentIndex has run off the end — the scan ignores currentIndex.
+	@Test
+	public void findsLowestAvailableIndex()
+	{
+		List<FlipRecommendation> queue = Arrays.asList(
+			profitable(1001), profitable(2002), profitable(3003));
+
+		int idx = AutoRecommendService.firstAvailableBuyIndex(queue, NONE_ACTIVE, 0, 1);
+
+		assertEquals(0, idx);
+	}
+
+	// Items already live on the GE are skipped — only a genuinely free item surfaces.
+	@Test
+	public void skipsItemsAlreadyOnTheGe()
+	{
+		List<FlipRecommendation> queue = Arrays.asList(
+			profitable(1001), profitable(2002), profitable(3003));
+		Set<Integer> active = new HashSet<>(Arrays.asList(1001, 2002));
+
+		int idx = AutoRecommendService.firstAvailableBuyIndex(queue, active, 0, 1);
+
+		assertEquals("first non-GE item", 2, idx);
+	}
+
+	// Items below the minimum-profit threshold are skipped.
+	@Test
+	public void skipsBelowMinProfit()
+	{
+		List<FlipRecommendation> queue = Arrays.asList(
+			unprofitable(1001), profitable(2002));
+
+		int idx = AutoRecommendService.firstAvailableBuyIndex(queue, NONE_ACTIVE, 0, 1);
+
+		assertEquals(1, idx);
+	}
+
+	// Nothing available -> -1, so the caller prompts collection instead of crashing (AC6 spirit).
+	@Test
+	public void returnsMinusOneWhenNothingAvailable()
+	{
+		List<FlipRecommendation> queue = Arrays.asList(
+			profitable(1001), profitable(2002));
+		Set<Integer> active = new HashSet<>(Arrays.asList(1001, 2002));
+
+		int idx = AutoRecommendService.firstAvailableBuyIndex(queue, active, 0, 1);
+
+		assertEquals(-1, idx);
+	}
+
+	@Test
+	public void returnsMinusOneForEmptyQueue()
+	{
+		int idx = AutoRecommendService.firstAvailableBuyIndex(
+			Collections.emptyList(), NONE_ACTIVE, 0, 1);
+
+		assertEquals(-1, idx);
+	}
+}


### PR DESCRIPTION
## Summary

Auto-mode was leaving a freed GE slot empty until the next full queue refresh (~every 2 min) when a flip was collected or a buy was cancelled. This PR fixes the freed-slot rewind, handles partial-buy and sell cancels correctly through the collect→sell pipeline, and prevents a cancelled item from immediately re-appearing as its own replacement.

Implements Flip-Smart/flip-smart#725.

## What changed

- **Freed-slot recommendation after collect/cancel.** `AutoRecommendService.currentIndex` advances monotonically and only resets on a full queue refresh. Once it reached the end, a freed slot surfaced nothing until the next refresh. A new pure helper `firstAvailableBuyIndex(queue, activeItemIds, excludeItemId, priceOffset, minProfit)` scans from the front; on slot-freeing events the rewind sets `currentIndex` to the first surfaceable buy (or to queue end, triggering `promptCollection`, when nothing is surfaceable).

- **Partial-buy cancel now proactively prompts Collect → Sell.** Previously a partially-filled buy cancel removed the tracked offer, orphaning the bought items — the later collect EMPTY event found no offer, so no sell ever surfaced, and with a free slot the rewind even showed a new buy. `GrandExchangeTracker.handleCancelledOffer` now keeps a partial-buy cancel as a completed, collectable offer so it routes through the normal collect→sell flow. Verified in-game: Earth orb 7666/11000 bought → cancel → Collect → Sell ×7666.

- **Cancel no longer re-recommends the just-cancelled item.** The freed-slot rewind accepts an `excludeItemId`; `onOfferCancelled` passes the cancelled item so an unfilled-buy cancel surfaces a different flip. Covered by `AutoRecommendFreeSlotBuyTest`.

- **Sell cancel with unsold items proactively re-prompts to sell.** The same keep-collectable treatment is extended to sell cancels where items remain (total − sold > 0): Collect → proactive re-Sell of the remaining quantity, instead of depending on an inventory-detection race. Verified in-game: SELL Earth orb 0/7666 listed → cancel → Collect → re-Sell ×7666.

- **Robustness: no-surfaceable-buy sets `currentIndex` to queue end.** When the rewind scan returns -1, `currentIndex` is set to `recommendationQueue.size()` so the subsequent bounds check falls through to `promptCollection` instead of calling `focusCurrent` on a stale index. Caught and fixed following an AI Reviewer comment.

## Acceptance criteria (Flip-Smart/flip-smart#725)

| AC | How it is satisfied |
|----|---------------------|
| AC1 — collect completed flip with free slot → new rec appears | `focusNextAvailableAction(true)` called on sell-collect and buy-collect-with-nothing-to-sell paths |
| AC2 — cancel unfilled buy → new rec appears | `focusNextAvailableAction(true)` called in the cancel path; cancelled item excluded via `excludeItemId` |
| AC3 — cancel partial buy → sell prompt, not a new buy rec | `GrandExchangeTracker` keeps partial-buy cancel as a collectable offer; collect EMPTY routes through collect→sell at higher priority than the rewind |
| AC4 — immediacy | All paths are event-driven (GE offer callback), not poll-driven |
| AC5 — lock-during-setup recovers | `currentIndex` is mutated by the rewind; when the offer-screen lock expires and re-runs the focus callback it picks up the rewound index |
| AC6 — sell cancel with unsold items → re-sell | `GrandExchangeTracker` keeps sell cancel with remaining quantity as a collectable offer; collect routes to re-sell |

## Testing

### Automated

- `./gradlew clean test` — BUILD SUCCESSFUL (6 tasks executed)
- `./gradlew build` — BUILD SUCCESSFUL
- `AutoRecommendFreeSlotBuyTest` covers `firstAvailableBuyIndex` exhaustively:

| Test | What it covers |
|------|----------------|
| `findsLowestAvailableIndex` | Scan returns index 0 even when `currentIndex` would have been past the end |
| `skipsItemsAlreadyOnTheGe` | Items already live on the GE are excluded |
| `skipsBelowMinProfit` | Items below the configured min-profit threshold are excluded |
| `excludesSpecifiedItemId` | The just-cancelled item is skipped so it is not immediately re-recommended |
| `returnsMinusOneWhenNothingAvailable` | All items active on GE → -1, caller falls through to `promptCollection` |
| `returnsMinusOneForEmptyQueue` | Empty queue → -1, no crash |

### Manual verification

- [x] Collect a completed flip (buy + sell) with an open slot — new recommendation appears without waiting for the 2-min refresh
- [x] Cancel an unfilled buy — new recommendation appears immediately, and the cancelled item is NOT the one surfaced
- [x] Cancel a partially-filled buy (e.g. 7666/11000 bought) — Collect prompt appears; after collecting, a Sell prompt appears for the bought quantity
- [x] Cancel a sell with items remaining (e.g. 0/7666 sold) — Collect prompt appears; after collecting, a re-Sell prompt appears for the remaining quantity
- [x] Open setup screen for a recommendation, then collect/cancel another offer in the background — after closing the setup screen, a new recommendation appears (lock-recovery case)

## Known follow-up

A cancelled sell's collect step currently shows the generic "Collect profit from GE" wording rather than an item-specific label. Cosmetic only; does not affect routing.

---

### 🩺 Codacy Quality Gate — fixed in this PR
- `0262b76` `Lizard_ccn-medium` adjacent fix: `AutoRecommendService.java:732` — when `firstAvailableBuyIndex` returns -1, set `currentIndex = recommendationQueue.size()` so the subsequent bounds check falls to `promptCollection` instead of calling `focusCurrent` on a just-determined-invalid item.

### 🩺 Codacy Quality Gate — dismissed via API (noise)
- `Lizard_ccn-medium` `src/main/java/com/flipsmart/AutoRecommendService.java:693` — cyclomatic complexity 9 on `focusNextAvailableAction(boolean, int)`; load-bearing state-machine branching (collect > sell > stale > buy > wait priority chain). Dismissed via Codacy v3 API; empty commit at `4c61d5c` retriggered analysis.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `0262b76` `AutoRecommendService.java:732` — `currentIndex` not set to queue end when `firstAvailableBuyIndex` returns -1; could call `focusCurrent` on an invalid item.

### 🤖 Codacy AI Reviewer — deferred (in-thread rationale)
- `AutoRecommendService.java:685` — suggestion to extract GE slot/buy logic into a helper; state-machine coordinator branches are intentionally load-bearing. Deferred for future refactor if method grows further.
- `AutoRecommendService.java:685` — `rewindToFirstAvailableBuy` not preserved in `onOverlayStepChanged` drain; rewind is intentionally scoped to slot-freeing events only. `onOverlayStepChanged` fires on UI-step transitions (different trigger); widening it would risk double-surfacing. Deferred pending AC5 in-game test results.

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `AutoRecommendFreeSlotBuyTest.java:109` — test duplication suggestion; each case is a distinct scenario with different input sets; factory methods and shared constants already cover the boilerplate.