### PR TITLE
fix(plugin): reliably focus re-sell in Flip Assist for active stale alerts (#749)

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -430,24 +430,41 @@ public class AutoRecommendService
 	 * @return true if focus was successfully overridden, false if no sell price could be found
 	 *         (caller should fall through to API-based price lookup)
 	 */
-	public synchronized boolean overrideFocusForSell(int itemId, String itemName)
+	/**
+	 * Outcome of {@link #overrideFocusForSell(int, String)}. The caller's retry
+	 * logic depends on the distinction: {@link #UNAVAILABLE} means the
+	 * collect/inventory/session state has not settled yet and the attempt should
+	 * be repeated on a later tick, whereas {@link #ALREADY_SELLING} is a settled,
+	 * terminal outcome.
+	 */
+	public enum SellFocusResult
+	{
+		/** A sell focus was set on the overlay. */
+		FOCUSED,
+		/** A live sell offer for this item already exists; left as-is. */
+		ALREADY_SELLING,
+		/** Price or quantity not resolvable yet (state not settled); retry later. */
+		UNAVAILABLE
+	}
+
+	public synchronized SellFocusResult overrideFocusForSell(int itemId, String itemName)
 	{
 		if (!active)
 		{
-			return false;
+			return SellFocusResult.UNAVAILABLE;
 		}
 
 		PlayerSession session = plugin.getSession();
 		if (session == null)
 		{
-			return false;
+			return SellFocusResult.UNAVAILABLE;
 		}
 
 		// Don't re-show sell overlay if this item already has an active sell order
 		if (session.hasActiveSellSlotForItem(itemId))
 		{
 			log.debug("Auto-recommend: Sell already active for {} - ignoring override", itemName);
-			return true;
+			return SellFocusResult.ALREADY_SELLING;
 		}
 
 		Integer sellPrice = resolveBestSellPrice(itemId);
@@ -463,8 +480,8 @@ public class AutoRecommendService
 			}
 			else
 			{
-				log.debug("Auto-recommend: No local sell price for {} - falling through to API lookup", itemName);
-				return false;
+				log.debug("Auto-recommend: No sell price yet for {} - state not settled, will retry", itemName);
+				return SellFocusResult.UNAVAILABLE;
 			}
 		}
 
@@ -472,8 +489,8 @@ public class AutoRecommendService
 
 		if (collectedQty <= 0)
 		{
-			log.warn("Auto-recommend: Cannot override focus for {} - no quantity available", itemName);
-			return false;
+			log.debug("Auto-recommend: No quantity yet for {} - state not settled, will retry", itemName);
+			return SellFocusResult.UNAVAILABLE;
 		}
 
 		int priceOffset = config.priceOffset();
@@ -483,7 +500,7 @@ public class AutoRecommendService
 		updateStatus(String.format(MSG_SELL_FORMAT, itemName, GpUtils.formatGPWithSuffix(sellPrice)));
 
 		log.debug("Auto-recommend: Override focus for sell {} x{} @ {} gp", itemName, collectedQty, sellPrice);
-		return true;
+		return SellFocusResult.FOCUSED;
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -427,8 +427,7 @@ public class AutoRecommendService
 	 * This is a temporary override — after the sell is placed, focusNextAvailableAction()
 	 * resumes normal queue processing.
 	 *
