### PR TITLE
feat(active-advisor): Active-mode stale-offer manager (consumer of /flip-finder/active/offer-action)

### DIFF
--- a/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
+++ b/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
@@ -29,6 +29,7 @@ public class ActiveOfferAdvisorService
 		switch (disposition)
 		{
 			case SURFACE_PRICE:
+				resp.setItemIdHint(itemId);
 				dispositions.put(itemId, resp);
 				if (onSurfacePrice != null)
 				{

--- a/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
+++ b/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
@@ -9,9 +9,9 @@ public class ActiveOfferAdvisorService
 {
 	private final Map<Integer, OfferAdviceResponse> dispositions = new ConcurrentHashMap<>();
 
-	private Consumer<OfferAdviceResponse> onSurfacePrice;
-	private IntConsumer onHandoff;
-	private IntConsumer onClearSurface;
+	private volatile Consumer<OfferAdviceResponse> onSurfacePrice;
+	private volatile IntConsumer onHandoff;
+	private volatile IntConsumer onClearSurface;
 
 	void setCallbacks(Consumer<OfferAdviceResponse> onSurfacePrice, IntConsumer onHandoff, IntConsumer onClearSurface)
 	{

--- a/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
+++ b/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
@@ -25,6 +25,22 @@ public class ActiveOfferAdvisorService
 		return dispositions.get(itemId);
 	}
 
+	/**
+	 * Drop dispositions for items that are no longer open active offers (sold, bought,
+	 * collected, cancelled) so their prompt/highlight clears immediately instead of
+	 * lingering until the next poll skips them.
+	 */
+	void reconcile(java.util.Set<Integer> activeItemIds)
+	{
+		for (Integer itemId : dispositions.keySet())
+		{
+			if (!activeItemIds.contains(itemId))
+			{
+				applyResponse(itemId, null);
+			}
+		}
+	}
+
 	void applyResponse(int itemId, OfferAdviceResponse resp)
 	{
 		OfferDisposition disposition = OfferDisposition.route(resp == null ? null : resp.getActionEnum());

--- a/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
+++ b/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
@@ -1,0 +1,28 @@
+package com.flipsmart;
+
+public class ActiveOfferAdvisorService
+{
+	static OfferAdviceRequest buildSnapshot(
+		TrackedOffer offer,
+		FlipSmartApiClient.WikiPrice market,
+		Integer userAvgBuyPrice,
+		Integer dailyVolume)
+	{
+		boolean isSell = !offer.isBuy();
+		long lastFill = offer.getLastActivityAtMillis();
+		return OfferAdviceRequest.builder()
+			.itemId(offer.getItemId())
+			.pool(OfferPoolClassifier.classify(dailyVolume))
+			.side(isSell ? "sell" : "buy")
+			.stage(offer.getOfferStage())
+			.listedAtMillis(offer.getCreatedAtMillis())
+			.listedPrice(offer.getPrice())
+			.listedQuantity(offer.getTotalQuantity())
+			.filledQuantity(offer.getPreviousQuantitySold())
+			.lastFillAtMillis(lastFill > 0 ? lastFill : null)
+			.currentMarketHigh(market == null ? null : market.instaBuy)
+			.currentMarketLow(market == null ? null : market.instaSell)
+			.userAvgBuyPrice(isSell ? userAvgBuyPrice : null)
+			.build();
+	}
+}

--- a/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
+++ b/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
@@ -11,11 +11,13 @@ public class ActiveOfferAdvisorService
 
 	private Consumer<OfferAdviceResponse> onSurfacePrice;
 	private IntConsumer onHandoff;
+	private IntConsumer onClearSurface;
 
-	void setCallbacks(Consumer<OfferAdviceResponse> onSurfacePrice, IntConsumer onHandoff)
+	void setCallbacks(Consumer<OfferAdviceResponse> onSurfacePrice, IntConsumer onHandoff, IntConsumer onClearSurface)
 	{
 		this.onSurfacePrice = onSurfacePrice;
 		this.onHandoff = onHandoff;
+		this.onClearSurface = onClearSurface;
 	}
 
 	public OfferAdviceResponse getDisposition(int itemId)
@@ -38,6 +40,10 @@ public class ActiveOfferAdvisorService
 				break;
 			case HANDOFF:
 				dispositions.remove(itemId);
+				if (onClearSurface != null)
+				{
+					onClearSurface.accept(itemId);
+				}
 				if (onHandoff != null)
 				{
 					onHandoff.accept(itemId);
@@ -46,6 +52,10 @@ public class ActiveOfferAdvisorService
 			case NONE:
 			default:
 				dispositions.remove(itemId);
+				if (onClearSurface != null)
+				{
+					onClearSurface.accept(itemId);
+				}
 				break;
 		}
 	}

--- a/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
+++ b/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
@@ -1,7 +1,54 @@
 package com.flipsmart;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
+
 public class ActiveOfferAdvisorService
 {
+	private final Map<Integer, OfferAdviceResponse> dispositions = new ConcurrentHashMap<>();
+
+	private Consumer<OfferAdviceResponse> onSurfacePrice;
+	private IntConsumer onHandoff;
+
+	void setCallbacks(Consumer<OfferAdviceResponse> onSurfacePrice, IntConsumer onHandoff)
+	{
+		this.onSurfacePrice = onSurfacePrice;
+		this.onHandoff = onHandoff;
+	}
+
+	public OfferAdviceResponse getDisposition(int itemId)
+	{
+		return dispositions.get(itemId);
+	}
+
+	void applyResponse(int itemId, OfferAdviceResponse resp)
+	{
+		OfferDisposition disposition = OfferDisposition.route(resp == null ? null : resp.getActionEnum());
+		switch (disposition)
+		{
+			case SURFACE_PRICE:
+				dispositions.put(itemId, resp);
+				if (onSurfacePrice != null)
+				{
+					onSurfacePrice.accept(resp);
+				}
+				break;
+			case HANDOFF:
+				dispositions.remove(itemId);
+				if (onHandoff != null)
+				{
+					onHandoff.accept(itemId);
+				}
+				break;
+			case NONE:
+			default:
+				dispositions.remove(itemId);
+				break;
+		}
+	}
+
 	static OfferAdviceRequest buildSnapshot(
 		TrackedOffer offer,
 		FlipSmartApiClient.WikiPrice market,

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -11,6 +11,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
 import java.util.function.ObjIntConsumer;
@@ -51,11 +53,11 @@ public class AutoRecommendService
 
 	// Items that have already been flagged as stale/uncompetitive — prevents repeated prompts
 	// Cleared when the offer is cancelled, filled, or a new offer is placed for the item
-	private final Set<Integer> promptedStaleItems = new HashSet<>();
+	private final Set<Integer> promptedStaleItems = ConcurrentHashMap.newKeySet();
 
 	// Stale offer queue — guides user through stale offers one at a time
-	private final List<TrackedOffer> staleOfferQueue = new ArrayList<>();
-	private final Map<Integer, Integer> staleResellPrices = new HashMap<>();
+	private final List<TrackedOffer> staleOfferQueue = new CopyOnWriteArrayList<>();
+	private final Map<Integer, Integer> staleResellPrices = new ConcurrentHashMap<>();
 	private final List<Runnable> deferredActions = new ArrayList<>();
 
 	// Queue state - guarded by synchronized(this)

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -1471,10 +1471,14 @@ public class AutoRecommendService
 		if (!next.isBuy() && resellPrice != null)
 		{
 			Integer net = staleResellNet.get(next.getItemId());
-			String netSuffix = net == null ? ""
-				: String.format(" (%s%,d)", net >= 0 ? "+" : "-", Math.abs(net));
+			String netLine = "";
+			if (net != null)
+			{
+				String keyword = net < 0 ? "Loss" : (net > 0 ? "Profit" : "Breakeven");
+				netLine = String.format("\n%s: %s%,d", keyword, net >= 0 ? "+" : "-", Math.abs(net));
+			}
 			overlayMsg = String.format("Re-sell %s at:\n%s gp%s", next.getItemName(),
-				String.format("%,d", resellPrice), netSuffix);
+				String.format("%,d", resellPrice), netLine);
 		}
 		else
 		{

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -58,6 +58,9 @@ public class AutoRecommendService
 	// Stale offer queue — guides user through stale offers one at a time
 	private final List<TrackedOffer> staleOfferQueue = new CopyOnWriteArrayList<>();
 	private final Map<Integer, Integer> staleResellPrices = new ConcurrentHashMap<>();
+	// Advisor-only: net profit/loss estimate to show alongside a re-sell prompt. Kept in
+	// sync with staleResellPrices at both put-sites, so it's never read with a stale price.
+	private final Map<Integer, Integer> staleResellNet = new ConcurrentHashMap<>();
 	private final List<Runnable> deferredActions = new ArrayList<>();
 
 	// Queue state - guarded by synchronized(this)
@@ -292,6 +295,7 @@ public class AutoRecommendService
 		promptedStaleItems.clear();
 		staleOfferQueue.clear();
 		staleResellPrices.clear();
+		staleResellNet.clear();
 		deferredActions.clear();
 		PlayerSession session = plugin.getSession();
 		if (session != null)
@@ -1466,8 +1470,11 @@ public class AutoRecommendService
 		String overlayMsg;
 		if (!next.isBuy() && resellPrice != null)
 		{
-			overlayMsg = String.format("Re-sell %s at:\n%s gp", next.getItemName(),
-				String.format("%,d", resellPrice));
+			Integer net = staleResellNet.get(next.getItemId());
+			String netSuffix = net == null ? ""
+				: String.format(" (%s%,d)", net >= 0 ? "+" : "-", Math.abs(net));
+			overlayMsg = String.format("Re-sell %s at:\n%s gp%s", next.getItemName(),
+				String.format("%,d", resellPrice), netSuffix);
 		}
 		else
 		{
@@ -1517,13 +1524,21 @@ public class AutoRecommendService
 	 * uses the advised price. Idempotent — addToStaleQueue dedupes by item, and the price
 	 * map is refreshed on each poll.
 	 */
-	public synchronized void surfaceAdvisorResell(TrackedOffer offer, int newPrice)
+	public synchronized void surfaceAdvisorResell(TrackedOffer offer, int newPrice, Integer netProfitEstimate)
 	{
 		if (offer == null)
 		{
 			return;
 		}
 		staleResellPrices.put(offer.getItemId(), newPrice);
+		if (netProfitEstimate != null)
+		{
+			staleResellNet.put(offer.getItemId(), netProfitEstimate);
+		}
+		else
+		{
+			staleResellNet.remove(offer.getItemId());
+		}
 		PlayerSession sess = plugin.getSession();
 		if (sess != null)
 		{
@@ -1758,6 +1773,7 @@ public class AutoRecommendService
 			// Unlike buy adjustments (where local wiki competitiveness is a useful gate),
 			// sell adjustments use backend market data which is authoritative.
 			staleResellPrices.put(offer.getItemId(), newPrice);
+			staleResellNet.remove(offer.getItemId());  // legacy adjustment has no advisor net estimate
 			addToStaleQueue(offer);
 
 			// Persist to session so relist auto-fill uses the adjusted price

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -1471,14 +1471,10 @@ public class AutoRecommendService
 		if (!next.isBuy() && resellPrice != null)
 		{
 			Integer net = staleResellNet.get(next.getItemId());
-			String netLine = "";
-			if (net != null)
-			{
-				String keyword = net < 0 ? "Loss" : (net > 0 ? "Profit" : "Breakeven");
-				netLine = String.format("\n%s: %s%,d", keyword, net >= 0 ? "+" : "-", Math.abs(net));
-			}
+			String netSuffix = net == null ? ""
+				: String.format(" (%s%s)", net >= 0 ? "+" : "-", GpUtils.formatGP(Math.abs(net)));
 			overlayMsg = String.format("Re-sell %s at:\n%s gp%s", next.getItemName(),
-				String.format("%,d", resellPrice), netLine);
+				String.format("%,d", resellPrice), netSuffix);
 		}
 		else
 		{

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -1496,6 +1496,42 @@ public class AutoRecommendService
 		}
 	}
 
+	/**
+	 * Surface an Active-mode advisor sell re-list recommendation through the stale-resell
+	 * prompt so the overlay shows "Re-sell &lt;item&gt; at: &lt;price&gt;" and the re-list auto-fill
+	 * uses the advised price. Idempotent — addToStaleQueue dedupes by item, and the price
+	 * map is refreshed on each poll.
+	 */
+	public synchronized void surfaceAdvisorResell(TrackedOffer offer, int newPrice)
+	{
+		if (offer == null)
+		{
+			return;
+		}
+		staleResellPrices.put(offer.getItemId(), newPrice);
+		PlayerSession sess = plugin.getSession();
+		if (sess != null)
+		{
+			sess.setRecommendedPrice(offer.getItemId(), newPrice);
+		}
+		addToStaleQueue(offer);
+	}
+
+	/**
+	 * Retract a previously-surfaced advisor sell prompt (the advisor changed its mind, e.g.
+	 * the market recovered and it now returns WAIT). Refreshes focus to whatever is next.
+	 */
+	public synchronized void removeAdvisorResell(int itemId)
+	{
+		boolean wasHead = !staleOfferQueue.isEmpty() && staleOfferQueue.get(0).getItemId() == itemId;
+		staleOfferQueue.removeIf(o -> o.getItemId() == itemId);
+		staleResellPrices.remove(itemId);
+		if (wasHead)
+		{
+			executeOrDefer(this::focusNextAvailableAction);
+		}
+	}
+
 	// =====================
 	// Sell Adjustment Timers
 	// =====================

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -2291,7 +2291,7 @@ public class AutoRecommendService
 		invokeFocusCallback(null);
 
 		List<TrackedOffer> completed = plugin.getSession().getCompletedOffers();
-		if (!completed.isEmpty())
+		if (!completed.isEmpty() && plugin.hasCollectableGEOffers())
 		{
 			TrackedOffer first = completed.get(0);
 			if (first.isBuy())

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -1474,7 +1474,7 @@ public class AutoRecommendService
 	 * Add a tracked offer to the stale queue if not already present.
 	 * If the queue was empty, immediately shows the first prompt.
 	 */
-	private void addToStaleQueue(TrackedOffer offer)
+	void addToStaleQueue(TrackedOffer offer)
 	{
 		// Don't add duplicates
 		for (TrackedOffer existing : staleOfferQueue)

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -1543,7 +1543,8 @@ public class AutoRecommendService
 		staleResellPrices.remove(itemId);
 		if (wasHead)
 		{
-			executeOrDefer(this::focusNextAvailableAction);
+			// Re-prompt the new head (re-highlights it) or clears highlights if the queue drained.
+			executeOrDefer(this::focusNextStaleOffer);
 		}
 	}
 

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -92,6 +92,10 @@ public class AutoRecommendService
 
 	private volatile java.util.function.IntConsumer onStaleOfferPrompted;
 
+	// Clears all GE slot adjustment highlights when the stale-offer queue drains,
+	// so a slot highlight never lingers without a matching prompt.
+	private volatile Runnable onClearAllHighlights;
+
 	// Provider for the panel's displayed (smart) sell price — preferred over session's stored price
 	private volatile IntFunction<Integer> displayedSellPriceProvider;
 
@@ -174,6 +178,11 @@ public class AutoRecommendService
 	public void setOnStaleOfferPrompted(java.util.function.IntConsumer callback)
 	{
 		this.onStaleOfferPrompted = callback;
+	}
+
+	public void setOnClearAllHighlights(Runnable callback)
+	{
+		this.onClearAllHighlights = callback;
 	}
 
 	public void setDisplayedSellPriceProvider(IntFunction<Integer> provider)
@@ -1443,7 +1452,11 @@ public class AutoRecommendService
 
 		if (staleOfferQueue.isEmpty())
 		{
-			// All stale offers handled — resume normal flow
+			// All stale offers handled — drop any lingering slot highlight, resume normal flow
+			if (onClearAllHighlights != null)
+			{
+				onClearAllHighlights.run();
+			}
 			focusNextAvailableAction();
 			return;
 		}

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -1140,10 +1140,20 @@ public class AutoRecommendService
 	 *
 	 * Called periodically from the auto-recommend refresh timer (2-minute interval).
 	 */
+	public static boolean shouldRunLegacyAdjustment(String timeframeApiValue, boolean activeAdvisorEnabled)
+	{
+		boolean isActive = "active".equals(timeframeApiValue);
+		return !(isActive && activeAdvisorEnabled);
+	}
+
 	public synchronized void checkAdjustmentTimers(
 		Map<Integer, TrackedOffer> trackedOffers,
 		List<FlipRecommendation> currentRecommendations)
 	{
+		if (!shouldRunLegacyAdjustment(config.flipTimeframe().getApiValue(), config.enableActiveOfferAdvisor()))
+		{
+			return;
+		}
 		if (!active || adjustmentDeadlines.isEmpty() || trackedOffers == null)
 		{
 			log.debug("Auto-recommend: checkAdjustmentTimers skipped (active={}, deadlines={}, offers={})",
@@ -1582,6 +1592,10 @@ public class AutoRecommendService
 	 */
 	public synchronized void checkSellAdjustmentTimers(Map<Integer, TrackedOffer> trackedOffers)
 	{
+		if (!shouldRunLegacyAdjustment(config.flipTimeframe().getApiValue(), config.enableActiveOfferAdvisor()))
+		{
+			return;
+		}
 		if (!active || sellAdjustmentStates.isEmpty() || trackedOffers == null)
 		{
 			return;

--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -34,7 +34,8 @@ import java.util.function.Consumer;
 @Slf4j
 public class FlipAssistOverlay extends Overlay
 {
-	private static final DecimalFormat PRICE_FORMAT = new DecimalFormat("#,###");
+	private static final ThreadLocal<DecimalFormat> PRICE_FORMAT =
+		ThreadLocal.withInitial(() -> new DecimalFormat("#,###"));
 	
 	// Color theme
 	private static final Color COLOR_BG_DARK = new Color(25, 22, 18, 200);
@@ -794,16 +795,16 @@ public class FlipAssistOverlay extends Overlay
 		int lineHeight = 12;
 
 		String priceLabel = flip.isBuying() ? "Buy at:" : "Sell at:";
-		drawLabelValue(graphics, priceLabel, PRICE_FORMAT.format(flip.getCurrentStepPrice()) + " gp",
+		drawLabelValue(graphics, priceLabel, PRICE_FORMAT.get().format(flip.getCurrentStepPrice()) + " gp",
 			y + lineHeight, flip.isBuying() ? COLOR_BUY : COLOR_SELL);
 
-		drawLabelValue(graphics, "Qty:", PRICE_FORMAT.format(flip.getCurrentStepQuantity()),
+		drawLabelValue(graphics, "Qty:", PRICE_FORMAT.get().format(flip.getCurrentStepQuantity()),
 			y + lineHeight * 2, COLOR_TEXT);
 
 		if (flip.isBuying() && flip.getSellPrice() > 0)
 		{
 			int totalProfit = calculateTotalProfit();
-			drawLabelValue(graphics, "Profit:", PRICE_FORMAT.format(totalProfit) + " gp",
+			drawLabelValue(graphics, "Profit:", PRICE_FORMAT.get().format(totalProfit) + " gp",
 				y + lineHeight * 3, totalProfit > 0 ? COLOR_PROFIT : new Color(255, 100, 100));
 		}
 	}
@@ -843,13 +844,13 @@ public class FlipAssistOverlay extends Overlay
 				int targetQty = flip.getCurrentStepQuantity();
 				// Just show the target quantity with hotkey
 				return String.format(currentStep.getDescription(), hotkeyName,
-					PRICE_FORMAT.format(targetQty));
+					PRICE_FORMAT.get().format(targetQty));
 			case SET_PRICE:
 			case SET_SELL_PRICE:
 				int targetPrice = flip.getCurrentStepPrice();
 				// Just show the target price with hotkey
 				return String.format(currentStep.getDescription(), hotkeyName,
-					PRICE_FORMAT.format(targetPrice));
+					PRICE_FORMAT.get().format(targetPrice));
 			default:
 				return currentStep.getDescription();
 		}

--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -169,13 +169,14 @@ public class FlipAssistOverlay extends Overlay
 	public void updateStep()
 	{
 		FlipAssistStep newStep;
-		if (focusedFlip == null)
+		final FocusedFlip flip = focusedFlip;
+		if (flip == null)
 		{
 			newStep = FlipAssistStep.SELECT_ITEM;
 		}
 		else if (!isGrandExchangeOpen())
 		{
-			newStep = focusedFlip.isBuying() ? FlipAssistStep.WAITING_BUY : FlipAssistStep.WAITING_SELL;
+			newStep = flip.isBuying() ? FlipAssistStep.WAITING_BUY : FlipAssistStep.WAITING_SELL;
 		}
 		else
 		{
@@ -195,9 +196,10 @@ public class FlipAssistOverlay extends Overlay
 	
 	private FlipAssistStep determineNumericInputStep()
 	{
-		if (isLikelyPriceInput())
+		final FocusedFlip flip = focusedFlip;
+		if (flip != null && isLikelyPriceInput())
 		{
-			return focusedFlip.isBuying() ? FlipAssistStep.SET_PRICE : FlipAssistStep.SET_SELL_PRICE;
+			return flip.isBuying() ? FlipAssistStep.SET_PRICE : FlipAssistStep.SET_SELL_PRICE;
 		}
 		return FlipAssistStep.SET_QUANTITY;
 	}
@@ -217,23 +219,33 @@ public class FlipAssistOverlay extends Overlay
 		{
 			return determineOfferSetupStep();
 		}
-		return focusedFlip.isBuying() ? FlipAssistStep.SELECT_ITEM : FlipAssistStep.SELL_ITEMS;
+		final FocusedFlip flip = focusedFlip;
+		if (flip == null)
+		{
+			return FlipAssistStep.SELECT_ITEM;
+		}
+		return flip.isBuying() ? FlipAssistStep.SELECT_ITEM : FlipAssistStep.SELL_ITEMS;
 	}
 
 	private FlipAssistStep determineOfferSetupStep()
 	{
-		boolean qtyCorrect = isValueWithinTolerance(getCurrentQuantityFromGE(), focusedFlip.getCurrentStepQuantity());
-		boolean priceCorrect = isValueWithinTolerance(getCurrentPriceFromGE(), focusedFlip.getCurrentStepPrice());
-		
+		final FocusedFlip flip = focusedFlip;
+		if (flip == null)
+		{
+			return FlipAssistStep.SELECT_ITEM;
+		}
+		boolean qtyCorrect = isValueWithinTolerance(getCurrentQuantityFromGE(), flip.getCurrentStepQuantity());
+		boolean priceCorrect = isValueWithinTolerance(getCurrentPriceFromGE(), flip.getCurrentStepPrice());
+
 		if (qtyCorrect && priceCorrect)
 		{
-			return focusedFlip.isBuying() ? FlipAssistStep.CONFIRM_OFFER : FlipAssistStep.CONFIRM_SELL;
+			return flip.isBuying() ? FlipAssistStep.CONFIRM_OFFER : FlipAssistStep.CONFIRM_SELL;
 		}
 		if (!qtyCorrect)
 		{
 			return FlipAssistStep.SET_QUANTITY;
 		}
-		return focusedFlip.isBuying() ? FlipAssistStep.SET_PRICE : FlipAssistStep.SET_SELL_PRICE;
+		return flip.isBuying() ? FlipAssistStep.SET_PRICE : FlipAssistStep.SET_SELL_PRICE;
 	}
 	
 	/**
@@ -603,23 +615,28 @@ public class FlipAssistOverlay extends Overlay
 	
 	private int renderHeader(Graphics2D graphics, int y)
 	{
+		final FocusedFlip flip = focusedFlip;
+		if (flip == null)
+		{
+			return y;
+		}
 		y += 4;
-		
-		AsyncBufferedImage itemImage = itemManager.getImage(focusedFlip.getItemId());
+
+		AsyncBufferedImage itemImage = itemManager.getImage(flip.getItemId());
 		if (itemImage != null)
 		{
 			graphics.drawImage(itemImage, SECTION_PADDING, y, ICON_SIZE, ICON_SIZE, null);
 		}
-		
+
 		graphics.setFont(FontManager.getRunescapeBoldFont());
 		graphics.setColor(COLOR_TEXT);
-		String itemName = truncateString(focusedFlip.getItemName(), PANEL_WIDTH - ICON_SIZE - SECTION_PADDING * 3, graphics.getFontMetrics());
+		String itemName = truncateString(flip.getItemName(), PANEL_WIDTH - ICON_SIZE - SECTION_PADDING * 3, graphics.getFontMetrics());
 		graphics.drawString(itemName, SECTION_PADDING + ICON_SIZE + 6, y + 10);
-		
+
 		graphics.setFont(FontManager.getRunescapeSmallFont());
-		graphics.setColor(focusedFlip.isBuying() ? COLOR_BUY : COLOR_SELL);
+		graphics.setColor(flip.isBuying() ? COLOR_BUY : COLOR_SELL);
 		String stepLabel;
-		if (focusedFlip.isBuying())
+		if (flip.isBuying())
 		{
 			stepLabel = "BUYING";
 		}
@@ -627,11 +644,11 @@ public class FlipAssistOverlay extends Overlay
 		{
 			// Show "MODIFY" if there's already an active sell order for this item
 			PlayerSession sess = flipSmartPlugin.getSession();
-			boolean hasActiveSell = sess != null && sess.hasActiveSellSlotForItem(focusedFlip.getItemId());
+			boolean hasActiveSell = sess != null && sess.hasActiveSellSlotForItem(flip.getItemId());
 			stepLabel = hasActiveSell ? "MODIFY" : "SELLING";
 		}
 		graphics.drawString(stepLabel, SECTION_PADDING + ICON_SIZE + 6, y + 24);
-		
+
 		return y + ICON_SIZE + 4;
 	}
 	
@@ -658,7 +675,12 @@ public class FlipAssistOverlay extends Overlay
 	
 	private FlipAssistStep[] getStepsForCurrentPhase()
 	{
-		if (focusedFlip.isBuying())
+		final FocusedFlip flip = focusedFlip;
+		if (flip == null)
+		{
+			return new FlipAssistStep[0];
+		}
+		if (flip.isBuying())
 		{
 			return new FlipAssistStep[]{
 				FlipAssistStep.SELECT_ITEM, FlipAssistStep.SET_QUANTITY,
@@ -754,17 +776,22 @@ public class FlipAssistOverlay extends Overlay
 	
 	private void renderFlipSummary(Graphics2D graphics, int y)
 	{
+		final FocusedFlip flip = focusedFlip;
+		if (flip == null)
+		{
+			return;
+		}
 		graphics.setFont(FontManager.getRunescapeSmallFont());
 		int lineHeight = 12;
-		
-		String priceLabel = focusedFlip.isBuying() ? "Buy at:" : "Sell at:";
-		drawLabelValue(graphics, priceLabel, PRICE_FORMAT.format(focusedFlip.getCurrentStepPrice()) + " gp",
-			y + lineHeight, focusedFlip.isBuying() ? COLOR_BUY : COLOR_SELL);
-		
-		drawLabelValue(graphics, "Qty:", PRICE_FORMAT.format(focusedFlip.getCurrentStepQuantity()),
+
+		String priceLabel = flip.isBuying() ? "Buy at:" : "Sell at:";
+		drawLabelValue(graphics, priceLabel, PRICE_FORMAT.format(flip.getCurrentStepPrice()) + " gp",
+			y + lineHeight, flip.isBuying() ? COLOR_BUY : COLOR_SELL);
+
+		drawLabelValue(graphics, "Qty:", PRICE_FORMAT.format(flip.getCurrentStepQuantity()),
 			y + lineHeight * 2, COLOR_TEXT);
-		
-		if (focusedFlip.isBuying() && focusedFlip.getSellPrice() > 0)
+
+		if (flip.isBuying() && flip.getSellPrice() > 0)
 		{
 			int totalProfit = calculateTotalProfit();
 			drawLabelValue(graphics, "Profit:", PRICE_FORMAT.format(totalProfit) + " gp",
@@ -782,25 +809,35 @@ public class FlipAssistOverlay extends Overlay
 	
 	private int calculateTotalProfit()
 	{
-		int margin = focusedFlip.getSellPrice() - focusedFlip.getBuyPrice();
-		int geTax = Math.min((int)(focusedFlip.getSellPrice() * 0.02), 5_000_000);
-		return (margin - geTax) * focusedFlip.getBuyQuantity();
+		final FocusedFlip flip = focusedFlip;
+		if (flip == null)
+		{
+			return 0;
+		}
+		int margin = flip.getSellPrice() - flip.getBuyPrice();
+		int geTax = Math.min((int)(flip.getSellPrice() * 0.02), 5_000_000);
+		return (margin - geTax) * flip.getBuyQuantity();
 	}
 	
 	private String formatStepDescription()
 	{
 		String hotkeyName = config.flipAssistHotkey().toString();
-		
+		final FocusedFlip flip = focusedFlip;
+		if (flip == null)
+		{
+			return currentStep.getDescription();
+		}
+
 		switch (currentStep)
 		{
 			case SET_QUANTITY:
-				int targetQty = focusedFlip.getCurrentStepQuantity();
+				int targetQty = flip.getCurrentStepQuantity();
 				// Just show the target quantity with hotkey
-				return String.format(currentStep.getDescription(), hotkeyName, 
+				return String.format(currentStep.getDescription(), hotkeyName,
 					PRICE_FORMAT.format(targetQty));
 			case SET_PRICE:
 			case SET_SELL_PRICE:
-				int targetPrice = focusedFlip.getCurrentStepPrice();
+				int targetPrice = flip.getCurrentStepPrice();
 				// Just show the target price with hotkey
 				return String.format(currentStep.getDescription(), hotkeyName,
 					PRICE_FORMAT.format(targetPrice));

--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -468,8 +468,7 @@ public class FlipAssistOverlay extends Overlay
 			int y = 32 + lineHeight;
 			for (String line : iconLines)
 			{
-				graphics.setColor(getHintLineColor(line));
-				graphics.drawString(line, textStartX, y);
+				drawHintLine(graphics, line, textStartX, y, smallMetrics);
 				y += lineHeight;
 			}
 		}
@@ -481,9 +480,8 @@ public class FlipAssistOverlay extends Overlay
 			int y = 28 + lineHeight;
 			for (String line : wrappedLines)
 			{
-				graphics.setColor(getHintLineColor(line));
 				int lineWidth = smallMetrics.stringWidth(line);
-				graphics.drawString(line, (HINT_PANEL_WIDTH - lineWidth) / 2, y);
+				drawHintLine(graphics, line, (HINT_PANEL_WIDTH - lineWidth) / 2, y, smallMetrics);
 				y += lineHeight;
 			}
 		}
@@ -548,6 +546,25 @@ public class FlipAssistOverlay extends Overlay
 
 			textY += lineHeight;
 		}
+	}
+
+	private void drawHintLine(Graphics2D graphics, String line, int x, int y, FontMetrics fm)
+	{
+		int parenIdx = line.lastIndexOf(" (");
+		boolean isNetParen = parenIdx > 0 && line.endsWith(")")
+			&& (line.startsWith("(-", parenIdx + 1) || line.startsWith("(+", parenIdx + 1));
+		if (!isNetParen)
+		{
+			graphics.setColor(getHintLineColor(line));
+			graphics.drawString(line, x, y);
+			return;
+		}
+		String base = line.substring(0, parenIdx);
+		String paren = line.substring(parenIdx);
+		graphics.setColor(getHintLineColor(base));
+		graphics.drawString(base, x, y);
+		graphics.setColor(paren.trim().startsWith("(-") ? COLOR_LOSS : COLOR_PROFIT);
+		graphics.drawString(paren, x + fm.stringWidth(base), y);
 	}
 
 	private Color getHintLineColor(String line)

--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -46,6 +46,7 @@ public class FlipAssistOverlay extends Overlay
 	private static final Color COLOR_BUY = new Color(100, 220, 130);
 	private static final Color COLOR_SELL = new Color(255, 140, 80);
 	private static final Color COLOR_PROFIT = new Color(80, 255, 120);
+	private static final Color COLOR_LOSS = new Color(255, 100, 100);
 	private static final Color COLOR_STEP_COMPLETE = new Color(80, 200, 100);
 	private static final Color COLOR_STEP_CURRENT = COLOR_ACCENT;
 	private static final Color COLOR_STEP_PENDING = new Color(80, 75, 70);
@@ -551,6 +552,14 @@ public class FlipAssistOverlay extends Overlay
 	private Color getHintLineColor(String line)
 	{
 		String trimmed = line.trim();
+		if (trimmed.startsWith("Loss"))
+		{
+			return COLOR_LOSS;
+		}
+		if (trimmed.startsWith("Profit") || trimmed.startsWith("Breakeven"))
+		{
+			return COLOR_PROFIT;
+		}
 		if (trimmed.startsWith("Open GE History"))
 		{
 			return COLOR_BUY;

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3138,19 +3138,25 @@ public class FlipFinderPanel extends PluginPanel
 		this.offerDispositionLookup = lookup;
 	}
 
-	private static String activeOfferVerb(OfferAction action)
+	private static String activeOfferVerb(OfferAction action, Integer netProfitEstimate)
 	{
+		boolean isLoss = netProfitEstimate != null && netProfitEstimate < 0;
 		switch (action)
 		{
 			case MOVE_PRICE_DOWN:
 				return "Move price down";
 			case EXIT_AT_BREAKEVEN:
-				return "Exit at breakeven";
+				return isLoss ? "Exit at a loss" : "Exit at breakeven";
 			case EXIT_AT_LOSS:
-				return "Exit at loss";
+				return "Exit at a loss";
 			default:
 				return "";
 		}
+	}
+
+	private static String formatSignedGp(int amount)
+	{
+		return (amount >= 0 ? "+" : "-") + GpUtils.formatGP(Math.abs(amount));
 	}
 
 	/**
@@ -3500,13 +3506,21 @@ public class FlipFinderPanel extends PluginPanel
 		if (offerDispositionLookup != null)
 		{
 			OfferAdviceResponse advice = offerDispositionLookup.apply(flip.getItemId());
-			if (advice != null && advice.getActionEnum() != null && !activeOfferVerb(advice.getActionEnum()).isEmpty())
+			String verb = advice != null && advice.getActionEnum() != null
+				? activeOfferVerb(advice.getActionEnum(), advice.getNetProfitEstimate())
+				: "";
+			if (!verb.isEmpty())
 			{
-				String verb = activeOfferVerb(advice.getActionEnum());
-				String text = advice.getNewPrice() != null
-					? verb + " → " + GpUtils.formatGP(advice.getNewPrice())
-					: verb;
-				JLabel adviceLabel = createStyledLabel(text, Color.ORANGE);
+				StringBuilder text = new StringBuilder(verb);
+				if (advice.getNewPrice() != null)
+				{
+					text.append(" → ").append(GpUtils.formatGP(advice.getNewPrice()));
+				}
+				if (advice.getNetProfitEstimate() != null)
+				{
+					text.append(" (").append(formatSignedGp(advice.getNetProfitEstimate())).append(")");
+				}
+				JLabel adviceLabel = createStyledLabel(text.toString(), Color.ORANGE);
 				adviceLabel.setToolTipText(advice.getReason());
 				detailsPanel.add(Box.createRigidArea(new Dimension(0, 2)));
 				detailsPanel.add(adviceLabel);

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -166,7 +166,8 @@ public class FlipFinderPanel extends PluginPanel
 	private transient JPanel currentFocusedPanel = null;
 	private transient int currentFocusedItemId = -1;
 	private transient java.util.function.Consumer<FocusedFlip> onFocusChanged;
-	
+	private transient java.util.function.IntFunction<OfferAdviceResponse> offerDispositionLookup;
+
 	// Cache displayed sell prices to ensure focus uses same price as shown in UI
 	// Key: itemId, Value: calculated sell price shown in the active flip panel
 	private final java.util.Map<Integer, Integer> displayedSellPrices = new java.util.concurrent.ConcurrentHashMap<>();
@@ -3131,7 +3132,27 @@ public class FlipFinderPanel extends PluginPanel
 	{
 		this.onFocusChanged = callback;
 	}
-	
+
+	public void setOfferDispositionLookup(java.util.function.IntFunction<OfferAdviceResponse> lookup)
+	{
+		this.offerDispositionLookup = lookup;
+	}
+
+	private static String activeOfferVerb(OfferAction action)
+	{
+		switch (action)
+		{
+			case MOVE_PRICE_DOWN:
+				return "Move price down";
+			case EXIT_AT_BREAKEVEN:
+				return "Exit at breakeven";
+			case EXIT_AT_LOSS:
+				return "Exit at loss";
+			default:
+				return "";
+		}
+	}
+
 	/**
 	 * Set the callback for when authentication succeeds.
 	 * This allows the plugin to sync RSN after Discord login.
@@ -3473,8 +3494,24 @@ public class FlipFinderPanel extends PluginPanel
 		JLabel riskLabel = createStyledLabel("Risk: ...", COLOR_YELLOW);
 
 		// Add all rows with small spacing
-		addLabelsWithSpacing(detailsPanel, pricesLabel, qtyLabel, taxLabel, marginLabel, 
+		addLabelsWithSpacing(detailsPanel, pricesLabel, qtyLabel, taxLabel, marginLabel,
 			profitCostLabel, liquidityLabel, riskLabel);
+
+		if (offerDispositionLookup != null)
+		{
+			OfferAdviceResponse advice = offerDispositionLookup.apply(flip.getItemId());
+			if (advice != null && advice.getActionEnum() != null && !activeOfferVerb(advice.getActionEnum()).isEmpty())
+			{
+				String verb = activeOfferVerb(advice.getActionEnum());
+				String text = advice.getNewPrice() != null
+					? verb + " → " + GpUtils.formatGP(advice.getNewPrice())
+					: verb;
+				JLabel adviceLabel = createStyledLabel(text, Color.ORANGE);
+				adviceLabel.setToolTipText(advice.getReason());
+				detailsPanel.add(Box.createRigidArea(new Dimension(0, 2)));
+				detailsPanel.add(adviceLabel);
+			}
+		}
 
 		panel.add(topPanel, BorderLayout.NORTH);
 		panel.add(detailsPanel, BorderLayout.CENTER);

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3159,6 +3159,18 @@ public class FlipFinderPanel extends PluginPanel
 		return (amount >= 0 ? "+" : "-") + GpUtils.formatGP(Math.abs(amount));
 	}
 
+	private static String activeOfferPricePrefix(OfferAction action)
+	{
+		switch (action)
+		{
+			case EXIT_AT_BREAKEVEN:
+			case EXIT_AT_LOSS:
+				return "Exit at:";
+			default:
+				return "Sell at:";
+		}
+	}
+
 	/**
 	 * Set the callback for when authentication succeeds.
 	 * This allows the plugin to sync RSN after Discord login.
@@ -3511,19 +3523,25 @@ public class FlipFinderPanel extends PluginPanel
 				: "";
 			if (!verb.isEmpty())
 			{
-				StringBuilder text = new StringBuilder(verb);
+				detailsPanel.add(Box.createRigidArea(new Dimension(0, 2)));
+
+				JLabel verbLabel = createStyledLabel(verb, Color.ORANGE);
+				verbLabel.setToolTipText(advice.getReason());
+				detailsPanel.add(verbLabel);
+
 				if (advice.getNewPrice() != null)
 				{
-					text.append(" → ").append(GpUtils.formatGP(advice.getNewPrice()));
+					String priceLine = activeOfferPricePrefix(advice.getActionEnum())
+						+ " " + String.format("%,d", advice.getNewPrice()) + "gp";
+					detailsPanel.add(createStyledLabel(priceLine, Color.ORANGE));
 				}
 				if (advice.getNetProfitEstimate() != null)
 				{
-					text.append(" (").append(formatSignedGp(advice.getNetProfitEstimate())).append(")");
+					int net = advice.getNetProfitEstimate();
+					String keyword = net < 0 ? "Loss" : (net > 0 ? "Profit" : "Breakeven");
+					Color netColor = net < 0 ? new Color(255, 100, 100) : new Color(80, 255, 120);
+					detailsPanel.add(createStyledLabel(keyword + ": " + formatSignedGp(net), netColor));
 				}
-				JLabel adviceLabel = createStyledLabel(text.toString(), Color.ORANGE);
-				adviceLabel.setToolTipText(advice.getReason());
-				detailsPanel.add(Box.createRigidArea(new Dimension(0, 2)));
-				detailsPanel.add(adviceLabel);
 			}
 		}
 

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3159,17 +3159,6 @@ public class FlipFinderPanel extends PluginPanel
 		return (amount >= 0 ? "+" : "-") + GpUtils.formatGP(Math.abs(amount));
 	}
 
-	private static String activeOfferPricePrefix(OfferAction action)
-	{
-		switch (action)
-		{
-			case EXIT_AT_BREAKEVEN:
-			case EXIT_AT_LOSS:
-				return "Exit at:";
-			default:
-				return "Sell at:";
-		}
-	}
 
 	/**
 	 * Set the callback for when authentication succeeds.
@@ -3525,16 +3514,13 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				detailsPanel.add(Box.createRigidArea(new Dimension(0, 2)));
 
-				JLabel verbLabel = createStyledLabel(verb, Color.ORANGE);
+				String verbLine = advice.getNewPrice() != null
+					? verb + ": " + String.format("%,d", advice.getNewPrice()) + "gp"
+					: verb;
+				JLabel verbLabel = createStyledLabel(verbLine, Color.ORANGE);
 				verbLabel.setToolTipText(advice.getReason());
 				detailsPanel.add(verbLabel);
 
-				if (advice.getNewPrice() != null)
-				{
-					String priceLine = activeOfferPricePrefix(advice.getActionEnum())
-						+ " " + String.format("%,d", advice.getNewPrice()) + "gp";
-					detailsPanel.add(createStyledLabel(priceLine, Color.ORANGE));
-				}
 				if (advice.getNetProfitEstimate() != null)
 				{
 					int net = advice.getNetProfitEstimate();

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -2321,6 +2321,50 @@ public class FlipSmartApiClient
 			gson.fromJson(jsonData, FlipAdjustmentResponse.class));
 	}
 
+	static JsonObject buildOfferActionBody(OfferAdviceRequest req)
+	{
+		JsonObject body = new JsonObject();
+		body.addProperty(JSON_KEY_ITEM_ID, req.getItemId());
+		body.addProperty("pool", req.getPool());
+		body.addProperty("side", req.getSide());
+		body.addProperty("stage", req.getStage());
+		String listedAt = req.getListedAtMillis() == null ? null : OfferAdviceRequest.toIsoUtc(req.getListedAtMillis());
+		if (listedAt != null)
+		{
+			body.addProperty("listed_at", listedAt);
+		}
+		body.addProperty("listed_price", req.getListedPrice());
+		body.addProperty("listed_quantity", req.getListedQuantity());
+		body.addProperty("filled_quantity", req.getFilledQuantity());
+		String lastFill = req.getLastFillAtMillis() == null ? null : OfferAdviceRequest.toIsoUtc(req.getLastFillAtMillis());
+		if (lastFill != null)
+		{
+			body.addProperty("last_fill_at", lastFill);
+		}
+		if (req.getCurrentMarketHigh() != null)
+		{
+			body.addProperty("current_market_high", req.getCurrentMarketHigh());
+		}
+		if (req.getCurrentMarketLow() != null)
+		{
+			body.addProperty("current_market_low", req.getCurrentMarketLow());
+		}
+		if (req.getUserAvgBuyPrice() != null)
+		{
+			body.addProperty("user_avg_buy_price", req.getUserAvgBuyPrice());
+		}
+		return body;
+	}
+
+	public CompletableFuture<OfferAdviceResponse> postOfferActionAsync(OfferAdviceRequest req)
+	{
+		String url = String.format("%s/flip-finder/active/offer-action", getApiUrl());
+		RequestBody body = RequestBody.create(JSON, buildOfferActionBody(req).toString());
+		Request.Builder requestBuilder = new Request.Builder().url(url).post(body);
+		return executeAuthenticatedAsync(requestBuilder, jsonData ->
+			gson.fromJson(jsonData, OfferAdviceResponse.class));
+	}
+
 	// =========================================================================
 	// Webhook API Methods
 	// =========================================================================

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -2365,6 +2365,27 @@ public class FlipSmartApiClient
 			gson.fromJson(jsonData, OfferAdviceResponse.class));
 	}
 
+	static JsonObject buildOfferActionsBody(java.util.List<OfferAdviceRequest> reqs)
+	{
+		JsonObject body = new JsonObject();
+		com.google.gson.JsonArray offers = new com.google.gson.JsonArray();
+		for (OfferAdviceRequest req : reqs)
+		{
+			offers.add(buildOfferActionBody(req));
+		}
+		body.add("offers", offers);
+		return body;
+	}
+
+	public CompletableFuture<OfferAdviceBatchResponse> postOfferActionsBatchAsync(java.util.List<OfferAdviceRequest> reqs)
+	{
+		String url = String.format("%s/flip-finder/active/offer-actions", getApiUrl());
+		RequestBody body = RequestBody.create(JSON, buildOfferActionsBody(reqs).toString());
+		Request.Builder requestBuilder = new Request.Builder().url(url).post(body);
+		return executeAuthenticatedAsync(requestBuilder, jsonData ->
+			gson.fromJson(jsonData, OfferAdviceBatchResponse.class));
+	}
+
 	// =========================================================================
 	// Webhook API Methods
 	// =========================================================================

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -2620,6 +2620,22 @@ public class FlipSmartApiClient
 	}
 
 	/**
+	 * Synchronous, non-blocking read of the daily-volume cache. Returns the
+	 * cached value when fresh, or {@code null} when not cached / expired —
+	 * never triggers a network fetch. Mirrors {@link #getWikiPrice(int)} so
+	 * timer threads can build snapshots without blocking on I/O.
+	 */
+	public Integer getCachedDailyVolume(int itemId)
+	{
+		CachedDailyVolume cached = dailyVolumeCache.get(itemId);
+		if (cached == null || cached.isExpired())
+		{
+			return null;
+		}
+		return cached.getVolume();
+	}
+
+	/**
 	 * Push the current open GE slot item IDs to the backend cache so the web
 	 * Trade Station's "Import from RuneLite" button (issue #683 AC7) can
 	 * read them. Best-effort — failures are swallowed by the caller because

--- a/src/main/java/com/flipsmart/FlipSmartConfig.java
+++ b/src/main/java/com/flipsmart/FlipSmartConfig.java
@@ -334,6 +334,18 @@ public interface FlipSmartConfig extends Config
 		return false;
 	}
 
+	@ConfigItem(
+		keyName = "enableActiveOfferAdvisor",
+		name = "Active Offer Advisor",
+		description = "In Active mode, advise when to wait, move price down, or exit aging GE offers",
+		section = displaySection,
+		position = 11
+	)
+	default boolean enableActiveOfferAdvisor()
+	{
+		return true;
+	}
+
 	// ============================================
 	// Flip Assistant Section (Guided Workflow + Quick Actions)
 	// ============================================

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1995,7 +1995,7 @@ public class FlipSmartPlugin extends Plugin
 			TrackedOffer offer = sess.getTrackedOffer(slot);
 			if (offer != null)
 			{
-				autoRecommendService.surfaceAdvisorResell(offer, resp.getNewPrice());
+				autoRecommendService.surfaceAdvisorResell(offer, resp.getNewPrice(), resp.getNetProfitEstimate());
 			}
 		}
 	}

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1888,10 +1888,7 @@ public class FlipSmartPlugin extends Plugin
 		{
 			activeOfferAdvisorService.reconcile(activeItemIds);
 		}
-		if (log.isDebugEnabled())
-		{
-			log.debug("active-offer advisor poll: {} tracked offers", sess.getTrackedOffers().size());
-		}
+		java.util.List<OfferAdviceRequest> requests = new java.util.ArrayList<>();
 		for (Map.Entry<Integer, TrackedOffer> entry : sess.getTrackedOffers().entrySet())
 		{
 			TrackedOffer offer = entry.getValue();
@@ -1912,22 +1909,63 @@ public class FlipSmartPlugin extends Plugin
 			FlipSmartApiClient.WikiPrice market = apiClient.getWikiPrice(offer.getItemId());
 			Integer avgBuy = offer.isBuy() ? null
 				: BuyPriceLookup.findAverageBuyPrice(getCurrentActiveFlips(), offer.getItemId());
-			OfferAdviceRequest req = ActiveOfferAdvisorService.buildSnapshot(offer, market, avgBuy, dailyVolume);
+			requests.add(ActiveOfferAdvisorService.buildSnapshot(offer, market, avgBuy, dailyVolume));
+		}
+		if (requests.isEmpty())
+		{
+			return;
+		}
+		if (log.isDebugEnabled())
+		{
+			log.debug("active-offer advisor poll: {} offers (batched)", requests.size());
+		}
+		apiClient.postOfferActionsBatchAsync(requests)
+			.thenAccept(batch ->
+			{
+				if (batch != null && batch.getResults() != null)
+				{
+					for (OfferAdviceResult result : batch.getResults())
+					{
+						if (log.isDebugEnabled())
+						{
+							log.debug("offer-action {} -> {} newPrice={}",
+								result.getItemId(), result.getAction(), result.getNewPrice());
+						}
+						activeOfferAdvisorService.applyResponse(result.getItemId(), result);
+					}
+				}
+				else
+				{
+					// Backend without the batch endpoint (or a transient failure) — fall back per-offer.
+					pollAdvisorPerOffer(requests);
+				}
+			})
+			.exceptionally(ex ->
+			{
+				pollAdvisorPerOffer(requests);
+				return null;
+			});
+	}
+
+	private void pollAdvisorPerOffer(java.util.List<OfferAdviceRequest> requests)
+	{
+		for (OfferAdviceRequest req : requests)
+		{
 			apiClient.postOfferActionAsync(req)
 				.thenAccept(resp ->
 				{
 					if (resp != null && log.isDebugEnabled())
 					{
 						log.debug("offer-action {} side={} stage={} -> {} newPrice={}",
-							offer.getItemName(), req.getSide(), req.getStage(), resp.getAction(), resp.getNewPrice());
+							req.getItemId(), req.getSide(), req.getStage(), resp.getAction(), resp.getNewPrice());
 					}
-					activeOfferAdvisorService.applyResponse(offer.getItemId(), resp);
+					activeOfferAdvisorService.applyResponse(req.getItemId(), resp);
 				})
 				.exceptionally(ex ->
 				{
 					if (log.isDebugEnabled())
 					{
-						log.debug("offer-action poll failed for {}: {}", offer.getItemId(), ex.getMessage());
+						log.debug("offer-action poll failed for {}: {}", req.getItemId(), ex.getMessage());
 					}
 					return null;
 				});

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1862,7 +1862,10 @@ public class FlipSmartPlugin extends Plugin
 				.thenAccept(resp -> activeOfferAdvisorService.applyResponse(offer.getItemId(), resp))
 				.exceptionally(ex ->
 				{
-					log.debug("offer-action poll failed for {}: {}", offer.getItemId(), ex.getMessage());
+					if (log.isDebugEnabled())
+					{
+						log.debug("offer-action poll failed for {}: {}", offer.getItemId(), ex.getMessage());
+					}
 					return null;
 				});
 		}

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -352,6 +352,27 @@ public class FlipSmartPlugin extends Plugin
 	}
 
 	/**
+	 * True when at least one GE slot holds uncollected items or coins. Used to
+	 * suppress collection prompts once everything has been collected (all slots EMPTY).
+	 */
+	public boolean hasCollectableGEOffers()
+	{
+		GrandExchangeOffer[] offers = client.getGrandExchangeOffers();
+		if (offers == null)
+		{
+			return false;
+		}
+		for (GrandExchangeOffer offer : offers)
+		{
+			if (offer.getState() != GrandExchangeOfferState.EMPTY && offer.getQuantitySold() > 0)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Get the inventory count for a specific item (delegate to ActiveFlipTracker).
 	 */
 	public int getInventoryCountForItem(int itemId)

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -632,6 +632,7 @@ public class FlipSmartPlugin extends Plugin
 		autoRecommendService.setOnOverlayMessageChanged(flipAssistOverlay::setAutoStatusMessage);
 		autoRecommendService.setDisplayedSellPriceProvider(itemId -> flipFinderPanel != null ? flipFinderPanel.getDisplayedSellPrice(itemId) : null);
 		autoRecommendService.setOnStaleOfferPrompted(this::highlightSlotForItem);
+		autoRecommendService.setOnClearAllHighlights(geSlotOverlay::clearAllAdjustmentHighlights);
 		flipAssistOverlay.setOnStepChanged(autoRecommendService::onOverlayStepChanged);
 	}
 

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -160,6 +160,7 @@ public class FlipSmartPlugin extends Plugin
 	// Active-offer advisor service + poll timer (30-second cycle)
 	private ActiveOfferAdvisorService activeOfferAdvisorService;
 	private java.util.Timer activeOfferAdvisorTimer;
+	private long lastAdvisorPollMs;
 
 	// Track all active one-shot Swing timers for cleanup on shutdown
 	private final List<javax.swing.Timer> activeOneShotTimers = new CopyOnWriteArrayList<>();
@@ -194,6 +195,7 @@ public class FlipSmartPlugin extends Plugin
 
 	/** Active-offer advisor poll interval (30 seconds) */
 	private static final long ACTIVE_OFFER_ADVISOR_INTERVAL_MS = 30_000L;
+	private static final long ACTIVE_OFFER_ADVISOR_EVENT_DEBOUNCE_MS = 3_000L;
 
 	// Flip Assist input listener for hotkey handling
 	private FlipAssistInputListener flipAssistInputListener;
@@ -766,7 +768,7 @@ public class FlipSmartPlugin extends Plugin
 		grandExchangeTracker.setAutoRecommendService(autoRecommendService);
 		grandExchangeTracker.setRsnSupplier(this::getCurrentRsnSafe);
 		grandExchangeTracker.setOnPanelRefresh(() -> { if (flipFinderPanel != null) flipFinderPanel.refresh(); });
-		grandExchangeTracker.setOnActiveFlipsRefresh(() -> { if (flipFinderPanel != null) { flipFinderPanel.refreshActiveFlips(); flipFinderPanel.reevaluateSlotLimitDisplay(); } });
+		grandExchangeTracker.setOnActiveFlipsRefresh(() -> { if (flipFinderPanel != null) { flipFinderPanel.refreshActiveFlips(); flipFinderPanel.reevaluateSlotLimitDisplay(); } maybeEventPollAdvisor(); });
 		grandExchangeTracker.setOnPendingOrdersUpdate(orders -> { if (flipFinderPanel != null) flipFinderPanel.updatePendingOrders(getPendingBuyOrders()); });
 		grandExchangeTracker.setOnFocusChanged(this::handleGETrackerFocusChanged);
 		grandExchangeTracker.setOnFocusClear(this::handleGETrackerFocusClear);
@@ -1848,6 +1850,20 @@ public class FlipSmartPlugin extends Plugin
 		}
 	}
 
+	// Re-evaluate promptly on GE offer changes (fill/complete/cancel/new) instead of
+	// waiting up to a full 30s cycle, debounced so a burst of slot events polls once.
+	private void maybeEventPollAdvisor()
+	{
+		if (!config.enableActiveOfferAdvisor() || config.flipTimeframe() != FlipSmartConfig.FlipTimeframe.ACTIVE)
+		{
+			return;
+		}
+		if (System.currentTimeMillis() - lastAdvisorPollMs >= ACTIVE_OFFER_ADVISOR_EVENT_DEBOUNCE_MS)
+		{
+			pollActiveOfferAdvisor();
+		}
+	}
+
 	private void pollActiveOfferAdvisor()
 	{
 		if (!config.enableActiveOfferAdvisor() || config.flipTimeframe() != FlipSmartConfig.FlipTimeframe.ACTIVE)
@@ -1858,6 +1874,19 @@ public class FlipSmartPlugin extends Plugin
 		if (sess == null)
 		{
 			return;
+		}
+		lastAdvisorPollMs = System.currentTimeMillis();
+		java.util.Set<Integer> activeItemIds = new java.util.HashSet<>();
+		for (TrackedOffer o : sess.getTrackedOffers().values())
+		{
+			if (o != null && !o.isCompleted())
+			{
+				activeItemIds.add(o.getItemId());
+			}
+		}
+		if (activeOfferAdvisorService != null)
+		{
+			activeOfferAdvisorService.reconcile(activeItemIds);
 		}
 		if (log.isDebugEnabled())
 		{

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -623,7 +623,8 @@ public class FlipSmartPlugin extends Plugin
 		activeOfferAdvisorService = new ActiveOfferAdvisorService();
 		activeOfferAdvisorService.setCallbacks(
 			resp -> javax.swing.SwingUtilities.invokeLater(() -> applyActiveOfferSurface(resp)),
-			this::handleActiveOfferHandoff);
+			itemId -> handleActiveOfferHandoff(itemId),
+			itemId -> javax.swing.SwingUtilities.invokeLater(() -> clearActiveOfferSurface(itemId)));
 
 		activeOfferAdvisorTimer = new java.util.Timer("ActiveOfferAdvisorTimer", true);
 		activeOfferAdvisorTimer.scheduleAtFixedRate(new java.util.TimerTask()
@@ -1843,6 +1844,10 @@ public class FlipSmartPlugin extends Plugin
 			{
 				continue;
 			}
+			if (offer.getCreatedAtMillis() <= 0)
+			{
+				continue;
+			}
 			if (autoRecommendService != null
 				&& Integer.valueOf(offer.getItemId()).equals(autoRecommendService.getLockedItemId()))
 			{
@@ -1884,6 +1889,24 @@ public class FlipSmartPlugin extends Plugin
 		if (slot != null && geSlotOverlay != null)
 		{
 			geSlotOverlay.setAdjustmentHighlight(slot, resp.getNewPrice());
+		}
+		if (flipFinderPanel != null)
+		{
+			flipFinderPanel.refreshActiveFlips();
+		}
+	}
+
+	private void clearActiveOfferSurface(int itemId)
+	{
+		PlayerSession sess = getSession();
+		if (sess == null)
+		{
+			return;
+		}
+		Integer slot = findSlotForItem(sess, itemId);
+		if (slot != null && geSlotOverlay != null)
+		{
+			geSlotOverlay.clearAdjustmentHighlight(slot);
 		}
 		if (flipFinderPanel != null)
 		{

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -157,6 +157,10 @@ public class FlipSmartPlugin extends Plugin
 	// Auto-recommend refresh timer (2-minute cycle)
 	private java.util.Timer autoRecommendRefreshTimer;
 
+	// Active-offer advisor service + poll timer (30-second cycle)
+	private ActiveOfferAdvisorService activeOfferAdvisorService;
+	private java.util.Timer activeOfferAdvisorTimer;
+
 	// Track all active one-shot Swing timers for cleanup on shutdown
 	private final List<javax.swing.Timer> activeOneShotTimers = new CopyOnWriteArrayList<>();
 
@@ -187,6 +191,9 @@ public class FlipSmartPlugin extends Plugin
 
 	/** Auto-recommend queue refresh interval (2 minutes) */
 	private static final long AUTO_RECOMMEND_REFRESH_INTERVAL_MS = 2 * 60 * 1000L;
+
+	/** Active-offer advisor poll interval (30 seconds) */
+	private static final long ACTIVE_OFFER_ADVISOR_INTERVAL_MS = 30_000L;
 
 	// Flip Assist input listener for hotkey handling
 	private FlipAssistInputListener flipAssistInputListener;
@@ -569,6 +576,7 @@ public class FlipSmartPlugin extends Plugin
 		// Wire service callbacks and initialize auto-recommend
 		wireServiceCallbacks();
 		initializeAutoRecommendService();
+		initializeActiveOfferAdvisor();
 		initializeManualAdjustmentTracker();
 		wireGrandExchangeTrackerCallbacks();
 
@@ -604,6 +612,28 @@ public class FlipSmartPlugin extends Plugin
 		autoRecommendService.setDisplayedSellPriceProvider(itemId -> flipFinderPanel != null ? flipFinderPanel.getDisplayedSellPrice(itemId) : null);
 		autoRecommendService.setOnStaleOfferPrompted(this::highlightSlotForItem);
 		flipAssistOverlay.setOnStepChanged(autoRecommendService::onOverlayStepChanged);
+	}
+
+	/**
+	 * Construct the active-offer advisor service, wire its callbacks, and start
+	 * the 30-second poll timer.
+	 */
+	private void initializeActiveOfferAdvisor()
+	{
+		activeOfferAdvisorService = new ActiveOfferAdvisorService();
+		activeOfferAdvisorService.setCallbacks(
+			resp -> javax.swing.SwingUtilities.invokeLater(() -> applyActiveOfferSurface(resp)),
+			this::handleActiveOfferHandoff);
+
+		activeOfferAdvisorTimer = new java.util.Timer("ActiveOfferAdvisorTimer", true);
+		activeOfferAdvisorTimer.scheduleAtFixedRate(new java.util.TimerTask()
+		{
+			@Override
+			public void run()
+			{
+				pollActiveOfferAdvisor();
+			}
+		}, ACTIVE_OFFER_ADVISOR_INTERVAL_MS, ACTIVE_OFFER_ADVISOR_INTERVAL_MS);
 	}
 
 	/**
@@ -835,6 +865,9 @@ public class FlipSmartPlugin extends Plugin
 			persistAutoRecommendState();
 			autoRecommendService.stop();
 		}
+
+		// Stop active-offer advisor poll timer
+		stopActiveOfferAdvisorTimer();
 
 		// Clear API client cache
 		apiClient.clearCache();
@@ -1777,6 +1810,86 @@ public class FlipSmartPlugin extends Plugin
 		{
 			autoRecommendRefreshTimer.cancel();
 			autoRecommendRefreshTimer = null;
+		}
+	}
+
+	void stopActiveOfferAdvisorTimer()
+	{
+		if (activeOfferAdvisorTimer != null)
+		{
+			activeOfferAdvisorTimer.cancel();
+			activeOfferAdvisorTimer = null;
+		}
+	}
+
+	private void pollActiveOfferAdvisor()
+	{
+		if (!config.enableActiveOfferAdvisor() || config.flipTimeframe() != FlipSmartConfig.FlipTimeframe.ACTIVE)
+		{
+			return;
+		}
+		PlayerSession sess = getSession();
+		if (sess == null)
+		{
+			return;
+		}
+		for (Map.Entry<Integer, TrackedOffer> entry : sess.getTrackedOffers().entrySet())
+		{
+			TrackedOffer offer = entry.getValue();
+			if (offer == null || offer.isCompleted())
+			{
+				continue;
+			}
+			if (autoRecommendService != null
+				&& Integer.valueOf(offer.getItemId()).equals(autoRecommendService.getLockedItemId()))
+			{
+				continue;
+			}
+			Integer dailyVolume = apiClient.getCachedDailyVolume(offer.getItemId());
+			FlipSmartApiClient.WikiPrice market = apiClient.getWikiPrice(offer.getItemId());
+			Integer avgBuy = offer.isBuy() ? null
+				: BuyPriceLookup.findAverageBuyPrice(getCurrentActiveFlips(), offer.getItemId());
+			OfferAdviceRequest req = ActiveOfferAdvisorService.buildSnapshot(offer, market, avgBuy, dailyVolume);
+			apiClient.postOfferActionAsync(req)
+				.thenAccept(resp -> activeOfferAdvisorService.applyResponse(offer.getItemId(), resp))
+				.exceptionally(ex ->
+				{
+					log.debug("offer-action poll failed for {}: {}", offer.getItemId(), ex.getMessage());
+					return null;
+				});
+		}
+	}
+
+	private void applyActiveOfferSurface(OfferAdviceResponse resp)
+	{
+		if (resp == null || resp.getNewPrice() == null)
+		{
+			return;
+		}
+		if (flipFinderPanel != null)
+		{
+			flipFinderPanel.refreshActiveFlips();
+		}
+	}
+
+	private void handleActiveOfferHandoff(int itemId)
+	{
+		if (autoRecommendService == null)
+		{
+			return;
+		}
+		PlayerSession sess = getSession();
+		if (sess == null)
+		{
+			return;
+		}
+		for (TrackedOffer offer : sess.getTrackedOffers().values())
+		{
+			if (offer != null && offer.getItemId() == itemId)
+			{
+				autoRecommendService.addToStaleQueue(offer);
+				break;
+			}
 		}
 	}
 

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1866,10 +1866,39 @@ public class FlipSmartPlugin extends Plugin
 		{
 			return;
 		}
+		PlayerSession sess = getSession();
+		if (sess == null)
+		{
+			return;
+		}
+		Integer itemId = resp.getItemIdHint();
+		if (itemId == null)
+		{
+			return;
+		}
+		sess.setRecommendedPrice(itemId, resp.getNewPrice());
+		Integer slot = findSlotForItem(sess, itemId);
+		if (slot != null && geSlotOverlay != null)
+		{
+			geSlotOverlay.setAdjustmentHighlight(slot, resp.getNewPrice());
+		}
 		if (flipFinderPanel != null)
 		{
 			flipFinderPanel.refreshActiveFlips();
 		}
+	}
+
+	private Integer findSlotForItem(PlayerSession sess, int itemId)
+	{
+		for (Map.Entry<Integer, TrackedOffer> e : sess.getTrackedOffers().entrySet())
+		{
+			TrackedOffer o = e.getValue();
+			if (o != null && o.getItemId() == itemId && !o.isCompleted())
+			{
+				return e.getKey();
+			}
+		}
+		return null;
 	}
 
 	private void handleActiveOfferHandoff(int itemId)

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1545,7 +1545,9 @@ public class FlipSmartPlugin extends Plugin
 				flipAssistOverlay.clearFocus();
 			}
 		});
-		
+
+		flipFinderPanel.setOfferDispositionLookup(id -> activeOfferAdvisorService.getDisposition(id));
+
 		// Connect auth success callback to sync RSN after Discord login
 		flipFinderPanel.setOnAuthSuccess(() -> {
 			// Sync RSN to API if we have one (player is logged in)

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1837,6 +1837,10 @@ public class FlipSmartPlugin extends Plugin
 		{
 			return;
 		}
+		if (log.isDebugEnabled())
+		{
+			log.debug("active-offer advisor poll: {} tracked offers", sess.getTrackedOffers().size());
+		}
 		for (Map.Entry<Integer, TrackedOffer> entry : sess.getTrackedOffers().entrySet())
 		{
 			TrackedOffer offer = entry.getValue();
@@ -1859,7 +1863,15 @@ public class FlipSmartPlugin extends Plugin
 				: BuyPriceLookup.findAverageBuyPrice(getCurrentActiveFlips(), offer.getItemId());
 			OfferAdviceRequest req = ActiveOfferAdvisorService.buildSnapshot(offer, market, avgBuy, dailyVolume);
 			apiClient.postOfferActionAsync(req)
-				.thenAccept(resp -> activeOfferAdvisorService.applyResponse(offer.getItemId(), resp))
+				.thenAccept(resp ->
+				{
+					if (resp != null && log.isDebugEnabled())
+					{
+						log.debug("offer-action {} side={} stage={} -> {} newPrice={}",
+							offer.getItemName(), req.getSide(), req.getStage(), resp.getAction(), resp.getNewPrice());
+					}
+					activeOfferAdvisorService.applyResponse(offer.getItemId(), resp);
+				})
 				.exceptionally(ex ->
 				{
 					if (log.isDebugEnabled())

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1926,6 +1926,14 @@ public class FlipSmartPlugin extends Plugin
 		{
 			geSlotOverlay.setAdjustmentHighlight(slot, resp.getNewPrice());
 		}
+		if (slot != null && autoRecommendService != null)
+		{
+			TrackedOffer offer = sess.getTrackedOffer(slot);
+			if (offer != null)
+			{
+				autoRecommendService.surfaceAdvisorResell(offer, resp.getNewPrice());
+			}
+		}
 		if (flipFinderPanel != null)
 		{
 			flipFinderPanel.refreshActiveFlips();
@@ -1943,6 +1951,10 @@ public class FlipSmartPlugin extends Plugin
 		if (slot != null && geSlotOverlay != null)
 		{
 			geSlotOverlay.clearAdjustmentHighlight(slot);
+		}
+		if (autoRecommendService != null)
+		{
+			autoRecommendService.removeAdvisorResell(itemId);
 		}
 		if (flipFinderPanel != null)
 		{

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1923,10 +1923,6 @@ public class FlipSmartPlugin extends Plugin
 		}
 		sess.setRecommendedPrice(itemId, resp.getNewPrice());
 		Integer slot = findSlotForItem(sess, itemId);
-		if (slot != null && geSlotOverlay != null)
-		{
-			geSlotOverlay.setAdjustmentHighlight(slot, resp.getNewPrice());
-		}
 		if (slot != null && autoRecommendService != null)
 		{
 			TrackedOffer offer = sess.getTrackedOffer(slot);
@@ -1939,16 +1935,6 @@ public class FlipSmartPlugin extends Plugin
 
 	private void clearActiveOfferSurface(int itemId)
 	{
-		PlayerSession sess = getSession();
-		if (sess == null)
-		{
-			return;
-		}
-		Integer slot = findSlotForItem(sess, itemId);
-		if (slot != null && geSlotOverlay != null)
-		{
-			geSlotOverlay.clearAdjustmentHighlight(slot);
-		}
 		if (autoRecommendService != null)
 		{
 			autoRecommendService.removeAdvisorResell(itemId);

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -676,6 +676,7 @@ public class FlipSmartPlugin extends Plugin
 		manualAdjustmentTracker.setMembersWorldSupplier(this::isMembersWorld);
 
 		grandExchangeTracker.setManualAdjustmentTracker(manualAdjustmentTracker);
+		grandExchangeTracker.setActiveOfferAdvisorService(activeOfferAdvisorService);
 		grandExchangeTracker.setAdjustmentPromptsEnabled(config::showAdjustmentPrompts);
 		grandExchangeTracker.setConfig(config);
 	}

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1934,10 +1934,6 @@ public class FlipSmartPlugin extends Plugin
 				autoRecommendService.surfaceAdvisorResell(offer, resp.getNewPrice());
 			}
 		}
-		if (flipFinderPanel != null)
-		{
-			flipFinderPanel.refreshActiveFlips();
-		}
 	}
 
 	private void clearActiveOfferSurface(int itemId)
@@ -1955,10 +1951,6 @@ public class FlipSmartPlugin extends Plugin
 		if (autoRecommendService != null)
 		{
 			autoRecommendService.removeAdvisorResell(itemId);
-		}
-		if (flipFinderPanel != null)
-		{
-			flipFinderPanel.refreshActiveFlips();
 		}
 	}
 

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -34,6 +34,7 @@ public class GrandExchangeTracker
 	// Set after construction (created in plugin startUp)
 	private AutoRecommendService autoRecommendService;
 	private ManualAdjustmentTracker manualAdjustmentTracker;
+	private ActiveOfferAdvisorService activeOfferAdvisorService;
 	private java.util.function.BooleanSupplier adjustmentPromptsEnabled;
 	private FlipSmartConfig config;
 
@@ -96,6 +97,11 @@ public class GrandExchangeTracker
 	public void setManualAdjustmentTracker(ManualAdjustmentTracker tracker)
 	{
 		this.manualAdjustmentTracker = tracker;
+	}
+
+	public void setActiveOfferAdvisorService(ActiveOfferAdvisorService service)
+	{
+		this.activeOfferAdvisorService = service;
 	}
 
 	public void setAdjustmentPromptsEnabled(java.util.function.BooleanSupplier supplier)
@@ -748,6 +754,21 @@ public class GrandExchangeTracker
 			int averageBuyPrice = (buyPrice != null && buyPrice > 0) ? buyPrice : ctx.price;
 			manualAdjustmentTracker.scheduleSellAdjustment(
 				ctx.itemId, ctx.itemName, ctx.slot, ctx.price, averageBuyPrice);
+		}
+
+		OfferAdviceResponse priorAdvice = (activeOfferAdvisorService != null)
+			? activeOfferAdvisorService.getDisposition(ctx.itemId)
+			: null;
+		if (priorAdvice != null
+			&& priorAdvice.getActionEnum() == OfferAction.EXIT_AT_BREAKEVEN
+			&& priorAdvice.getNewPrice() != null)
+		{
+			TrackedOffer relisted = session.getTrackedOffer(ctx.slot);
+			if (relisted != null
+				&& TrackedOffer.shouldAdvanceToBreakevenRelist(true, ctx.price, priorAdvice.getNewPrice()))
+			{
+				relisted.setOfferStage(TrackedOffer.STAGE_BREAKEVEN_RELIST);
+			}
 		}
 	}
 

--- a/src/main/java/com/flipsmart/OfferAction.java
+++ b/src/main/java/com/flipsmart/OfferAction.java
@@ -1,0 +1,39 @@
+package com.flipsmart;
+
+public enum OfferAction
+{
+	WAIT("wait"),
+	CANCEL_AND_RELIST_OTHER("cancel_and_relist_other"),
+	CANCEL_AND_SELL_PARTIAL("cancel_and_sell_partial"),
+	MOVE_PRICE_DOWN("move_price_down"),
+	EXIT_AT_BREAKEVEN("exit_at_breakeven"),
+	EXIT_AT_LOSS("exit_at_loss");
+
+	private final String wire;
+
+	OfferAction(String wire)
+	{
+		this.wire = wire;
+	}
+
+	public String getWire()
+	{
+		return wire;
+	}
+
+	public static OfferAction fromWire(String value)
+	{
+		if (value == null)
+		{
+			return null;
+		}
+		for (OfferAction action : values())
+		{
+			if (action.wire.equals(value))
+			{
+				return action;
+			}
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/flipsmart/OfferAdviceBatchResponse.java
+++ b/src/main/java/com/flipsmart/OfferAdviceBatchResponse.java
@@ -1,0 +1,10 @@
+package com.flipsmart;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class OfferAdviceBatchResponse
+{
+	private List<OfferAdviceResult> results;
+}

--- a/src/main/java/com/flipsmart/OfferAdviceRequest.java
+++ b/src/main/java/com/flipsmart/OfferAdviceRequest.java
@@ -1,0 +1,33 @@
+package com.flipsmart;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OfferAdviceRequest
+{
+	private final int itemId;
+	private final String pool;
+	private final String side;
+	private final String stage;
+	private final Long listedAtMillis;
+	private final int listedPrice;
+	private final int listedQuantity;
+	private final int filledQuantity;
+	private final Long lastFillAtMillis;
+	private final Integer currentMarketHigh;
+	private final Integer currentMarketLow;
+	private final Integer userAvgBuyPrice;
+
+	public static String toIsoUtc(long epochMillis)
+	{
+		if (epochMillis <= 0)
+		{
+			return null;
+		}
+		return DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(epochMillis));
+	}
+}

--- a/src/main/java/com/flipsmart/OfferAdviceResponse.java
+++ b/src/main/java/com/flipsmart/OfferAdviceResponse.java
@@ -15,6 +15,18 @@ public class OfferAdviceResponse
 	@SerializedName("net_profit_estimate")
 	private Integer netProfitEstimate;
 
+	private transient Integer itemIdHint;
+
+	public Integer getItemIdHint()
+	{
+		return itemIdHint;
+	}
+
+	public void setItemIdHint(Integer itemIdHint)
+	{
+		this.itemIdHint = itemIdHint;
+	}
+
 	public OfferAction getActionEnum()
 	{
 		return OfferAction.fromWire(action);

--- a/src/main/java/com/flipsmart/OfferAdviceResponse.java
+++ b/src/main/java/com/flipsmart/OfferAdviceResponse.java
@@ -1,0 +1,22 @@
+package com.flipsmart;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class OfferAdviceResponse
+{
+	private String action;
+	private String reason;
+
+	@SerializedName("new_price")
+	private Integer newPrice;
+
+	@SerializedName("net_profit_estimate")
+	private Integer netProfitEstimate;
+
+	public OfferAction getActionEnum()
+	{
+		return OfferAction.fromWire(action);
+	}
+}

--- a/src/main/java/com/flipsmart/OfferAdviceResult.java
+++ b/src/main/java/com/flipsmart/OfferAdviceResult.java
@@ -1,0 +1,13 @@
+package com.flipsmart;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class OfferAdviceResult extends OfferAdviceResponse
+{
+	@SerializedName("item_id")
+	private int itemId;
+}

--- a/src/main/java/com/flipsmart/OfferDisposition.java
+++ b/src/main/java/com/flipsmart/OfferDisposition.java
@@ -1,0 +1,29 @@
+package com.flipsmart;
+
+public enum OfferDisposition
+{
+	SURFACE_PRICE,
+	HANDOFF,
+	NONE;
+
+	public static OfferDisposition route(OfferAction action)
+	{
+		if (action == null)
+		{
+			return NONE;
+		}
+		switch (action)
+		{
+			case MOVE_PRICE_DOWN:
+			case EXIT_AT_BREAKEVEN:
+			case EXIT_AT_LOSS:
+				return SURFACE_PRICE;
+			case CANCEL_AND_RELIST_OTHER:
+			case CANCEL_AND_SELL_PARTIAL:
+				return HANDOFF;
+			case WAIT:
+			default:
+				return NONE;
+		}
+	}
+}

--- a/src/main/java/com/flipsmart/OfferPoolClassifier.java
+++ b/src/main/java/com/flipsmart/OfferPoolClassifier.java
@@ -1,0 +1,21 @@
+package com.flipsmart;
+
+public final class OfferPoolClassifier
+{
+	static final int HIGH_VOL_THRESHOLD = 500_000;
+	static final String HIGH_VOL = "high_vol";
+	static final String MID_VOL = "mid_vol";
+
+	private OfferPoolClassifier()
+	{
+	}
+
+	public static String classify(Integer dailyVolume)
+	{
+		if (dailyVolume != null && dailyVolume >= HIGH_VOL_THRESHOLD)
+		{
+			return HIGH_VOL;
+		}
+		return MID_VOL;
+	}
+}

--- a/src/main/java/com/flipsmart/TrackedOffer.java
+++ b/src/main/java/com/flipsmart/TrackedOffer.java
@@ -171,4 +171,17 @@ public class TrackedOffer
 	{
 		return lastActivityAtMillis > 0 ? lastActivityAtMillis : createdAtMillis;
 	}
+
+	// 2 % keeps noise from price rounding from triggering false negatives
+	private static final double BREAKEVEN_RELIST_TOLERANCE = 0.02;
+
+	public static boolean shouldAdvanceToBreakevenRelist(boolean breakevenExitAccepted, int observedRelistPrice, int advisedPrice)
+	{
+		if (!breakevenExitAccepted || advisedPrice <= 0 || observedRelistPrice <= 0)
+		{
+			return false;
+		}
+		double delta = Math.abs(observedRelistPrice - advisedPrice);
+		return delta <= advisedPrice * BREAKEVEN_RELIST_TOLERANCE;
+	}
 }

--- a/src/main/java/com/flipsmart/TrackedOffer.java
+++ b/src/main/java/com/flipsmart/TrackedOffer.java
@@ -22,6 +22,10 @@ public class TrackedOffer
 	private long createdAtMillis;  // Timestamp when offer was created (for timer display)
 	private long completedAtMillis;  // Timestamp when offer completed (0 if not complete)
 	private long lastActivityAtMillis;  // Timestamp of most recent fill (for timer display & stale detection)
+	private String offerStage;
+
+	public static final String STAGE_INITIAL = "initial";
+	public static final String STAGE_BREAKEVEN_RELIST = "breakeven_relist";
 
 	public TrackedOffer(int itemId, String itemName, boolean isBuy, int totalQuantity, int price, int quantitySold)
 	{
@@ -41,6 +45,7 @@ public class TrackedOffer
 		this.previousQuantitySold = quantitySold;
 		this.createdAtMillis = createdAtMillis;
 		this.lastActivityAtMillis = createdAtMillis;
+		this.offerStage = STAGE_INITIAL;
 	}
 
 	/**
@@ -82,6 +87,11 @@ public class TrackedOffer
 		if (existing != null && existing.getLastActivityAtMillis() > 0)
 		{
 			offer.setLastActivityAtMillis(existing.getLastActivityAtMillis());
+		}
+
+		if (existing != null)
+		{
+			offer.setOfferStage(existing.getOfferStage());
 		}
 
 		if (state == GrandExchangeOfferState.BOUGHT || state == GrandExchangeOfferState.SOLD)
@@ -141,6 +151,16 @@ public class TrackedOffer
 	public void setLastActivityAtMillis(long lastActivityAtMillis)
 	{
 		this.lastActivityAtMillis = lastActivityAtMillis;
+	}
+
+	public String getOfferStage()
+	{
+		return offerStage == null ? STAGE_INITIAL : offerStage;
+	}
+
+	public void setOfferStage(String offerStage)
+	{
+		this.offerStage = offerStage;
 	}
 
 	/**

--- a/src/test/java/com/flipsmart/ActiveOfferDispositionCacheTest.java
+++ b/src/test/java/com/flipsmart/ActiveOfferDispositionCacheTest.java
@@ -3,6 +3,7 @@ package com.flipsmart;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ActiveOfferDispositionCacheTest
 {
@@ -23,9 +24,12 @@ public class ActiveOfferDispositionCacheTest
 	}
 
 	@Test
-	public void waitResponseClearsAnyPriorDisposition()
+	public void waitResponseClearsCacheAndFiresClearCallback()
 	{
 		ActiveOfferAdvisorService svc = new ActiveOfferAdvisorService();
+		final int[] cleared = {-1};
+		svc.setCallbacks(null, null, id -> cleared[0] = id);
+
 		OfferAdviceResponse move = new OfferAdviceResponse();
 		move.setAction("move_price_down");
 		svc.applyResponse(1, move);
@@ -35,14 +39,16 @@ public class ActiveOfferDispositionCacheTest
 		svc.applyResponse(1, wait);
 
 		assertNull(svc.getDisposition(1));
+		assertEquals(1, cleared[0]);
 	}
 
 	@Test
-	public void handoffInvokesCallbackAndClearsCache()
+	public void handoffFiresHandoffAndClearCallbacksAndClearsCache()
 	{
 		ActiveOfferAdvisorService svc = new ActiveOfferAdvisorService();
 		final int[] handoffItem = {-1};
-		svc.setCallbacks(null, id -> handoffItem[0] = id);
+		final int[] cleared = {-1};
+		svc.setCallbacks(null, id -> handoffItem[0] = id, id -> cleared[0] = id);
 
 		OfferAdviceResponse move = new OfferAdviceResponse();
 		move.setAction("move_price_down");
@@ -53,6 +59,21 @@ public class ActiveOfferDispositionCacheTest
 		svc.applyResponse(7, cancel);
 
 		assertEquals(7, handoffItem[0]);
+		assertEquals(7, cleared[0]);
 		assertNull(svc.getDisposition(7));
+	}
+
+	@Test
+	public void surfacePriceDoesNotFireClearCallback()
+	{
+		ActiveOfferAdvisorService svc = new ActiveOfferAdvisorService();
+		final boolean[] clearFired = {false};
+		svc.setCallbacks(null, null, id -> clearFired[0] = true);
+
+		OfferAdviceResponse move = new OfferAdviceResponse();
+		move.setAction("move_price_down");
+		svc.applyResponse(2, move);
+
+		assertTrue("clear must not fire on surface", !clearFired[0]);
 	}
 }

--- a/src/test/java/com/flipsmart/ActiveOfferDispositionCacheTest.java
+++ b/src/test/java/com/flipsmart/ActiveOfferDispositionCacheTest.java
@@ -1,0 +1,58 @@
+package com.flipsmart;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ActiveOfferDispositionCacheTest
+{
+	@Test
+	public void surfacePriceResponseIsCachedForPanel()
+	{
+		ActiveOfferAdvisorService svc = new ActiveOfferAdvisorService();
+		OfferAdviceResponse resp = new OfferAdviceResponse();
+		resp.setAction("move_price_down");
+		resp.setReason("Move down to 1050");
+		resp.setNewPrice(1050);
+
+		svc.applyResponse(12345, resp);
+
+		OfferAdviceResponse cached = svc.getDisposition(12345);
+		assertEquals("move_price_down", cached.getAction());
+		assertEquals(Integer.valueOf(1050), cached.getNewPrice());
+	}
+
+	@Test
+	public void waitResponseClearsAnyPriorDisposition()
+	{
+		ActiveOfferAdvisorService svc = new ActiveOfferAdvisorService();
+		OfferAdviceResponse move = new OfferAdviceResponse();
+		move.setAction("move_price_down");
+		svc.applyResponse(1, move);
+
+		OfferAdviceResponse wait = new OfferAdviceResponse();
+		wait.setAction("wait");
+		svc.applyResponse(1, wait);
+
+		assertNull(svc.getDisposition(1));
+	}
+
+	@Test
+	public void handoffInvokesCallbackAndClearsCache()
+	{
+		ActiveOfferAdvisorService svc = new ActiveOfferAdvisorService();
+		final int[] handoffItem = {-1};
+		svc.setCallbacks(null, id -> handoffItem[0] = id);
+
+		OfferAdviceResponse move = new OfferAdviceResponse();
+		move.setAction("move_price_down");
+		svc.applyResponse(7, move);
+
+		OfferAdviceResponse cancel = new OfferAdviceResponse();
+		cancel.setAction("cancel_and_relist_other");
+		svc.applyResponse(7, cancel);
+
+		assertEquals(7, handoffItem[0]);
+		assertNull(svc.getDisposition(7));
+	}
+}

--- a/src/test/java/com/flipsmart/ActiveOfferDispositionCacheTest.java
+++ b/src/test/java/com/flipsmart/ActiveOfferDispositionCacheTest.java
@@ -7,19 +7,21 @@ import static org.junit.Assert.assertTrue;
 
 public class ActiveOfferDispositionCacheTest
 {
+	private static final String MOVE_PRICE_DOWN = "move_price_down";
+
 	@Test
 	public void surfacePriceResponseIsCachedForPanel()
 	{
 		ActiveOfferAdvisorService svc = new ActiveOfferAdvisorService();
 		OfferAdviceResponse resp = new OfferAdviceResponse();
-		resp.setAction("move_price_down");
+		resp.setAction(MOVE_PRICE_DOWN);
 		resp.setReason("Move down to 1050");
 		resp.setNewPrice(1050);
 
 		svc.applyResponse(12345, resp);
 
 		OfferAdviceResponse cached = svc.getDisposition(12345);
-		assertEquals("move_price_down", cached.getAction());
+		assertEquals(MOVE_PRICE_DOWN, cached.getAction());
 		assertEquals(Integer.valueOf(1050), cached.getNewPrice());
 	}
 
@@ -31,7 +33,7 @@ public class ActiveOfferDispositionCacheTest
 		svc.setCallbacks(null, null, id -> cleared[0] = id);
 
 		OfferAdviceResponse move = new OfferAdviceResponse();
-		move.setAction("move_price_down");
+		move.setAction(MOVE_PRICE_DOWN);
 		svc.applyResponse(1, move);
 
 		OfferAdviceResponse wait = new OfferAdviceResponse();
@@ -51,7 +53,7 @@ public class ActiveOfferDispositionCacheTest
 		svc.setCallbacks(null, id -> handoffItem[0] = id, id -> cleared[0] = id);
 
 		OfferAdviceResponse move = new OfferAdviceResponse();
-		move.setAction("move_price_down");
+		move.setAction(MOVE_PRICE_DOWN);
 		svc.applyResponse(7, move);
 
 		OfferAdviceResponse cancel = new OfferAdviceResponse();
@@ -71,7 +73,7 @@ public class ActiveOfferDispositionCacheTest
 		svc.setCallbacks(null, null, id -> clearFired[0] = true);
 
 		OfferAdviceResponse move = new OfferAdviceResponse();
-		move.setAction("move_price_down");
+		move.setAction(MOVE_PRICE_DOWN);
 		svc.applyResponse(2, move);
 
 		assertTrue("clear must not fire on surface", !clearFired[0]);

--- a/src/test/java/com/flipsmart/ActiveOfferSnapshotTest.java
+++ b/src/test/java/com/flipsmart/ActiveOfferSnapshotTest.java
@@ -1,0 +1,48 @@
+package com.flipsmart;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ActiveOfferSnapshotTest
+{
+	@Test
+	public void buildsSellSnapshotWithMarketAndBuyPrice()
+	{
+		TrackedOffer offer = new TrackedOffer(12345, "Item", false, 10, 1000, 2);
+		FlipSmartApiClient.WikiPrice market = new FlipSmartApiClient.WikiPrice(1080, 1020);
+
+		OfferAdviceRequest req = ActiveOfferAdvisorService.buildSnapshot(offer, market, 990, 600000);
+
+		assertEquals(12345, req.getItemId());
+		assertEquals("high_vol", req.getPool());
+		assertEquals("sell", req.getSide());
+		assertEquals("initial", req.getStage());
+		assertEquals(1000, req.getListedPrice());
+		assertEquals(10, req.getListedQuantity());
+		assertEquals(2, req.getFilledQuantity());
+		assertEquals(Integer.valueOf(1080), req.getCurrentMarketHigh());
+		assertEquals(Integer.valueOf(1020), req.getCurrentMarketLow());
+		assertEquals(Integer.valueOf(990), req.getUserAvgBuyPrice());
+	}
+
+	@Test
+	public void classifiesHighVolFromDailyVolume()
+	{
+		TrackedOffer offer = new TrackedOffer(1, "Item", true, 1, 5, 0);
+		OfferAdviceRequest req = ActiveOfferAdvisorService.buildSnapshot(offer, null, null, 600000);
+		assertEquals("high_vol", req.getPool());
+		assertEquals("buy", req.getSide());
+		assertNull(req.getCurrentMarketHigh());
+		assertNull(req.getUserAvgBuyPrice());
+	}
+
+	@Test
+	public void buyOfferOmitsUserAvgBuyPriceEvenIfProvided()
+	{
+		TrackedOffer offer = new TrackedOffer(1, "Item", true, 1, 5, 0);
+		OfferAdviceRequest req = ActiveOfferAdvisorService.buildSnapshot(offer, null, 990, 100000);
+		assertEquals("mid_vol", req.getPool());
+		assertNull(req.getUserAvgBuyPrice());
+	}
+}

--- a/src/test/java/com/flipsmart/BreakevenRelistDetectionTest.java
+++ b/src/test/java/com/flipsmart/BreakevenRelistDetectionTest.java
@@ -1,0 +1,33 @@
+package com.flipsmart;
+
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BreakevenRelistDetectionTest
+{
+	@Test
+	public void advancesWhenRelistAtAdvisedPriceWithinTolerance()
+	{
+		assertTrue(TrackedOffer.shouldAdvanceToBreakevenRelist(true, 1048, 1050));
+		assertTrue(TrackedOffer.shouldAdvanceToBreakevenRelist(true, 1050, 1050));
+	}
+
+	@Test
+	public void doesNotAdvanceWhenBreakevenNotAccepted()
+	{
+		assertFalse(TrackedOffer.shouldAdvanceToBreakevenRelist(false, 1050, 1050));
+	}
+
+	@Test
+	public void doesNotAdvanceWhenRelistPriceFarFromAdvised()
+	{
+		assertFalse(TrackedOffer.shouldAdvanceToBreakevenRelist(true, 1200, 1050));
+	}
+
+	@Test
+	public void doesNotAdvanceWithoutAdvisedPrice()
+	{
+		assertFalse(TrackedOffer.shouldAdvanceToBreakevenRelist(true, 1050, 0));
+	}
+}

--- a/src/test/java/com/flipsmart/LegacyAdjustmentGuardTest.java
+++ b/src/test/java/com/flipsmart/LegacyAdjustmentGuardTest.java
@@ -1,0 +1,27 @@
+package com.flipsmart;
+
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class LegacyAdjustmentGuardTest
+{
+	@Test
+	public void legacyDisabledInActiveWhenAdvisorOn()
+	{
+		assertFalse(AutoRecommendService.shouldRunLegacyAdjustment("active", true));
+	}
+
+	@Test
+	public void legacyEnabledInActiveWhenAdvisorOff()
+	{
+		assertTrue(AutoRecommendService.shouldRunLegacyAdjustment("active", false));
+	}
+
+	@Test
+	public void legacyEnabledInNonActiveRegardlessOfAdvisor()
+	{
+		assertTrue(AutoRecommendService.shouldRunLegacyAdjustment("2h", true));
+		assertTrue(AutoRecommendService.shouldRunLegacyAdjustment("30m", true));
+	}
+}

--- a/src/test/java/com/flipsmart/OfferActionBodyTest.java
+++ b/src/test/java/com/flipsmart/OfferActionBodyTest.java
@@ -1,0 +1,57 @@
+package com.flipsmart;
+
+import com.google.gson.JsonObject;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class OfferActionBodyTest
+{
+	@Test
+	public void includesRequiredFieldsAndOmitsNulls()
+	{
+		OfferAdviceRequest req = OfferAdviceRequest.builder()
+			.itemId(12345)
+			.pool("high_vol")
+			.side("sell")
+			.stage("initial")
+			.listedAtMillis(1781035200000L)
+			.listedPrice(1000)
+			.listedQuantity(10)
+			.filledQuantity(0)
+			.currentMarketHigh(1080)
+			.currentMarketLow(1020)
+			.userAvgBuyPrice(990)
+			.build();
+
+		JsonObject body = FlipSmartApiClient.buildOfferActionBody(req);
+
+		assertEquals(12345, body.get("item_id").getAsInt());
+		assertEquals("high_vol", body.get("pool").getAsString());
+		assertEquals("sell", body.get("side").getAsString());
+		assertEquals("initial", body.get("stage").getAsString());
+		assertEquals("2026-06-09T20:00:00Z", body.get("listed_at").getAsString());
+		assertEquals(1000, body.get("listed_price").getAsInt());
+		assertEquals(10, body.get("listed_quantity").getAsInt());
+		assertEquals(0, body.get("filled_quantity").getAsInt());
+		assertEquals(1080, body.get("current_market_high").getAsInt());
+		assertEquals(1020, body.get("current_market_low").getAsInt());
+		assertEquals(990, body.get("user_avg_buy_price").getAsInt());
+		assertFalse("null last_fill omitted", body.has("last_fill_at"));
+	}
+
+	@Test
+	public void omitsNullMarketAndBuyPrice()
+	{
+		OfferAdviceRequest req = OfferAdviceRequest.builder()
+			.itemId(1).pool("mid_vol").side("buy").stage("initial")
+			.listedAtMillis(1781035200000L).listedPrice(5).listedQuantity(1).filledQuantity(0)
+			.build();
+		JsonObject body = FlipSmartApiClient.buildOfferActionBody(req);
+		assertFalse(body.has("current_market_high"));
+		assertFalse(body.has("current_market_low"));
+		assertFalse(body.has("user_avg_buy_price"));
+		assertTrue(body.has("item_id"));
+	}
+}

--- a/src/test/java/com/flipsmart/OfferActionTest.java
+++ b/src/test/java/com/flipsmart/OfferActionTest.java
@@ -1,0 +1,26 @@
+package com.flipsmart;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class OfferActionTest
+{
+	@Test
+	public void parsesEveryWireValue()
+	{
+		assertEquals(OfferAction.WAIT, OfferAction.fromWire("wait"));
+		assertEquals(OfferAction.CANCEL_AND_RELIST_OTHER, OfferAction.fromWire("cancel_and_relist_other"));
+		assertEquals(OfferAction.CANCEL_AND_SELL_PARTIAL, OfferAction.fromWire("cancel_and_sell_partial"));
+		assertEquals(OfferAction.MOVE_PRICE_DOWN, OfferAction.fromWire("move_price_down"));
+		assertEquals(OfferAction.EXIT_AT_BREAKEVEN, OfferAction.fromWire("exit_at_breakeven"));
+		assertEquals(OfferAction.EXIT_AT_LOSS, OfferAction.fromWire("exit_at_loss"));
+	}
+
+	@Test
+	public void unknownOrNullWireValueIsNull()
+	{
+		assertNull(OfferAction.fromWire("bogus"));
+		assertNull(OfferAction.fromWire(null));
+	}
+}

--- a/src/test/java/com/flipsmart/OfferActionsBatchTest.java
+++ b/src/test/java/com/flipsmart/OfferActionsBatchTest.java
@@ -1,0 +1,52 @@
+package com.flipsmart;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.util.Arrays;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class OfferActionsBatchTest
+{
+	@Test
+	public void bodyWrapsEachOfferUnderOffersArray()
+	{
+		OfferAdviceRequest a = OfferAdviceRequest.builder()
+			.itemId(1).pool("high_vol").side("buy").stage("initial")
+			.listedAtMillis(1781035200000L).listedPrice(5).listedQuantity(1).filledQuantity(0).build();
+		OfferAdviceRequest b = OfferAdviceRequest.builder()
+			.itemId(2).pool("mid_vol").side("sell").stage("initial")
+			.listedAtMillis(1781035200000L).listedPrice(50).listedQuantity(3).filledQuantity(1)
+			.userAvgBuyPrice(40).build();
+
+		JsonObject body = FlipSmartApiClient.buildOfferActionsBody(Arrays.asList(a, b));
+
+		assertTrue(body.has("offers"));
+		assertEquals(2, body.getAsJsonArray("offers").size());
+		assertEquals(1, body.getAsJsonArray("offers").get(0).getAsJsonObject().get("item_id").getAsInt());
+		assertEquals(2, body.getAsJsonArray("offers").get(1).getAsJsonObject().get("item_id").getAsInt());
+	}
+
+	@Test
+	public void deserializesBatchResponseWithItemIdAndAdvice()
+	{
+		String json = "{\"results\":["
+			+ "{\"item_id\":111,\"action\":\"move_price_down\",\"reason\":\"r\",\"new_price\":1050,\"net_profit_estimate\":900},"
+			+ "{\"item_id\":222,\"action\":\"wait\",\"reason\":\"w\"}]}";
+
+		OfferAdviceBatchResponse resp = new Gson().fromJson(json, OfferAdviceBatchResponse.class);
+
+		assertEquals(2, resp.getResults().size());
+		OfferAdviceResult first = resp.getResults().get(0);
+		assertEquals(111, first.getItemId());
+		assertEquals(OfferAction.MOVE_PRICE_DOWN, first.getActionEnum());
+		assertEquals(Integer.valueOf(1050), first.getNewPrice());
+
+		OfferAdviceResult second = resp.getResults().get(1);
+		assertEquals(222, second.getItemId());
+		assertEquals(OfferAction.WAIT, second.getActionEnum());
+		assertNull(second.getNewPrice());
+	}
+}

--- a/src/test/java/com/flipsmart/OfferActionsBatchTest.java
+++ b/src/test/java/com/flipsmart/OfferActionsBatchTest.java
@@ -10,6 +10,8 @@ import static org.junit.Assert.assertTrue;
 
 public class OfferActionsBatchTest
 {
+	private static final String OFFERS_KEY = "offers";
+
 	@Test
 	public void bodyWrapsEachOfferUnderOffersArray()
 	{
@@ -23,10 +25,10 @@ public class OfferActionsBatchTest
 
 		JsonObject body = FlipSmartApiClient.buildOfferActionsBody(Arrays.asList(a, b));
 
-		assertTrue(body.has("offers"));
-		assertEquals(2, body.getAsJsonArray("offers").size());
-		assertEquals(1, body.getAsJsonArray("offers").get(0).getAsJsonObject().get("item_id").getAsInt());
-		assertEquals(2, body.getAsJsonArray("offers").get(1).getAsJsonObject().get("item_id").getAsInt());
+		assertTrue(body.has(OFFERS_KEY));
+		assertEquals(2, body.getAsJsonArray(OFFERS_KEY).size());
+		assertEquals(1, body.getAsJsonArray(OFFERS_KEY).get(0).getAsJsonObject().get("item_id").getAsInt());
+		assertEquals(2, body.getAsJsonArray(OFFERS_KEY).get(1).getAsJsonObject().get("item_id").getAsInt());
 	}
 
 	@Test

--- a/src/test/java/com/flipsmart/OfferAdviceRequestTest.java
+++ b/src/test/java/com/flipsmart/OfferAdviceRequestTest.java
@@ -1,0 +1,39 @@
+package com.flipsmart;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class OfferAdviceRequestTest
+{
+	@Test
+	public void formatsEpochMillisAsIsoUtc()
+	{
+		assertEquals("2026-06-09T20:00:00Z", OfferAdviceRequest.toIsoUtc(1781035200000L));
+	}
+
+	@Test
+	public void zeroOrNegativeMillisIsNull()
+	{
+		assertNull(OfferAdviceRequest.toIsoUtc(0L));
+		assertNull(OfferAdviceRequest.toIsoUtc(-1L));
+	}
+
+	@Test
+	public void builderCarriesFields()
+	{
+		OfferAdviceRequest req = OfferAdviceRequest.builder()
+			.itemId(1)
+			.pool("high_vol")
+			.side("sell")
+			.stage("initial")
+			.listedPrice(1000)
+			.listedQuantity(10)
+			.filledQuantity(2)
+			.build();
+		assertEquals(1, req.getItemId());
+		assertEquals("high_vol", req.getPool());
+		assertEquals("sell", req.getSide());
+		assertEquals(2, req.getFilledQuantity());
+	}
+}

--- a/src/test/java/com/flipsmart/OfferAdviceResponseTest.java
+++ b/src/test/java/com/flipsmart/OfferAdviceResponseTest.java
@@ -1,0 +1,34 @@
+package com.flipsmart;
+
+import com.google.gson.Gson;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class OfferAdviceResponseTest
+{
+	private final Gson gson = new Gson();
+
+	@Test
+	public void deserializesMoveDownResponse()
+	{
+		String json = "{\"action\":\"move_price_down\",\"reason\":\"Move down\","
+			+ "\"new_price\":1050,\"net_profit_estimate\":12500}";
+		OfferAdviceResponse r = gson.fromJson(json, OfferAdviceResponse.class);
+		assertEquals("move_price_down", r.getAction());
+		assertEquals(OfferAction.MOVE_PRICE_DOWN, r.getActionEnum());
+		assertEquals("Move down", r.getReason());
+		assertEquals(Integer.valueOf(1050), r.getNewPrice());
+		assertEquals(Integer.valueOf(12500), r.getNetProfitEstimate());
+	}
+
+	@Test
+	public void deserializesWaitResponseWithNulls()
+	{
+		String json = "{\"action\":\"wait\",\"reason\":\"waiting\"}";
+		OfferAdviceResponse r = gson.fromJson(json, OfferAdviceResponse.class);
+		assertEquals(OfferAction.WAIT, r.getActionEnum());
+		assertNull(r.getNewPrice());
+		assertNull(r.getNetProfitEstimate());
+	}
+}

--- a/src/test/java/com/flipsmart/OfferDispositionTest.java
+++ b/src/test/java/com/flipsmart/OfferDispositionTest.java
@@ -1,0 +1,29 @@
+package com.flipsmart;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class OfferDispositionTest
+{
+	@Test
+	public void priceActionsSurface()
+	{
+		assertEquals(OfferDisposition.SURFACE_PRICE, OfferDisposition.route(OfferAction.MOVE_PRICE_DOWN));
+		assertEquals(OfferDisposition.SURFACE_PRICE, OfferDisposition.route(OfferAction.EXIT_AT_BREAKEVEN));
+		assertEquals(OfferDisposition.SURFACE_PRICE, OfferDisposition.route(OfferAction.EXIT_AT_LOSS));
+	}
+
+	@Test
+	public void cancelActionsHandOff()
+	{
+		assertEquals(OfferDisposition.HANDOFF, OfferDisposition.route(OfferAction.CANCEL_AND_RELIST_OTHER));
+		assertEquals(OfferDisposition.HANDOFF, OfferDisposition.route(OfferAction.CANCEL_AND_SELL_PARTIAL));
+	}
+
+	@Test
+	public void waitAndUnknownAreNone()
+	{
+		assertEquals(OfferDisposition.NONE, OfferDisposition.route(OfferAction.WAIT));
+		assertEquals(OfferDisposition.NONE, OfferDisposition.route(null));
+	}
+}

--- a/src/test/java/com/flipsmart/OfferPoolClassifierTest.java
+++ b/src/test/java/com/flipsmart/OfferPoolClassifierTest.java
@@ -1,0 +1,27 @@
+package com.flipsmart;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class OfferPoolClassifierTest
+{
+	@Test
+	public void atOrAboveThresholdIsHighVol()
+	{
+		assertEquals("high_vol", OfferPoolClassifier.classify(500_000));
+		assertEquals("high_vol", OfferPoolClassifier.classify(1_000_000));
+	}
+
+	@Test
+	public void belowThresholdIsMidVol()
+	{
+		assertEquals("mid_vol", OfferPoolClassifier.classify(499_999));
+		assertEquals("mid_vol", OfferPoolClassifier.classify(0));
+	}
+
+	@Test
+	public void unknownVolumeFallsBackToMidVol()
+	{
+		assertEquals("mid_vol", OfferPoolClassifier.classify(null));
+	}
+}

--- a/src/test/java/com/flipsmart/TrackedOfferStageTest.java
+++ b/src/test/java/com/flipsmart/TrackedOfferStageTest.java
@@ -1,0 +1,33 @@
+package com.flipsmart;
+
+import com.google.gson.Gson;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class TrackedOfferStageTest
+{
+	@Test
+	public void defaultsToInitial()
+	{
+		TrackedOffer offer = new TrackedOffer(1, "Item", true, 10, 1000, 0);
+		assertEquals("initial", offer.getOfferStage());
+	}
+
+	@Test
+	public void stageRoundTripsThroughGson()
+	{
+		TrackedOffer offer = new TrackedOffer(1, "Item", false, 10, 1000, 0);
+		offer.setOfferStage("breakeven_relist");
+		Gson gson = new Gson();
+		TrackedOffer restored = gson.fromJson(gson.toJson(offer), TrackedOffer.class);
+		assertEquals("breakeven_relist", restored.getOfferStage());
+	}
+
+	@Test
+	public void nullStageReadsAsInitial()
+	{
+		Gson gson = new Gson();
+		TrackedOffer legacy = gson.fromJson("{\"itemId\":1,\"isBuy\":true}", TrackedOffer.class);
+		assertEquals("initial", legacy.getOfferStage());
+	}
+}


### PR DESCRIPTION
## Summary

Plugin-side consumer of the backend `POST /flip-finder/active/offer-action` advisor (shipped in backend PR #714). While the user is in the **Active** timeframe, a 30-second timer polls the advisor for each open FlipSmart-originated GE offer and surfaces graduated stale-offer recommendations — move price down, exit at breakeven, exit at loss, or cancel and hand off — directly on the active-flip panel row and via GE slot highlight. Non-Active timeframe behavior (legacy `/flips/adjustment` flow) is unchanged.

## Changes

### ✨ New Features
- **ActiveOfferAdvisorService**: daemon Timer that polls `POST /flip-finder/active/offer-action` every ~30s per open FlipSmart offer while in Active timeframe
- **Per-offer stage tracking**: `offerStage` field added to `TrackedOffer`; reuses existing `PlayerSession.trackedOffers` map
- **Graduated surface**: non-WAIT advisor actions (move_price_down, exit_at_breakeven, exit_at_loss, cancel_and_relist_other, cancel_and_sell_partial) surfaced on panel row with rationale + advised price; GE slot highlighted
- **Hotkey integration**: move_price_down / exit_at_breakeven / exit_at_loss stage the advised price via `session.setRecommendedPrice` → existing setVarc fill; player confirms — no synthetic input
- **Breakeven-relist detection**: AC5 — offer stage advances to `breakeven_relist` on re-list at advised price within 2% tolerance
- **Cancel-and-handoff**: cancel_and_relist_other / cancel_and_sell_partial delegate to Auto-recommend via `addToStaleQueue`
- **Config toggle**: `enableActiveOfferAdvisor()` (default on); gated alongside Active timeframe check
- **Suppression of legacy double-prompt**: while Active timeframe is active, legacy `/flips/adjustment` timers are superseded — no duplicate surface

### ♻️ Refactoring
- `TrackedOffer` extended with `offerStage` to carry advisor state across poll cycles

### ✅ Tests
- 11 new test classes covering advisor service, stage transitions, handoff logic, WAIT suppression, and tolerance-based breakeven detection

## Testing

### Automated Tests
- ✅ All unit tests passing (`./gradlew clean test build`)
- ✅ 11 new test classes green
- ✅ Build succeeds

### Manual Testing (in-game — Playwright cannot drive RuneLite)
- [ ] In Active mode, list a buy and let it age past the window → cancel/handoff recommendation appears on the panel row + slot highlight.
- [ ] List a sell and observe the progression over time: Move price down → Exit at breakeven → Exit at loss.
- [ ] Press the hotkey on a "Move price down" → the advised price fills in the modify screen; confirm manually.
- [ ] Accept a breakeven exit and re-list at the advised price → offer stage advances to breakeven_relist; later advice uses the post-breakeven window.
- [ ] Confirm NO double-prompt from the legacy adjustment flow while in Active mode.
- [ ] Switch to a non-Active timeframe → legacy /flips/adjustment behavior still works.
- [ ] An offer with no market data → no recommendation surfaces.
- [ ] When a recommendation is retracted on a later poll (advisor returns WAIT) → the slot highlight clears (it no longer lingers).

## API Changes

**Consumes (new)**:
- `POST /flip-finder/active/offer-action` — polls per open offer for stale-offer advisor action

No new endpoints introduced. Backend shipped this endpoint in PR #714.

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: New `enableActiveOfferAdvisor()` config toggle (default on); surfaced under plugin config panel
- [ ] Requires database migration: No

## Checklist

- [x] Tests added/updated (11 new test classes)
- [x] Code follows RuneLite plugin style guidelines
- [x] Commits are clean and descriptive
- [x] No synthetic input — player confirms all price changes
- [x] Legacy non-Active behavior unchanged
- [x] Config toggle defaults to on

## Related Issues

Implements Flip-Smart/flip-smart#719

---
### Codacy Quality Gate — fixed in this PR
- `a14cfde` PMD_UnsynchronizedStaticFormatter FlipAssistOverlay.java:37 — changed static DecimalFormat to ThreadLocal<DecimalFormat>; all call sites updated to .get().format()
- `a14cfde` PMD_AvoidDuplicateLiterals OfferActionsBatchTest.java:26 — extracted OFFERS_KEY constant; all four occurrences replaced

### Codacy Quality Gate — dismissed via API (noise)
- Lizard_nloc-medium FlipSmartPlugin.java:1867 — pollActiveOfferAdvisor has 81 LOC; sequential per-offer guards are idiomatic and not extractable without context loss
- Semgrep_codacy.java.i18n.no-hardcoded-decimal-format FlipAssistOverlay.java:38 — "#,###" is an OSRS-specific integer formatting convention; locale-specific format would produce wrong output in RuneLite context

### Codacy AI Reviewer — fixed in this PR
- `dd3a733` ActiveOfferAdvisorService.java:14 — all three callback fields marked volatile for cross-thread visibility (comment 3408909374)
- `6cf7ea5` FlipSmartPlugin.java:1860 — log.debug wrapped in isDebugEnabled() guard in poll error handler (comment 3408909375)
- `6cf7ea5` FlipSmartPlugin.java:1865 — log.debug wrapped in isDebugEnabled() guard in poll loop (comment 3408910254)
- `204d37f` ActiveOfferDispositionCacheTest.java:14 — extracted MOVE_PRICE_DOWN constant; all four occurrences updated (comment 3408910255)

### Codacy AI Reviewer — deferred (in-thread rationale)
- AutoRecommendService.java:1499 — addToStaleQueue synchronization requires broader thread-safety audit across the service (comments 3408909370, 3408910249)
- FlipSmartPlugin.java:1892 — background-thread iteration of tracked offers; clientThread dispatch requires session access refactor (comment 3408909371)
- FlipSmartPlugin.java:2043 — handoff callback on timer thread; EDT dispatch is architectural (comment 3408910248)
- ActiveOfferAdvisorService.java:10 — slot-index keyed cache redesign is an API change across service and plugin (comment 3408910250)
- FlipSmartPlugin.java:2011 — slot-keyed resolution tied to cache redesign above (comment 3408910251)
- ActiveOfferAdvisorService.java:68 — WAIT clear-highlight callback is a follow-up UI improvement (comment 3408910253)

### Codacy AI Reviewer — false positives (in-thread rationale)
- ActiveOfferAdvisorService.java:44 — switch-on-enum dispatch with two callback invocations per case is idiomatic; three branches at minimal granularity (comment 3408909372)
- FlipSmartPlugin.java:1867 — sequential null guards on iteration are idiomatic Java; complexity metric over-counts guard chains (comments 3408909373, 3408910252)