### PR TITLE
refactor(plugin): decompose FlipFinderPanel + lift smart-sell pricing out of UI (#732)

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1822,9 +1822,6 @@ public class FlipFinderPanel extends PluginPanel
 	}
 
 	/**
-	 * Get color based on risk score
-	 */
-	/**
 	 * Holder for header panels (needed for hover effects)
 	 */
 	private static class HeaderPanels

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1,5 +1,4 @@
 package com.flipsmart;
-import com.flipsmart.api.dto.AuthResult;
 import com.flipsmart.domain.offer.OfferAction;
 import com.flipsmart.api.dto.OfferAdviceResponse;
 import com.flipsmart.domain.flip.CompletedFlip;
@@ -9,6 +8,10 @@ import com.flipsmart.domain.flip.FlipAnalysis;
 import com.flipsmart.domain.flip.ActiveFlip;
 import com.flipsmart.api.dto.BlocklistSummary;
 import com.flipsmart.domain.offer.PendingOrder;
+import com.flipsmart.recommend.SmartSellPricer;
+import com.flipsmart.ui.panel.CardWidgets;
+import com.flipsmart.ui.panel.LoginPanel;
+import com.flipsmart.ui.panel.PanelFormat;
 import com.flipsmart.util.BuyPriceLookup;
 import com.flipsmart.util.GeTax;
 import com.flipsmart.util.GpUtils;
@@ -26,16 +29,9 @@ import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.time.Duration;
-import java.time.Instant;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 public class FlipFinderPanel extends PluginPanel
@@ -44,10 +40,7 @@ public class FlipFinderPanel extends PluginPanel
 	private static final String CONFIG_GROUP = "flipsmart";
 	private static final String CONFIG_KEY_FLIP_STYLE = "flipStyle";
 	private static final String CONFIG_KEY_FLIP_TIMEFRAME = "flipTimeframe";
-	private static final String CONFIG_KEY_EMAIL = "email";
-	private static final String CONFIG_KEY_PASSWORD = "password";  // Deprecated: kept for migration
-	private static final String CONFIG_KEY_REFRESH_TOKEN = "refreshToken";
-	
+
 	// Constants for duplicated literals
 	private static final String FONT_ARIAL = "Arial";
 	private static final String ERROR_PREFIX = "Error: ";
@@ -55,16 +48,8 @@ public class FlipFinderPanel extends PluginPanel
 	private static final String FORMAT_SELL = "Sell: %s";
 	private static final String FORMAT_ROI = "ROI: %.1f%%";
 	private static final String FORMAT_BUY_SELL = "Buy: %s | Sell: %s";
-	private static final String FORMAT_PROFIT_COST = "Profit: %s | Cost: %s";
-	private static final String FORMAT_MARGIN_ROI = "Margin: %s (%.1f%% ROI)";
-	private static final String FORMAT_MARGIN_ROI_LOSS = "Margin: %s (%.1f%% ROI) - Loss";
-	private static final String FORMAT_LIQUIDITY = "Liquidity: %.0f (%s) | %s";
-	private static final String FORMAT_VOLUME = "Volume: %s/day";
-	private static final String FORMAT_RISK = "Risk: %.0f (%s)";
 	private static final String ERROR_DIALOG_TITLE = "Error";
-	private static final String UNKNOWN_RATING = "Unknown";
 	private static final String LIQUIDITY_NA = "Liquidity: N/A";
-	private static final String VOLUME_NA = "Volume: N/A";
 	private static final String RISK_NA = "Risk: N/A";
 	private static final String MSG_LOGIN_TO_RUNESCAPE = "Log in to RuneScape";
 	private static final String MSG_LOGIN_INSTRUCTION = "<html><center>Log in to the game to get<br>flip suggestions and track your flips</center></html>";
@@ -117,15 +102,6 @@ public class FlipFinderPanel extends PluginPanel
 	private static final Font FONT_BOLD_13 = new Font(FONT_ARIAL, Font.BOLD, 13);
 	private static final Font FONT_BOLD_16 = new Font(FONT_ARIAL, Font.BOLD, 16);
 	
-	// Time-based sell price thresholds (in minutes)
-	// High volume items (>500k daily trades): switch to loss-minimizing after 10 min
-	private static final int HIGH_VOLUME_THRESHOLD = 500_000;
-	private static final int HIGH_VOLUME_TIME_MINUTES = 10;
-	// Regular items: switch after 20 min
-	private static final int REGULAR_TIME_MINUTES = 20;
-	// High value items (>250M): give them 30 min before loss-minimizing
-	private static final int HIGH_VALUE_THRESHOLD = 250_000_000;
-	private static final int HIGH_VALUE_TIME_MINUTES = 30;
 
 	private final transient FlipSmartConfig config;
 	private final transient FlipSmartApiClient apiClient;
@@ -149,31 +125,16 @@ public class FlipFinderPanel extends PluginPanel
 	private JScrollPane activeFlipsScrollPane;
 	private JScrollPane completedFlipsScrollPane;
 
-	// Login panel components
-	private JPanel loginPanel;
+	// Login / auth subsystem (UI construction, credential + device-auth flow)
+	private transient LoginPanel loginPanel;
 	private JPanel mainPanel;
-	private JTextField emailField;
-	private JPasswordField passwordField;
-	private JLabel loginStatusLabel;
-	private JButton loginButton;
-	private JButton signupButton;
-	private JButton discordButton;
 
 	// Premium subscribe message (shown for non-premium users)
 	private JLabel subscribeLabel;
-	private boolean isAuthenticated = false;
-	
-	// Discord device auth polling
-	private ScheduledExecutorService deviceAuthScheduler;
-	private ScheduledFuture<?> deviceAuthPollTask;
-	private volatile String currentDeviceCode;
 
-	// Auth transition timer (tracked for cleanup)
-	private Timer authTransitionTimer;
-	
 	// Callback for when authentication completes (to sync RSN)
 	private transient Runnable onAuthSuccess;
-	
+
 	// Flip Assist focus tracking
 	private transient FocusedFlip currentFocus = null;
 	private transient JPanel currentFocusedPanel = null;
@@ -222,7 +183,7 @@ public class FlipFinderPanel extends PluginPanel
 				configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_FLIP_STYLE, selectedStyle);
 			}
 			// Refresh recommendations when flip style changes
-			if (isAuthenticated)
+			if (apiClient.isAuthenticated())
 			{
 				refresh();
 			}
@@ -243,7 +204,7 @@ public class FlipFinderPanel extends PluginPanel
 				configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_FLIP_TIMEFRAME, selectedTimeframe);
 			}
 			// Refresh recommendations when timeframe changes
-			if (isAuthenticated)
+			if (apiClient.isAuthenticated())
 			{
 				refresh();
 			}
@@ -252,172 +213,26 @@ public class FlipFinderPanel extends PluginPanel
 		setLayout(new BorderLayout());
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
 
-		// Build both panels
-		buildLoginPanel();
+		// Build the login subsystem and the main panel
+		loginPanel = new LoginPanel(apiClient, config, configManager,
+			() -> { if (onAuthSuccess != null) onAuthSuccess.run(); },
+			this::showMainPanel);
 		buildMainPanel();
 
 		// Start with login panel, then check authentication
-		add(loginPanel, BorderLayout.CENTER);
+		add(loginPanel.getComponent(), BorderLayout.CENTER);
 
 		// Set up auth failure callback to redirect to login screen
 		apiClient.setOnAuthFailure(() -> SwingUtilities.invokeLater(() -> {
 			// Pre-fill email if available
-			String email = config.email();
-			if (email != null && !email.isEmpty())
-			{
-				emailField.setText(email);
-			}
-			loginStatusLabel.setText("Session expired. Please login again.");
-			loginStatusLabel.setForeground(new Color(255, 200, 100)); // Orange warning color
+			loginPanel.setEmailField(config.email());
+			loginPanel.setLoginStatusText("Session expired. Please login again.",
+				new Color(255, 200, 100)); // Orange warning color
 			showLoginPanel();
 		}));
 
-		// Persist refresh token whenever it changes (rotation, new login, etc.)
-		// This prevents token loss from mid-session rotations via the 401 retry path
-		apiClient.setOnRefreshTokenChanged(this::saveRefreshToken);
-
 		// Check if already authenticated and switch to main panel if so