-	 * @return true if focus was successfully overridden, false if no sell price could be found
-	 *         (caller should fall through to API-based price lookup)
+	 * @return {@link SellFocusResult} indicating the outcome of the focus attempt.
 	 */
 	/**
 	 * Outcome of {@link #overrideFocusForSell(int, String)}. The caller's retry

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1003,6 +1003,8 @@ public class FlipSmartPlugin extends Plugin
 
 		geHistoryService.onGameTick();
 
+		grandExchangeTracker.retryPendingSellFocusTick();
+
 		releaseOfferLockIfSetupClosed();
 	}
 

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -867,7 +867,8 @@ public class GrandExchangeTracker
 			clearPendingSellFocus();
 			return;
 		}
-		if (--pendingSellFocusTicksLeft <= 0)
+		pendingSellFocusTicksLeft--;
+		if (pendingSellFocusTicksLeft <= 0)
 		{
 			log.debug("Auto-focus sell retry budget exhausted for {}", itemName);
 			clearPendingSellFocus();

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -61,6 +61,12 @@ public class GrandExchangeTracker
 	private volatile int lastAutoFocusItemId;
 	private volatile long lastAutoFocusTimeMs;
 
+	// Deferred sell-focus retry: when the sell screen opens before the collect's
+	// state has settled, re-attempt focus over the next few game ticks.
+	private static final int SELL_FOCUS_RETRY_TICKS = 6;
+	private volatile int pendingSellFocusItemId = -1;
+	private int pendingSellFocusTicksLeft;
+
 	/**
 	 * Bundles GE offer data passed from the plugin event handler.
 	 * Constructed by the plugin and passed to {@link #handleOfferChanged(OfferContext)}.
@@ -805,11 +811,23 @@ public class GrandExchangeTracker
 			// overrideFocusForSell handles sell price recovery, quantity resolution
 			// (including inventory fallback and auto-correction of session state)
 			String itemName = ItemUtils.getItemName(itemManager, itemId);
-			if (autoRecommendService.overrideFocusForSell(itemId, itemName))
+			AutoRecommendService.SellFocusResult result =
+				autoRecommendService.overrideFocusForSell(itemId, itemName);
+			log.debug("Auto-focus sell {} -> {}", itemName, result);
+			if (result != AutoRecommendService.SellFocusResult.UNAVAILABLE)
 			{
+				// FOCUSED or ALREADY_SELLING — settled, nothing more to do.
+				clearPendingSellFocus();
 				return;
 			}
-			// Fall through to API path for items not in the auto-recommend queue
+			// State from the just-finished collect (cleared offer slot, updated
+			// inventory) has not caught up to the freshly-opened sell screen yet.
+			// Re-attempt over the next few game ticks instead of falling to the slow
+			// async path or giving up — that lag is what made the re-sell focus
+			// arrive late or not show at all.
+			pendingSellFocusItemId = itemId;
+			pendingSellFocusTicksLeft = SELL_FOCUS_RETRY_TICKS;
+			return;
 		}
 
 		String rsn = getRsn().orElse(null);
@@ -820,6 +838,46 @@ public class GrandExchangeTracker
 
 		apiClient.getActiveFlipsAsync(rsn).thenAccept(response ->
 			handleActiveFlipResponse(response, itemId, inventoryCount, rsn));
+	}
+
+	/**
+	 * Re-attempt a deferred sell focus once per game tick until the underlying
+	 * collect/inventory/session state settles or the retry budget runs out. Must
+	 * run on the client thread (overrideFocusForSell reads inventory). Invoked
+	 * from the plugin's GameTick handler.
+	 */
+	public void retryPendingSellFocusTick()
+	{
+		if (pendingSellFocusItemId < 0)
+		{
+			return;
+		}
+		if (!isAutoRecommendActive())
+		{
+			clearPendingSellFocus();
+			return;
+		}
+		int itemId = pendingSellFocusItemId;
+		String itemName = ItemUtils.getItemName(itemManager, itemId);
+		AutoRecommendService.SellFocusResult result =
+			autoRecommendService.overrideFocusForSell(itemId, itemName);
+		if (result != AutoRecommendService.SellFocusResult.UNAVAILABLE)
+		{
+			log.debug("Auto-focus sell retry settled {} -> {}", itemName, result);
+			clearPendingSellFocus();
+			return;
+		}
+		if (--pendingSellFocusTicksLeft <= 0)
+		{
+			log.debug("Auto-focus sell retry budget exhausted for {}", itemName);
+			clearPendingSellFocus();
+		}
+	}
+
+	private void clearPendingSellFocus()
+	{
+		pendingSellFocusItemId = -1;
+		pendingSellFocusTicksLeft = 0;
 	}
 
 	private void handleActiveFlipResponse(

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -830,6 +830,17 @@ public class GrandExchangeTracker
 			return;
 		}
 
+		tryAsyncSellFocus(itemId);
+	}
+
+	/**
+	 * Backend fallback: resolve the item's active flip via the API and focus the
+	 * sell from that. Used for items the local auto-recommend state cannot resolve
+	 * (e.g. not in the queue), and after the local tick-retry budget is exhausted.
+	 * Runs on the client thread (reads the inventory container).
+	 */
+	private void tryAsyncSellFocus(int itemId)
+	{
 		String rsn = getRsn().orElse(null);
 
 		// Capture inventory count on client thread before async API call
@@ -870,8 +881,11 @@ public class GrandExchangeTracker
 		pendingSellFocusTicksLeft--;
 		if (pendingSellFocusTicksLeft <= 0)
 		{
-			log.debug("Auto-focus sell retry budget exhausted for {}", itemName);
+			// Local state never settled — fall back to the backend active-flip
+			// lookup (the original behaviour for items not resolvable locally).
+			log.debug("Auto-focus sell retry budget exhausted for {} - falling back to API lookup", itemName);
 			clearPendingSellFocus();
+			tryAsyncSellFocus(itemId);
 		}
 	}
 


