### PR TITLE
fix(overlay): suppress collect-profit prompt during GE offer setup

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -35,6 +35,7 @@ public class AutoRecommendService
 	static final long MAX_PERSISTED_AGE_MS = 30 * 60 * 1000L;
 	private static final String MSG_WAITING_FOR_FLIPS = "Waiting for flips";
 	private static final String MSG_SELL_FORMAT = "Auto: Sell %s @ %s";
+	private static final String MSG_BUY_FORMAT = "Auto: Buy %s @ %s";
 
 
 	private final FlipSmartConfig config;
@@ -461,6 +462,40 @@ public class AutoRecommendService
 		updateStatus(String.format(MSG_SELL_FORMAT, itemName, GpUtils.formatGPWithSuffix(sellPrice)));
 
 		log.debug("Auto-recommend: Override focus for sell {} x{} @ {} gp", itemName, collectedQty, sellPrice);
+		return true;
+	}
+
+	/**
+	 * Override the auto-recommend focus to show a buy overlay for the item whose offer
+	 * setup screen is open, when it is a current queue recommendation. Lets the buy the
+	 * player is setting up take priority over a pending collect/history prompt while the
+	 * offer screen is up. Temporary — focus returns to the queue when the setup screen
+	 * closes (lock release via refreshFocusAfterUnlock) or the buy is placed.
+	 *
+	 * @return true if a buy overlay was focused, false if the item is not a surfaceable
+	 *         queued recommendation (caller leaves the overlay as-is).
+	 */
+	public synchronized boolean overrideFocusForBuy(int itemId)
+	{
+		if (!active)
+		{
+			return false;
+		}
+		// Already live on the GE — the player is past the buy stage for this item.
+		if (plugin.getActiveFlipItemIds().contains(itemId))
+		{
+			return false;
+		}
+		FlipRecommendation rec = findRecommendationForItem(itemId);
+		if (rec == null)
+		{
+			return false;
+		}
+		focusBuyOverlay(itemId, rec.getItemName(),
+			rec.getRecommendedBuyPrice(), rec.getRecommendedQuantity(), rec.getRecommendedSellPrice(),
+			String.format(MSG_BUY_FORMAT, rec.getItemName(),
+				GpUtils.formatGPWithSuffix(rec.getRecommendedBuyPrice())));
+		log.debug("Auto-recommend: Override focus for buy {} @ {} gp", rec.getItemName(), rec.getRecommendedBuyPrice());
 		return true;
 	}
 

--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -261,20 +261,18 @@ public class FlipAssistOverlay extends Overlay
 			{
 				return null;
 			}