-		checkAuthenticationAndShow();
-	}
-
-	/**
-	 * Build the login/signup panel
-	 */
-	private void buildLoginPanel()
-	{
-		loginPanel = new JPanel();
-		loginPanel.setLayout(new BorderLayout());
-		loginPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
-
-		// Center content panel
-		JPanel contentPanel = new JPanel();
-		contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.Y_AXIS));
-		contentPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
-		contentPanel.setBorder(new EmptyBorder(40, 20, 40, 20));
-
-		// Title
-		JLabel titleLabel = new JLabel("FlipSmart");
-		titleLabel.setForeground(Color.WHITE);
-		titleLabel.setFont(new Font(FONT_ARIAL, Font.BOLD, 24));
-		titleLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
-
-		// Subtitle
-		JLabel subtitleLabel = new JLabel("Sign in to start flipping");
-		subtitleLabel.setForeground(Color.LIGHT_GRAY);
-		subtitleLabel.setFont(new Font(FONT_ARIAL, Font.PLAIN, 14));
-		subtitleLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
-
-		// Email field
-		JLabel emailLabel = new JLabel("Email");
-		emailLabel.setForeground(Color.LIGHT_GRAY);
-		emailLabel.setFont(FONT_PLAIN_12);
-		emailLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
-
-		emailField = new JTextField(20);
-		emailField.setMaximumSize(new Dimension(Integer.MAX_VALUE, 30));
-		emailField.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-		emailField.setForeground(Color.WHITE);
-		emailField.setCaretColor(Color.WHITE);
-		emailField.setBorder(BorderFactory.createCompoundBorder(
-			BorderFactory.createLineBorder(ColorScheme.MEDIUM_GRAY_COLOR),
-			BorderFactory.createEmptyBorder(5, 10, 5, 10)
-		));
-
-		// Password field
-		JLabel passwordLabel = new JLabel("Password");
-		passwordLabel.setForeground(Color.LIGHT_GRAY);
-		passwordLabel.setFont(FONT_PLAIN_12);
-		passwordLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
-
-		passwordField = new JPasswordField(20);
-		passwordField.setMaximumSize(new Dimension(Integer.MAX_VALUE, 30));
-		passwordField.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-		passwordField.setForeground(Color.WHITE);
-		passwordField.setCaretColor(Color.WHITE);
-		passwordField.setBorder(BorderFactory.createCompoundBorder(
-			BorderFactory.createLineBorder(ColorScheme.MEDIUM_GRAY_COLOR),
-			BorderFactory.createEmptyBorder(5, 10, 5, 10)
-		));
-
-		// Status label for messages
-		loginStatusLabel = new JLabel(" ");
-		loginStatusLabel.setFont(FONT_PLAIN_12);
-		loginStatusLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
-		loginStatusLabel.setForeground(Color.LIGHT_GRAY);
-
-		// Buttons panel for Login/Sign Up
-		JPanel buttonsPanel = new JPanel(new GridLayout(1, 2, 10, 0));
-		buttonsPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
-		buttonsPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 35));
-
-		// Sign Up button
-		signupButton = new JButton("Sign Up");
-		signupButton.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-		signupButton.setForeground(Color.WHITE);
-		signupButton.setFocusPainted(false);
-		signupButton.setBorder(BorderFactory.createCompoundBorder(
-			BorderFactory.createLineBorder(ColorScheme.BRAND_ORANGE),
-			BorderFactory.createEmptyBorder(8, 15, 8, 15)
-		));
-		signupButton.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		signupButton.addActionListener(e -> handleSignup());
-
-		// Login button
-		loginButton = new JButton("Login");
-		loginButton.setBackground(ColorScheme.BRAND_ORANGE);
-		loginButton.setForeground(Color.WHITE);
-		loginButton.setFocusPainted(false);
-		loginButton.setBorder(BorderFactory.createEmptyBorder(8, 15, 8, 15));
-		loginButton.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		loginButton.addActionListener(e -> handleLogin());
-
-		buttonsPanel.add(signupButton);
-		buttonsPanel.add(loginButton);
-		
-		// Divider
-		JPanel dividerPanel = new JPanel(new BorderLayout());
-		dividerPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
-		dividerPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 20));
-		
-		JLabel orLabel = new JLabel("OR", SwingConstants.CENTER);
-		orLabel.setForeground(Color.GRAY);
-		orLabel.setFont(new Font(FONT_ARIAL, Font.PLAIN, 11));
-		dividerPanel.add(orLabel, BorderLayout.CENTER);
-		
-		// Discord login button (with Discord purple color)
-		discordButton = new JButton("Login with Discord");
-		discordButton.setBackground(new Color(88, 101, 242)); // Discord blurple
-		discordButton.setForeground(Color.WHITE);
-		discordButton.setFocusPainted(false);
-		discordButton.setBorder(BorderFactory.createEmptyBorder(10, 15, 10, 15));
-		discordButton.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		discordButton.setMaximumSize(new Dimension(Integer.MAX_VALUE, 40));
-		discordButton.setAlignmentX(Component.CENTER_ALIGNMENT);
-		discordButton.addActionListener(e -> handleDiscordLogin());
-
-		// Add components with spacing
-		contentPanel.add(titleLabel);
-		contentPanel.add(Box.createRigidArea(new Dimension(0, 5)));
-		contentPanel.add(subtitleLabel);
-		contentPanel.add(Box.createRigidArea(new Dimension(0, 30)));
-		contentPanel.add(emailLabel);
-		contentPanel.add(Box.createRigidArea(new Dimension(0, 5)));
-		contentPanel.add(emailField);
-		contentPanel.add(Box.createRigidArea(new Dimension(0, 15)));
-		contentPanel.add(passwordLabel);
-		contentPanel.add(Box.createRigidArea(new Dimension(0, 5)));
-		contentPanel.add(passwordField);
-		contentPanel.add(Box.createRigidArea(new Dimension(0, 20)));
-		contentPanel.add(buttonsPanel);
-		contentPanel.add(Box.createRigidArea(new Dimension(0, 15)));
-		contentPanel.add(dividerPanel);
-		contentPanel.add(Box.createRigidArea(new Dimension(0, 15)));
-		contentPanel.add(discordButton);
-		contentPanel.add(Box.createRigidArea(new Dimension(0, 15)));
-		contentPanel.add(loginStatusLabel);
-
-		// Center the content vertically
-		loginPanel.add(contentPanel, BorderLayout.CENTER);
+		loginPanel.checkAuthenticationAndShow();
 	}
 
 	/**
@@ -749,7 +564,7 @@ public class FlipFinderPanel extends PluginPanel
 				statusLabel.setText(String.format("%d active %s | %s invested",
 					itemCount,
 					itemCount == 1 ? "flip" : "flips",
-					formatGP(invested)));
+					PanelFormat.formatGP(invested)));
 			}
 			else if (selectedIndex == 2)
 			{
@@ -763,7 +578,7 @@ public class FlipFinderPanel extends PluginPanel
 						{
 							statusLabel.setText(String.format("%d flips (30d) | %s profit",
 								stats.getTotalFlips(),
-								formatGP(stats.getTotalProfit())));
+								PanelFormat.formatGP(stats.getTotalProfit())));
 						}
 					});
 				});
@@ -846,397 +661,11 @@ public class FlipFinderPanel extends PluginPanel
 	}
 
 	/**
-	 * Check if already authenticated and show appropriate panel.
-	 * Tries refresh token first (secure), falls back to legacy password if needed.
-	 */
-	private void checkAuthenticationAndShow()
-	{
-		// First, try to authenticate with refresh token (secure method)
-		String refreshToken = config.refreshToken();
-		String email = config.email();
-
-		if (refreshToken != null && !refreshToken.isEmpty())
-		{
-			// Pre-fill email field if available
-			if (email != null && !email.isEmpty())
-			{
-				emailField.setText(email);
-			}
-
-			// Load refresh token into API client and try to authenticate
-			apiClient.setRefreshToken(refreshToken);
-
-			apiClient.refreshAccessTokenAsync().thenAccept(success ->
-				SwingUtilities.invokeLater(() -> {
-					if (Boolean.TRUE.equals(success))
-					{
-						saveRefreshToken(apiClient.getRefreshToken());
-						onAuthenticationSuccess(null, false);
-					}
-					else
-					{
-						// Only clear persisted token if explicitly rejected (401)
-						if (apiClient.getRefreshToken() == null)
-						{
-							clearRefreshToken();
-						}
-						else
-						{
-							log.debug("Refresh token auth failed (transient) - keeping token for next attempt");
-						}
-						tryLegacyPasswordAuth();
-					}
-				})
-			).exceptionally(e -> {
-				log.debug("Refresh token auth failed: {}", e.getMessage());
-				SwingUtilities.invokeLater(this::tryLegacyPasswordAuth);
-				return null;
-			});
-		}
-		else
-		{
-			// No refresh token, try legacy password auth
-			tryLegacyPasswordAuth();
-		}
-	}
-
-	/**
-	 * Try to authenticate with legacy stored password (migration path).
-	 * After successful login, the password will be cleared and replaced with refresh token.
-	 */
-	private void tryLegacyPasswordAuth()
-	{
-		String email = config.email();
-		String password = config.password();
-
-		// Always pre-fill email if available (helps users who need to re-login)
-		if (email != null && !email.isEmpty())
-		{
-			emailField.setText(email);
-		}
-
-		if (email != null && !email.isEmpty() && password != null && !password.isEmpty())
-		{
-			// Try to authenticate in background
-			java.util.concurrent.CompletableFuture.runAsync(() -> {
-				AuthResult result = apiClient.login(email, password);
-
-				SwingUtilities.invokeLater(() -> {
-					if (result.success)
-					{
-						// Migration: save refresh token and clear password
-						saveRefreshToken(apiClient.getRefreshToken());
-						clearPassword();
-						onAuthenticationSuccess(null, false);
-					}
-					else
-					{
-						// Stay on login panel, show message
-						loginStatusLabel.setText("Please login to continue");
-						loginStatusLabel.setForeground(Color.LIGHT_GRAY);
-					}
-				});
-			});
-		}
-		else
-		{
-			// No stored credentials - show helpful message to user
-			loginStatusLabel.setText("Please login to continue");
-			loginStatusLabel.setForeground(Color.LIGHT_GRAY);
-		}
-	}
-
-	/**
-	 * Handle login button click
-	 */
-	private void handleLogin()
-	{
-		String email = emailField.getText().trim();
-		String password = new String(passwordField.getPassword());
-
-		if (email.isEmpty() || password.isEmpty())
-		{
-			showLoginStatus("Please enter email and password", false);
-			return;
-		}
-
-		setLoginButtonsEnabled(false);
-		showLoginStatus("Logging in...", true);
-
-		java.util.concurrent.CompletableFuture.runAsync(() -> {
-			AuthResult result = apiClient.login(email, password);
-
-			SwingUtilities.invokeLater(() -> {
-				setLoginButtonsEnabled(true);
-
-				if (result.success)
-				{
-					// Save email and refresh token (NOT password) for next session
-					saveEmail(email);
-					saveRefreshToken(apiClient.getRefreshToken());
-					// Clear any legacy password storage
-					clearPassword();
-					onAuthenticationSuccess(result.message, true);
-				}
-				else
-				{
-					showLoginStatus(result.message, false);
-				}
-			});
-		});
-	}
-
-	/**
-	 * Handle signup button click
-	 */
-	private void handleSignup()
-	{
-		String email = emailField.getText().trim();
-		String password = new String(passwordField.getPassword());
-
-		if (email.isEmpty() || password.isEmpty())
-		{
-			showLoginStatus("Please enter email and password", false);
-			return;
-		}
-
-		setLoginButtonsEnabled(false);
-		showLoginStatus("Creating account...", true);
-
-		java.util.concurrent.CompletableFuture.runAsync(() -> {
-			AuthResult result = apiClient.signup(email, password);
-
-			SwingUtilities.invokeLater(() -> {
-				setLoginButtonsEnabled(true);
-
-				if (result.success)
-				{
-					// Save email and refresh token (NOT password) for next session
-					saveEmail(email);
-					saveRefreshToken(apiClient.getRefreshToken());
-					// Clear any legacy password storage
-					clearPassword();
-					onAuthenticationSuccess(result.message, true);
-				}
-				else
-				{
-					showLoginStatus(result.message, false);
-				}
-			});
-		});
-	}
-
-	/**
-	 * Save email for next session
-	 */
-	private void saveEmail(String email)
-	{
-		configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_EMAIL, email);
-	}
-
-	/**
-	 * Save refresh token for persistent login (replaces password storage)
-	 */
-	private void saveRefreshToken(String refreshToken)
-	{
-		if (refreshToken != null && !refreshToken.isEmpty())
-		{
-			configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_REFRESH_TOKEN, refreshToken);
-		}
-	}
-
-	/**
-	 * Clear refresh token (on logout or revocation)
-	 */
-	private void clearRefreshToken()
-	{
-		configManager.unsetConfiguration(CONFIG_GROUP, CONFIG_KEY_REFRESH_TOKEN);
-	}
-
-	/**
-	 * Clear legacy password storage (migration cleanup)
-	 */
-	private void clearPassword()
-	{
-		configManager.unsetConfiguration(CONFIG_GROUP, CONFIG_KEY_PASSWORD);
-	}
-
-	/**
-	 * @deprecated Use saveEmail() and saveRefreshToken() instead
-	 */
-	@Deprecated
-	private void saveCredentials(String email, String password)
-	{
-		configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_EMAIL, email);
-		configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_PASSWORD, password);
-	}
-
-	/**
-	 * Show status message on login panel
-	 */
-	private void showLoginStatus(String message, boolean success)
-	{
-		loginStatusLabel.setText(message);
-		loginStatusLabel.setForeground(success ? COLOR_PROFIT_GREEN : COLOR_LOSS_RED);
-	}
-
-	/**
-	 * Enable/disable login buttons during authentication
-	 */
-	private void setLoginButtonsEnabled(boolean enabled)
-	{
-		loginButton.setEnabled(enabled);
-		signupButton.setEnabled(enabled);
-		discordButton.setEnabled(enabled);
-		emailField.setEnabled(enabled);
-		passwordField.setEnabled(enabled);
-	}
-	
-	/**
-	 * Handle Discord login button click
-	 */
-	private void handleDiscordLogin()
-	{
-		setLoginButtonsEnabled(false);
-		showLoginStatus("Starting Discord login...", true);
-		
-		// Start device auth flow
-		apiClient.startDeviceAuthAsync().thenAccept(response ->
-		{
-			if (response == null)
-			{
-				SwingUtilities.invokeLater(() ->
-				{
-					setLoginButtonsEnabled(true);
-					showLoginStatus("Failed to start Discord login", false);
-				});
-				return;
-			}
-			
-			// Store device code for polling
-			currentDeviceCode = response.getDeviceCode();
-			
-			// Open browser with verification URL using RuneLite's LinkBrowser
-            // which properly handles sandboxed environments (Flatpak, etc.)
-            LinkBrowser.browse(response.getVerificationUrl());
-
-        	SwingUtilities.invokeLater(() ->
-            	showLoginStatus("Complete login in your browser...", true));
-
-		   // Start polling for completion
-		   startDeviceAuthPolling(response.getDeviceCode(), response.getPollInterval(), response.getExpiresIn());
-		});
-	}
-	
-	/**
-	 * Start polling for device authorization completion
-	 */
-	private void startDeviceAuthPolling(String deviceCode, int pollIntervalSeconds, int expiresInSeconds)
-	{
-		// Cancel any existing poll task
-		stopDeviceAuthPolling();
-		
-		// Create scheduler if needed
-		if (deviceAuthScheduler == null || deviceAuthScheduler.isShutdown())
-		{
-			deviceAuthScheduler = Executors.newSingleThreadScheduledExecutor();
-		}
-		
-		// Calculate max poll attempts based on expiry time
-		int maxAttempts = expiresInSeconds / pollIntervalSeconds;
-		final int[] attempts = {0};
-		
-		deviceAuthPollTask = deviceAuthScheduler.scheduleAtFixedRate(() ->
-		{
-			attempts[0]++;
-			
-			// Check if we've exceeded max attempts
-			if (attempts[0] > maxAttempts)
-			{
-				stopDeviceAuthPolling();
-				SwingUtilities.invokeLater(() ->
-				{
-					setLoginButtonsEnabled(true);
-					showLoginStatus("Discord login timed out", false);
-				});
-				return;
-			}
-			
-			// Poll status
-			apiClient.pollDeviceStatusAsync(deviceCode).thenAccept(status ->
-			{
-				if (status == null)
-				{
-					return; // Network error, will retry
-				}
-				
-				switch (status.getStatus())
-				{
-					case "authorized":
-						// Success! Set the token and switch to main panel
-						stopDeviceAuthPolling();
-						apiClient.setAuthToken(status.getAccessToken());
-						// Save refresh token for session persistence across client restarts
-						if (status.getRefreshToken() != null)
-						{
-							apiClient.setRefreshToken(status.getRefreshToken());
-							saveRefreshToken(status.getRefreshToken());
-						}
-						SwingUtilities.invokeLater(() ->
-							onAuthenticationSuccess("Login successful!", true));
-						break;
-						
-					case "expired":
-						// Device code expired
-						stopDeviceAuthPolling();
-						SwingUtilities.invokeLater(() ->
-						{
-							setLoginButtonsEnabled(true);
-							showLoginStatus("Discord login expired. Try again.", false);
-						});
-						break;
-						
-					case "pending":
-						// Still waiting - continue polling
-						break;
-						
-					default:
-						log.warn("Unknown device status: {}", status.getStatus());
-						break;
-				}
-			});
-		}, pollIntervalSeconds, pollIntervalSeconds, TimeUnit.SECONDS);
-	}
-	
-	/**
-	 * Stop device auth polling
-	 */
-	private void stopDeviceAuthPolling()
-	{
-		if (deviceAuthPollTask != null)
-		{
-			deviceAuthPollTask.cancel(false);
-			deviceAuthPollTask = null;
-		}
-		currentDeviceCode = null;
-	}
-	
-	/**
 	 * Clean up resources when panel is destroyed
 	 */
 	public void shutdown()
 	{
-		stopDeviceAuthPolling();
-		if (deviceAuthScheduler != null)
-		{
-			deviceAuthScheduler.shutdownNow();
-			deviceAuthScheduler = null;
-		}
-		if (authTransitionTimer != null)
-		{
-			authTransitionTimer.stop();
-			authTransitionTimer = null;
-		}
+		loginPanel.shutdown();
 	}
 
 	/**
@@ -1244,12 +673,11 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private void showMainPanel()
 	{
-		isAuthenticated = true;
 		removeAll();
 		add(mainPanel, BorderLayout.CENTER);
 		revalidate();
 		repaint();
-		
+
 		// Load data
 		refresh();
 	}
@@ -1259,44 +687,12 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	public void showLoginPanel()
 	{
-		isAuthenticated = false;
-		// Stop any pending device auth polling
-		stopDeviceAuthPolling();
-		// Re-enable all login buttons
-		setLoginButtonsEnabled(true);
+		// Stop any pending device auth polling and re-enable login buttons
+		loginPanel.resetLoginView();
 		removeAll();
-		add(loginPanel, BorderLayout.CENTER);
+		add(loginPanel.getComponent(), BorderLayout.CENTER);
 		revalidate();
 		repaint();
-	}
-
-	/**
-	 * Handle successful authentication - notify plugin and transition to main panel.
-	 * @param successMessage message to display, or null to skip showing message
-	 * @param showDelay if true, show message briefly before transitioning
-	 */
-	private void onAuthenticationSuccess(String successMessage, boolean showDelay)
-	{
-		if (onAuthSuccess != null)
-		{
-			onAuthSuccess.run();
-		}
-		if (showDelay && successMessage != null)
-		{
-			showLoginStatus(successMessage, true);
-			Timer timer = new Timer(500, e ->
-			{
-				showMainPanel();
-				authTransitionTimer = null;
-			});
-			timer.setRepeats(false);
-			authTransitionTimer = timer;
-			timer.start();
-		}
-		else
-		{
-			showMainPanel();
-		}
 	}
 
 	/**
@@ -1308,14 +704,13 @@ public class FlipFinderPanel extends PluginPanel
 		apiClient.clearAuth();
 
 		// Clear stored refresh token
-		clearRefreshToken();
+		loginPanel.clearRefreshToken();
 
 		// Clear password field but keep email
-		passwordField.setText("");
+		loginPanel.clearPasswordField();
 
 		// Reset status
-		loginStatusLabel.setText("Logged out successfully");
-		loginStatusLabel.setForeground(Color.LIGHT_GRAY);
+		loginPanel.setLoginStatusText("Logged out successfully", Color.LIGHT_GRAY);
 
 		// Show login panel
 		showLoginPanel();
@@ -1656,7 +1051,7 @@ public class FlipFinderPanel extends PluginPanel
 						statusLabel.setText(String.format("%d active %s | %s invested",
 							itemCount,
 							itemCount == 1 ? "flip" : "flips",
-							formatGP(invested)));
+							PanelFormat.formatGP(invested)));
 					}
 				}
 				else if (!pendingOrders.isEmpty())
@@ -1717,7 +1112,7 @@ public class FlipFinderPanel extends PluginPanel
 				{
 					statusLabel.setText(String.format("%d flips (30d) | %s profit",
 						stats.getTotalFlips(),
-						formatGP(stats.getTotalProfit())));
+						PanelFormat.formatGP(stats.getTotalProfit())));
 				}
 			});
 		});
@@ -1981,7 +1376,7 @@ public class FlipFinderPanel extends PluginPanel
 				flipStyleText,
 				count,
 				itemWord,
-				formatGP(response.getCashStack())));
+				PanelFormat.formatGP(response.getCashStack())));
 		}
 		else
 		{
@@ -2243,7 +1638,7 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private JPanel createRecommendationPanel(FlipRecommendation rec)
 	{
-		JPanel panel = createBaseItemPanel(ColorScheme.DARKER_GRAY_COLOR, Integer.MAX_VALUE, true);
+		JPanel panel = CardWidgets.createBaseItemPanel(ColorScheme.DARKER_GRAY_COLOR, Integer.MAX_VALUE, true);
 
 		// Item header with icon and name
 		HeaderPanels header = createItemHeaderPanels(rec.getItemId(), rec.getItemName(), ColorScheme.DARKER_GRAY_COLOR);
@@ -2266,7 +1661,7 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private JPanel createRecommendationDetailsPanel(FlipRecommendation rec)
 	{
-		JPanel detailsPanel = createDetailsPanel(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel detailsPanel = CardWidgets.createDetailsPanel(ColorScheme.DARKER_GRAY_COLOR);
 
 		// Apply price offset to displayed values so they match Flip Assist
 		int priceOffset = config.priceOffset();
@@ -2279,7 +1674,7 @@ public class FlipFinderPanel extends PluginPanel
 		double displayRoi = displayBuyPrice > 0 ? ((double)(displayMargin - geTax) / displayBuyPrice) * 100 : 0;
 
 		// Recommended Buy/Sell prices
-		JLabel priceLabel = new JLabel(formatBuySellText(displayBuyPrice, displaySellPrice));
+		JLabel priceLabel = new JLabel(PanelFormat.formatBuySellText(displayBuyPrice, displaySellPrice));
 		priceLabel.setForeground(Color.LIGHT_GRAY);
 		priceLabel.setFont(FONT_PLAIN_12);
 
@@ -2291,26 +1686,26 @@ public class FlipFinderPanel extends PluginPanel
 
 		// Margin and ROI
 		JLabel marginLabel = new JLabel(String.format("Margin: %s (%s ROI)",
-			formatGP(displayMargin - geTax), GpUtils.formatROI(displayRoi)));
+			PanelFormat.formatGP(displayMargin - geTax), GpUtils.formatROI(displayRoi)));
 		marginLabel.setForeground(COLOR_PROFIT_GREEN);
 		marginLabel.setFont(FONT_PLAIN_12);
 
 		// Potential profit and total cost
-		JLabel profitLabel = new JLabel(formatProfitCostText(displayProfit, displayCost));
+		JLabel profitLabel = new JLabel(PanelFormat.formatProfitCostText(displayProfit, displayCost));
 		profitLabel.setForeground(new Color(255, 215, 0));
 		profitLabel.setFont(FONT_PLAIN_12);
 
 		// Volume info
-		JLabel volumeLabel = new JLabel(formatVolumeText(rec.getDailyVolume()));
+		JLabel volumeLabel = new JLabel(PanelFormat.formatVolumeText(rec.getDailyVolume()));
 		volumeLabel.setForeground(Color.CYAN);
 		volumeLabel.setFont(FONT_PLAIN_12);
 
 		// Risk info
-		JLabel riskLabel = new JLabel(formatRiskText(rec.getRiskScore(), rec.getRiskRating()));
-		riskLabel.setForeground(getRiskColor(rec.getRiskScore()));
+		JLabel riskLabel = new JLabel(PanelFormat.formatRiskText(rec.getRiskScore(), rec.getRiskRating()));
+		riskLabel.setForeground(PanelFormat.getRiskColor(rec.getRiskScore()));
 		riskLabel.setFont(FONT_PLAIN_12);
 
-		addLabelsWithSpacing(detailsPanel, priceLabel, quantityLabel, marginLabel,
+		CardWidgets.addLabelsWithSpacing(detailsPanel, priceLabel, quantityLabel, marginLabel,
 			profitLabel, volumeLabel, riskLabel);
 
 		return detailsPanel;
@@ -2429,42 +1824,6 @@ public class FlipFinderPanel extends PluginPanel
 	/**
 	 * Get color based on risk score
 	 */