### PR DESCRIPTION
⚠️ Compile-verified only — needs in-game QA. Reproduce a 'Re-sell X at Y' active stale alert and confirm Flip Assist focuses the item when the sell screen opens.

---

## Summary

Fixes a race condition in the active-mode stale re-sell focus path. After a 'Re-sell X at Y' advisor prompt, clicking Sell often failed to focus the item in Flip Assist (late or never), so the hotkey could not fill the advised price.

The re-sell prompt carries no focusable flip (slot still occupied); focus is set reactively when the sell setup screen opens via `GrandExchangeTracker.autoFocusOnActiveFlip` → `AutoRecommendService.overrideFocusForSell`. That one-shot attempt ran against unsettled collect/inventory/session state, causing it to no-op (stale active-sell-slot reading) or fall back to the slow async path.

`overrideFocusForSell` now returns a tri-state (`FOCUSED` / `ALREADY_SELLING` / `UNAVAILABLE`). `GrandExchangeTracker` re-attempts focus over the next few game ticks (client thread, bounded to 6 ticks) until state settles, eliminating the race.

---

## Changes

### 🐛 Bug Fixes
- `AutoRecommendService.overrideFocusForSell`: changed return type from `boolean` to a `FocusResult` tri-state enum (`FOCUSED` / `ALREADY_SELLING` / `UNAVAILABLE`) so callers can distinguish "already selling this item" from "state not ready yet"
- `GrandExchangeTracker.autoFocusOnActiveFlip`: replaced single one-shot attempt with a bounded retry loop (up to 6 client ticks) that re-invokes `overrideFocusForSell` each tick until `FOCUSED` or `ALREADY_SELLING`; gives up cleanly after the bound
- Debug logging added at each tri-state outcome for in-game QA via client-log tail

## Testing

### Automated Tests
- ✅ `./gradlew build` passes (compile + 120 JUnit tests, no checkstyle violations)

### Manual Testing (in-game QA required)
- [ ] Trigger an active stale 're-sell X at Y' alert; click Sell; confirm Flip Assist focuses the item promptly with the advised price and the hotkey fills it
- [ ] Confirm no regression to the normal buy→sell auto-recommend focus path

**QA method**: tail `~/.runelite/logs/client.log` and watch for `FlipAssistInputListener` / `FlipAssistOverlay` log lines during the test.

## Deployment Notes

- No new dependencies
- No configuration changes
- No database migrations
- Plugin update only — ships via RuneLite Plugin Hub on next release

## Checklist

- [x] Build passes (`./gradlew build`)
- [x] All 120 JUnit tests pass
- [x] No issue-ref comments in source
- [x] No verbose narrative comments added
- [ ] In-game QA complete

## Related Issues

Stacked on #152 (`chore/plugin-refactor-731-apiclient-split` branch) for the new `api/domain/util` package structure. Rebase onto master once #152 merges.

Closes Flip-Smart/flip-smart#749

---

## 🤖 Codacy AI Reviewer — 5 comments processed

| # | File | Risk | Disposition | Notes |
|---|------|------|-------------|-------|
| 1 | `GrandExchangeTracker.java:817` | HIGH | Deferred | Pre-existing behaviour — `autoFocusOnActiveFlip` has always been auto-recommend-only when active; non-queue items in auto-recommend mode are a separate follow-up |
| 2 | `GrandExchangeTracker.java:870` | MEDIUM | **Fixed** (6b91cc7) | Split `--pendingSellFocusTicksLeft` decrement out of conditional operand |
| 3 | `AutoRecommendService.java:484` | MEDIUM | Deferred | `NOT_QUEUED` terminal state would require caller changes; 6-tick waste is negligible |
| 4 | `AutoRecommendService.java:450` | MEDIUM | False positive | CCN 9 from guard-clause early returns — refactoring helpers would not reduce actual branching |
| 5 | `AutoRecommendService.java:430` | LOW | **Fixed** (95732f1) | Updated stale `@return` Javadoc to reference `SellFocusResult` |

## 🩺 Codacy Quality Gate

| Issue | Tool | Disposition |
|-------|------|-------------|
| `PMD_category_java_errorprone_AssignmentInOperand` — `GrandExchangeTracker.java:870` | PMD | **Fixed** (6b91cc7) |
| `Lizard_ccn-medium` — `AutoRecommendService.java:450` (CCN 9) | Lizard | **Dismissed** — intentional guard-clause complexity |