### PR TITLE
refactor(plugin): extract DTOs to api/dto + domain models to domain/ (#730)

### DIFF
--- a/src/main/java/com/flipsmart/ActiveFlipTracker.java
+++ b/src/main/java/com/flipsmart/ActiveFlipTracker.java
@@ -1,4 +1,6 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.TrackedOffer;
+import com.flipsmart.domain.flip.ActiveFlip;
 
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;

--- a/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
+++ b/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
@@ -1,4 +1,8 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.TrackedOffer;
+import com.flipsmart.api.dto.OfferAdviceResponse;
+import com.flipsmart.domain.offer.OfferDisposition;
+import com.flipsmart.api.dto.OfferAdviceRequest;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
+++ b/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.WikiPrice;
 import com.flipsmart.domain.offer.TrackedOffer;
 import com.flipsmart.api.dto.OfferAdviceResponse;
 import com.flipsmart.domain.offer.OfferDisposition;
@@ -82,7 +83,7 @@ public class ActiveOfferAdvisorService
 
 	static OfferAdviceRequest buildSnapshot(
 		TrackedOffer offer,
-		FlipSmartApiClient.WikiPrice market,
+		WikiPrice market,
 		Integer userAvgBuyPrice,
 		Integer dailyVolume)
 	{

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -1,4 +1,6 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.FlipAdjustmentRequest;
+import com.flipsmart.api.dto.WikiPrice;
 import com.flipsmart.api.dto.FlipAdjustmentResponse;
 import com.flipsmart.domain.offer.TrackedOffer;
 import com.flipsmart.domain.flip.FlipRecommendation;
@@ -647,7 +649,7 @@ public class AutoRecommendService
 			return;
 		}
 
-		FlipSmartApiClient.WikiPrice wikiPrice = plugin.getWikiPrice(itemId);
+		WikiPrice wikiPrice = plugin.getWikiPrice(itemId);
 		if (wikiPrice != null && wikiPrice.instaBuy > 0)
 		{
 			plugin.setRecommendedSellPrice(itemId, wikiPrice.instaBuy);
@@ -1239,7 +1241,7 @@ public class AutoRecommendService
 		log.debug("Auto-recommend: Checking buy adjustment for {} (price={}, {}min elapsed)",
 			itemName, offer.getPrice(), minutesSince);
 
-		plugin.getApiClient().getFlipAdjustmentAsync(FlipSmartApiClient.FlipAdjustmentRequest.builder()
+		plugin.getApiClient().getFlipAdjustmentAsync(FlipAdjustmentRequest.builder()
 			.itemId(itemId)
 			.isBuyOffer(true)
 			.offerPrice(offer.getPrice())
@@ -1719,7 +1721,7 @@ public class AutoRecommendService
 		PlayerSession session = plugin.getSession();
 		String rsn = session != null ? session.getRsnSafe().orElse(null) : null;
 
-		plugin.getApiClient().getFlipAdjustmentAsync(FlipSmartApiClient.FlipAdjustmentRequest.builder()
+		plugin.getApiClient().getFlipAdjustmentAsync(FlipAdjustmentRequest.builder()
 			.itemId(state.itemId)
 			.isBuyOffer(false)
 			.offerPrice(offer.getPrice())

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -1,4 +1,7 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.FlipAdjustmentResponse;
+import com.flipsmart.domain.offer.TrackedOffer;
+import com.flipsmart.domain.flip.FlipRecommendation;
 import com.flipsmart.util.GpUtils;
 
 import com.flipsmart.FlipAssistOverlay.FlipAssistStep;

--- a/src/main/java/com/flipsmart/BankSnapshotService.java
+++ b/src/main/java/com/flipsmart/BankSnapshotService.java
@@ -1,4 +1,6 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.BankItemId;
+import com.flipsmart.api.dto.BankItem;
 import com.flipsmart.domain.offer.TrackedOffer;
 import com.flipsmart.util.ItemUtils;
 
@@ -125,7 +127,7 @@ public class BankSnapshotService
 	{
 		try
 		{
-			List<FlipSmartApiClient.BankItem> items = collectTradeableBankItems();
+			List<BankItem> items = collectTradeableBankItems();
 
 			if (items == null || items.isEmpty())
 			{
@@ -133,8 +135,8 @@ public class BankSnapshotService
 				return;
 			}
 
-			List<FlipSmartApiClient.BankItemId> inventoryItems = collectInventoryItems();
-			List<FlipSmartApiClient.BankItemId> gearItems = collectGearItems();
+			List<BankItemId> inventoryItems = collectInventoryItems();
+			List<BankItemId> gearItems = collectGearItems();
 			long geOffersValue = calculateGEOffersValue();
 
 			log.debug("Capturing bank snapshot: {} bank items, {} inv items, {} gear items, ge={} for RSN {}",
@@ -194,7 +196,7 @@ public class BankSnapshotService
 	/**
 	 * Collect all tradeable items from the bank with their GE prices.
 	 */
-	private List<FlipSmartApiClient.BankItem> collectTradeableBankItems()
+	private List<BankItem> collectTradeableBankItems()
 	{
 		ItemContainer bank = client.getItemContainer(InventoryID.BANK);
 		if (bank == null)
@@ -210,11 +212,11 @@ public class BankSnapshotService
 			return null;
 		}
 
-		List<FlipSmartApiClient.BankItem> items = new ArrayList<>();
+		List<BankItem> items = new ArrayList<>();
 
 		for (Item item : bankItems)
 		{
-			FlipSmartApiClient.BankItem bankItem = toTradeableBankItem(item);
+			BankItem bankItem = toTradeableBankItem(item);
 			if (bankItem != null)
 			{
 				items.add(bankItem);
@@ -232,7 +234,7 @@ public class BankSnapshotService
 	/**
 	 * Convert a bank item to a BankItem if it's tradeable and has a price, or if it's coins.
 	 */
-	private FlipSmartApiClient.BankItem toTradeableBankItem(Item item)
+	private BankItem toTradeableBankItem(Item item)
 	{
 		int itemId = item.getId();
 		int quantity = item.getQuantity();
@@ -244,7 +246,7 @@ public class BankSnapshotService
 
 		if (itemId == COINS_ITEM_ID)
 		{
-			return new FlipSmartApiClient.BankItem(itemId, quantity, 1);
+			return new BankItem(itemId, quantity, 1);
 		}
 
 		if (!ItemUtils.isTradeable(itemManager, itemId))
@@ -258,7 +260,7 @@ public class BankSnapshotService
 			return null;
 		}
 
-		return new FlipSmartApiClient.BankItem(itemId, quantity, gePrice);
+		return new BankItem(itemId, quantity, gePrice);
 	}
 
 	/**
@@ -266,7 +268,7 @@ public class BankSnapshotService
 	 * The backend prices these server-side, so no GE price is computed here.
 	 * Coins (item_id 995) are included; backend prices coins as 1 GP each.
 	 */
-	private List<FlipSmartApiClient.BankItemId> collectInventoryItems()
+	private List<BankItemId> collectInventoryItems()
 	{
 		ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
 		if (inventory == null)
@@ -280,7 +282,7 @@ public class BankSnapshotService
 	 * Collect tradeable equipped gear items from the EQUIPMENT container.
 	 * The backend prices these server-side.
 	 */
-	private List<FlipSmartApiClient.BankItemId> collectGearItems()
+	private List<BankItemId> collectGearItems()
 	{
 		ItemContainer equipment = client.getItemContainer(InventoryID.EQUIPMENT);
 		if (equipment == null)
@@ -294,9 +296,9 @@ public class BankSnapshotService
 	 * Filter an item array to tradeable items (or coins) and return as a list
 	 * of BankItemId records (item_id + quantity, no client-side price).
 	 */
-	private List<FlipSmartApiClient.BankItemId> collectItemIds(Item[] items)
+	private List<BankItemId> collectItemIds(Item[] items)
 	{
-		List<FlipSmartApiClient.BankItemId> out = new ArrayList<>();
+		List<BankItemId> out = new ArrayList<>();
 		if (items == null)
 		{
 			return out;
@@ -311,7 +313,7 @@ public class BankSnapshotService
 			}
 			if (itemId == COINS_ITEM_ID || ItemUtils.isTradeable(itemManager, itemId))
 			{
-				out.add(new FlipSmartApiClient.BankItemId(itemId, quantity));
+				out.add(new BankItemId(itemId, quantity));
 			}
 		}
 		return out;

--- a/src/main/java/com/flipsmart/BankSnapshotService.java
+++ b/src/main/java/com/flipsmart/BankSnapshotService.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.TrackedOffer;
 import com.flipsmart.util.ItemUtils;
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/flipsmart/DumpAlertService.java
+++ b/src/main/java/com/flipsmart/DumpAlertService.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.DumpEvent;
 
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.AuthResult;
 import com.flipsmart.domain.offer.OfferAction;
 import com.flipsmart.api.dto.OfferAdviceResponse;
 import com.flipsmart.domain.flip.CompletedFlip;
@@ -918,7 +919,7 @@ public class FlipFinderPanel extends PluginPanel
 		{
 			// Try to authenticate in background
 			java.util.concurrent.CompletableFuture.runAsync(() -> {
-				FlipSmartApiClient.AuthResult result = apiClient.login(email, password);
+				AuthResult result = apiClient.login(email, password);
 
 				SwingUtilities.invokeLater(() -> {
 					if (result.success)
@@ -963,7 +964,7 @@ public class FlipFinderPanel extends PluginPanel
 		showLoginStatus("Logging in...", true);
 
 		java.util.concurrent.CompletableFuture.runAsync(() -> {
-			FlipSmartApiClient.AuthResult result = apiClient.login(email, password);
+			AuthResult result = apiClient.login(email, password);
 
 			SwingUtilities.invokeLater(() -> {
 				setLoginButtonsEnabled(true);
@@ -1003,7 +1004,7 @@ public class FlipFinderPanel extends PluginPanel
 		showLoginStatus("Creating account...", true);
 
 		java.util.concurrent.CompletableFuture.runAsync(() -> {
-			FlipSmartApiClient.AuthResult result = apiClient.signup(email, password);
+			AuthResult result = apiClient.signup(email, password);
 
 			SwingUtilities.invokeLater(() -> {
 				setLoginButtonsEnabled(true);

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1,4 +1,13 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.OfferAction;
+import com.flipsmart.api.dto.OfferAdviceResponse;
+import com.flipsmart.domain.flip.CompletedFlip;
+import com.flipsmart.domain.flip.FlipRecommendation;
+import com.flipsmart.api.dto.FlipFinderResponse;
+import com.flipsmart.domain.flip.FlipAnalysis;
+import com.flipsmart.domain.flip.ActiveFlip;
+import com.flipsmart.api.dto.BlocklistSummary;
+import com.flipsmart.domain.offer.PendingOrder;
 import com.flipsmart.util.BuyPriceLookup;
 import com.flipsmart.util.GeTax;
 import com.flipsmart.util.GpUtils;

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -1,4 +1,18 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.ActiveFlipsResponse;
+import com.flipsmart.api.dto.CompletedFlipsResponse;
+import com.flipsmart.api.dto.FlipAdjustmentResponse;
+import com.flipsmart.api.dto.OfferAdviceResponse;
+import com.flipsmart.api.dto.OfferAdviceBatchResponse;
+import com.flipsmart.api.dto.BankSnapshotResponse;
+import com.flipsmart.api.dto.TimeframeFlipFinderResponse;
+import com.flipsmart.api.dto.FlipFinderResponse;
+import com.flipsmart.api.dto.BlocklistsResponse;
+import com.flipsmart.domain.flip.FlipAnalysis;
+import com.flipsmart.api.dto.DumpEvent;
+import com.flipsmart.api.dto.FlipStatisticsResponse;
+import com.flipsmart.api.dto.BankSnapshotStatusResponse;
+import com.flipsmart.api.dto.OfferAdviceRequest;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -13,6 +13,17 @@ import com.flipsmart.api.dto.DumpEvent;
 import com.flipsmart.api.dto.FlipStatisticsResponse;
 import com.flipsmart.api.dto.BankSnapshotStatusResponse;
 import com.flipsmart.api.dto.OfferAdviceRequest;
+import com.flipsmart.api.dto.AuthResult;
+import com.flipsmart.api.dto.DeviceAuthResponse;
+import com.flipsmart.api.dto.DeviceStatusResponse;
+import com.flipsmart.api.dto.MotdResponse;
+import com.flipsmart.api.dto.TransactionRequest;
+import com.flipsmart.api.dto.HistoryBackfillEntry;
+import com.flipsmart.api.dto.DumpsResponse;
+import com.flipsmart.api.dto.BankItem;
+import com.flipsmart.api.dto.BankItemId;
+import com.flipsmart.api.dto.WikiPrice;
+import com.flipsmart.api.dto.FlipAdjustmentRequest;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -147,21 +158,6 @@ public class FlipSmartApiClient
 		return URLEncoder.encode(value, StandardCharsets.UTF_8);
 	}
 
-	/**
-	 * Authentication result with status and message
-	 */
-	public static class AuthResult
-	{
-		public final boolean success;
-		public final String message;
-		
-		public AuthResult(boolean success, String message)
-		{
-			this.success = success;
-			this.message = message;
-		}
-	}
-	
 	/**
 	 * Execute an HTTP request asynchronously with automatic retry on 401
 	 * This is the core method that handles all HTTP requests off the main threads
@@ -898,90 +894,6 @@ public class FlipSmartApiClient
 	// ============================================================================
 	
 	/**
-	 * Response from starting device authorization
-	 */
-	public static class DeviceAuthResponse
-	{
-		private String deviceCode;
-		private String userCode;
-		private String verificationUrl;
-		private int expiresIn;
-		private int pollInterval;
-		
-		/** Default constructor required for Gson deserialization */
-		public DeviceAuthResponse() { }
-		
-		public String getDeviceCode() { return deviceCode; }
-		public void setDeviceCode(String deviceCode) { this.deviceCode = deviceCode; }
-		
-		public String getUserCode() { return userCode; }
-		public void setUserCode(String userCode) { this.userCode = userCode; }
-		
-		public String getVerificationUrl() { return verificationUrl; }
-		public void setVerificationUrl(String verificationUrl) { this.verificationUrl = verificationUrl; }
-		
-		public int getExpiresIn() { return expiresIn; }
-		public void setExpiresIn(int expiresIn) { this.expiresIn = expiresIn; }
-		
-		public int getPollInterval() { return pollInterval; }
-		public void setPollInterval(int pollInterval) { this.pollInterval = pollInterval; }
-	}
-	
-	/**
-	 * Response from polling device authorization status
-	 */
-	public static class DeviceStatusResponse
-	{
-		private String status;  // pending, authorized, expired
-		private String accessToken;
-		private String tokenType;
-		private String refreshToken;  // For session persistence across client restarts
-
-		/** Default constructor required for Gson deserialization */
-		public DeviceStatusResponse() { }
-
-		public String getStatus() { return status; }
-		public void setStatus(String status) { this.status = status; }
-
-		public String getAccessToken() { return accessToken; }
-		public void setAccessToken(String accessToken) { this.accessToken = accessToken; }
-
-		public String getTokenType() { return tokenType; }
-		public void setTokenType(String tokenType) { this.tokenType = tokenType; }
-
-		public String getRefreshToken() { return refreshToken; }
-		public void setRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
-	}
-
-	/**
-	 * Per-channel MOTD payload returned by GET /motd.
-	 */
-	public static class MotdChannelData
-	{
-		private String message;
-		private boolean enabled;
-		private String version;
-		private String severity;
-
-		public String getMessage() { return message; }
-		public boolean isEnabled() { return enabled; }
-		public String getVersion() { return version; }
-		public String getSeverity() { return severity; }
-	}
-
-	/**
-	 * Response shape for GET /motd.
-	 */
-	public static class MotdResponse
-	{
-		private MotdChannelData web;
-		private MotdChannelData plugin;
-
-		public MotdChannelData getWeb() { return web; }
-		public MotdChannelData getPlugin() { return plugin; }
-	}
-
-	/**
 	 * Start the device authorization flow for Discord login.
 	 * Returns a device code and verification URL that the user should open in their browser.
 	 * 
@@ -1025,13 +937,13 @@ public class FlipSmartApiClient
 					JsonObject json = gson.fromJson(jsonData, JsonObject.class);
 					
 					DeviceAuthResponse authResponse = new DeviceAuthResponse();
-					authResponse.deviceCode = json.get("device_code").getAsString();
-					authResponse.userCode = json.get("user_code").getAsString();
-					authResponse.verificationUrl = json.get("verification_url").getAsString();
-					authResponse.expiresIn = json.get("expires_in").getAsInt();
-					authResponse.pollInterval = json.get("poll_interval").getAsInt();
-					
-					log.debug("Device auth started, verification URL: {}", authResponse.verificationUrl);
+					authResponse.setDeviceCode(json.get("device_code").getAsString());
+					authResponse.setUserCode(json.get("user_code").getAsString());
+					authResponse.setVerificationUrl(json.get("verification_url").getAsString());
+					authResponse.setExpiresIn(json.get("expires_in").getAsInt());
+					authResponse.setPollInterval(json.get("poll_interval").getAsInt());
+
+					log.debug("Device auth started, verification URL: {}", authResponse.getVerificationUrl());
 					future.complete(authResponse);
 				}
 				catch (Exception e)
@@ -1081,7 +993,7 @@ public class FlipSmartApiClient
 					{
 						// Device code not found - treat as expired
 						DeviceStatusResponse statusResponse = new DeviceStatusResponse();
-						statusResponse.status = "expired";
+						statusResponse.setStatus("expired");
 						future.complete(statusResponse);
 						return;
 					}
@@ -1316,69 +1228,6 @@ public class FlipSmartApiClient
 	}
 
 	/**
-	 * Data class for transaction request parameters (use Builder to construct)
-	 */
-	public static class TransactionRequest
-	{
-		public final int itemId;
-		public final String itemName;
-		public final boolean isBuy;
-		public final int quantity;
-		public final int pricePerItem;
-		public final Integer geSlot;
-		public final Integer recommendedSellPrice;
-		public final String rsn;
-		public final Integer totalQuantity;
-
-		private TransactionRequest(Builder builder)
-		{
-			this.itemId = builder.itemId;
-			this.itemName = builder.itemName;
-			this.isBuy = builder.isBuy;
-			this.quantity = builder.quantity;
-			this.pricePerItem = builder.pricePerItem;
-			this.geSlot = builder.geSlot;
-			this.recommendedSellPrice = builder.recommendedSellPrice;
-			this.rsn = builder.rsn;
-			this.totalQuantity = builder.totalQuantity;
-		}
-
-		public static Builder builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
-		{
-			return new Builder(itemId, itemName, isBuy, quantity, pricePerItem);
-		}
-
-		public static class Builder
-		{
-			private final int itemId;
-			private final String itemName;
-			private final boolean isBuy;
-			private final int quantity;
-			private final int pricePerItem;
-			private Integer geSlot;
-			private Integer recommendedSellPrice;
-			private String rsn;
-			private Integer totalQuantity;
-
-			private Builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
-			{
-				this.itemId = itemId;
-				this.itemName = itemName;
-				this.isBuy = isBuy;
-				this.quantity = quantity;
-				this.pricePerItem = pricePerItem;
-			}
-
-			public Builder geSlot(Integer geSlot) { this.geSlot = geSlot; return this; }
-			public Builder recommendedSellPrice(Integer price) { this.recommendedSellPrice = price; return this; }
-			public Builder rsn(String rsn) { this.rsn = rsn; return this; }
-			public Builder totalQuantity(Integer qty) { this.totalQuantity = qty; return this; }
-
-			public TransactionRequest build() { return new TransactionRequest(this); }
-		}
-	}
-
-	/**
 	 * Record a Grand Exchange transaction asynchronously
 	 */
 	public CompletableFuture<Void> recordTransactionAsync(TransactionRequest request)
@@ -1445,27 +1294,6 @@ public class FlipSmartApiClient
 			.build();
 		
 		return recordTransactionAsync(request);
-	}
-
-	/**
-	 * Single GE History row, used by recordHistoryBackfillBatchAsync.
-	 */
-	public static class HistoryBackfillEntry
-	{
-		public final int itemId;
-		public final String itemName;
-		public final boolean isBuy;
-		public final int quantity;
-		public final int pricePerItem;
-
-		public HistoryBackfillEntry(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
-		{
-			this.itemId = itemId;
-			this.itemName = itemName;
-			this.isBuy = isBuy;
-			this.quantity = quantity;
-			this.pricePerItem = pricePerItem;
-		}
 	}
 
 	/**
@@ -1776,16 +1604,6 @@ public class FlipSmartApiClient
 	}
 
 	/**
-	 * Response wrapper for dumps API
-	 */
-	public static class DumpsResponse
-	{
-		public DumpEvent[] dumps;
-		public int count;
-		public String sort_by;
-	}
-
-	/**
 	 * Fetch market dumps from the API asynchronously
 	 *
 	 * @param sortBy Sort order: "recency" or "profit"
@@ -1907,39 +1725,6 @@ public class FlipSmartApiClient
 	// ============================================================================
 
 	/**
-	 * Data class for bank snapshot item
-	 */
-	public static class BankItem
-	{
-		public final int itemId;
-		public final int quantity;
-		public final int valuePerItem;
-
-		public BankItem(int itemId, int quantity, int valuePerItem)
-		{
-			this.itemId = itemId;
-			this.quantity = quantity;
-			this.valuePerItem = valuePerItem;
-		}
-	}
-
-	/**
-	 * Data class for an inventory or gear item.
-	 * Backend prices these server-side, so no value_per_item is sent.
-	 */
-	public static class BankItemId
-	{
-		public final int itemId;
-		public final int quantity;
-
-		public BankItemId(int itemId, int quantity)
-		{
-			this.itemId = itemId;
-			this.quantity = quantity;
-		}
-	}
-
-	/**
 	 * Check if a bank snapshot can be taken (rate limit check)
 	 *
 	 * @param rsn RuneScape Name to check
@@ -2037,28 +1822,6 @@ public class FlipSmartApiClient
 	private final Map<Integer, WikiPrice> wikiPriceCache = new ConcurrentHashMap<>();
 	private final AtomicLong lastWikiPriceFetch = new AtomicLong(0);
 	private final AtomicBoolean wikiPriceFetchInProgress = new AtomicBoolean(false);
-
-	/**
-	 * Real-time price data from the wiki API
-	 */
-	public static class WikiPrice
-	{
-		public final int instaBuy;   // High price - what buyers pay to instant-buy
-		public final int instaSell;  // Low price - what sellers receive when instant-selling
-		public final long fetchedAt;
-
-		public WikiPrice(int instaBuy, int instaSell)
-		{
-			this.instaBuy = instaBuy;
-			this.instaSell = instaSell;
-			this.fetchedAt = System.currentTimeMillis();
-		}
-
-		public boolean isExpired()
-		{
-			return System.currentTimeMillis() - fetchedAt > WIKI_PRICE_CACHE_DURATION_MS;
-		}
-	}
 
 	/**
 	 * Get cached wiki price for an item. Returns null if not cached or expired.
@@ -2279,24 +2042,6 @@ public class FlipSmartApiClient
 	// =========================================================================
 	// Flip Adjustment API Methods
 	// =========================================================================
-
-	/**
-	 * Request parameters for the flip adjustment API.
-	 */
-	@lombok.Builder
-	public static class FlipAdjustmentRequest
-	{
-		final int itemId;
-		final boolean isBuyOffer;
-		final int offerPrice;
-		final int averageBuyPrice;
-		final int minutesSinceOffer;
-		final int adjustmentCount;
-		final int quantityFilled;
-		final int totalQuantity;
-		final String timeframe;
-		final String rsn;
-	}
 
 	/**
 	 * Get a flip adjustment recommendation from the backend.

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1,4 +1,10 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.TrackedOffer;
+import com.flipsmart.api.dto.OfferAdviceResponse;
+import com.flipsmart.domain.flip.ActiveFlip;
+import com.flipsmart.domain.offer.PendingOrder;
+import com.flipsmart.api.dto.OfferAdviceResult;
+import com.flipsmart.api.dto.OfferAdviceRequest;
 import com.flipsmart.util.BuyPriceLookup;
 import com.flipsmart.util.ItemUtils;
 import com.flipsmart.util.TimeUtils;

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.WikiPrice;
 import com.flipsmart.domain.offer.TrackedOffer;
 import com.flipsmart.api.dto.OfferAdviceResponse;
 import com.flipsmart.domain.flip.ActiveFlip;
@@ -449,7 +450,7 @@ public class FlipSmartPlugin extends Plugin
 		}
 
 		// Try to get real-time wiki prices first
-		FlipSmartApiClient.WikiPrice wikiPrice = apiClient.getWikiPrice(offer.getItemId());
+		WikiPrice wikiPrice = apiClient.getWikiPrice(offer.getItemId());
 
 		if (wikiPrice != null)
 		{
@@ -485,7 +486,7 @@ public class FlipSmartPlugin extends Plugin
 	/**
 	 * Get real-time wiki price for an item (for tooltip display)
 	 */
-	public FlipSmartApiClient.WikiPrice getWikiPrice(int itemId)
+	public WikiPrice getWikiPrice(int itemId)
 	{
 		return apiClient.getWikiPrice(itemId);
 	}
@@ -1916,7 +1917,7 @@ public class FlipSmartPlugin extends Plugin
 				continue;
 			}
 			Integer dailyVolume = apiClient.getCachedDailyVolume(offer.getItemId());
-			FlipSmartApiClient.WikiPrice market = apiClient.getWikiPrice(offer.getItemId());
+			WikiPrice market = apiClient.getWikiPrice(offer.getItemId());
 			Integer avgBuy = offer.isBuy() ? null
 				: BuyPriceLookup.findAverageBuyPrice(getCurrentActiveFlips(), offer.getItemId());
 			requests.add(ActiveOfferAdvisorService.buildSnapshot(offer, market, avgBuy, dailyVolume));

--- a/src/main/java/com/flipsmart/FocusedFlip.java
+++ b/src/main/java/com/flipsmart/FocusedFlip.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.domain.flip.FlipRecommendation;
 import com.flipsmart.util.GeTax;
 
 import lombok.Data;

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.TrackedOffer;
 
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.HistoryBackfillEntry;
 import com.flipsmart.domain.offer.TrackedOffer;
 
 import lombok.extern.slf4j.Slf4j;
@@ -415,10 +416,10 @@ public class GEHistoryService
 		for (TrackedOffer o : session.getTrackedOffers().values()) nameByItem.put(o.getItemId(), o.getItemName());
 		for (TrackedOffer o : recentlyPersistedOffers.values()) nameByItem.putIfAbsent(o.getItemId(), o.getItemName());
 
-		List<FlipSmartApiClient.HistoryBackfillEntry> batch = new ArrayList<>(entries.size());
+		List<HistoryBackfillEntry> batch = new ArrayList<>(entries.size());
 		for (GEHistoryEntry e : entries)
 		{
-			batch.add(new FlipSmartApiClient.HistoryBackfillEntry(
+			batch.add(new HistoryBackfillEntry(
 				e.getItemId(), nameByItem.get(e.getItemId()),
 				e.isBuy(), e.getQuantity(), e.getPricePerItem()
 			));

--- a/src/main/java/com/flipsmart/GeOfferDescriptionService.java
+++ b/src/main/java/com/flipsmart/GeOfferDescriptionService.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.WikiPrice;
 import com.flipsmart.domain.offer.TrackedOffer;
 import com.flipsmart.util.BuyPriceLookup;
 
@@ -430,7 +431,7 @@ public class GeOfferDescriptionService
 
 	private Integer lookupWikiInstaBuy(int itemId)
 	{
-		FlipSmartApiClient.WikiPrice price = apiClient.getWikiPrice(itemId);
+		WikiPrice price = apiClient.getWikiPrice(itemId);
 		return (price != null && price.instaBuy > 0) ? price.instaBuy : null;
 	}
 

--- a/src/main/java/com/flipsmart/GeOfferDescriptionService.java
+++ b/src/main/java/com/flipsmart/GeOfferDescriptionService.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.TrackedOffer;
 import com.flipsmart.util.BuyPriceLookup;
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/flipsmart/GrandExchangeOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeOverlay.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.TrackedOffer;
 import com.flipsmart.util.ItemUtils;
 
 import net.runelite.api.Client;

--- a/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.TrackedOffer;
 import com.flipsmart.util.BuyPriceLookup;
 import com.flipsmart.util.GeTax;
 import com.flipsmart.util.TimeUtils;

--- a/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.WikiPrice;
 import com.flipsmart.domain.offer.TrackedOffer;
 import com.flipsmart.util.BuyPriceLookup;
 import com.flipsmart.util.GeTax;
@@ -203,7 +204,7 @@ public class GrandExchangeSlotOverlay extends Overlay
 	private static class TooltipData
 	{
 		GrandExchangeOffer offer;
-		FlipSmartApiClient.WikiPrice wikiPrice;
+		WikiPrice wikiPrice;
 		int offerPrice;
 		int x;
 		int y;
@@ -456,7 +457,7 @@ public class GrandExchangeSlotOverlay extends Overlay
 	 * Draw a custom tooltip with background showing real-time insta prices
 	 */
 	private void drawPriceTooltip(Graphics2D graphics, int x, int y, GrandExchangeOffer offer,
-								  FlipSmartApiClient.WikiPrice wikiPrice, int offerPrice, Integer buyPrice)
+								  WikiPrice wikiPrice, int offerPrice, Integer buyPrice)
 	{
 		boolean isBuy = isOfferBuyType(offer);
 
@@ -484,7 +485,7 @@ public class GrandExchangeSlotOverlay extends Overlay
 	/**
 	 * Build tooltip text lines based on wiki price data
 	 */
-	private java.util.List<String> buildTooltipLines(FlipSmartApiClient.WikiPrice wikiPrice, int offerPrice,
+	private java.util.List<String> buildTooltipLines(WikiPrice wikiPrice, int offerPrice,
 													  Integer buyPrice, boolean isBuy, int totalQuantity, int itemId)
 	{
 		java.util.List<String> lines = new java.util.ArrayList<>();
@@ -500,7 +501,7 @@ public class GrandExchangeSlotOverlay extends Overlay
 		return lines;
 	}
 
-	private void addPriceLines(java.util.List<String> lines, FlipSmartApiClient.WikiPrice wikiPrice)
+	private void addPriceLines(java.util.List<String> lines, WikiPrice wikiPrice)
 	{
 		if (wikiPrice == null || (wikiPrice.instaBuy <= 0 && wikiPrice.instaSell <= 0))
 		{
@@ -547,7 +548,7 @@ public class GrandExchangeSlotOverlay extends Overlay
 	/**
 	 * Determine color for user's price based on competitiveness
 	 */
-	private Color determineYourPriceColor(FlipSmartApiClient.WikiPrice wikiPrice, int offerPrice, boolean isBuy)
+	private Color determineYourPriceColor(WikiPrice wikiPrice, int offerPrice, boolean isBuy)
 	{
 		if (wikiPrice == null || (wikiPrice.instaBuy <= 0 && wikiPrice.instaSell <= 0))
 		{

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -1,4 +1,11 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.OfferAction;
+import com.flipsmart.api.dto.ActiveFlipsResponse;
+import com.flipsmart.domain.offer.TrackedOffer;
+import com.flipsmart.api.dto.OfferAdviceResponse;
+import com.flipsmart.domain.flip.FlipRecommendation;
+import com.flipsmart.domain.flip.ActiveFlip;
+import com.flipsmart.domain.offer.PendingOrder;
 import com.flipsmart.util.ItemUtils;
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.TransactionRequest;
 import com.flipsmart.domain.offer.OfferAction;
 import com.flipsmart.api.dto.ActiveFlipsResponse;
 import com.flipsmart.domain.offer.TrackedOffer;
@@ -297,7 +298,7 @@ public class GrandExchangeTracker
 
 			Integer recommendedSellPrice = ctx.isBuy ? session.getRecommendedPrice(ctx.itemId) : null;
 
-			apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
+			apiClient.recordTransactionAsync(TransactionRequest
 				.builder(ctx.itemId, ctx.itemName, ctx.isBuy, newQuantity, pricePerItem)
 				.geSlot(ctx.slot)
 				.recommendedSellPrice(recommendedSellPrice)
@@ -606,7 +607,7 @@ public class GrandExchangeTracker
 
 		Integer recommendedSellPrice = ctx.isBuy ? session.getRecommendedPrice(ctx.itemId) : null;
 
-		apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
+		apiClient.recordTransactionAsync(TransactionRequest
 			.builder(ctx.itemId, ctx.itemName, ctx.isBuy, newQuantity, pricePerItem)
 			.geSlot(ctx.slot)
 			.recommendedSellPrice(recommendedSellPrice)
@@ -727,7 +728,7 @@ public class GrandExchangeTracker
 
 		Integer recommendedSellPrice = session.getRecommendedPrice(ctx.itemId);
 
-		apiClient.recordTransactionAsync(FlipSmartApiClient.TransactionRequest
+		apiClient.recordTransactionAsync(TransactionRequest
 			.builder(ctx.itemId, ctx.itemName, true, 0, ctx.price)
 			.geSlot(ctx.slot)
 			.recommendedSellPrice(recommendedSellPrice)

--- a/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
+++ b/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
@@ -1,4 +1,8 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.FlipAdjustmentResponse;
+import com.flipsmart.domain.offer.TrackedOffer;
+import com.flipsmart.domain.flip.FlipRecommendation;
+import com.flipsmart.api.dto.FlipFinderResponse;
 import com.flipsmart.util.GpUtils;
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
+++ b/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.FlipAdjustmentRequest;
 import com.flipsmart.api.dto.FlipAdjustmentResponse;
 import com.flipsmart.domain.offer.TrackedOffer;
 import com.flipsmart.domain.flip.FlipRecommendation;
@@ -289,7 +290,7 @@ public class ManualAdjustmentTracker
 
 		String rsn = rsnSupplier != null ? rsnSupplier.get() : null;
 
-		apiClient.getFlipAdjustmentAsync(FlipSmartApiClient.FlipAdjustmentRequest.builder()
+		apiClient.getFlipAdjustmentAsync(FlipAdjustmentRequest.builder()
 			.itemId(state.itemId)
 			.isBuyOffer(state.isBuy)
 			.offerPrice(offer.getPrice())

--- a/src/main/java/com/flipsmart/MotdService.java
+++ b/src/main/java/com/flipsmart/MotdService.java
@@ -1,4 +1,6 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.MotdChannelData;
+import com.flipsmart.api.dto.MotdResponse;
 
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
@@ -43,7 +45,7 @@ public class MotdService
 	private ScheduledExecutorService executor;
 	private ScheduledFuture<?> pollingTask;
 
-	private FlipSmartApiClient.MotdResponse latest;
+	private MotdResponse latest;
 
 	@Inject
 	public MotdService(
@@ -98,7 +100,7 @@ public class MotdService
 	}
 
 	/** Visible for testing. */
-	void handleResponse(FlipSmartApiClient.MotdResponse response)
+	void handleResponse(MotdResponse response)
 	{
 		if (response == null) return;
 		latest = response;
@@ -122,7 +124,7 @@ public class MotdService
 	{
 		if (!config.motdEnabled()) return;
 		if (latest == null) return;
-		FlipSmartApiClient.MotdChannelData plugin = latest.getPlugin();
+		MotdChannelData plugin = latest.getPlugin();
 		if (plugin == null) return;
 		if (!plugin.isEnabled()) return;
 		String message = plugin.getMessage();

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.TrackedOffer;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;

--- a/src/main/java/com/flipsmart/PlayerSession.java
+++ b/src/main/java/com/flipsmart/PlayerSession.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.TrackedOffer;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/flipsmart/api/dto/ActiveFlipsResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/ActiveFlipsResponse.java
@@ -1,4 +1,5 @@
-package com.flipsmart;
+package com.flipsmart.api.dto;
+import com.flipsmart.domain.flip.ActiveFlip;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;

--- a/src/main/java/com/flipsmart/api/dto/AuthResult.java
+++ b/src/main/java/com/flipsmart/api/dto/AuthResult.java
@@ -1,0 +1,16 @@
+package com.flipsmart.api.dto;
+
+/**
+ * Authentication result with status and message
+ */
+public class AuthResult
+{
+	public final boolean success;
+	public final String message;
+
+	public AuthResult(boolean success, String message)
+	{
+		this.success = success;
+		this.message = message;
+	}
+}

--- a/src/main/java/com/flipsmart/api/dto/BankItem.java
+++ b/src/main/java/com/flipsmart/api/dto/BankItem.java
@@ -1,0 +1,18 @@
+package com.flipsmart.api.dto;
+
+/**
+ * Data class for bank snapshot item
+ */
+public class BankItem
+{
+	public final int itemId;
+	public final int quantity;
+	public final int valuePerItem;
+
+	public BankItem(int itemId, int quantity, int valuePerItem)
+	{
+		this.itemId = itemId;
+		this.quantity = quantity;
+		this.valuePerItem = valuePerItem;
+	}
+}

--- a/src/main/java/com/flipsmart/api/dto/BankItemId.java
+++ b/src/main/java/com/flipsmart/api/dto/BankItemId.java
@@ -1,0 +1,17 @@
+package com.flipsmart.api.dto;
+
+/**
+ * Data class for an inventory or gear item.
+ * Backend prices these server-side, so no value_per_item is sent.
+ */
+public class BankItemId
+{
+	public final int itemId;
+	public final int quantity;
+
+	public BankItemId(int itemId, int quantity)
+	{
+		this.itemId = itemId;
+		this.quantity = quantity;
+	}
+}

--- a/src/main/java/com/flipsmart/api/dto/BankSnapshotResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/BankSnapshotResponse.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.api.dto;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;

--- a/src/main/java/com/flipsmart/api/dto/BankSnapshotStatusResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/BankSnapshotStatusResponse.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.api.dto;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;

--- a/src/main/java/com/flipsmart/api/dto/BlocklistSummary.java
+++ b/src/main/java/com/flipsmart/api/dto/BlocklistSummary.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.api.dto;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;

--- a/src/main/java/com/flipsmart/api/dto/BlocklistsResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/BlocklistsResponse.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.api.dto;
 
 import lombok.Data;
 import java.util.List;

--- a/src/main/java/com/flipsmart/api/dto/CompletedFlipsResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/CompletedFlipsResponse.java
@@ -1,4 +1,5 @@
-package com.flipsmart;
+package com.flipsmart.api.dto;
+import com.flipsmart.domain.flip.CompletedFlip;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;

--- a/src/main/java/com/flipsmart/api/dto/DeviceAuthResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/DeviceAuthResponse.java
@@ -1,0 +1,31 @@
+package com.flipsmart.api.dto;
+
+/**
+ * Response from starting device authorization
+ */
+public class DeviceAuthResponse
+{
+	private String deviceCode;
+	private String userCode;
+	private String verificationUrl;
+	private int expiresIn;
+	private int pollInterval;
+
+	/** Default constructor required for Gson deserialization */
+	public DeviceAuthResponse() { }
+
+	public String getDeviceCode() { return deviceCode; }
+	public void setDeviceCode(String deviceCode) { this.deviceCode = deviceCode; }
+
+	public String getUserCode() { return userCode; }
+	public void setUserCode(String userCode) { this.userCode = userCode; }
+
+	public String getVerificationUrl() { return verificationUrl; }
+	public void setVerificationUrl(String verificationUrl) { this.verificationUrl = verificationUrl; }
+
+	public int getExpiresIn() { return expiresIn; }
+	public void setExpiresIn(int expiresIn) { this.expiresIn = expiresIn; }
+
+	public int getPollInterval() { return pollInterval; }
+	public void setPollInterval(int pollInterval) { this.pollInterval = pollInterval; }
+}

--- a/src/main/java/com/flipsmart/api/dto/DeviceStatusResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/DeviceStatusResponse.java
@@ -1,0 +1,27 @@
+package com.flipsmart.api.dto;
+
+/**
+ * Response from polling device authorization status
+ */
+public class DeviceStatusResponse
+{
+	private String status;  // pending, authorized, expired
+	private String accessToken;
+	private String tokenType;
+	private String refreshToken;  // For session persistence across client restarts
+
+	/** Default constructor required for Gson deserialization */
+	public DeviceStatusResponse() { }
+
+	public String getStatus() { return status; }
+	public void setStatus(String status) { this.status = status; }
+
+	public String getAccessToken() { return accessToken; }
+	public void setAccessToken(String accessToken) { this.accessToken = accessToken; }
+
+	public String getTokenType() { return tokenType; }
+	public void setTokenType(String tokenType) { this.tokenType = tokenType; }
+
+	public String getRefreshToken() { return refreshToken; }
+	public void setRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
+}

--- a/src/main/java/com/flipsmart/api/dto/DumpEvent.java
+++ b/src/main/java/com/flipsmart/api/dto/DumpEvent.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.api.dto;
 import com.flipsmart.util.GpUtils;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/com/flipsmart/api/dto/DumpsResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/DumpsResponse.java
@@ -1,0 +1,11 @@
+package com.flipsmart.api.dto;
+
+/**
+ * Response wrapper for dumps API
+ */
+public class DumpsResponse
+{
+	public DumpEvent[] dumps;
+	public int count;
+	public String sort_by;
+}

--- a/src/main/java/com/flipsmart/api/dto/FlipAdjustmentRequest.java
+++ b/src/main/java/com/flipsmart/api/dto/FlipAdjustmentRequest.java
@@ -1,0 +1,21 @@
+package com.flipsmart.api.dto;
+
+import lombok.Builder;
+
+/**
+ * Request parameters for the flip adjustment API.
+ */
+@Builder
+public class FlipAdjustmentRequest
+{
+	public final int itemId;
+	public final boolean isBuyOffer;
+	public final int offerPrice;
+	public final int averageBuyPrice;
+	public final int minutesSinceOffer;
+	public final int adjustmentCount;
+	public final int quantityFilled;
+	public final int totalQuantity;
+	public final String timeframe;
+	public final String rsn;
+}

--- a/src/main/java/com/flipsmart/api/dto/FlipAdjustmentResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/FlipAdjustmentResponse.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.api.dto;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;

--- a/src/main/java/com/flipsmart/api/dto/FlipFinderResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/FlipFinderResponse.java
@@ -1,4 +1,5 @@
-package com.flipsmart;
+package com.flipsmart.api.dto;
+import com.flipsmart.domain.flip.FlipRecommendation;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;

--- a/src/main/java/com/flipsmart/api/dto/FlipStatisticsResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/FlipStatisticsResponse.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.api.dto;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;

--- a/src/main/java/com/flipsmart/api/dto/HistoryBackfillEntry.java
+++ b/src/main/java/com/flipsmart/api/dto/HistoryBackfillEntry.java
@@ -1,0 +1,22 @@
+package com.flipsmart.api.dto;
+
+/**
+ * Single GE History row, used by recordHistoryBackfillBatchAsync.
+ */
+public class HistoryBackfillEntry
+{
+	public final int itemId;
+	public final String itemName;
+	public final boolean isBuy;
+	public final int quantity;
+	public final int pricePerItem;
+
+	public HistoryBackfillEntry(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
+	{
+		this.itemId = itemId;
+		this.itemName = itemName;
+		this.isBuy = isBuy;
+		this.quantity = quantity;
+		this.pricePerItem = pricePerItem;
+	}
+}

--- a/src/main/java/com/flipsmart/api/dto/MotdChannelData.java
+++ b/src/main/java/com/flipsmart/api/dto/MotdChannelData.java
@@ -1,0 +1,17 @@
+package com.flipsmart.api.dto;
+
+/**
+ * Per-channel MOTD payload returned by GET /motd.
+ */
+public class MotdChannelData
+{
+	private String message;
+	private boolean enabled;
+	private String version;
+	private String severity;
+
+	public String getMessage() { return message; }
+	public boolean isEnabled() { return enabled; }
+	public String getVersion() { return version; }
+	public String getSeverity() { return severity; }
+}

--- a/src/main/java/com/flipsmart/api/dto/MotdResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/MotdResponse.java
@@ -1,0 +1,13 @@
+package com.flipsmart.api.dto;
+
+/**
+ * Response shape for GET /motd.
+ */
+public class MotdResponse
+{
+	private MotdChannelData web;
+	private MotdChannelData plugin;
+
+	public MotdChannelData getWeb() { return web; }
+	public MotdChannelData getPlugin() { return plugin; }
+}

--- a/src/main/java/com/flipsmart/api/dto/OfferAdviceBatchResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/OfferAdviceBatchResponse.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.api.dto;
 
 import java.util.List;
 import lombok.Data;

--- a/src/main/java/com/flipsmart/api/dto/OfferAdviceRequest.java
+++ b/src/main/java/com/flipsmart/api/dto/OfferAdviceRequest.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.api.dto;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;

--- a/src/main/java/com/flipsmart/api/dto/OfferAdviceResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/OfferAdviceResponse.java
@@ -1,4 +1,5 @@
-package com.flipsmart;
+package com.flipsmart.api.dto;
+import com.flipsmart.domain.offer.OfferAction;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;

--- a/src/main/java/com/flipsmart/api/dto/OfferAdviceResult.java
+++ b/src/main/java/com/flipsmart/api/dto/OfferAdviceResult.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.api.dto;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;

--- a/src/main/java/com/flipsmart/api/dto/TimeframeFlipFinderResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/TimeframeFlipFinderResponse.java
@@ -1,4 +1,5 @@
-package com.flipsmart;
+package com.flipsmart.api.dto;
+import com.flipsmart.domain.flip.FlipRecommendation;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;

--- a/src/main/java/com/flipsmart/api/dto/TransactionRequest.java
+++ b/src/main/java/com/flipsmart/api/dto/TransactionRequest.java
@@ -1,0 +1,64 @@
+package com.flipsmart.api.dto;
+
+/**
+ * Data class for transaction request parameters (use Builder to construct)
+ */
+public class TransactionRequest
+{
+	public final int itemId;
+	public final String itemName;
+	public final boolean isBuy;
+	public final int quantity;
+	public final int pricePerItem;
+	public final Integer geSlot;
+	public final Integer recommendedSellPrice;
+	public final String rsn;
+	public final Integer totalQuantity;
+
+	private TransactionRequest(Builder builder)
+	{
+		this.itemId = builder.itemId;
+		this.itemName = builder.itemName;
+		this.isBuy = builder.isBuy;
+		this.quantity = builder.quantity;
+		this.pricePerItem = builder.pricePerItem;
+		this.geSlot = builder.geSlot;
+		this.recommendedSellPrice = builder.recommendedSellPrice;
+		this.rsn = builder.rsn;
+		this.totalQuantity = builder.totalQuantity;
+	}
+
+	public static Builder builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
+	{
+		return new Builder(itemId, itemName, isBuy, quantity, pricePerItem);
+	}
+
+	public static class Builder
+	{
+		private final int itemId;
+		private final String itemName;
+		private final boolean isBuy;
+		private final int quantity;
+		private final int pricePerItem;
+		private Integer geSlot;
+		private Integer recommendedSellPrice;
+		private String rsn;
+		private Integer totalQuantity;
+
+		private Builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
+		{
+			this.itemId = itemId;
+			this.itemName = itemName;
+			this.isBuy = isBuy;
+			this.quantity = quantity;
+			this.pricePerItem = pricePerItem;
+		}
+
+		public Builder geSlot(Integer geSlot) { this.geSlot = geSlot; return this; }
+		public Builder recommendedSellPrice(Integer price) { this.recommendedSellPrice = price; return this; }
+		public Builder rsn(String rsn) { this.rsn = rsn; return this; }
+		public Builder totalQuantity(Integer qty) { this.totalQuantity = qty; return this; }
+
+		public TransactionRequest build() { return new TransactionRequest(this); }
+	}
+}

--- a/src/main/java/com/flipsmart/api/dto/WikiPrice.java
+++ b/src/main/java/com/flipsmart/api/dto/WikiPrice.java
@@ -1,0 +1,25 @@
+package com.flipsmart.api.dto;
+
+/**
+ * Real-time price data from the wiki API
+ */
+public class WikiPrice
+{
+	private static final long WIKI_PRICE_CACHE_DURATION_MS = 60_000; // 1 minute cache
+
+	public final int instaBuy;   // High price - what buyers pay to instant-buy
+	public final int instaSell;  // Low price - what sellers receive when instant-selling
+	public final long fetchedAt;
+
+	public WikiPrice(int instaBuy, int instaSell)
+	{
+		this.instaBuy = instaBuy;
+		this.instaSell = instaSell;
+		this.fetchedAt = System.currentTimeMillis();
+	}
+
+	public boolean isExpired()
+	{
+		return System.currentTimeMillis() - fetchedAt > WIKI_PRICE_CACHE_DURATION_MS;
+	}
+}

--- a/src/main/java/com/flipsmart/domain/flip/ActiveFlip.java
+++ b/src/main/java/com/flipsmart/domain/flip/ActiveFlip.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.domain.flip;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;

--- a/src/main/java/com/flipsmart/domain/flip/CompletedFlip.java
+++ b/src/main/java/com/flipsmart/domain/flip/CompletedFlip.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.domain.flip;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;

--- a/src/main/java/com/flipsmart/domain/flip/FlipAnalysis.java
+++ b/src/main/java/com/flipsmart/domain/flip/FlipAnalysis.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.domain.flip;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;

--- a/src/main/java/com/flipsmart/domain/flip/FlipRecommendation.java
+++ b/src/main/java/com/flipsmart/domain/flip/FlipRecommendation.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.domain.flip;
 import com.flipsmart.util.GpUtils;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/com/flipsmart/domain/offer/OfferAction.java
+++ b/src/main/java/com/flipsmart/domain/offer/OfferAction.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.domain.offer;
 
 public enum OfferAction
 {

--- a/src/main/java/com/flipsmart/domain/offer/OfferDisposition.java
+++ b/src/main/java/com/flipsmart/domain/offer/OfferDisposition.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.domain.offer;
 
 public enum OfferDisposition
 {

--- a/src/main/java/com/flipsmart/domain/offer/PendingOrder.java
+++ b/src/main/java/com/flipsmart/domain/offer/PendingOrder.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.domain.offer;
 
 /**
  * Represents a pending buy order in a GE slot.

--- a/src/main/java/com/flipsmart/domain/offer/TrackedOffer.java
+++ b/src/main/java/com/flipsmart/domain/offer/TrackedOffer.java
@@ -1,4 +1,4 @@
-package com.flipsmart;
+package com.flipsmart.domain.offer;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/flipsmart/util/BuyPriceLookup.java
+++ b/src/main/java/com/flipsmart/util/BuyPriceLookup.java
@@ -1,6 +1,6 @@
 package com.flipsmart.util;
+import com.flipsmart.domain.flip.ActiveFlip;
 
-import com.flipsmart.ActiveFlip;
 import java.util.List;
 
 /**

--- a/src/test/java/com/flipsmart/ActiveOfferDispositionCacheTest.java
+++ b/src/test/java/com/flipsmart/ActiveOfferDispositionCacheTest.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.OfferAdviceResponse;
 
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/flipsmart/ActiveOfferSnapshotTest.java
+++ b/src/test/java/com/flipsmart/ActiveOfferSnapshotTest.java
@@ -1,4 +1,6 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.TrackedOffer;
+import com.flipsmart.api.dto.OfferAdviceRequest;
 
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/flipsmart/ActiveOfferSnapshotTest.java
+++ b/src/test/java/com/flipsmart/ActiveOfferSnapshotTest.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.WikiPrice;
 import com.flipsmart.domain.offer.TrackedOffer;
 import com.flipsmart.api.dto.OfferAdviceRequest;
 
@@ -12,7 +13,7 @@ public class ActiveOfferSnapshotTest
 	public void buildsSellSnapshotWithMarketAndBuyPrice()
 	{
 		TrackedOffer offer = new TrackedOffer(12345, "Item", false, 10, 1000, 2);
-		FlipSmartApiClient.WikiPrice market = new FlipSmartApiClient.WikiPrice(1080, 1020);
+		WikiPrice market = new WikiPrice(1080, 1020);
 
 		OfferAdviceRequest req = ActiveOfferAdvisorService.buildSnapshot(offer, market, 990, 600000);
 

--- a/src/test/java/com/flipsmart/AutoRecommendFreeSlotBuyTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendFreeSlotBuyTest.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.domain.flip.FlipRecommendation;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/com/flipsmart/AutoRecommendRefreshQueueTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendRefreshQueueTest.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.domain.flip.FlipRecommendation;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/com/flipsmart/BreakevenRelistDetectionTest.java
+++ b/src/test/java/com/flipsmart/BreakevenRelistDetectionTest.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.TrackedOffer;
 
 import org.junit.Test;
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/com/flipsmart/MotdServiceTest.java
+++ b/src/test/java/com/flipsmart/MotdServiceTest.java
@@ -1,4 +1,6 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.MotdChannelData;
+import com.flipsmart.api.dto.MotdResponse;
 
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
@@ -54,21 +56,21 @@ public class MotdServiceTest
 		service = new MotdService(client, config, apiClient, chatMessageManager, clientThread, configManager);
 	}
 
-	private FlipSmartApiClient.MotdResponse buildResponse(String pluginMessage, boolean enabled, String version)
+	private MotdResponse buildResponse(String pluginMessage, boolean enabled, String version)
 	{
 		return buildResponse(pluginMessage, enabled, version, "normal");
 	}
 
-	private FlipSmartApiClient.MotdResponse buildResponse(String pluginMessage, boolean enabled, String version, String severity)
+	private MotdResponse buildResponse(String pluginMessage, boolean enabled, String version, String severity)
 	{
-		FlipSmartApiClient.MotdChannelData plugin = mock(FlipSmartApiClient.MotdChannelData.class);
+		MotdChannelData plugin = mock(MotdChannelData.class);
 		when(plugin.getMessage()).thenReturn(pluginMessage);
 		when(plugin.isEnabled()).thenReturn(enabled);
 		when(plugin.getVersion()).thenReturn(version);
 		when(plugin.getSeverity()).thenReturn(severity);
 
-		FlipSmartApiClient.MotdChannelData web = mock(FlipSmartApiClient.MotdChannelData.class);
-		FlipSmartApiClient.MotdResponse resp = mock(FlipSmartApiClient.MotdResponse.class);
+		MotdChannelData web = mock(MotdChannelData.class);
+		MotdResponse resp = mock(MotdResponse.class);
 		when(resp.getWeb()).thenReturn(web);
 		when(resp.getPlugin()).thenReturn(plugin);
 		return resp;
@@ -136,7 +138,7 @@ public class MotdServiceTest
 	@Test
 	public void onLoginShowsOnceAndDedupsOnSameVersion()
 	{
-		FlipSmartApiClient.MotdResponse resp = buildResponse("Welcome back", true, "v1");
+		MotdResponse resp = buildResponse("Welcome back", true, "v1");
 
 		when(client.getGameState()).thenReturn(GameState.LOGIN_SCREEN);
 		service.handleResponse(resp);
@@ -159,13 +161,13 @@ public class MotdServiceTest
 	@Test
 	public void onLoginPostsAgainOnNewVersion()
 	{
-		FlipSmartApiClient.MotdResponse v1 = buildResponse("Hi", true, "v1");
+		MotdResponse v1 = buildResponse("Hi", true, "v1");
 		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(v1));
 		service.onLogin();
 		verify(chatMessageManager, times(1)).queue(any());
 
 		when(configManager.getConfiguration("flipsmart", "motd.lastShownVersion")).thenReturn("v1");
-		FlipSmartApiClient.MotdResponse v2 = buildResponse("Hi updated", true, "v2");
+		MotdResponse v2 = buildResponse("Hi updated", true, "v2");
 		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(v2));
 		service.onLogin();
 		verify(chatMessageManager, times(2)).queue(any());
@@ -174,7 +176,7 @@ public class MotdServiceTest
 	@Test
 	public void onLoginNoOpWhenChannelDisabled()
 	{
-		FlipSmartApiClient.MotdResponse resp = buildResponse("Hi", false, "v1");
+		MotdResponse resp = buildResponse("Hi", false, "v1");
 		service.handleResponse(resp);
 		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(resp));
 		service.onLogin();
@@ -185,7 +187,7 @@ public class MotdServiceTest
 	public void onLoginNoOpWhenConfigToggleOff()
 	{
 		when(config.motdEnabled()).thenReturn(false);
-		FlipSmartApiClient.MotdResponse resp = buildResponse("Hi", true, "v1");
+		MotdResponse resp = buildResponse("Hi", true, "v1");
 		service.handleResponse(resp);
 		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(resp));
 		service.onLogin();
@@ -195,11 +197,11 @@ public class MotdServiceTest
 	@Test
 	public void onLoginUsesFreshFetchEvenWhenCachedSaysEnabled()
 	{
-		FlipSmartApiClient.MotdResponse cachedEnabled = buildResponse("Old hi", true, "v1");
+		MotdResponse cachedEnabled = buildResponse("Old hi", true, "v1");
 		service.handleResponse(cachedEnabled);
 		org.mockito.Mockito.clearInvocations(chatMessageManager);
 
-		FlipSmartApiClient.MotdResponse freshDisabled = buildResponse("Old hi", false, "v1");
+		MotdResponse freshDisabled = buildResponse("Old hi", false, "v1");
 		when(apiClient.getMotdAsync()).thenReturn(CompletableFuture.completedFuture(freshDisabled));
 
 		service.onLogin();

--- a/src/test/java/com/flipsmart/OfferActionBodyTest.java
+++ b/src/test/java/com/flipsmart/OfferActionBodyTest.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.OfferAdviceRequest;
 
 import com.google.gson.JsonObject;
 import org.junit.Test;

--- a/src/test/java/com/flipsmart/OfferActionTest.java
+++ b/src/test/java/com/flipsmart/OfferActionTest.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.OfferAction;
 
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/flipsmart/OfferActionsBatchTest.java
+++ b/src/test/java/com/flipsmart/OfferActionsBatchTest.java
@@ -1,4 +1,8 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.OfferAction;
+import com.flipsmart.api.dto.OfferAdviceBatchResponse;
+import com.flipsmart.api.dto.OfferAdviceResult;
+import com.flipsmart.api.dto.OfferAdviceRequest;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;

--- a/src/test/java/com/flipsmart/OfferAdviceRequestTest.java
+++ b/src/test/java/com/flipsmart/OfferAdviceRequestTest.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.api.dto.OfferAdviceRequest;
 
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/flipsmart/OfferAdviceResponseTest.java
+++ b/src/test/java/com/flipsmart/OfferAdviceResponseTest.java
@@ -1,4 +1,6 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.OfferAction;
+import com.flipsmart.api.dto.OfferAdviceResponse;
 
 import com.google.gson.Gson;
 import org.junit.Test;

--- a/src/test/java/com/flipsmart/OfferDispositionTest.java
+++ b/src/test/java/com/flipsmart/OfferDispositionTest.java
@@ -1,4 +1,6 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.OfferAction;
+import com.flipsmart.domain.offer.OfferDisposition;
 
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/flipsmart/PlayerSessionTest.java
+++ b/src/test/java/com/flipsmart/PlayerSessionTest.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.TrackedOffer;
 
 import org.junit.Test;
 

--- a/src/test/java/com/flipsmart/TrackedOfferStageTest.java
+++ b/src/test/java/com/flipsmart/TrackedOfferStageTest.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+import com.flipsmart.domain.offer.TrackedOffer;
 
 import com.google.gson.Gson;
 import org.junit.Test;


### PR DESCRIPTION
## Summary

Pure structural refactor moving all standalone DTO and domain model classes into their new packages established in the #729 skeleton. No behavior changes — only file locations, package declarations, and import paths are altered. Stacked on #150 (review and merge #150 first).

Part of epic #728. Stacked on #150.

## Changes

### ♻️ Refactoring

**Commit 1 — Move standalone DTOs and domain models into packages**

- 15 API-layer DTOs moved into `com.flipsmart.api.dto`:
  `FlipFinderResponse`, `ActiveFlipsResponse`, `CompletedFlipsResponse`, `FlipStatisticsResponse`, `BankSnapshotResponse`, `BankSnapshotStatusResponse`, `BlocklistsResponse`, `BlocklistSummary`, `FlipAdjustmentResponse`, `TimeframeFlipFinderResponse`, `OfferAdviceRequest`, `OfferAdviceResponse`, `OfferAdviceBatchResponse`, `OfferAdviceResult`, `DumpEvent`
- 4 flip domain models moved into `com.flipsmart.domain.flip`:
  `FlipRecommendation`, `FlipAnalysis`, `ActiveFlip`, `CompletedFlip`
- 4 offer domain models moved into `com.flipsmart.domain.offer`:
  `TrackedOffer`, `PendingOrder`, `OfferDisposition`, `OfferAction`
- Minor access-level widening on a couple of request DTOs (fields made `public final`) to preserve direct-read access patterns that existed before packaging

**Commit 2 — Extract inner DTOs from FlipSmartApiClient**

- 12 public DTOs that were nested inside `FlipSmartApiClient` extracted into top-level files in `com.flipsmart.api.dto`:
  `AuthResult`, `DeviceAuthResponse`, `DeviceStatusResponse`, `MotdChannelData`, `MotdResponse`, `TransactionRequest` (+ Builder), `HistoryBackfillEntry`, `DumpsResponse`, `BankItem`, `BankItemId`, `WikiPrice`, `FlipAdjustmentRequest`
- 2 private cache-helper classes remain nested (not public API surface)
- All `FlipSmartApiClient.<Name>` qualified references updated across the codebase to use the new unqualified imports

## Testing

### Automated Tests
- `./gradlew build` passes green (compileJava + compileTestJava + full JUnit suite)
- No checkstyle config exists; `:check` runs the test suite

### Manual Testing
- Pure structural refactor — no runtime behavior changed
- Compile + unit tests is the verification ceiling for a move-only change; no in-game runtime test required

## Deployment Notes

- No environment variable changes
- No configuration changes
- No database migrations
- No new dependencies

## Checklist

- [x] Build passes (`./gradlew build`)
- [x] Unit tests passing
- [x] No issue-ref comments in plugin source
- [x] No `.claude/` or Claude config added to public repo
- [x] No AI attribution in commits

## Related Issues

Closes Flip-Smart/flip-smart#730
Part of epic Flip-Smart/flip-smart#728

---

## 🤖 Codacy AI Reviewer — 3 comments processed

| # | File | Risk | Disposition | Rationale |
|---|------|------|-------------|-----------|
| 1 | `GrandExchangeTracker.java:301` | MEDIUM | Deferred | Extracting shared transaction-building helper is out of scope for a pure structural refactor |
| 2 | `WikiPrice.java:8` | MEDIUM | Deferred | Duplicate constant is intentional — decouples WikiPrice from FlipSmartApiClient; consolidation in a later pass |
| 3 | `DeviceAuthResponse.java:30` | LOW | Deferred | Switching to @SerializedName deserialization is out of scope; PR only moved the file |

All 3 threads replied and resolved.

## 🩺 Codacy Quality Gate — 5 issues dismissed

| Pattern | File | Disposition | Rationale |
|---------|------|-------------|-----------|
| `PMD AvoidFieldNameMatchingMethodName` | `TransactionRequest.java:43-46` | Dismissed | Builder inner class fields matching setter method names — standard Java builder pattern, PMD false positive |
| `PMD GuardLogStatement` | `FlipSmartApiClient.java:946` | Dismissed | SLF4J parameterized `log.debug("{}", val)` does not evaluate eagerly; guard is unnecessary |

Gate status: re-analysis triggered via empty commit `a11a202`.