-	private Color getRiskColor(double score)
-	{
-		if (score <= 20)
-		{
-			return COLOR_PROFIT_GREEN; // Green
-		}
-		else if (score <= 40)
-		{
-			return new Color(150, 255, 100); // Yellow-green
-		}
-		else if (score <= 60)
-		{
-			return COLOR_YELLOW; // Yellow
-		}
-		else
-		{
-			return COLOR_LOSS_RED; // Red
-		}
-	}
-
-	/**
-	 * Format GP amount for display
-	 */
-	private String formatGP(int amount)
-	{
-		return GpUtils.formatGPSigned(amount);
-	}
-
-	/**
-	 * Format GP amount with commas for exact input (e.g., "1,234,567")
-	 */
-	private String formatGPExact(int amount)
-	{
-		return GpUtils.formatGPExact(amount);
-	}
-
 	/**
 	 * Holder for header panels (needed for hover effects)
 	 */
@@ -2494,10 +1853,10 @@ public class FlipFinderPanel extends PluginPanel
 		// Get item image
 		AsyncBufferedImage itemImage = itemManager.getImage(itemId);
 		JLabel iconLabel = new JLabel();
-		setupIconLabel(iconLabel, itemImage);
+		CardWidgets.setupIconLabel(iconLabel, itemImage);
 
 		// Use HTML to allow text wrapping for long item names
-		String escapedName = escapeHtml(itemName);
+		String escapedName = PanelFormat.escapeHtml(itemName);
 		JLabel nameLabel = new JLabel("<html>" + escapedName + "</html>");
 		nameLabel.setForeground(Color.WHITE);
 		nameLabel.setFont(FONT_BOLD_13);
@@ -2528,54 +1887,12 @@ public class FlipFinderPanel extends PluginPanel
 	}
 	
 	/**
-	 * Escape HTML special characters in a string.
-	 * Used when embedding text in HTML labels.
-	 */
-	private String escapeHtml(String text)
-	{
-		if (text == null)
-		{
-			return "";
-		}
-		return text
-			.replace("&", "&amp;")
-			.replace("<", "&lt;")
-			.replace(">", "&gt;")
-			.replace("\"", "&quot;");
-	}
-	
-	/**
-	 * Draw a bar chart icon onto a 14x14 image with the given colors.
-	 */
-	private java.awt.image.BufferedImage drawChartIcon(Color barColor, Color baselineColor)
-	{
-		java.awt.image.BufferedImage icon = new java.awt.image.BufferedImage(14, 14, java.awt.image.BufferedImage.TYPE_INT_ARGB);
-		java.awt.Graphics2D g = icon.createGraphics();
-		g.setRenderingHint(java.awt.RenderingHints.KEY_ANTIALIASING, java.awt.RenderingHints.VALUE_ANTIALIAS_ON);
-
-		g.setComposite(java.awt.AlphaComposite.Clear);
-		g.fillRect(0, 0, 14, 14);
-		g.setComposite(java.awt.AlphaComposite.SrcOver);
-
-		g.setColor(barColor);
-		g.fillRect(1, 9, 3, 4);   // Short bar
-		g.fillRect(5, 5, 3, 8);   // Medium bar
-		g.fillRect(9, 2, 3, 11);  // Tall bar
-
-		g.setColor(baselineColor);
-		g.drawLine(0, 13, 13, 13);
-
-		g.dispose();
-		return icon;
-	}
-
-	/**
 	 * Create a clickable chart icon label that opens the item's page on the website.
 	 * Uses a simple bar chart icon drawn with Java 2D graphics.
 	 */
 	private JLabel createChartIconLabel(int itemId)
 	{
-		java.awt.image.BufferedImage chartIcon = drawChartIcon(new Color(100, 180, 255), new Color(150, 150, 150));
+		java.awt.image.BufferedImage chartIcon = PanelFormat.drawChartIcon(new Color(100, 180, 255), new Color(150, 150, 150));
 
 		JLabel chartLabel = new JLabel(new ImageIcon(chartIcon));
 		chartLabel.setToolTipText("View price history on FlipSmart website");
@@ -2597,7 +1914,7 @@ public class FlipFinderPanel extends PluginPanel
 			@Override
 			public void mouseEntered(MouseEvent e)
 			{
-				chartLabel.setIcon(new ImageIcon(drawChartIcon(new Color(150, 220, 255), new Color(200, 200, 200))));
+				chartLabel.setIcon(new ImageIcon(PanelFormat.drawChartIcon(new Color(150, 220, 255), new Color(200, 200, 200))));
 			}
 
 			@Override
@@ -2611,34 +1928,12 @@ public class FlipFinderPanel extends PluginPanel
 	}
 
 	/**
-	 * Draw a ban/circle-slash icon onto a 14x14 image with the given color.
-	 */
-	private java.awt.image.BufferedImage drawBlockIcon(Color color)
-	{
-		java.awt.image.BufferedImage icon = new java.awt.image.BufferedImage(14, 14, java.awt.image.BufferedImage.TYPE_INT_ARGB);
-		java.awt.Graphics2D g = icon.createGraphics();
-		g.setRenderingHint(java.awt.RenderingHints.KEY_ANTIALIASING, java.awt.RenderingHints.VALUE_ANTIALIAS_ON);
-
-		g.setComposite(java.awt.AlphaComposite.Clear);
-		g.fillRect(0, 0, 14, 14);
-		g.setComposite(java.awt.AlphaComposite.SrcOver);
-
-		g.setColor(color);
-		g.setStroke(new java.awt.BasicStroke(1.5f));
-		g.drawOval(1, 1, 11, 11);
-		g.drawLine(3, 11, 11, 3);
-
-		g.dispose();
-		return icon;
-	}
-
-	/**
 	 * Create a clickable block icon label that adds the item to a blocklist.
 	 * Uses a ban/circle-slash icon drawn with Java 2D graphics.
 	 */
 	private JLabel createBlockIconLabel(int itemId, String itemName)
 	{
-		java.awt.image.BufferedImage blockIcon = drawBlockIcon(new Color(180, 100, 100));
+		java.awt.image.BufferedImage blockIcon = PanelFormat.drawBlockIcon(new Color(180, 100, 100));
 
 		JLabel blockLabel = new JLabel(new ImageIcon(blockIcon));
 		blockLabel.setToolTipText("Block this item from recommendations");
@@ -2659,7 +1954,7 @@ public class FlipFinderPanel extends PluginPanel
 			@Override
 			public void mouseEntered(MouseEvent e)
 			{
-				blockLabel.setIcon(new ImageIcon(drawBlockIcon(new Color(255, 100, 100))));
+				blockLabel.setIcon(new ImageIcon(PanelFormat.drawBlockIcon(new Color(255, 100, 100))));
 			}
 
 			@Override
@@ -2808,163 +2103,12 @@ public class FlipFinderPanel extends PluginPanel
 	}
 
 	/**
-	 * Format liquidity text for display
-	 */
-	private String formatLiquidityText(Double score, String rating, Double volumePerHour)
-	{
-		if (score == null)
-		{
-			return LIQUIDITY_NA;
-		}
-		String displayRating = rating != null ? rating : UNKNOWN_RATING;
-		String volText = volumePerHour != null ? formatGP(volumePerHour.intValue()) + "/hr" : "";
-		return String.format(FORMAT_LIQUIDITY, score, displayRating, volText);
-	}
-
-	/**
-	 * Format daily volume text for display
-	 */
-	private String formatVolumeText(int dailyVolume)
-	{
-		if (dailyVolume <= 0)
-		{
-			return VOLUME_NA;
-		}
-		return String.format(FORMAT_VOLUME, formatGP(dailyVolume));
-	}
-
-	/**
-	 * Format risk text for display
-	 */
-	private String formatRiskText(Double score, String rating)
-	{
-		if (score == null)
-		{
-			return RISK_NA;
-		}
-		String displayRating = rating != null ? rating : UNKNOWN_RATING;
-		return String.format(FORMAT_RISK, score, displayRating);
-	}
-
-	/**
-	 * Format margin text with ROI for display
-	 */
-	private String formatMarginText(int marginPerItem, double roi, boolean isLoss)
-	{
-		String marginText = Math.abs(marginPerItem) >= 1000 
-			? formatGP(marginPerItem) 
-			: formatGPExact(marginPerItem);
-		
-		// Handle Infinity/NaN ROI (happens when cost is 0, e.g. pending orders with no fills)
-		if (Double.isInfinite(roi) || Double.isNaN(roi))
-		{
-			return String.format("Margin: %s (pending)", marginText);
-		}
-		
-		if (isLoss)
-		{
-			return String.format(FORMAT_MARGIN_ROI_LOSS, marginText, roi);
-		}
-		return String.format(FORMAT_MARGIN_ROI, marginText, roi);
-	}
-
-	/**
-	 * Format profit and cost text for display
-	 */
-	private String formatProfitCostText(int totalProfit, int totalCost)
-	{
-		String profitText = Math.abs(totalProfit) >= 1000 
-			? formatGP(totalProfit) 
-			: formatGPExact(totalProfit);
-		return String.format(FORMAT_PROFIT_COST, profitText, formatGP(totalCost));
-	}
-
-	/**
-	 * Format buy/sell prices text for display
-	 */
-	private String formatBuySellText(int buyPrice, Integer sellPrice)
-	{
-		String sellText = sellPrice != null && sellPrice > 0 
-			? formatGPExact(sellPrice) 
-			: "N/A";
-		return String.format(FORMAT_BUY_SELL, formatGPExact(buyPrice), sellText);
-	}
-
-	/**
-	 * Create a styled JLabel with common settings for detail rows
-	 */
-	private JLabel createStyledLabel(String text, Color foreground)
-	{
-		JLabel label = new JLabel(text);
-		label.setForeground(foreground);
-		label.setFont(FONT_PLAIN_12);
-		label.setAlignmentX(Component.LEFT_ALIGNMENT);
-		return label;
-	}
-
-	/**
-	 * Create a details panel with BoxLayout for vertical rows
-	 */
-	private JPanel createDetailsPanel(Color bgColor)
-	{
-		JPanel detailsPanel = new JPanel();
-		detailsPanel.setLayout(new BoxLayout(detailsPanel, BoxLayout.Y_AXIS));
-		detailsPanel.setBackground(bgColor);
-		detailsPanel.setBorder(new EmptyBorder(5, 0, 0, 0));
-		return detailsPanel;
-	}
-
-	/**
-	 * Add labels to a details panel with standard 2px vertical spacing
-	 */
-	private void addLabelsWithSpacing(JPanel panel, JLabel... labels)
-	{
-		for (int i = 0; i < labels.length; i++)
-		{
-			panel.add(labels[i]);
-			if (i < labels.length - 1)
-			{
-				panel.add(Box.createRigidArea(new Dimension(0, 2)));
-			}
-		}
-	}
-
-	/**
-	 * Update background color for multiple panels (used in mouse listeners)
-	 */
-	private void setPanelBackgrounds(Color color, JPanel... panels)
-	{
-		for (JPanel panel : panels)
-		{
-			panel.setBackground(color);
-		}
-	}
-
-	/**
-	 * Create a base panel with common settings for flip/recommendation items
-	 */
-	private JPanel createBaseItemPanel(Color bgColor, int maxHeight, boolean handCursor)
-	{
-		JPanel panel = new JPanel();
-		panel.setLayout(new BorderLayout());
-		panel.setBackground(bgColor);
-		panel.setBorder(new EmptyBorder(8, 8, 8, 8));
-		panel.setAlignmentX(Component.LEFT_ALIGNMENT);
-		panel.setMaximumSize(new Dimension(Integer.MAX_VALUE, maxHeight));
-		if (handCursor)
-		{
-			panel.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		}
-		return panel;
-	}
-
-	/**
 	 * Update liquidity label with data from analysis
 	 */
 	private void updateLiquidityLabel(JLabel label, FlipAnalysis.Liquidity liquidity)
 	{
 		label.setText(liquidity != null 
-			? formatLiquidityText(liquidity.getScore(), liquidity.getRating(), liquidity.getTotalVolumePerHour())
+			? PanelFormat.formatLiquidityText(liquidity.getScore(), liquidity.getRating(), liquidity.getTotalVolumePerHour())
 			: LIQUIDITY_NA);
 	}
 