-			// History-backfill prompt takes priority over auto-recommend status
-			// messages ("Monitoring active offers", "Collect profit from GE", etc.).
-			// Offline trade recovery is one-shot per session — once the user
-			// closes the History tab the data is gone — so the prompt has to
-			// surface even when the auto-recommend overlay is otherwise active.
-			//
-			// Everything below history is suppressed while the player is mid
-			// offer-setup so prompts never overlay the buy/sell screen.
+			// While the player is in any buy/sell offer interface (item search,
+			// numeric qty/price input, or the offer-setup screen) the offer takes
+			// priority — every status/hint prompt, including the History-backfill
+			// prompt, is suppressed so nothing overlays the buy/sell screens. The
+			// prompts re-surface at the main GE view. Off the offer interface, the
+			// History prompt still takes priority over the auto-recommend status.
 			String fallbackMessage = flipSmartPlugin.isAutoRecommendActive()
 				? flipSmartPlugin.getAutoRecommendOverlayMessage()
 				: null;
 			String message = selectNoFocusMessage(
 				isGrandExchangeOpen() && geHistoryService.hasUnverifiedOfflineFills(),
-				isOfferSetupOpen(),
+				isInOfferInterface(),
 				autoStatusMessage,
 				fallbackMessage,
 				flipSmartPlugin.getApiClient().isAuthenticated(),
@@ -894,16 +892,33 @@ public class FlipAssistOverlay extends Overlay
 	}
 
 	/**
+	 * True while the player is in any GE buy/sell offer interface: the item-search
+	 * screen, the numeric quantity/price input, or the offer-setup screen. While one
+	 * is open the offer takes priority and transient status prompts are hidden.
+	 */
+	private boolean isInOfferInterface()
+	{
+		if (!isGrandExchangeOpen())
+		{
+			return false;
+		}
+		int inputType = getInputType();
+		return inputType == INPUT_TYPE_GE_SEARCH
+			|| inputType == INPUT_TYPE_NUMERIC
+			|| isOfferSetupOpen();
+	}
+
+	/**
 	 * Pick the hint/status message to draw when no flip is focused, or null to draw
-	 * nothing. The history-backfill prompt is one-shot per session and surfaces even
-	 * over an open offer-setup screen; every other auto-status/hint box is suppressed
-	 * while the player is mid offer-setup so prompts like "Collect profit" never
-	 * overlay the buy/sell screen or compete with the auto-list hotkey. The
-	 * suppressed message is not cleared — it re-surfaces as soon as setup closes.
+	 * nothing. While any buy/sell offer interface is open the offer takes priority and
+	 * ALL prompts — including the one-shot history-backfill prompt — are suppressed so
+	 * nothing overlays the buy/sell screens; the prompts re-surface at the main GE view
+	 * (none of them are cleared). Off the offer interface the history prompt takes
+	 * priority over the auto-recommend status, then login, then the generic hint.
 	 */
 	static String selectNoFocusMessage(
 		boolean showHistoryPrompt,
-		boolean offerSetupOpen,
+		boolean offerInterfaceOpen,
 		String autoStatusMessage,
 		String autoRecommendFallback,
 		boolean authenticated,
@@ -911,13 +926,13 @@ public class FlipAssistOverlay extends Overlay
 		String loginMessage,
 		String hintMessage)
 	{
+		if (offerInterfaceOpen)
+		{
+			return null;
+		}
 		if (showHistoryPrompt)
 		{
 			return historyMessage;
-		}
-		if (offerSetupOpen)
-		{
-			return null;
 		}
 		if (autoStatusMessage != null)
 		{

--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -266,29 +266,26 @@ public class FlipAssistOverlay extends Overlay
 			// Offline trade recovery is one-shot per session — once the user
 			// closes the History tab the data is gone — so the prompt has to
 			// surface even when the auto-recommend overlay is otherwise active.
-			if (isGrandExchangeOpen() && geHistoryService.hasUnverifiedOfflineFills())
+			//
+			// Everything below history is suppressed while the player is mid
+			// offer-setup so prompts never overlay the buy/sell screen.
+			String fallbackMessage = flipSmartPlugin.isAutoRecommendActive()
+				? flipSmartPlugin.getAutoRecommendOverlayMessage()
+				: null;
+			String message = selectNoFocusMessage(
+				isGrandExchangeOpen() && geHistoryService.hasUnverifiedOfflineFills(),
+				isOfferSetupOpen(),
+				autoStatusMessage,
+				fallbackMessage,
+				flipSmartPlugin.getApiClient().isAuthenticated(),
+				HISTORY_PROMPT_MESSAGE,
+				LOGIN_MESSAGE,
+				HINT_MESSAGE);
+			if (message == null)
 			{
-				return renderHintBox(graphics, HISTORY_PROMPT_MESSAGE);
+				return null;
 			}
-			if (autoStatusMessage != null)
-			{
-				return renderHintBox(graphics, autoStatusMessage);
-			}
-			// Fallback: read the last overlay message directly from auto-recommend
-			// in case the async callback result was lost due to race conditions
-			if (flipSmartPlugin.isAutoRecommendActive())
-			{
-				String fallbackMessage = flipSmartPlugin.getAutoRecommendOverlayMessage();
-				if (fallbackMessage != null)
-				{
-					return renderHintBox(graphics, fallbackMessage);
-				}
-			}
-			if (!flipSmartPlugin.getApiClient().isAuthenticated())
-			{
-				return renderHintBox(graphics, LOGIN_MESSAGE);
-			}
-			return renderHintBox(graphics, HINT_MESSAGE);
+			return renderHintBox(graphics, message);
 		}
 		
 		// Only show when GE is open or when we have an active flip
@@ -894,6 +891,47 @@ public class FlipAssistOverlay extends Overlay
 			}
 		}
 		return hasQuantityLabel && hasPriceCoins;