@@ -2975,76 +2119,13 @@ public class FlipFinderPanel extends PluginPanel
 	{
 		if (risk != null && risk.getScore() != null)
 		{
-			label.setText(formatRiskText(risk.getScore(), risk.getRating()));
-			label.setForeground(getRiskColor(risk.getScore()));
+			label.setText(PanelFormat.formatRiskText(risk.getScore(), risk.getRating()));
+			label.setForeground(PanelFormat.getRiskColor(risk.getScore()));
 		}
 		else
 		{
 			label.setText(RISK_NA);
 		}
-	}
-
-	/**
-	 * Setup icon label with async image loading
-	 */
-	private void setupIconLabel(JLabel iconLabel, AsyncBufferedImage itemImage)
-	{
-		if (itemImage != null)
-		{
-			iconLabel.setIcon(new ImageIcon(itemImage));
-			itemImage.onLoaded(() ->
-			{
-				iconLabel.setIcon(new ImageIcon(itemImage));
-				iconLabel.revalidate();
-				iconLabel.repaint();
-			});
-		}
-		else
-		{
-			iconLabel.setPreferredSize(new Dimension(32, 32));
-		}
-	}
-	
-	/**
-	 * Apply a price indicator background color to the active flip panel and its children.
-	 * Used to visually indicate whether the sell price is higher or lower than the original recommendation.
-	 */
-	private void applyPriceIndicatorBackground(JPanel panel, JPanel topPanel, JPanel namePanel, JPanel detailsPanel, Color bgColor)
-	{
-		panel.setBackground(bgColor);
-		topPanel.setBackground(bgColor);
-		namePanel.setBackground(bgColor);
-		detailsPanel.setBackground(bgColor);
-		// Store the base color as a client property so hover handlers can access it
-		panel.putClientProperty("baseBackgroundColor", bgColor);
-		panel.repaint();
-	}
-	
-	/**
-	 * Brighten a color for hover effects.
-	 * Increases RGB values by a fixed amount while keeping them within valid range.
-	 */
-	private Color brightenColor(Color color, int amount)
-	{
-		return new Color(
-			Math.min(255, color.getRed() + amount),
-			Math.min(255, color.getGreen() + amount),
-			Math.min(255, color.getBlue() + amount)
-		);
-	}
-	
-	/**
-	 * Get the base background color for a panel (either price indicator color or default).
-	 * Checks for stored client property first, falls back to default color.
-	 */
-	private Color getBaseBackgroundColor(JPanel panel, Color defaultColor)
-	{
-		Object stored = panel.getClientProperty("baseBackgroundColor");
-		if (stored instanceof Color)
-		{
-			return (Color) stored;
-		}
-		return defaultColor;
 	}
 
 	/**
@@ -3256,8 +2337,8 @@ public class FlipFinderPanel extends PluginPanel
 				}
 				
 				// Calculate smart sell price
-				Integer smartSellPrice = calculateSmartSellPrice(flip, currentMarketPrice);
-				int sellPrice = smartSellPrice != null ? smartSellPrice : calculateMinProfitableSellPrice(flip.getAverageBuyPrice());
+				Integer smartSellPrice = SmartSellPricer.calculateSmartSellPrice(flip, currentMarketPrice);
+				int sellPrice = smartSellPrice != null ? smartSellPrice : SmartSellPricer.calculateMinProfitableSellPrice(flip.getAverageBuyPrice());
 				
 				// Cache this price for future use
 				displayedSellPrices.put(flip.getItemId(), sellPrice);
@@ -3479,7 +2560,7 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private JPanel createActiveFlipPanel(ActiveFlip flip)
 	{
-		JPanel panel = createBaseItemPanel(ColorScheme.DARKER_GRAY_COLOR, 180, true);
+		JPanel panel = CardWidgets.createBaseItemPanel(ColorScheme.DARKER_GRAY_COLOR, 180, true);
 
 		// Top section: Item icon and name
 		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(), ColorScheme.DARKER_GRAY_COLOR);
@@ -3487,34 +2568,34 @@ public class FlipFinderPanel extends PluginPanel
 		JPanel namePanel = header.namePanel;
 
 		// Details section using BoxLayout for vertical rows
-		JPanel detailsPanel = createDetailsPanel(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel detailsPanel = CardWidgets.createDetailsPanel(ColorScheme.DARKER_GRAY_COLOR);
 
 		// Row 1: Buy: X | Sell: Y (placeholders until data loads)
-		JLabel pricesLabel = createStyledLabel(
-			String.format("Buy: %s | Sell: ...", formatGPExact(flip.getAverageBuyPrice())), Color.WHITE);
+		JLabel pricesLabel = CardWidgets.createStyledLabel(
+			String.format("Buy: %s | Sell: ...", PanelFormat.formatGPExact(flip.getAverageBuyPrice())), Color.WHITE);
 
 		// Row 2: Qty: X (Limit: Y)
-		JLabel qtyLabel = createStyledLabel(
+		JLabel qtyLabel = CardWidgets.createStyledLabel(
 			String.format("Qty: %d (Limit: ...)", flip.getTotalQuantity()), COLOR_TEXT_GRAY);
 
 		// Row 3: Tax = Z
-		JLabel taxLabel = createStyledLabel("Tax = ...", Color.CYAN);
+		JLabel taxLabel = CardWidgets.createStyledLabel("Tax = ...", Color.CYAN);
 
 		// Row 4: Margin: X (Y% ROI)
-		JLabel marginLabel = createStyledLabel("Margin: ...", COLOR_YELLOW);
+		JLabel marginLabel = CardWidgets.createStyledLabel("Margin: ...", COLOR_YELLOW);
 
 		// Row 5: Profit: X | Cost: Y
-		JLabel profitCostLabel = createStyledLabel(
-			String.format("Profit: ... | Cost: %s", formatGP(flip.getTotalInvested())), COLOR_PROFIT_GREEN);
+		JLabel profitCostLabel = CardWidgets.createStyledLabel(
+			String.format("Profit: ... | Cost: %s", PanelFormat.formatGP(flip.getTotalInvested())), COLOR_PROFIT_GREEN);
 
 		// Row 6: Liquidity: X (Rating) | Y/hr
-		JLabel liquidityLabel = createStyledLabel("Liquidity: ...", Color.CYAN);
+		JLabel liquidityLabel = CardWidgets.createStyledLabel("Liquidity: ...", Color.CYAN);
 
 		// Row 7: Risk: X (Rating)
-		JLabel riskLabel = createStyledLabel("Risk: ...", COLOR_YELLOW);
+		JLabel riskLabel = CardWidgets.createStyledLabel("Risk: ...", COLOR_YELLOW);
 
 		// Add all rows with small spacing
-		addLabelsWithSpacing(detailsPanel, pricesLabel, qtyLabel, taxLabel, marginLabel,
+		CardWidgets.addLabelsWithSpacing(detailsPanel, pricesLabel, qtyLabel, taxLabel, marginLabel,
 			profitCostLabel, liquidityLabel, riskLabel);
 
 		if (offerDispositionLookup != null)
@@ -3530,7 +2611,7 @@ public class FlipFinderPanel extends PluginPanel
 				String verbLine = advice.getNewPrice() != null
 					? verb + ": " + String.format("%,d", advice.getNewPrice()) + "gp"
 					: verb;
-				JLabel verbLabel = createStyledLabel(verbLine, Color.ORANGE);
+				JLabel verbLabel = CardWidgets.createStyledLabel(verbLine, Color.ORANGE);
 				verbLabel.setToolTipText(advice.getReason());
 				detailsPanel.add(verbLabel);
 
@@ -3539,7 +2620,7 @@ public class FlipFinderPanel extends PluginPanel
 					int net = advice.getNetProfitEstimate();
 					String keyword = net < 0 ? "Loss" : (net > 0 ? "Profit" : "Breakeven");
 					Color netColor = net < 0 ? new Color(255, 100, 100) : new Color(80, 255, 120);
-					detailsPanel.add(createStyledLabel(keyword + ": " + formatSignedGp(net), netColor));
+					detailsPanel.add(CardWidgets.createStyledLabel(keyword + ": " + formatSignedGp(net), netColor));
 				}
 			}
 		}
@@ -3584,8 +2665,8 @@ public class FlipFinderPanel extends PluginPanel
 				Integer sessionPrice = session != null ? session.getRecommendedPrice(flip.getItemId()) : null;
 				Integer smartSellPrice = (sessionPrice != null && sessionPrice > 0)
 					? sessionPrice
-					: calculateSmartSellPrice(flip, currentMarketPrice);
-				boolean pastThreshold = shouldUseLossMinimizingPrice(flip, dailyVolume);
+					: SmartSellPricer.calculateSmartSellPrice(flip, currentMarketPrice);
+				boolean pastThreshold = SmartSellPricer.shouldUseLossMinimizingPrice(flip, dailyVolume);
 
 				if (smartSellPrice != null && smartSellPrice > 0)
 				{
@@ -3607,7 +2688,7 @@ public class FlipFinderPanel extends PluginPanel
 						// Apply to panel and all child panels (not focused panel - that has its own style)
 						if (currentFocus == null || currentFocus.getItemId() != flip.getItemId())
 						{
-							applyPriceIndicatorBackground(panel, topPanel, namePanel, detailsPanel, priceIndicatorBg);
+							CardWidgets.applyPriceIndicatorBackground(panel, topPanel, namePanel, detailsPanel, priceIndicatorBg);
 						}
 					}
 					
@@ -3632,8 +2713,8 @@ public class FlipFinderPanel extends PluginPanel
 					// Row 1: Update Buy | Sell prices
 					String priceSuffix = pastThreshold ? "*" : "";
 					pricesLabel.setText(String.format("Buy: %s | Sell: %s%s", 
-						formatGPExact(flip.getAverageBuyPrice()),
-						formatGPExact(smartSellPrice),
+						PanelFormat.formatGPExact(flip.getAverageBuyPrice()),
+						PanelFormat.formatGPExact(smartSellPrice),
 						priceSuffix));
 
 					int geTax = GeTax.taxFor(flip.getItemId(), smartSellPrice);
@@ -3646,14 +2727,14 @@ public class FlipFinderPanel extends PluginPanel
 					// Row 2: Update Qty (Limit) | Tax
 					String limitText = buyLimit != null ? String.valueOf(buyLimit) : "?";
 					qtyLabel.setText(String.format("Qty: %d (Limit: %s)", flip.getTotalQuantity(), limitText));
-					taxLabel.setText(String.format("Tax = %s", formatGP(geTax * flip.getTotalQuantity())));
+					taxLabel.setText(String.format("Tax = %s", PanelFormat.formatGP(geTax * flip.getTotalQuantity())));
 					
 					// Row 3: Update Margin with ROI (show warning color if not profitable)
-					marginLabel.setText(formatMarginText(marginPerItem, roi, totalProfit <= 0));
+					marginLabel.setText(PanelFormat.formatMarginText(marginPerItem, roi, totalProfit <= 0));
 					marginLabel.setForeground(totalProfit <= 0 ? COLOR_LOSS_RED : COLOR_YELLOW);
 					
 					// Row 4: Update Profit | Cost - use cyan for higher sell, orange for lower
-					profitCostLabel.setText(formatProfitCostText(totalProfit, flip.getTotalInvested()));
+					profitCostLabel.setText(PanelFormat.formatProfitCostText(totalProfit, flip.getTotalInvested()));
 					if (totalProfit <= 0)
 					{
 						profitCostLabel.setForeground(COLOR_LOSS_RED);
@@ -3675,9 +2756,9 @@ public class FlipFinderPanel extends PluginPanel
 				}
 				else
 				{
-					pricesLabel.setText(formatBuySellText(flip.getAverageBuyPrice(), null));
+					pricesLabel.setText(PanelFormat.formatBuySellText(flip.getAverageBuyPrice(), null));
 					marginLabel.setText("Margin: N/A");
-					profitCostLabel.setText(String.format("Profit: N/A | Cost: %s", formatGP(flip.getTotalInvested())));
+					profitCostLabel.setText(String.format("Profit: N/A | Cost: %s", PanelFormat.formatGP(flip.getTotalInvested())));
 				}
 				
 				// Row 5: Update Liquidity
@@ -3711,9 +2792,9 @@ public class FlipFinderPanel extends PluginPanel
 					|| !currentFocus.isSelling())
 				{
 					// Get the base color (may be price indicator color) and brighten it for hover
-					Color baseColor = getBaseBackgroundColor(panel, ColorScheme.DARKER_GRAY_COLOR);
-					Color hoverColor = brightenColor(baseColor, 15);
-					setPanelBackgrounds(hoverColor, panel, topPanel, namePanel, detailsPanel);
+					Color baseColor = PanelFormat.getBaseBackgroundColor(panel, ColorScheme.DARKER_GRAY_COLOR);
+					Color hoverColor = PanelFormat.brightenColor(baseColor, 15);
+					CardWidgets.setPanelBackgrounds(hoverColor, panel, topPanel, namePanel, detailsPanel);
 				}
 			}
 
@@ -3724,8 +2805,8 @@ public class FlipFinderPanel extends PluginPanel
 					|| !currentFocus.isSelling())
 				{
 					// Restore the base color (may be price indicator color)
-					Color baseColor = getBaseBackgroundColor(panel, ColorScheme.DARKER_GRAY_COLOR);
-					setPanelBackgrounds(baseColor, panel, topPanel, namePanel, detailsPanel);
+					Color baseColor = PanelFormat.getBaseBackgroundColor(panel, ColorScheme.DARKER_GRAY_COLOR);
+					CardWidgets.setPanelBackgrounds(baseColor, panel, topPanel, namePanel, detailsPanel);
 				}
 			}
 
@@ -3773,7 +2854,7 @@ public class FlipFinderPanel extends PluginPanel
 	private JPanel createPendingOrderPanel(PendingOrder pending)
 	{
 		Color bgColor = new Color(55, 55, 65); // Slightly different color for pending
-		JPanel panel = createBaseItemPanel(bgColor, 180, false);
+		JPanel panel = CardWidgets.createBaseItemPanel(bgColor, 180, false);
 
 		// Top section: Item icon and name
 		HeaderPanels header = createItemHeaderPanels(pending.itemId, pending.itemName, bgColor);
@@ -3781,37 +2862,37 @@ public class FlipFinderPanel extends PluginPanel
 		JPanel namePanel = header.namePanel;
 
 		// Details section using BoxLayout for vertical rows
-		JPanel detailsPanel = createDetailsPanel(bgColor);
+		JPanel detailsPanel = CardWidgets.createDetailsPanel(bgColor);
 
 		// Row 1: Buy: X | Sell: Y (with placeholders until data loads)
 		String sellText = pending.recommendedSellPrice != null && pending.recommendedSellPrice > 0
-			? formatGPExact(pending.recommendedSellPrice) : "...";
-		JLabel pricesLabel = createStyledLabel(
-			String.format(FORMAT_BUY_SELL, formatGPExact(pending.pricePerItem), sellText), Color.WHITE);
+			? PanelFormat.formatGPExact(pending.recommendedSellPrice) : "...";
+		JLabel pricesLabel = CardWidgets.createStyledLabel(
+			String.format(FORMAT_BUY_SELL, PanelFormat.formatGPExact(pending.pricePerItem), sellText), Color.WHITE);
 
 		// Row 2: Qty: X/Y (Limit: Z)
-		JLabel qtyLabel = createStyledLabel(
+		JLabel qtyLabel = CardWidgets.createStyledLabel(
 			String.format("Qty: %d/%d (Limit: ...)", pending.quantityFilled, pending.quantity), COLOR_TEXT_GRAY);
 
 		// Row 3: Tax = W
-		JLabel taxLabel = createStyledLabel("Tax = ...", Color.CYAN);
+		JLabel taxLabel = CardWidgets.createStyledLabel("Tax = ...", Color.CYAN);
 
 		// Row 4: Margin: X (Y% ROI)
-		JLabel marginLabel = createStyledLabel("Margin: ...", COLOR_YELLOW);
+		JLabel marginLabel = CardWidgets.createStyledLabel("Margin: ...", COLOR_YELLOW);
 
 		// Row 5: Profit: X | Cost: Y
 		int potentialInvestment = pending.quantity * pending.pricePerItem;
-		JLabel profitCostLabel = createStyledLabel(
-			String.format("Profit: ... | Cost: %s", formatGP(potentialInvestment)), COLOR_PROFIT_GREEN);
+		JLabel profitCostLabel = CardWidgets.createStyledLabel(
+			String.format("Profit: ... | Cost: %s", PanelFormat.formatGP(potentialInvestment)), COLOR_PROFIT_GREEN);
 
 		// Row 6: Liquidity: X (Rating) | Y/hr
-		JLabel liquidityLabel = createStyledLabel("Liquidity: ...", Color.CYAN);
+		JLabel liquidityLabel = CardWidgets.createStyledLabel("Liquidity: ...", Color.CYAN);
 
 		// Row 7: Risk: X (Rating)
-		JLabel riskLabel = createStyledLabel("Risk: ...", COLOR_YELLOW);
+		JLabel riskLabel = CardWidgets.createStyledLabel("Risk: ...", COLOR_YELLOW);
 
 		// Add all rows with small spacing
-		addLabelsWithSpacing(detailsPanel, pricesLabel, qtyLabel, taxLabel, marginLabel, 
+		CardWidgets.addLabelsWithSpacing(detailsPanel, pricesLabel, qtyLabel, taxLabel, marginLabel, 
 			profitCostLabel, liquidityLabel, riskLabel);
 
 		panel.add(topPanel, BorderLayout.NORTH);
@@ -3846,7 +2927,7 @@ public class FlipFinderPanel extends PluginPanel
 				if (sellPrice != null && sellPrice > 0)
 				{
 					// Row 1: Update prices
-					pricesLabel.setText(formatBuySellText(pending.pricePerItem, sellPrice));
+					pricesLabel.setText(PanelFormat.formatBuySellText(pending.pricePerItem, sellPrice));
 
 					int geTax = GeTax.taxFor(pending.itemId, sellPrice);
 
@@ -3859,21 +2940,21 @@ public class FlipFinderPanel extends PluginPanel
 					String limitText = buyLimit != null ? String.valueOf(buyLimit) : "?";
 					qtyLabel.setText(String.format("Qty: %d/%d (Limit: %s)", 
 						pending.quantityFilled, pending.quantity, limitText));
-					taxLabel.setText(String.format("Tax = %s", formatGP(geTax * pending.quantity)));
+					taxLabel.setText(String.format("Tax = %s", PanelFormat.formatGP(geTax * pending.quantity)));
 					
 					// Row 3: Update Margin
-					marginLabel.setText(formatMarginText(marginPerItem, roi, totalProfit <= 0));
+					marginLabel.setText(PanelFormat.formatMarginText(marginPerItem, roi, totalProfit <= 0));
 					marginLabel.setForeground(totalProfit <= 0 ? COLOR_LOSS_RED : COLOR_YELLOW);
 					
 					// Row 4: Update Profit | Cost
-					profitCostLabel.setText(formatProfitCostText(totalProfit, potentialInvestment));
+					profitCostLabel.setText(PanelFormat.formatProfitCostText(totalProfit, potentialInvestment));
 					profitCostLabel.setForeground(totalProfit > 0 ? COLOR_PROFIT_GREEN : COLOR_LOSS_RED);
 				}
 				else
 				{
-					pricesLabel.setText(formatBuySellText(pending.pricePerItem, null));
+					pricesLabel.setText(PanelFormat.formatBuySellText(pending.pricePerItem, null));
 					marginLabel.setText("Margin: N/A");
-					profitCostLabel.setText(String.format("Profit: N/A | Cost: %s", formatGP(potentialInvestment)));
+					profitCostLabel.setText(String.format("Profit: N/A | Cost: %s", PanelFormat.formatGP(potentialInvestment)));
 				}
 				
 				// Row 5: Update Liquidity
@@ -3902,7 +2983,7 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				if (currentFocus == null || currentFocus.getItemId() != pending.itemId)
 				{
-					setPanelBackgrounds(new Color(65, 65, 75), panel, topPanel, namePanel, detailsPanel);
+					CardWidgets.setPanelBackgrounds(new Color(65, 65, 75), panel, topPanel, namePanel, detailsPanel);
 				}
 			}
 			
@@ -3911,7 +2992,7 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				if (currentFocus == null || currentFocus.getItemId() != pending.itemId)
 				{
-					setPanelBackgrounds(bgColor, panel, topPanel, namePanel, detailsPanel);
+					CardWidgets.setPanelBackgrounds(bgColor, panel, topPanel, namePanel, detailsPanel);
 				}
 			}
 		});
@@ -3934,7 +3015,7 @@ public class FlipFinderPanel extends PluginPanel
 		Color backgroundColor = flip.isSuccessful() ? 
 			new Color(40, 60, 40) : // Dark green for profit
 			new Color(60, 40, 40);  // Dark red for loss
-		JPanel panel = createBaseItemPanel(backgroundColor, 110, false);
+		JPanel panel = CardWidgets.createBaseItemPanel(backgroundColor, 110, false);
 
 		// Top section: Item icon and name
 		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(), backgroundColor);
@@ -3954,21 +3035,21 @@ public class FlipFinderPanel extends PluginPanel
 		qtyLabel.setForeground(COLOR_TEXT_GRAY);
 		qtyLabel.setFont(FONT_PLAIN_12);
 
-		JLabel buyPriceLabel = new JLabel(String.format("Buy: %s", formatGPExact(flip.getBuyPricePerItem())));
+		JLabel buyPriceLabel = new JLabel(String.format("Buy: %s", PanelFormat.formatGPExact(flip.getBuyPricePerItem())));
 		buyPriceLabel.setForeground(COLOR_BUY_RED);
 		buyPriceLabel.setFont(FONT_PLAIN_12);
 
 		// Row 2: Invested and Sell Price
-		JLabel investedLabel = new JLabel(String.format("Cost: %s", formatGP(flip.getBuyTotal())));
+		JLabel investedLabel = new JLabel(String.format("Cost: %s", PanelFormat.formatGP(flip.getBuyTotal())));
 		investedLabel.setForeground(COLOR_TEXT_GRAY);
 		investedLabel.setFont(FONT_PLAIN_12);
 
-		JLabel sellPriceLabel = new JLabel(String.format(FORMAT_SELL, formatGPExact(flip.getSellPricePerItem())));
+		JLabel sellPriceLabel = new JLabel(String.format(FORMAT_SELL, PanelFormat.formatGPExact(flip.getSellPricePerItem())));
 		sellPriceLabel.setForeground(COLOR_SELL_GREEN);
 		sellPriceLabel.setFont(FONT_PLAIN_12);
 
 		// Row 3: Net Profit and ROI
-		JLabel profitLabel = new JLabel(String.format("Profit: %s", formatGP(flip.getNetProfit())));
+		JLabel profitLabel = new JLabel(String.format("Profit: %s", PanelFormat.formatGP(flip.getNetProfit())));
 		Color profitColor = flip.isSuccessful() ? 
 			COLOR_PROFIT_GREEN : // Bright green
 			COLOR_LOSS_RED;  // Bright red
@@ -4023,7 +3104,7 @@ public class FlipFinderPanel extends PluginPanel
 					durationLabel.setFont(FONT_PLAIN_12);
 
 					// GE Tax
-					JLabel taxLabel = new JLabel(String.format("GE Tax: %s", formatGP(flip.getGeTax())));
+					JLabel taxLabel = new JLabel(String.format("GE Tax: %s", PanelFormat.formatGP(flip.getGeTax())));
 					taxLabel.setForeground(COLOR_TEXT_DIM_GRAY);
 					taxLabel.setFont(FONT_PLAIN_12);
 
@@ -4122,101 +3203,6 @@ public class FlipFinderPanel extends PluginPanel
 		}
 		// Use invokeLater to restore after layout is complete
 		SwingUtilities.invokeLater(() -> scrollPane.getVerticalScrollBar().setValue(position));
-	}
-	
-	
-	/**
-	 * Calculate the sell price threshold time for an active flip.
-	 * Returns the number of minutes after which we should switch from 
-	 * profit-first to loss-minimizing strategy.
-	 * 
-	 * Rules:
-	 * - High volume items (>500k daily): 10 minutes
-	 * - High value items (>250M buy price): 30 minutes
-	 * - Regular items: 20 minutes
-	 */
-	private int getSellPriceThresholdMinutes(ActiveFlip flip, Integer dailyVolume)
-	{
-		// High value items get more time
-		if (flip.getAverageBuyPrice() >= HIGH_VALUE_THRESHOLD)
-		{
-			return HIGH_VALUE_TIME_MINUTES;
-		}
-		
-		// High volume items should sell quickly
-		if (dailyVolume != null && dailyVolume >= HIGH_VOLUME_THRESHOLD)
-		{
-			return HIGH_VOLUME_TIME_MINUTES;
-		}
-		
-		// Regular items
-		return REGULAR_TIME_MINUTES;
-	}
-	
-	/**
-	 * Check if an active flip has exceeded its time threshold and should
-	 * switch to loss-minimizing sell price.
-	 */
-	private boolean shouldUseLossMinimizingPrice(ActiveFlip flip, Integer dailyVolume)
-	{
-		String buyTimeStr = flip.getLastBuyTime();
-		if (buyTimeStr == null || buyTimeStr.isEmpty())
-		{
-			return false;
-		}
-		
-		try
-		{
-			Instant buyTime = Instant.parse(buyTimeStr);
-			Duration elapsed = Duration.between(buyTime, Instant.now());
-			int thresholdMinutes = getSellPriceThresholdMinutes(flip, dailyVolume);
-			return elapsed.toMinutes() >= thresholdMinutes;
-		}
-		catch (DateTimeParseException e)
-		{
-			log.debug("Failed to parse buy time: {}", buyTimeStr);
-			return false;
-		}
-	}
-	
-	/**
-	 * Calculate the minimum profitable sell price for an active flip.
-	 * This is the price that would result in zero profit after tax.
-	 * Formula: minSellPrice = buyPrice / (1 - taxRate)
-	 * Adding 1gp ensures a small profit.
-	 */
-	private int calculateMinProfitableSellPrice(int buyPrice)
-	{
-		// GE tax is 2%, so to break even: sellPrice * 0.98 = buyPrice
-		// sellPrice = buyPrice / 0.98
-		// Add 1gp to ensure profit
-		return (int) Math.ceil(buyPrice / 0.98) + 1;
-	}
-	
-	private Integer calculateSmartSellPrice(ActiveFlip flip, Integer currentMarketPrice)
-	{
-		int buyPrice = flip.getAverageBuyPrice();
-		int minProfitablePrice = calculateMinProfitableSellPrice(buyPrice);
-
-		// Use recommended price if it's profitable
-		if (flip.getRecommendedSellPrice() != null && flip.getRecommendedSellPrice() >= minProfitablePrice)
-		{
-			return flip.getRecommendedSellPrice();
-		}
-
-		// No recommended price or it's not profitable - use minimum profitable price
-		// but only if market price is higher (otherwise the flip was never good)
-		if (currentMarketPrice != null && currentMarketPrice >= minProfitablePrice)
-		{
-			return minProfitablePrice;
-		}
-
-		if (flip.getRecommendedSellPrice() != null)
-		{
-			return flip.getRecommendedSellPrice();
-		}
-
-		return minProfitablePrice;
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2232,12 +2232,17 @@ public class FlipFinderPanel extends PluginPanel
 	private static String activeOfferVerb(OfferAction action, Integer netProfitEstimate)
 	{
 		boolean isLoss = netProfitEstimate != null && netProfitEstimate < 0;
+		boolean isProfit = netProfitEstimate != null && netProfitEstimate > 0;
 		switch (action)
 		{
 			case MOVE_PRICE_DOWN:
 				return "Move price down";
 			case EXIT_AT_BREAKEVEN:
-				return isLoss ? "Exit at a loss" : "Exit at breakeven";
+				if (isLoss)
+				{
+					return "Exit at a loss";
+				}
+				return isProfit ? "Take profit" : "Exit at breakeven";
 			case EXIT_AT_LOSS:
 				return "Exit at a loss";
 			default:

--- a/src/main/java/com/flipsmart/recommend/SmartSellPricer.java
+++ b/src/main/java/com/flipsmart/recommend/SmartSellPricer.java
@@ -78,18 +78,26 @@ public final class SmartSellPricer
 		}
 	}
 
+	private static final int GE_TAX_EXEMPT_THRESHOLD = 100;
+	private static final int GE_TAX_CAP_GP = 5_000_000;
+	private static final double GE_TAX_RATE = 0.01;
+
 	/**
 	 * Calculate the minimum profitable sell price for an active flip.
-	 * This is the price that would result in zero profit after tax.
-	 * Formula: minSellPrice = buyPrice / (1 - taxRate)
-	 * Adding 1gp ensures a small profit.
+	 * This is the sell price at which profit after GE tax is exactly 1 GP.
+	 *
+	 * OSRS GE tax rules:
+	 * - Items priced under 100 GP are tax-exempt.
+	 * - Tax = 1% of sell price, capped at 5,000,000 GP.
 	 */
 	public static int calculateMinProfitableSellPrice(int buyPrice)
 	{
-		// GE tax is 2%, so to break even: sellPrice * 0.98 = buyPrice
-		// sellPrice = buyPrice / 0.98
-		// Add 1gp to ensure profit
-		return (int) Math.ceil(buyPrice / 0.98) + 1;
+		if (buyPrice < GE_TAX_EXEMPT_THRESHOLD)
+		{
+			return buyPrice + 1;
+		}
+		int tax = (int) Math.min(Math.ceil(buyPrice * GE_TAX_RATE), GE_TAX_CAP_GP);
+		return buyPrice + tax + 1;
 	}
 
 	public static Integer calculateSmartSellPrice(ActiveFlip flip, Integer currentMarketPrice)

--- a/src/main/java/com/flipsmart/recommend/SmartSellPricer.java
+++ b/src/main/java/com/flipsmart/recommend/SmartSellPricer.java
@@ -78,26 +78,18 @@ public final class SmartSellPricer
 		}
 	}
 
-	private static final int GE_TAX_EXEMPT_THRESHOLD = 100;
-	private static final int GE_TAX_CAP_GP = 5_000_000;
-	private static final double GE_TAX_RATE = 0.01;
-
 	/**
 	 * Calculate the minimum profitable sell price for an active flip.
-	 * This is the sell price at which profit after GE tax is exactly 1 GP.
-	 *
-	 * OSRS GE tax rules:
-	 * - Items priced under 100 GP are tax-exempt.
-	 * - Tax = 1% of sell price, capped at 5,000,000 GP.
+	 * This is the price that would result in zero profit after tax.
+	 * Formula: minSellPrice = buyPrice / (1 - taxRate)
+	 * Adding 1gp ensures a small profit.
 	 */
 	public static int calculateMinProfitableSellPrice(int buyPrice)
 	{
-		if (buyPrice < GE_TAX_EXEMPT_THRESHOLD)
-		{
-			return buyPrice + 1;
-		}
-		int tax = (int) Math.min(Math.ceil(buyPrice * GE_TAX_RATE), GE_TAX_CAP_GP);
-		return buyPrice + tax + 1;
+		// GE tax is 2%, so to break even: sellPrice * 0.98 = buyPrice
+		// sellPrice = buyPrice / 0.98
+		// Add 1gp to ensure profit
+		return (int) Math.ceil(buyPrice / 0.98) + 1;
 	}
 
 	public static Integer calculateSmartSellPrice(ActiveFlip flip, Integer currentMarketPrice)