+	}
+
+	/**
+	 * Pick the hint/status message to draw when no flip is focused, or null to draw
+	 * nothing. The history-backfill prompt is one-shot per session and surfaces even
+	 * over an open offer-setup screen; every other auto-status/hint box is suppressed
+	 * while the player is mid offer-setup so prompts like "Collect profit" never
+	 * overlay the buy/sell screen or compete with the auto-list hotkey. The
+	 * suppressed message is not cleared — it re-surfaces as soon as setup closes.
+	 */
+	static String selectNoFocusMessage(
+		boolean showHistoryPrompt,
+		boolean offerSetupOpen,
+		String autoStatusMessage,
+		String autoRecommendFallback,
+		boolean authenticated,
+		String historyMessage,
+		String loginMessage,
+		String hintMessage)
+	{
+		if (showHistoryPrompt)
+		{
+			return historyMessage;
+		}
+		if (offerSetupOpen)
+		{
+			return null;
+		}
+		if (autoStatusMessage != null)
+		{
+			return autoStatusMessage;
+		}
+		if (autoRecommendFallback != null)
+		{
+			return autoRecommendFallback;
+		}
+		if (!authenticated)
+		{
+			return loginMessage;
+		}
+		return hintMessage;
 	}
 	
 	private Widget[] getOfferPanelChildren()

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1311,9 +1311,18 @@ public class FlipSmartPlugin extends Plugin
 			autoRecommendService.acquireOfferLock(openItemId);
 		}
 
+		// GE_NEWOFFER_TYPE == 1 is a sell; anything else is a buy.
 		int offerType = client.getVarbitValue(VarbitID.GE_NEWOFFER_TYPE);
 		if (offerType != 1)
 		{
+			// Buy setup: focus the queued buy recommendation for this item (if any) so
+			// the overlay guides the buy the player is setting up, taking priority over
+			// a pending collect/history prompt. Focus returns to the queue on lock
+			// release once the setup screen closes.
+			if (openItemId > 0 && autoRecommendService != null)
+			{
+				autoRecommendService.overrideFocusForBuy(openItemId);
+			}
 			return;
 		}
 

--- a/src/test/java/com/flipsmart/FlipAssistNoFocusMessageTest.java
+++ b/src/test/java/com/flipsmart/FlipAssistNoFocusMessageTest.java
@@ -16,6 +16,7 @@ public class FlipAssistNoFocusMessageTest
 	private static final String HIST = "history";
 	private static final String LOGIN = "login";
 	private static final String HINT = "hint";
+	private static final String COLLECT = "Collect profit from GE";
 
 	private static String select(boolean showHistory, boolean offerSetupOpen,
 		String autoStatus, String fallback, boolean authenticated)
@@ -28,7 +29,7 @@ public class FlipAssistNoFocusMessageTest
 	@Test
 	public void suppressesAutoStatusDuringOfferSetup()
 	{
-		assertNull(select(false, true, "Collect profit from GE", null, true));
+		assertNull(select(false, true, COLLECT, null, true));
 	}
 
 	// Suppression also hides the auto-recommend fallback message during setup.