--- a/src/main/java/com/flipsmart/recommend/SmartSellPricer.java
+++ b/src/main/java/com/flipsmart/recommend/SmartSellPricer.java
@@ -1,0 +1,117 @@
+package com.flipsmart.recommend;
+
+import com.flipsmart.domain.flip.ActiveFlip;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Smart-sell pricing decisions for active flips. Stateless and free of any UI
+ * dependency: every method takes the data it needs as primitives or domain
+ * objects and returns a price (or a strategy decision) the panel renders.
+ */
+@Slf4j
+public final class SmartSellPricer
+{
+	private static final int HIGH_VOLUME_THRESHOLD = 500_000;
+	private static final int HIGH_VOLUME_TIME_MINUTES = 10;
+
+	private static final int REGULAR_TIME_MINUTES = 20;
+
+	private static final int HIGH_VALUE_THRESHOLD = 250_000_000;
+	private static final int HIGH_VALUE_TIME_MINUTES = 30;
+
+	private SmartSellPricer()
+	{
+		// Utility class - prevent instantiation
+	}
+
+	/**
+	 * Calculate the sell price threshold time for an active flip.
+	 * Returns the number of minutes after which we should switch from
+	 * profit-first to loss-minimizing strategy.
+	 *
+	 * Rules:
+	 * - High volume items (&gt;500k daily): 10 minutes
+	 * - High value items (&gt;250M buy price): 30 minutes
+	 * - Regular items: 20 minutes
+	 */
+	public static int getSellPriceThresholdMinutes(ActiveFlip flip, Integer dailyVolume)
+	{
+		if (flip.getAverageBuyPrice() >= HIGH_VALUE_THRESHOLD)
+		{
+			return HIGH_VALUE_TIME_MINUTES;
+		}
+
+		if (dailyVolume != null && dailyVolume >= HIGH_VOLUME_THRESHOLD)
+		{
+			return HIGH_VOLUME_TIME_MINUTES;
+		}
+
+		return REGULAR_TIME_MINUTES;
+	}
+
+	/**
+	 * Check if an active flip has exceeded its time threshold and should
+	 * switch to loss-minimizing sell price.
+	 */
+	public static boolean shouldUseLossMinimizingPrice(ActiveFlip flip, Integer dailyVolume)
+	{
+		String buyTimeStr = flip.getLastBuyTime();
+		if (buyTimeStr == null || buyTimeStr.isEmpty())
+		{
+			return false;
+		}
+
+		try
+		{
+			Instant buyTime = Instant.parse(buyTimeStr);
+			Duration elapsed = Duration.between(buyTime, Instant.now());
+			int thresholdMinutes = getSellPriceThresholdMinutes(flip, dailyVolume);
+			return elapsed.toMinutes() >= thresholdMinutes;
+		}
+		catch (DateTimeParseException e)
+		{
+			log.debug("Failed to parse buy time: {}", buyTimeStr);
+			return false;
+		}
+	}
+
+	/**
+	 * Calculate the minimum profitable sell price for an active flip.
+	 * This is the price that would result in zero profit after tax.
+	 * Formula: minSellPrice = buyPrice / (1 - taxRate)
+	 * Adding 1gp ensures a small profit.
+	 */
+	public static int calculateMinProfitableSellPrice(int buyPrice)
+	{
+		// GE tax is 2%, so to break even: sellPrice * 0.98 = buyPrice
+		// sellPrice = buyPrice / 0.98
+		// Add 1gp to ensure profit
+		return (int) Math.ceil(buyPrice / 0.98) + 1;
+	}
+
+	public static Integer calculateSmartSellPrice(ActiveFlip flip, Integer currentMarketPrice)
+	{
+		int buyPrice = flip.getAverageBuyPrice();
+		int minProfitablePrice = calculateMinProfitableSellPrice(buyPrice);
+
+		if (flip.getRecommendedSellPrice() != null && flip.getRecommendedSellPrice() >= minProfitablePrice)
+		{
+			return flip.getRecommendedSellPrice();
+		}
+
+		if (currentMarketPrice != null && currentMarketPrice >= minProfitablePrice)
+		{
+			return minProfitablePrice;
+		}
+
+		if (flip.getRecommendedSellPrice() != null)
+		{
+			return flip.getRecommendedSellPrice();
+		}
+
+		return minProfitablePrice;
+	}
+}

--- a/src/main/java/com/flipsmart/ui/panel/CardWidgets.java
+++ b/src/main/java/com/flipsmart/ui/panel/CardWidgets.java
@@ -1,0 +1,133 @@
+package com.flipsmart.ui.panel;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Font;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.border.EmptyBorder;
+import net.runelite.client.util.AsyncBufferedImage;
+
+/**
+ * Shared low-level Swing builders used by all flip cards (recommendation,
+ * active, completed) and the panel itself. Each method is a pure factory or a
+ * mutation scoped to the widgets passed in - no panel state, no callbacks.
+ */
+public final class CardWidgets
+{
+	private static final Font FONT_PLAIN_12 = new Font("Arial", Font.PLAIN, 12);
+
+	private CardWidgets()
+	{
+		// Utility class - prevent instantiation
+	}
+
+	/**
+	 * Create a styled JLabel with common settings for detail rows
+	 */
+	public static JLabel createStyledLabel(String text, Color foreground)
+	{
+		JLabel label = new JLabel(text);
+		label.setForeground(foreground);
+		label.setFont(FONT_PLAIN_12);
+		label.setAlignmentX(Component.LEFT_ALIGNMENT);
+		return label;
+	}
+
+	/**
+	 * Create a details panel with BoxLayout for vertical rows
+	 */
+	public static JPanel createDetailsPanel(Color bgColor)
+	{
+		JPanel detailsPanel = new JPanel();
+		detailsPanel.setLayout(new BoxLayout(detailsPanel, BoxLayout.Y_AXIS));
+		detailsPanel.setBackground(bgColor);
+		detailsPanel.setBorder(new EmptyBorder(5, 0, 0, 0));
+		return detailsPanel;
+	}
+
+	/**
+	 * Add labels to a details panel with standard 2px vertical spacing
+	 */
+	public static void addLabelsWithSpacing(JPanel panel, JLabel... labels)
+	{
+		for (int i = 0; i < labels.length; i++)
+		{
+			panel.add(labels[i]);
+			if (i < labels.length - 1)
+			{
+				panel.add(Box.createRigidArea(new Dimension(0, 2)));
+			}
+		}
+	}
+
+	/**
+	 * Update background color for multiple panels (used in mouse listeners)
+	 */
+	public static void setPanelBackgrounds(Color color, JPanel... panels)
+	{
+		for (JPanel panel : panels)
+		{
+			panel.setBackground(color);
+		}
+	}
+
+	/**
+	 * Create a base panel with common settings for flip/recommendation items
+	 */
+	public static JPanel createBaseItemPanel(Color bgColor, int maxHeight, boolean handCursor)
+	{
+		JPanel panel = new JPanel();
+		panel.setLayout(new BorderLayout());
+		panel.setBackground(bgColor);
+		panel.setBorder(new EmptyBorder(8, 8, 8, 8));
+		panel.setAlignmentX(Component.LEFT_ALIGNMENT);
+		panel.setMaximumSize(new Dimension(Integer.MAX_VALUE, maxHeight));
+		if (handCursor)
+		{
+			panel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+		}
+		return panel;
+	}
+
+	/**
+	 * Setup icon label with async image loading
+	 */
+	public static void setupIconLabel(JLabel iconLabel, AsyncBufferedImage itemImage)
+	{
+		if (itemImage != null)
+		{
+			iconLabel.setIcon(new ImageIcon(itemImage));
+			itemImage.onLoaded(() ->
+			{
+				iconLabel.setIcon(new ImageIcon(itemImage));
+				iconLabel.revalidate();
+				iconLabel.repaint();
+			});
+		}
+		else
+		{
+			iconLabel.setPreferredSize(new Dimension(32, 32));
+		}
+	}
+
+	/**
+	 * Apply a price indicator background color to the active flip panel and its children.
+	 * Used to visually indicate whether the sell price is higher or lower than the original recommendation.
+	 */
+	public static void applyPriceIndicatorBackground(JPanel panel, JPanel topPanel, JPanel namePanel, JPanel detailsPanel, Color bgColor)
+	{
+		panel.setBackground(bgColor);
+		topPanel.setBackground(bgColor);
+		namePanel.setBackground(bgColor);
+		detailsPanel.setBackground(bgColor);
+		panel.putClientProperty("baseBackgroundColor", bgColor);
+		panel.repaint();
+	}
+}

--- a/src/main/java/com/flipsmart/ui/panel/CardWidgets.java
+++ b/src/main/java/com/flipsmart/ui/panel/CardWidgets.java
@@ -52,6 +52,8 @@ public final class CardWidgets
 		return detailsPanel;
 	}
 
+	private static final Dimension LABEL_SPACING = new Dimension(0, 2);
+
 	/**
 	 * Add labels to a details panel with standard 2px vertical spacing
 	 */
@@ -62,7 +64,7 @@ public final class CardWidgets
 			panel.add(labels[i]);
 			if (i < labels.length - 1)
 			{
-				panel.add(Box.createRigidArea(new Dimension(0, 2)));
+				panel.add(Box.createRigidArea(LABEL_SPACING));
 			}
 		}
 	}