@@ -42,21 +43,21 @@ public class FlipAssistNoFocusMessageTest
 	@Test
 	public void showsAutoStatusWhenNotInSetup()
 	{
-		assertEquals("Collect profit from GE", select(false, false, "Collect profit from GE", null, true));
+		assertEquals(COLLECT, select(false, false, COLLECT, null, true));
 	}
 
 	// History-backfill recovery is one-shot per session — it still surfaces during setup.
 	@Test
 	public void historyPromptSurfacesEvenDuringOfferSetup()
 	{
-		assertEquals(HIST, select(true, true, "Collect profit from GE", null, true));
+		assertEquals(HIST, select(true, true, COLLECT, null, true));
 	}
 
 	// History takes precedence over auto-status when both are present.
 	@Test
 	public void historyTakesPrecedenceOverAutoStatus()
 	{
-		assertEquals(HIST, select(true, false, "Collect profit from GE", null, true));
+		assertEquals(HIST, select(true, false, COLLECT, null, true));
 	}
 
 	// Falls back to the auto-recommend fallback message when no autoStatus.

--- a/src/test/java/com/flipsmart/FlipAssistNoFocusMessageTest.java
+++ b/src/test/java/com/flipsmart/FlipAssistNoFocusMessageTest.java
@@ -1,0 +1,82 @@
+package com.flipsmart;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Covers {@link FlipAssistOverlay#selectNoFocusMessage} — which hint/status box (if any)
+ * the overlay draws when no flip is focused. Issue #726: the "Collect profit" prompt
+ * (and friends) must NOT overlay the GE buy/sell offer-setup screen, but must re-surface
+ * once setup closes, and the history-backfill prompt stays the one high-priority exception.
+ */
+public class FlipAssistNoFocusMessageTest
+{
+	private static final String HIST = "history";
+	private static final String LOGIN = "login";
+	private static final String HINT = "hint";
+
+	private static String select(boolean showHistory, boolean offerSetupOpen,
+		String autoStatus, String fallback, boolean authenticated)
+	{
+		return FlipAssistOverlay.selectNoFocusMessage(
+			showHistory, offerSetupOpen, autoStatus, fallback, authenticated, HIST, LOGIN, HINT);
+	}
+
+	// AC1/AC2 — collect-profit (autoStatus) is suppressed while in the offer-setup screen.
+	@Test
+	public void suppressesAutoStatusDuringOfferSetup()
+	{
+		assertNull(select(false, true, "Collect profit from GE", null, true));
+	}
+
+	// Suppression also hides the auto-recommend fallback message during setup.
+	@Test
+	public void suppressesFallbackDuringOfferSetup()
+	{
+		assertNull(select(false, true, null, "Monitoring active offers", true));
+	}
+
+	// AC4/AC5 — when NOT in setup, the collect-profit prompt shows normally.
+	@Test
+	public void showsAutoStatusWhenNotInSetup()
+	{
+		assertEquals("Collect profit from GE", select(false, false, "Collect profit from GE", null, true));
+	}
+
+	// History-backfill recovery is one-shot per session — it still surfaces during setup.
+	@Test
+	public void historyPromptSurfacesEvenDuringOfferSetup()
+	{
+		assertEquals(HIST, select(true, true, "Collect profit from GE", null, true));
+	}
+
+	// History takes precedence over auto-status when both are present.
+	@Test
+	public void historyTakesPrecedenceOverAutoStatus()
+	{
+		assertEquals(HIST, select(true, false, "Collect profit from GE", null, true));
+	}
+
+	// Falls back to the auto-recommend fallback message when no autoStatus.
+	@Test
+	public void usesFallbackWhenNoAutoStatus()
+	{
+		assertEquals("fallback msg", select(false, false, null, "fallback msg", true));
+	}
+
+	// Login prompt when unauthenticated and nothing else to show.
+	@Test
+	public void showsLoginWhenUnauthenticatedAndNoMessages()
+	{
+		assertEquals(LOGIN, select(false, false, null, null, false));
+	}
+
+	// Generic hint when authenticated and nothing else to show.
+	@Test
+	public void showsHintWhenAuthenticatedAndNothingElse()
+	{
+		assertEquals(HINT, select(false, false, null, null, true));
+	}
+}

--- a/src/test/java/com/flipsmart/FlipAssistNoFocusMessageTest.java
+++ b/src/test/java/com/flipsmart/FlipAssistNoFocusMessageTest.java
@@ -18,39 +18,40 @@ public class FlipAssistNoFocusMessageTest
 	private static final String HINT = "hint";
 	private static final String COLLECT = "Collect profit from GE";
 
-	private static String select(boolean showHistory, boolean offerSetupOpen,
+	private static String select(boolean showHistory, boolean offerInterfaceOpen,
 		String autoStatus, String fallback, boolean authenticated)
 	{
 		return FlipAssistOverlay.selectNoFocusMessage(
-			showHistory, offerSetupOpen, autoStatus, fallback, authenticated, HIST, LOGIN, HINT);
+			showHistory, offerInterfaceOpen, autoStatus, fallback, authenticated, HIST, LOGIN, HINT);
 	}
 
-	// AC1/AC2 — collect-profit (autoStatus) is suppressed while in the offer-setup screen.
+	// Collect-profit (autoStatus) is suppressed while in any offer interface.
 	@Test
-	public void suppressesAutoStatusDuringOfferSetup()
+	public void suppressesAutoStatusDuringOfferInterface()
 	{
 		assertNull(select(false, true, COLLECT, null, true));
 	}
 
-	// Suppression also hides the auto-recommend fallback message during setup.
+	// Suppression also hides the auto-recommend fallback message during an offer interface.
 	@Test
-	public void suppressesFallbackDuringOfferSetup()
+	public void suppressesFallbackDuringOfferInterface()
 	{
 		assertNull(select(false, true, null, "Monitoring active offers", true));
 	}
 
-	// AC4/AC5 — when NOT in setup, the collect-profit prompt shows normally.
+	// When NOT in an offer interface, the collect-profit prompt shows normally.
 	@Test
-	public void showsAutoStatusWhenNotInSetup()
+	public void showsAutoStatusWhenNotInOfferInterface()
 	{
 		assertEquals(COLLECT, select(false, false, COLLECT, null, true));
 	}
 
-	// History-backfill recovery is one-shot per session — it still surfaces during setup.
+	// The offer interface now takes priority over EVERYTHING — even the one-shot
+	// history-backfill prompt is suppressed while a buy/sell screen is up.
 	@Test
-	public void historyPromptSurfacesEvenDuringOfferSetup()
+	public void suppressesHistoryDuringOfferInterface()
 	{
-		assertEquals(HIST, select(true, true, COLLECT, null, true));
+		assertNull(select(true, true, COLLECT, null, true));
 	}
 
 	// History takes precedence over auto-status when both are present.


### PR DESCRIPTION
## Summary

This PR fixes a class of overlay interruptions where FlipSmart prompts (collect-profit, history backfill, auto-recommend fallback) appeared over the GE offer interface screens. It also wires up auto-focus for buy-side setups so the overlay shows the correct buy guidance while a queued buy is being entered, matching the existing sell-side behavior.

Implements Flip-Smart/flip-smart#726.

## What changed

- **Collect-profit prompt no longer interrupts the GE offer screens.** The Flip Assist overlay used to draw its auto-status hint box (e.g. "Collect profit from GE") unconditionally, including over whatever was on screen when no flip was focused. The no-focus message selection was extracted into a pure static helper `selectNoFocusMessage(...)` so the logic is independently testable.

- **Suppression now covers the whole offer flow, including the History prompt.** Detection was broadened from just the offer-setup screen to the full offer interface — item search (`INPUT_TYPE_GE_SEARCH`), numeric qty/price input (`INPUT_TYPE_NUMERIC`), and the setup screen itself — via a new `isInOfferInterface()`. While any offer interface is open, all transient prompts are suppressed, including the one-shot "Open GE History to Backfill" prompt. They re-surface at the main GE view. Outside the offer interface the prior precedence order (history → status → fallback → login → hint) is unchanged.

- **Buy offer setup now focuses the item being bought.** The plugin already auto-focused sells on setup-build via `autoFocusOnActiveFlip`; a symmetric `overrideFocusForBuy(itemId)` method was added and wired into the setup-build handler on the buy path. When the player sets up a buy for a queued recommendation, the overlay shows that item's buy guidance ("Auto: Buy \<item\> @ \<price\>") instead of a blank box or a stale collect-profit prompt. Focus returns to the auto queue when the order is placed (`onBuyOrderPlaced → advanceToNext`) or when the setup screen closes (lock release). A side benefit: the auto-list hotkey now works for these buys — previously `focusedFlip` was null during collect-profit so it no-op'd.

## Behavior

While any offer interface screen is open (search, qty/price input, or setup), the overlay takes no action on transient prompts — collect-profit and the history backfill prompt both clear until the player returns to the main GE view. Once the offer interface closes, the normal precedence resumes and the pending prompt re-surfaces. On a buy setup for a queued item, the overlay actively shows buy guidance for that item for the duration of the setup.

## Testing

### Automated tests

- `FlipAssistNoFocusMessageTest` — 8 cases covering `selectNoFocusMessage`: suppression of collect-profit and fallback during the offer interface, re-surface outside the offer interface, suppression of the history prompt during the offer interface, history/auto-status/fallback/login/hint precedence ordering.
- `AutoRecommendFreeSlotBuyTest` — covers the buy-focus and post-order advance-to-next paths.
- Full suite: `./gradlew clean test build` — BUILD SUCCESSFUL.

### Manual verification

- [ ] With collect-profit pending and the history backfill prompt pending, open a buy offer search screen — neither prompt appears; the offer interface is unobstructed.
- [ ] Step through qty and price entry — no FlipSmart overlay interruption throughout.
- [ ] Reach the offer-setup screen — still no collect-profit or history prompt.
- [ ] Close or submit the offer — prompts re-surface on the main GE view.
- [ ] With a queued buy recommendation, open its buy offer: the overlay shows the buy guidance ("Auto: Buy \<item\> @ \<price\>") for that item.
- [ ] Place the buy order — overlay reverts to the next queued item (or collect-profit if queue is empty).

## Files changed

- `src/main/java/com/flipsmart/FlipAssistOverlay.java` — extracted `selectNoFocusMessage`, added `isInOfferInterface()`, wired offer-interface suppression
- `src/main/java/com/flipsmart/AutoRecommendService.java` — added `overrideFocusForBuy(itemId)`
- `src/main/java/com/flipsmart/FlipSmartPlugin.java` — wired `overrideFocusForBuy` into buy setup-build handler; `onBuyOrderPlaced → advanceToNext`
- `src/main/java/com/flipsmart/GrandExchangeTracker.java` — `onBuyOrderPlaced` hook
- `src/test/java/com/flipsmart/FlipAssistNoFocusMessageTest.java` — new (8 cases)
- `src/test/java/com/flipsmart/AutoRecommendFreeSlotBuyTest.java` — new (buy-focus paths)

---

### 🩺 Codacy Quality Gate — fixed in this PR
- `933fda9` PMD_AvoidDuplicateLiterals FlipAssistNoFocusMessageTest.java:31 — extracted repeated "Collect profit from GE" literal into COLLECT constant

### 🩺 Codacy Quality Gate
Gate: PASS (gate_ok=true, new=0 at head 4ac0cec)

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- FlipAssistNoFocusMessageTest.java:31 — `COLLECT` constant was already extracted in 933fda9; Codacy comment anchored to old diff snapshot
- FlipAssistOverlay.java:281 — short-circuit `!showHistory && isOfferSetupOpen()` suggestion would bypass the offer-interface suppression when history condition is also true, changing intentional semantics

### 🤖 Codacy AI Reviewer — deferred (in-thread rationale)
- FlipAssistOverlay.java:277 — lazy-eval of `isOfferSetupOpen()` micro-optimisation; widget scan only runs when GE is open, overhead negligible
- FlipAssistOverlay.java:919 (x2) — Parameter Object refactor for `selectNoFocusMessage`; architectural change out of scope for this targeted bug-fix