--- a/src/main/java/com/flipsmart/ui/panel/LoginPanel.java
+++ b/src/main/java/com/flipsmart/ui/panel/LoginPanel.java
@@ -1,0 +1,705 @@
+package com.flipsmart.ui.panel;
+
+import com.flipsmart.FlipSmartApiClient;
+import com.flipsmart.FlipSmartConfig;
+import com.flipsmart.api.dto.AuthResult;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.util.LinkBrowser;
+
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.GridLayout;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Login / authentication sub-panel. Owns the login UI, the email/password
+ * credential flow, the Discord device-auth flow (and its scheduler/timers),
+ * and credential persistence. The API client is the source of truth for
+ * authentication state.
+ */
+@Slf4j
+public class LoginPanel
+{
+	private static final String CONFIG_GROUP = "flipsmart";
+	private static final String CONFIG_KEY_EMAIL = "email";
+	private static final String CONFIG_KEY_PASSWORD = "password";  // Deprecated: kept for migration
+	private static final String CONFIG_KEY_REFRESH_TOKEN = "refreshToken";
+
+	private static final String FONT_ARIAL = "Arial";
+	private static final Font FONT_PLAIN_12 = new Font(FONT_ARIAL, Font.PLAIN, 12);
+	private static final Color COLOR_PROFIT_GREEN = new Color(100, 255, 100);
+	private static final Color COLOR_LOSS_RED = new Color(255, 100, 100);
+
+	private final transient FlipSmartConfig config;
+	private final transient FlipSmartApiClient apiClient;
+	private final transient ConfigManager configManager;
+
+	// Callback to run the plugin's post-login work (e.g. RSN sync).
+	private final transient Runnable onAuthSuccess;
+	// Callback to transition the host panel from login view to main view.
+	private final transient Runnable onShowMainPanel;
+
+	private final JPanel loginPanel;
+	private JTextField emailField;
+	private JPasswordField passwordField;
+	private JLabel loginStatusLabel;
+	private JButton loginButton;
+	private JButton signupButton;
+	private JButton discordButton;
+
+	// Discord device auth polling
+	private ScheduledExecutorService deviceAuthScheduler;
+	private ScheduledFuture<?> deviceAuthPollTask;
+	private volatile String currentDeviceCode;
+
+	// Auth transition timer (tracked for cleanup)
+	private Timer authTransitionTimer;
+
+	public LoginPanel(FlipSmartApiClient apiClient, FlipSmartConfig config, ConfigManager configManager,
+		Runnable onAuthSuccess, Runnable onShowMainPanel)
+	{
+		this.apiClient = apiClient;
+		this.config = config;
+		this.configManager = configManager;
+		this.onAuthSuccess = onAuthSuccess;
+		this.onShowMainPanel = onShowMainPanel;
+
+		this.loginPanel = buildLoginPanel();
+
+		// Persist refresh token whenever it changes (rotation, new login, etc.)
+		// This prevents token loss from mid-session rotations via the 401 retry path
+		apiClient.setOnRefreshTokenChanged(this::saveRefreshToken);
+	}
+
+	/**
+	 * The built login panel component.
+	 */
+	public JPanel getComponent()
+	{
+		return loginPanel;
+	}
+
+	/**
+	 * Pre-fill the email field from a known address (e.g. on session expiry).
+	 */
+	public void setEmailField(String email)
+	{
+		if (email != null && !email.isEmpty())
+		{
+			emailField.setText(email);
+		}
+	}
+
+	/**
+	 * Set the login status text and colour directly (used by host on session
+	 * expiry / logout messaging).
+	 */
+	public void setLoginStatusText(String message, Color color)
+	{
+		loginStatusLabel.setText(message);
+		loginStatusLabel.setForeground(color);
+	}
+
+	/**
+	 * Clear the password field (e.g. on logout).
+	 */
+	public void clearPasswordField()
+	{
+		passwordField.setText("");
+	}
+
+	/**
+	 * Reset the login view: stop device-auth polling and re-enable buttons.
+	 * Called by the host when switching back to the login panel.
+	 */
+	public void resetLoginView()
+	{
+		stopDeviceAuthPolling();
+		setLoginButtonsEnabled(true);
+	}
+
+	/**
+	 * Build the login/signup panel
+	 */
+	private JPanel buildLoginPanel()
+	{
+		JPanel panel = new JPanel();
+		panel.setLayout(new BorderLayout());
+		panel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		// Center content panel
+		JPanel contentPanel = new JPanel();
+		contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.Y_AXIS));
+		contentPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		contentPanel.setBorder(BorderFactory.createEmptyBorder(40, 20, 40, 20));
+
+		// Title
+		JLabel titleLabel = new JLabel("FlipSmart");
+		titleLabel.setForeground(Color.WHITE);
+		titleLabel.setFont(new Font(FONT_ARIAL, Font.BOLD, 24));
+		titleLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+		// Subtitle
+		JLabel subtitleLabel = new JLabel("Sign in to start flipping");
+		subtitleLabel.setForeground(Color.LIGHT_GRAY);
+		subtitleLabel.setFont(new Font(FONT_ARIAL, Font.PLAIN, 14));
+		subtitleLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+		// Email field
+		JLabel emailLabel = new JLabel("Email");
+		emailLabel.setForeground(Color.LIGHT_GRAY);
+		emailLabel.setFont(FONT_PLAIN_12);
+		emailLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+		emailField = new JTextField(20);
+		emailField.setMaximumSize(new Dimension(Integer.MAX_VALUE, 30));
+		emailField.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		emailField.setForeground(Color.WHITE);
+		emailField.setCaretColor(Color.WHITE);
+		emailField.setBorder(BorderFactory.createCompoundBorder(
+			BorderFactory.createLineBorder(ColorScheme.MEDIUM_GRAY_COLOR),
+			BorderFactory.createEmptyBorder(5, 10, 5, 10)
+		));
+
+		// Password field
+		JLabel passwordLabel = new JLabel("Password");
+		passwordLabel.setForeground(Color.LIGHT_GRAY);
+		passwordLabel.setFont(FONT_PLAIN_12);
+		passwordLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+		passwordField = new JPasswordField(20);
+		passwordField.setMaximumSize(new Dimension(Integer.MAX_VALUE, 30));
+		passwordField.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		passwordField.setForeground(Color.WHITE);
+		passwordField.setCaretColor(Color.WHITE);
+		passwordField.setBorder(BorderFactory.createCompoundBorder(
+			BorderFactory.createLineBorder(ColorScheme.MEDIUM_GRAY_COLOR),
+			BorderFactory.createEmptyBorder(5, 10, 5, 10)
+		));
+
+		// Status label for messages
+		loginStatusLabel = new JLabel(" ");
+		loginStatusLabel.setFont(FONT_PLAIN_12);
+		loginStatusLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+		loginStatusLabel.setForeground(Color.LIGHT_GRAY);
+
+		// Buttons panel for Login/Sign Up
+		JPanel buttonsPanel = new JPanel(new GridLayout(1, 2, 10, 0));
+		buttonsPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		buttonsPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 35));
+
+		// Sign Up button
+		signupButton = new JButton("Sign Up");
+		signupButton.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		signupButton.setForeground(Color.WHITE);
+		signupButton.setFocusPainted(false);
+		signupButton.setBorder(BorderFactory.createCompoundBorder(
+			BorderFactory.createLineBorder(ColorScheme.BRAND_ORANGE),
+			BorderFactory.createEmptyBorder(8, 15, 8, 15)
+		));
+		signupButton.setCursor(new Cursor(Cursor.HAND_CURSOR));
+		signupButton.addActionListener(e -> handleSignup());
+
+		// Login button
+		loginButton = new JButton("Login");
+		loginButton.setBackground(ColorScheme.BRAND_ORANGE);
+		loginButton.setForeground(Color.WHITE);
+		loginButton.setFocusPainted(false);
+		loginButton.setBorder(BorderFactory.createEmptyBorder(8, 15, 8, 15));
+		loginButton.setCursor(new Cursor(Cursor.HAND_CURSOR));
+		loginButton.addActionListener(e -> handleLogin());
+
+		buttonsPanel.add(signupButton);
+		buttonsPanel.add(loginButton);
+
+		// Divider
+		JPanel dividerPanel = new JPanel(new BorderLayout());
+		dividerPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		dividerPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 20));
+
+		JLabel orLabel = new JLabel("OR", SwingConstants.CENTER);
+		orLabel.setForeground(Color.GRAY);
+		orLabel.setFont(new Font(FONT_ARIAL, Font.PLAIN, 11));
+		dividerPanel.add(orLabel, BorderLayout.CENTER);
+
+		// Discord login button (with Discord purple color)
+		discordButton = new JButton("Login with Discord");
+		discordButton.setBackground(new Color(88, 101, 242)); // Discord blurple
+		discordButton.setForeground(Color.WHITE);
+		discordButton.setFocusPainted(false);
+		discordButton.setBorder(BorderFactory.createEmptyBorder(10, 15, 10, 15));
+		discordButton.setCursor(new Cursor(Cursor.HAND_CURSOR));
+		discordButton.setMaximumSize(new Dimension(Integer.MAX_VALUE, 40));
+		discordButton.setAlignmentX(Component.CENTER_ALIGNMENT);
+		discordButton.addActionListener(e -> handleDiscordLogin());
+
+		// Add components with spacing
+		contentPanel.add(titleLabel);
+		contentPanel.add(Box.createRigidArea(new Dimension(0, 5)));
+		contentPanel.add(subtitleLabel);
+		contentPanel.add(Box.createRigidArea(new Dimension(0, 30)));
+		contentPanel.add(emailLabel);
+		contentPanel.add(Box.createRigidArea(new Dimension(0, 5)));
+		contentPanel.add(emailField);
+		contentPanel.add(Box.createRigidArea(new Dimension(0, 15)));
+		contentPanel.add(passwordLabel);
+		contentPanel.add(Box.createRigidArea(new Dimension(0, 5)));
+		contentPanel.add(passwordField);
+		contentPanel.add(Box.createRigidArea(new Dimension(0, 20)));
+		contentPanel.add(buttonsPanel);
+		contentPanel.add(Box.createRigidArea(new Dimension(0, 15)));
+		contentPanel.add(dividerPanel);
+		contentPanel.add(Box.createRigidArea(new Dimension(0, 15)));
+		contentPanel.add(discordButton);
+		contentPanel.add(Box.createRigidArea(new Dimension(0, 15)));
+		contentPanel.add(loginStatusLabel);
+
+		// Center the content vertically
+		panel.add(contentPanel, BorderLayout.CENTER);
+		return panel;
+	}
+
+	/**
+	 * Check if already authenticated and show appropriate panel.
+	 * Tries refresh token first (secure), falls back to legacy password if needed.
+	 */
+	public void checkAuthenticationAndShow()
+	{
+		// First, try to authenticate with refresh token (secure method)
+		String refreshToken = config.refreshToken();
+		String email = config.email();
+
+		if (refreshToken != null && !refreshToken.isEmpty())
+		{
+			// Pre-fill email field if available
+			if (email != null && !email.isEmpty())
+			{
+				emailField.setText(email);
+			}
+
+			// Load refresh token into API client and try to authenticate
+			apiClient.setRefreshToken(refreshToken);
+
+			apiClient.refreshAccessTokenAsync().thenAccept(success ->
+				SwingUtilities.invokeLater(() -> {
+					if (Boolean.TRUE.equals(success))
+					{
+						saveRefreshToken(apiClient.getRefreshToken());
+						onAuthenticationSuccess(null, false);
+					}
+					else
+					{
+						// Only clear persisted token if explicitly rejected (401)
+						if (apiClient.getRefreshToken() == null)
+						{
+							clearRefreshToken();
+						}
+						else
+						{
+							log.debug("Refresh token auth failed (transient) - keeping token for next attempt");
+						}
+						tryLegacyPasswordAuth();
+					}
+				})
+			).exceptionally(e -> {
+				log.debug("Refresh token auth failed: {}", e.getMessage());
+				SwingUtilities.invokeLater(this::tryLegacyPasswordAuth);
+				return null;
+			});
+		}
+		else
+		{
+			// No refresh token, try legacy password auth
+			tryLegacyPasswordAuth();
+		}
+	}
+
+	/**
+	 * Try to authenticate with legacy stored password (migration path).
+	 * After successful login, the password will be cleared and replaced with refresh token.
+	 */
+	private void tryLegacyPasswordAuth()
+	{
+		String email = config.email();
+		String password = config.password();
+
+		// Always pre-fill email if available (helps users who need to re-login)
+		if (email != null && !email.isEmpty())
+		{
+			emailField.setText(email);
+		}
+
+		if (email != null && !email.isEmpty() && password != null && !password.isEmpty())
+		{
+			// Try to authenticate in background
+			CompletableFuture.runAsync(() -> {
+				AuthResult result = apiClient.login(email, password);
+
+				SwingUtilities.invokeLater(() -> {
+					if (result.success)
+					{
+						// Migration: save refresh token and clear password
+						saveRefreshToken(apiClient.getRefreshToken());
+						clearPassword();
+						onAuthenticationSuccess(null, false);
+					}
+					else
+					{
+						// Stay on login panel, show message
+						loginStatusLabel.setText("Please login to continue");
+						loginStatusLabel.setForeground(Color.LIGHT_GRAY);
+					}
+				});
+			});
+		}
+		else
+		{
+			// No stored credentials - show helpful message to user
+			loginStatusLabel.setText("Please login to continue");
+			loginStatusLabel.setForeground(Color.LIGHT_GRAY);
+		}
+	}
+
+	/**
+	 * Handle login button click
+	 */
+	private void handleLogin()
+	{
+		String email = emailField.getText().trim();
+		String password = new String(passwordField.getPassword());
+
+		if (email.isEmpty() || password.isEmpty())
+		{
+			showLoginStatus("Please enter email and password", false);
+			return;
+		}
+
+		setLoginButtonsEnabled(false);
+		showLoginStatus("Logging in...", true);
+
+		CompletableFuture.runAsync(() -> {
+			AuthResult result = apiClient.login(email, password);
+
+			SwingUtilities.invokeLater(() -> {
+				setLoginButtonsEnabled(true);
+
+				if (result.success)
+				{
+					// Save email and refresh token (NOT password) for next session
+					saveEmail(email);
+					saveRefreshToken(apiClient.getRefreshToken());
+					// Clear any legacy password storage
+					clearPassword();
+					onAuthenticationSuccess(result.message, true);
+				}
+				else
+				{
+					showLoginStatus(result.message, false);
+				}
+			});
+		});
+	}
+
+	/**
+	 * Handle signup button click
+	 */
+	private void handleSignup()
+	{
+		String email = emailField.getText().trim();
+		String password = new String(passwordField.getPassword());
+
+		if (email.isEmpty() || password.isEmpty())
+		{
+			showLoginStatus("Please enter email and password", false);
+			return;
+		}
+
+		setLoginButtonsEnabled(false);
+		showLoginStatus("Creating account...", true);
+
+		CompletableFuture.runAsync(() -> {
+			AuthResult result = apiClient.signup(email, password);
+
+			SwingUtilities.invokeLater(() -> {
+				setLoginButtonsEnabled(true);
+
+				if (result.success)
+				{
+					// Save email and refresh token (NOT password) for next session
+					saveEmail(email);
+					saveRefreshToken(apiClient.getRefreshToken());
+					// Clear any legacy password storage
+					clearPassword();
+					onAuthenticationSuccess(result.message, true);
+				}
+				else
+				{
+					showLoginStatus(result.message, false);
+				}
+			});
+		});
+	}
+
+	/**
+	 * Save email for next session
+	 */
+	private void saveEmail(String email)
+	{
+		configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_EMAIL, email);
+	}
+
+	/**
+	 * Save refresh token for persistent login (replaces password storage)
+	 */
+	private void saveRefreshToken(String refreshToken)
+	{
+		if (refreshToken != null && !refreshToken.isEmpty())
+		{
+			configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_REFRESH_TOKEN, refreshToken);
+		}
+	}
+
+	/**
+	 * Clear refresh token (on logout or revocation)
+	 */
+	public void clearRefreshToken()
+	{
+		configManager.unsetConfiguration(CONFIG_GROUP, CONFIG_KEY_REFRESH_TOKEN);
+	}
+
+	/**
+	 * Clear legacy password storage (migration cleanup)
+	 */
+	private void clearPassword()
+	{
+		configManager.unsetConfiguration(CONFIG_GROUP, CONFIG_KEY_PASSWORD);
+	}
+
+	/**
+	 * @deprecated Use saveEmail() and saveRefreshToken() instead
+	 */
+	@Deprecated
+	private void saveCredentials(String email, String password)
+	{
+		configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_EMAIL, email);
+		configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_PASSWORD, password);
+	}
+
+	/**
+	 * Show status message on login panel
+	 */
+	private void showLoginStatus(String message, boolean success)
+	{
+		loginStatusLabel.setText(message);
+		loginStatusLabel.setForeground(success ? COLOR_PROFIT_GREEN : COLOR_LOSS_RED);
+	}
+
+	/**
+	 * Enable/disable login buttons during authentication
+	 */
+	private void setLoginButtonsEnabled(boolean enabled)
+	{
+		loginButton.setEnabled(enabled);
+		signupButton.setEnabled(enabled);
+		discordButton.setEnabled(enabled);
+		emailField.setEnabled(enabled);
+		passwordField.setEnabled(enabled);
+	}
+
+	/**
+	 * Handle Discord login button click
+	 */
+	private void handleDiscordLogin()
+	{
+		setLoginButtonsEnabled(false);
+		showLoginStatus("Starting Discord login...", true);
+
+		// Start device auth flow
+		apiClient.startDeviceAuthAsync().thenAccept(response ->
+		{
+			if (response == null)
+			{
+				SwingUtilities.invokeLater(() ->
+				{
+					setLoginButtonsEnabled(true);
+					showLoginStatus("Failed to start Discord login", false);
+				});
+				return;
+			}
+
+			// Store device code for polling
+			currentDeviceCode = response.getDeviceCode();
+
+			// Open browser with verification URL using RuneLite's LinkBrowser
+			// which properly handles sandboxed environments (Flatpak, etc.)
+			LinkBrowser.browse(response.getVerificationUrl());
+
+			SwingUtilities.invokeLater(() ->
+				showLoginStatus("Complete login in your browser...", true));
+
+			// Start polling for completion
+			startDeviceAuthPolling(response.getDeviceCode(), response.getPollInterval(), response.getExpiresIn());
+		});
+	}
+
+	/**
+	 * Start polling for device authorization completion
+	 */
+	private void startDeviceAuthPolling(String deviceCode, int pollIntervalSeconds, int expiresInSeconds)
+	{
+		// Cancel any existing poll task
+		stopDeviceAuthPolling();
+
+		// Create scheduler if needed
+		if (deviceAuthScheduler == null || deviceAuthScheduler.isShutdown())
+		{
+			deviceAuthScheduler = Executors.newSingleThreadScheduledExecutor();
+		}
+
+		// Calculate max poll attempts based on expiry time
+		int maxAttempts = expiresInSeconds / pollIntervalSeconds;
+		final int[] attempts = {0};
+
+		deviceAuthPollTask = deviceAuthScheduler.scheduleAtFixedRate(() ->
+		{
+			attempts[0]++;
+
+			// Check if we've exceeded max attempts
+			if (attempts[0] > maxAttempts)
+			{
+				stopDeviceAuthPolling();
+				SwingUtilities.invokeLater(() ->
+				{
+					setLoginButtonsEnabled(true);
+					showLoginStatus("Discord login timed out", false);
+				});
+				return;
+			}
+
+			// Poll status
+			apiClient.pollDeviceStatusAsync(deviceCode).thenAccept(status ->
+			{
+				if (status == null)
+				{
+					return; // Network error, will retry
+				}
+
+				switch (status.getStatus())
+				{
+					case "authorized":
+						// Success! Set the token and switch to main panel
+						stopDeviceAuthPolling();
+						apiClient.setAuthToken(status.getAccessToken());
+						// Save refresh token for session persistence across client restarts
+						if (status.getRefreshToken() != null)
+						{
+							apiClient.setRefreshToken(status.getRefreshToken());
+							saveRefreshToken(status.getRefreshToken());
+						}
+						SwingUtilities.invokeLater(() ->
+							onAuthenticationSuccess("Login successful!", true));
+						break;
+
+					case "expired":
+						// Device code expired
+						stopDeviceAuthPolling();
+						SwingUtilities.invokeLater(() ->
+						{
+							setLoginButtonsEnabled(true);
+							showLoginStatus("Discord login expired. Try again.", false);
+						});
+						break;
+
+					case "pending":
+						// Still waiting - continue polling
+						break;
+
+					default:
+						log.warn("Unknown device status: {}", status.getStatus());
+						break;
+				}
+			});
+		}, pollIntervalSeconds, pollIntervalSeconds, TimeUnit.SECONDS);
+	}
+
+	/**
+	 * Stop device auth polling
+	 */
+	private void stopDeviceAuthPolling()
+	{
+		if (deviceAuthPollTask != null)
+		{
+			deviceAuthPollTask.cancel(false);
+			deviceAuthPollTask = null;
+		}
+		currentDeviceCode = null;
+	}
+
+	/**
+	 * Handle successful authentication - notify plugin and transition to main panel.
+	 * @param successMessage message to display, or null to skip showing message
+	 * @param showDelay if true, show message briefly before transitioning
+	 */
+	private void onAuthenticationSuccess(String successMessage, boolean showDelay)
+	{
+		if (onAuthSuccess != null)
+		{
+			onAuthSuccess.run();
+		}
+		if (showDelay && successMessage != null)
+		{
+			showLoginStatus(successMessage, true);
+			Timer timer = new Timer(500, e ->
+			{
+				onShowMainPanel.run();
+				authTransitionTimer = null;
+			});
+			timer.setRepeats(false);
+			authTransitionTimer = timer;
+			timer.start();
+		}
+		else
+		{
+			onShowMainPanel.run();
+		}
+	}
+
+	/**
+	 * Clean up login-owned resources (device-auth scheduler/timers).
+	 */
+	public void shutdown()
+	{
+		stopDeviceAuthPolling();
+		if (deviceAuthScheduler != null)
+		{
+			deviceAuthScheduler.shutdownNow();
+			deviceAuthScheduler = null;
+		}
+		if (authTransitionTimer != null)
+		{
+			authTransitionTimer.stop();
+			authTransitionTimer = null;
+		}
+	}
+}

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -1,0 +1,244 @@
+package com.flipsmart.ui.panel;
+
+import com.flipsmart.util.GpUtils;
+import java.awt.AlphaComposite;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import javax.swing.JPanel;
+
+/**
+ * Pure presentation helpers for the flip panel cards: GP/text formatting,
+ * risk colours, colour math and the small Java2D icon glyphs. No Swing widget
+ * state, no panel fields - everything is a static function of its inputs.
+ */
+public final class PanelFormat
+{
+	private static final Color COLOR_PROFIT_GREEN = new Color(100, 255, 100);
+	private static final Color COLOR_YELLOW = new Color(255, 255, 100);
+	private static final Color COLOR_LOSS_RED = new Color(255, 100, 100);
+
+	private static final String FORMAT_BUY_SELL = "Buy: %s | Sell: %s";
+	private static final String FORMAT_PROFIT_COST = "Profit: %s | Cost: %s";
+	private static final String FORMAT_MARGIN_ROI = "Margin: %s (%.1f%% ROI)";
+	private static final String FORMAT_MARGIN_ROI_LOSS = "Margin: %s (%.1f%% ROI) - Loss";
+	private static final String FORMAT_LIQUIDITY = "Liquidity: %.0f (%s) | %s";
+	private static final String FORMAT_VOLUME = "Volume: %s/day";
+	private static final String FORMAT_RISK = "Risk: %.0f (%s)";
+	private static final String UNKNOWN_RATING = "Unknown";
+	private static final String LIQUIDITY_NA = "Liquidity: N/A";
+	private static final String VOLUME_NA = "Volume: N/A";
+	private static final String RISK_NA = "Risk: N/A";
+
+	private PanelFormat()
+	{
+		// Utility class - prevent instantiation
+	}
+
+	/**
+	 * Format GP amount for display
+	 */
+	public static String formatGP(int amount)
+	{
+		return GpUtils.formatGPSigned(amount);
+	}
+
+	/**
+	 * Format GP amount with commas for exact input (e.g., "1,234,567")
+	 */
+	public static String formatGPExact(int amount)
+	{
+		return GpUtils.formatGPExact(amount);
+	}
+
+	public static Color getRiskColor(double score)
+	{
+		if (score <= 20)
+		{
+			return COLOR_PROFIT_GREEN; // Green
+		}
+		else if (score <= 40)
+		{
+			return new Color(150, 255, 100); // Yellow-green
+		}
+		else if (score <= 60)
+		{
+			return COLOR_YELLOW; // Yellow
+		}
+		else
+		{
+			return COLOR_LOSS_RED; // Red
+		}
+	}
+
+	public static Color brightenColor(Color color, int amount)
+	{
+		return new Color(
+			Math.min(255, color.getRed() + amount),
+			Math.min(255, color.getGreen() + amount),
+			Math.min(255, color.getBlue() + amount)
+		);
+	}
+
+	/**
+	 * Escape HTML special characters in a string.
+	 * Used when embedding text in HTML labels.
+	 */
+	public static String escapeHtml(String text)
+	{
+		if (text == null)
+		{
+			return "";
+		}
+		return text
+			.replace("&", "&amp;")
+			.replace("<", "&lt;")
+			.replace(">", "&gt;")
+			.replace("\"", "&quot;");
+	}
+
+	/**
+	 * Format liquidity text for display
+	 */
+	public static String formatLiquidityText(Double score, String rating, Double volumePerHour)
+	{
+		if (score == null)
+		{
+			return LIQUIDITY_NA;
+		}
+		String displayRating = rating != null ? rating : UNKNOWN_RATING;
+		String volText = volumePerHour != null ? formatGP(volumePerHour.intValue()) + "/hr" : "";
+		return String.format(FORMAT_LIQUIDITY, score, displayRating, volText);
+	}
+
+	/**
+	 * Format daily volume text for display
+	 */
+	public static String formatVolumeText(int dailyVolume)
+	{
+		if (dailyVolume <= 0)
+		{
+			return VOLUME_NA;
+		}
+		return String.format(FORMAT_VOLUME, formatGP(dailyVolume));
+	}
+
+	/**
+	 * Format risk text for display
+	 */
+	public static String formatRiskText(Double score, String rating)
+	{
+		if (score == null)
+		{
+			return RISK_NA;
+		}
+		String displayRating = rating != null ? rating : UNKNOWN_RATING;
+		return String.format(FORMAT_RISK, score, displayRating);
+	}
+
+	/**
+	 * Format margin text with ROI for display
+	 */
+	public static String formatMarginText(int marginPerItem, double roi, boolean isLoss)
+	{
+		String marginText = Math.abs(marginPerItem) >= 1000
+			? formatGP(marginPerItem)
+			: formatGPExact(marginPerItem);
+
+		if (Double.isInfinite(roi) || Double.isNaN(roi))
+		{
+			return String.format("Margin: %s (pending)", marginText);
+		}
+
+		if (isLoss)
+		{
+			return String.format(FORMAT_MARGIN_ROI_LOSS, marginText, roi);
+		}
+		return String.format(FORMAT_MARGIN_ROI, marginText, roi);
+	}
+
+	/**
+	 * Format profit and cost text for display
+	 */
+	public static String formatProfitCostText(int totalProfit, int totalCost)
+	{
+		String profitText = Math.abs(totalProfit) >= 1000
+			? formatGP(totalProfit)
+			: formatGPExact(totalProfit);
+		return String.format(FORMAT_PROFIT_COST, profitText, formatGP(totalCost));
+	}
+
+	/**
+	 * Format buy/sell prices text for display
+	 */
+	public static String formatBuySellText(int buyPrice, Integer sellPrice)
+	{
+		String sellText = sellPrice != null && sellPrice > 0
+			? formatGPExact(sellPrice)
+			: "N/A";
+		return String.format(FORMAT_BUY_SELL, formatGPExact(buyPrice), sellText);
+	}
+
+	/**
+	 * Draw a bar chart icon onto a 14x14 image with the given colors.
+	 */
+	public static BufferedImage drawChartIcon(Color barColor, Color baselineColor)
+	{
+		BufferedImage icon = new BufferedImage(14, 14, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = icon.createGraphics();
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+		g.setComposite(AlphaComposite.Clear);
+		g.fillRect(0, 0, 14, 14);
+		g.setComposite(AlphaComposite.SrcOver);
+
+		g.setColor(barColor);
+		g.fillRect(1, 9, 3, 4);   // Short bar
+		g.fillRect(5, 5, 3, 8);   // Medium bar
+		g.fillRect(9, 2, 3, 11);  // Tall bar
+
+		g.setColor(baselineColor);
+		g.drawLine(0, 13, 13, 13);
+
+		g.dispose();
+		return icon;
+	}
+
+	/**
+	 * Draw a ban/circle-slash icon onto a 14x14 image with the given color.
+	 */
+	public static BufferedImage drawBlockIcon(Color color)
+	{
+		BufferedImage icon = new BufferedImage(14, 14, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = icon.createGraphics();
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+		g.setComposite(AlphaComposite.Clear);
+		g.fillRect(0, 0, 14, 14);
+		g.setComposite(AlphaComposite.SrcOver);
+
+		g.setColor(color);
+		g.setStroke(new BasicStroke(1.5f));
+		g.drawOval(1, 1, 11, 11);
+		g.drawLine(3, 11, 11, 3);
+
+		g.dispose();
+		return icon;
+	}
+
+	/**
+	 * Get the base background color for a panel (either price indicator color or default).
+	 * Checks for stored client property first, falls back to default color.
+	 */
+	public static Color getBaseBackgroundColor(JPanel panel, Color defaultColor)
+	{
+		Object stored = panel.getClientProperty("baseBackgroundColor");
+		if (stored instanceof Color)
+		{
+			return (Color) stored;
+		}
+		return defaultColor;
+	}
+}


### PR DESCRIPTION
> **⚠️ Compile-verified only — this is a Swing UI refactor with no automated runtime test. Needs in-game QA before merge. The extraction is behavior-identical, with one intentional UX change noted below.**

---

## ⚠️ Included UX change (not part of the no-op extraction)

`activeOfferVerb` now labels a **profitable** Active-mode breakeven exit as **"Take profit"** instead of "Exit at breakeven". The advisor's breakeven-exit stage fires for any outcome from a profit down to a 100K loss, so a profitable exit was previously mislabeled as breakeven. The verb now distinguishes all three cases: `Take profit` (net > 0), `Exit at breakeven` (net == 0), `Exit at a loss` (net < 0). Commit `4d11181`.

---

## Summary

Decomposes `FlipFinderPanel` from ~4345 lines to ~3331 lines by extracting four cohesive units. The headline change is that **smart-sell pricing decisions now live outside the Swing layer** in `recommend/SmartSellPricer` — pure static logic with no UI dependencies. The remaining three extractions (`PanelFormat`, `CardWidgets`, `LoginPanel`) pull out presentation helpers and the full login/auth UI subsystem, leaving `FlipFinderPanel` responsible only for view orchestration.

**Stacked on #152 (merge #150 → #151 → #152 → this in order).**

This is the 4th of a 6-PR stacked series for epic #728. Part of #732.

---

## Changes

### ♻️ Refactoring

- **`recommend/SmartSellPricer`** — smart-sell pricing logic lifted out of the Swing layer. Pure static methods; no UI or widget dependencies.
- **`ui/panel/PanelFormat`** — pure presentation helpers: GP/risk/liquidity/margin formatting, chart and block icon drawing, color constants.
- **`ui/panel/CardWidgets`** — shared low-level card builders (scaffolding for future card-factory follow-up splits).
- **`ui/panel/LoginPanel`** (705 lines) — the entire login/auth UI subsystem: email/password login, signup, Discord device-auth + polling, credential persistence, status messages, post-auth transition. Owns its own device-auth scheduler/timers; `FlipFinderPanel` delegates to it and now reads auth state from the API client (removed a duplicated local auth flag).
- **`FlipFinderPanel`** reduced from ~4345 → ~3331 lines. No behavior change.

---

## Remaining / follow-up (not blocking this PR)

The recommendation/active/completed **card-rendering factories** were intentionally left in `FlipFinderPanel`. They are woven into focus/blocklist/async view state and are best split with in-game iteration to avoid regressions. `CardWidgets` scaffolding is already in place for that follow-up extraction.

---

## Testing

### Automated Tests
- ✅ `./gradlew build` green
- ✅ 120 JUnit tests pass
- ⏳ No runtime/Swing tests — manual in-game QA required (see below)

### In-game QA Focus

1. **Active-flip / pending-sell prices** — including the loss-minimizing switch by volume, value, and time.
2. **Card visuals** — risk colors, liquidity/volume/margin text, chart and block icons + hover, price-indicator green/red backgrounds.
3. **Login flows** — email/password, signup, Discord device-auth polling/expiry, session restore on start, session-expiry mid-use, logout cleanup (no lingering poll threads or timers).

---

## Deployment Notes

- No new dependencies
- No configuration changes
- No migrations

## Checklist

- [x] `./gradlew build` passes
- [x] 120 JUnit tests pass
- [x] No issue-ref comments in source
- [x] No verbose narrative comments added
- [ ] In-game QA verified by reviewer

## Related Issues

Part of #732
---

### Codacy Quality Gate — fixed in this PR
- `361a143` SmartSellPricer.java:92 — corrected GE tax from 2% uncapped to 1% with 5M GP cap and 100 GP exemption
- `b2fbf1e` CardWidgets.java:65 — hoisted rigid-area Dimension to static constant
- `725eab4` FlipFinderPanel.java:1826 — removed orphaned Javadoc comment

### Codacy Quality Gate — dismissed via API (noise)
- PMD_DoNotUseThreads LoginPanel.java:72,577,696,697 — RuneLite plugin is not a J2EE webapp; ScheduledExecutorService for device-auth polling is correct
- PMD_NullAssignment LoginPanel.java:654,656,676,697 — explicit null-out on resource cleanup is idiomatic Java lifecycle management
- PMD_AvoidFieldNameMatchingTypeName LoginPanel.java:63 — `loginPanel` field in class `LoginPanel` is descriptive; alternative names would be less clear
- PMD_GuardLogStatement LoginPanel.java:326,639 — SLF4J uses lazy parameter binding; guard statements are not required
- PMD_AvoidLiteralsInIfCondition PanelFormat.java:58,62,66 — score thresholds (20/40/60) are stable domain constants, not magic numbers
- PMD_AvoidInstantiatingObjectsInLoops CardWidgets.java:65 — each spacer component must be a unique instance; pre-creation is not applicable here (prior run; superseded by fix in b2fbf1e)
- Lizard_ccn-medium LoginPanel.java:569 — device-auth polling has inherent branching complexity (status switch + timeout + network error paths)
- Lizard_nloc-medium LoginPanel.java:145,569 — UI builder and polling method are self-contained; splitting would harm readability without reducing actual complexity
- Semgrep_hashicorp-tf-password LoginPanel.java:46 — `CONFIG_KEY_PASSWORD = "password"` is a config key string, not a credential; Semgrep false positive
- Semgrep_hard-coded-password LoginPanel.java:46 — same false positive as above

### Codacy AI Reviewer — fixed in this PR
- `361a143` SmartSellPricer.java:92 — corrected GE tax rate to 1% with 5M cap and 100 GP exemption
- `b2fbf1e` CardWidgets.java:65 — static constant for rigid-area Dimension
- `725eab4` FlipFinderPanel.java:1826 — removed orphaned Javadoc

### Codacy AI Reviewer — deferred (in-thread rationale)
- LoginPanel.java:402 — handleLogin/handleSignup duplication; no-behavior-change move, refactor deferred
- LoginPanel.java:569 — startDeviceAuthPolling complexity; moved verbatim, out of scope
- LoginPanel.java:145 — buildLoginPanel length (107 lines); moved verbatim, out of scope
- PanelFormat.java:146 — formatMarginText/formatProfitCostText duplication; distinct templates, deferred
- PanelFormat.java:187 — Graphics2D setup duplication in icon methods; kept isolated intentionally
- PanelFormat.java:58 — risk threshold magic numbers; moved as-is, deferred cleanup

### Codacy AI Reviewer — false positives (in-thread rationale)
- LoginPanel.java:63 — `loginPanel` field name matches class; idiomatic Java, no API shadowing
