### PR TITLE
feat(offers): #759 plugin half — offerId linkage + GE-History prompt de-nag

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -1602,7 +1602,14 @@ public class AutoRecommendService
 			return;
 		}
 
-		renderStaleOfferPrompt(staleOffers.head());
+		OfferRecord next = staleOffers.head();
+		if (next == null)
+		{
+			// The queue drained between the isEmpty() check above and here; nothing to prompt.
+			focusNextAvailableAction();
+			return;
+		}
+		renderStaleOfferPrompt(next);
 	}
 
 	private void renderStaleOfferPrompt(OfferRecord offer)

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -403,6 +403,30 @@ public class GEHistoryService
 		return (text == null) ? "" : text.replaceAll("<[^>]*>", "");
 	}
 
+	/**
+	 * Conservatively resolve a History row to a tracked OfferStore offerId so the
+	 * backend can reconcile it per-offer. Matches on (itemId, isBuy, price) and
+	 * returns the offerId ONLY when exactly one distinct offer matches — a wrong
+	 * offerId is worse than none, so any ambiguity (or no match) returns null and
+	 * the backend falls back to the item-level path.
+	 */
+	static Long matchOfferId(List<OfferRecord> candidates, int itemId, boolean isBuy, int pricePerItem)
+	{
+		Long found = null;
+		for (OfferRecord o : candidates)
+		{
+			if (o.getItemId() == itemId && o.isBuy() == isBuy && o.getPrice() == pricePerItem)
+			{
+				if (found != null && found.longValue() != o.getOfferId())
+				{
+					return null;
+				}
+				found = o.getOfferId();
+			}
+		}
+		return found;
+	}
+
 	private void backfillOfflineFills(List<GEHistoryEntry> entries)
 	{
 		if (!session.isOfflineSyncCompleted() || entries.isEmpty())
@@ -423,12 +447,17 @@ public class GEHistoryService
 		for (OfferRecord o : offerStore.allRecords()) nameByItem.put(o.getItemId(), o.getItemName());
 		for (OfferRecord o : recentlyPersistedOffers.values()) nameByItem.putIfAbsent(o.getItemId(), o.getItemName());
 
+		// Candidate offers for offer_id linkage: live + recently-persisted.
+		List<OfferRecord> candidates = new ArrayList<>(offerStore.allRecords());
+		candidates.addAll(recentlyPersistedOffers.values());
+
 		List<HistoryBackfillEntry> batch = new ArrayList<>(entries.size());
 		for (GEHistoryEntry e : entries)
 		{
+			Long offerId = matchOfferId(candidates, e.getItemId(), e.isBuy(), e.getPricePerItem());
 			batch.add(new HistoryBackfillEntry(
 				e.getItemId(), nameByItem.get(e.getItemId()),
-				e.isBuy(), e.getQuantity(), e.getPricePerItem()
+				e.isBuy(), e.getQuantity(), e.getPricePerItem(), offerId
 			));
 		}
 

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -158,10 +158,12 @@ public class GEHistoryService
 	}
 
 	/**
-	 * Snapshot of offers persisted at the previous session's logout — used
-	 * for item-name resolution in the backfill payload, and as the trigger
-	 * for the chat prompt (any persisted state means there might be offline
-	 * activity worth backfilling).
+	 * Snapshot of offers persisted at the previous session's logout — used for
+	 * item-name resolution and offerId matching in the backfill payload. This
+	 * does NOT prompt: merely having tracked offers last session is not missing
+	 * data. The prompt is driven solely by genuinely-unverified offline fills
+	 * registered via {@link #registerOfflineFill} (offers the reconciler found
+	 * gone from their slot on login).
 	 */
 	public void setRecentlyPersistedOffers(List<OfferRecord> offers)
 	{
@@ -173,23 +175,15 @@ public class GEHistoryService
 				recentlyPersistedOffers.put(o.getItemId(), o);
 			}
 		}
-		// Any prior-session activity is reason enough to prompt the user to
-		// open History. Backend dedup makes the backfill safe regardless:
-		// covered rows dedupe, missing ones get inserted.
-		if (!recentlyPersistedOffers.isEmpty())
-		{
-			maybeSendChatPrompt();
-		}
 	}
 
 	public boolean hasUnverifiedOfflineFills()
 	{
-		// Prompt the overlay banner whenever we haven't yet read the History
-		// this session and there's *any* signal that offline activity might
-		// have happened — either the narrow per-item detection registered
-		// something, or the user simply had persisted offer state from the
-		// prior session.
-		return !historyReadThisSession && (!pendingOfflineFillItemIds.isEmpty() || !recentlyPersistedOffers.isEmpty());
+		// Only prompt/flag when we haven't read History yet this session AND the
+		// reconciler registered a genuinely-unverified offline fill. Persisted
+		// offer state alone is not missing data — the live OfferStore pipeline
+		// already records in-slot offline completions.
+		return !historyReadThisSession && !pendingOfflineFillItemIds.isEmpty();
 	}
 
 	public void reset()

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -295,8 +295,11 @@ public class OfflineSyncService
 		}
 		offerStore.importRecords(toImport);
 
-		log.debug("Reconciled persisted offers into store: {} reattached, {} minted, {} offline-collected (slots readable: {})",
-			plan.reattached.size(), plan.minted.size(), plan.offlineCollected.size(), !liveSlots.isEmpty());
+		if (log.isDebugEnabled())
+		{
+			log.debug("Reconciled persisted offers into store: {} reattached, {} minted, {} offline-collected (slots readable: {})",
+				plan.reattached.size(), plan.minted.size(), plan.offlineCollected.size(), !liveSlots.isEmpty());
+		}
 	}
 
 	/** Reduce the live GE slots to {@link OfferSignal}s for reconciliation. */

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -43,6 +43,9 @@ public class OfflineSyncService
 	private static final String COLLECTED_QUANTITIES_KEY_PREFIX = "collectedQuantities_";
 	private static final String COLLECTED_ITEMS_SAVED_AT_KEY_PREFIX = "collectedItemsSavedAt_";
 	private static final String LAST_KNOWN_RSN_KEY = "lastKnownRsn";
+	// Wall-clock of the last completed offline sync, per RSN. A persisted offer is only a genuine
+	// offline fill if it was active since this marker; older leftovers are already-known history.
+	private static final String OFFLINE_SYNC_MARKER_KEY_PREFIX = "offlineSyncAt_";
 
 	/** Persisted collected-item entries older than this are dropped on restore. */
 	static final long MAX_PERSISTED_COLLECTED_AGE_MS = 7L * 24 * 60 * 60 * 1000;
@@ -342,6 +345,8 @@ public class OfflineSyncService
 
 	private void reconcileOfflineFills(List<OfferRecord> persistedRecords)
 	{
+		long now = System.currentTimeMillis();
+		long freshnessThreshold = readOfflineFillFreshnessThreshold(now);
 		Map<Integer, OfferRecord> currentOffers = liveOffersBySlot();
 		log.debug("Loaded {} persisted offers, comparing with {} current offers",
 			persistedRecords.size(), currentOffers.size());
@@ -352,9 +357,11 @@ public class OfflineSyncService
 		geHistoryService.setRecentlyPersistedOffers(persistedRecords);
 
 		// Reconcile persisted records against live slots to determine which offers
-		// completed or were cancelled while offline.
+		// completed or were cancelled while offline. Records last active before the
+		// freshness cutoff are leftovers from prior sessions (already backfilled) and
+		// are routed to staleHistory so they never re-fire the "open GE History" prompt.
 		List<OfferSignal> liveSlots = buildLiveSlotSignals();
-		OfferReconciler.Plan plan = OfferReconciler.reconcile(persistedRecords, liveSlots, System.currentTimeMillis());
+		OfferReconciler.Plan plan = OfferReconciler.reconcile(persistedRecords, liveSlots, now, freshnessThreshold);
 
 		// Restore original timestamps on still-live offers whose persisted record is older.
 		for (OfferRecord reattached : plan.reattached)
@@ -390,12 +397,56 @@ public class OfflineSyncService
 			}
 		}
 
+		if (!plan.staleHistory.isEmpty())
+		{
+			log.debug("Skipped {} stale persisted offer(s) older than last sync — already-known history, not prompted",
+				plan.staleHistory.size());
+		}
+
 		pruneStaleCollectedItems();
+		writeOfflineSyncMarker(now);
 		persistOfferState();
 
 		if (onSyncComplete != null)
 		{
 			onSyncComplete.run();
+		}
+	}
+
+	/**
+	 * Freshness cutoff for treating a persisted offer as a genuine offline fill: the wall-clock of
+	 * the previous completed offline sync. On the first sync for an account (marker absent) the whole
+	 * persisted blob predates the marker, so we return {@code now} — every existing record is treated
+	 * as already-known history and suppressed, rather than nagging for a backlog the backend already has.
+	 */
+	private long readOfflineFillFreshnessThreshold(long now)
+	{
+		String rsn = resolvePersistenceRsn();
+		if (rsn == null)
+		{
+			return now;
+		}
+		String raw = configManager.getConfiguration(CONFIG_GROUP, OFFLINE_SYNC_MARKER_KEY_PREFIX + rsn);
+		if (raw == null || raw.isEmpty())
+		{
+			return now;
+		}
+		try
+		{
+			return Long.parseLong(raw);
+		}
+		catch (NumberFormatException e)
+		{
+			return now;
+		}
+	}
+
+	private void writeOfflineSyncMarker(long now)
+	{
+		String rsn = resolvePersistenceRsn();
+		if (rsn != null)
+		{
+			configManager.setConfiguration(CONFIG_GROUP, OFFLINE_SYNC_MARKER_KEY_PREFIX + rsn, Long.toString(now));
 		}
 	}
 

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -397,7 +397,7 @@ public class OfflineSyncService
 			}
 		}
 
-		if (!plan.staleHistory.isEmpty())
+		if (!plan.staleHistory.isEmpty() && log.isDebugEnabled())
 		{
 			log.debug("Skipped {} stale persisted offer(s) older than last sync — already-known history, not prompted",
 				plan.staleHistory.size());

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -278,18 +278,25 @@ public class OfflineSyncService
 
 		List<OfferRecord> toImport = new ArrayList<>();
 		toImport.addAll(plan.reattached);
-		// Offline-collected records often persist as CANCELLED_PARTIAL, which is non-terminal:
-		// imported as-is they masquerade as live offers, so liveOffers() keeps returning them
-		// (auto-mode stale-prompt flap) and pruning refuses to drop them. Terminalize to COLLECTED
-		// so they read as finished history. plan.reattached (still-live slots) is left untouched.
-		for (OfferRecord collected : plan.offlineCollected)
+		// Terminalize offline-collected records to COLLECTED only when we can actually read the live
+		// slots. At preload time the GE slots are usually NOT loaded yet (empty snapshot), and
+		// reconciling against that would misclassify every still-live offer as offline-collected and
+		// import a COLLECTED duplicate — growing the persisted blob every login. When the snapshot is
+		// unreadable, defer classification to the +2s offline sync, which runs once slots are loaded.
+		// When slots ARE readable, terminalizing keeps genuinely-gone records (often CANCELLED_PARTIAL,
+		// non-terminal) from masquerading as live offers (auto-mode stale-prompt flap) and lets pruning
+		// drop them. plan.reattached (still-live slots) is left untouched.
+		if (!liveSlots.isEmpty())
 		{
-			toImport.add(collected.withState(OfferState.COLLECTED, now));
+			for (OfferRecord collected : plan.offlineCollected)
+			{
+				toImport.add(collected.withState(OfferState.COLLECTED, now));
+			}
 		}
 		offerStore.importRecords(toImport);
 
-		log.debug("Reconciled persisted offers into store: {} reattached, {} minted, {} offline-collected",
-			plan.reattached.size(), plan.minted.size(), plan.offlineCollected.size());
+		log.debug("Reconciled persisted offers into store: {} reattached, {} minted, {} offline-collected (slots readable: {})",
+			plan.reattached.size(), plan.minted.size(), plan.offlineCollected.size(), !liveSlots.isEmpty());
 	}
 
 	/** Reduce the live GE slots to {@link OfferSignal}s for reconciliation. */

--- a/src/main/java/com/flipsmart/api/dto/HistoryBackfillEntry.java
+++ b/src/main/java/com/flipsmart/api/dto/HistoryBackfillEntry.java
@@ -10,13 +10,15 @@ public class HistoryBackfillEntry
 	public final boolean isBuy;
 	public final int quantity;
 	public final int pricePerItem;
+	public final Long offerId;
 
-	public HistoryBackfillEntry(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
+	public HistoryBackfillEntry(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem, Long offerId)
 	{
 		this.itemId = itemId;
 		this.itemName = itemName;
 		this.isBuy = isBuy;
 		this.quantity = quantity;
 		this.pricePerItem = pricePerItem;
+		this.offerId = offerId;
 	}
 }

--- a/src/main/java/com/flipsmart/api/dto/TransactionRequest.java
+++ b/src/main/java/com/flipsmart/api/dto/TransactionRequest.java
@@ -15,6 +15,7 @@ public class TransactionRequest
 	public final String rsn;
 	public final Integer totalQuantity;
 	public final String idempotencyKey;
+	public final Long offerId;
 
 	private TransactionRequest(Builder builder)
 	{
@@ -28,6 +29,7 @@ public class TransactionRequest
 		this.rsn = builder.rsn;
 		this.totalQuantity = builder.totalQuantity;
 		this.idempotencyKey = builder.idempotencyKey;
+		this.offerId = builder.offerId;
 	}
 
 	public static Builder builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
@@ -47,6 +49,7 @@ public class TransactionRequest
 		private String rsn;
 		private Integer totalQuantity;
 		private String idempotencyKey;
+		private Long offerId;
 
 		private Builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
 		{
@@ -62,6 +65,7 @@ public class TransactionRequest
 		public Builder rsn(String rsn) { this.rsn = rsn; return this; }
 		public Builder totalQuantity(Integer qty) { this.totalQuantity = qty; return this; }
 		public Builder idempotencyKey(String key) { this.idempotencyKey = key; return this; }
+		public Builder offerId(Long offerId) { this.offerId = offerId; return this; }
 
 		public TransactionRequest build() { return new TransactionRequest(this); }
 	}

--- a/src/main/java/com/flipsmart/api/endpoints/TransactionEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/TransactionEndpoints.java
@@ -69,6 +69,10 @@ public class TransactionEndpoints
 		{
 			jsonBody.addProperty("idempotency_key", request.idempotencyKey);
 		}
+		if (request.offerId != null)
+		{
+			jsonBody.addProperty("offer_id", request.offerId);
+		}
 
 		RequestBody body = RequestBody.create(JSON, jsonBody.toString());
 
@@ -122,6 +126,7 @@ public class TransactionEndpoints
 			o.addProperty("is_buy", e.isBuy);
 			o.addProperty(JSON_KEY_QUANTITY, e.quantity);
 			o.addProperty(JSON_KEY_PRICE_PER_ITEM, e.pricePerItem);
+			if (e.offerId != null) o.addProperty("offer_id", e.offerId);
 			arr.add(o);
 		}
 		body.add("entries", arr);

--- a/src/main/java/com/flipsmart/recommend/StaleOfferQueue.java
+++ b/src/main/java/com/flipsmart/recommend/StaleOfferQueue.java
@@ -41,7 +41,7 @@ public final class StaleOfferQueue
 
 	public OfferRecord head()
 	{
-		return queue.get(0);
+		return queue.isEmpty() ? null : queue.get(0);
 	}
 
 	public List<OfferRecord> snapshot() {

--- a/src/main/java/com/flipsmart/trading/OfferReconciler.java
+++ b/src/main/java/com/flipsmart/trading/OfferReconciler.java
@@ -16,9 +16,25 @@ public final class OfferReconciler
         public final List<OfferRecord> reattached = new ArrayList<>();
         public final List<OfferSignal> minted = new ArrayList<>();
         public final List<OfferRecord> offlineCollected = new ArrayList<>();
+        // Non-terminal records last active before the freshness cutoff: leftovers from older
+        // sessions (already known to the backend). Terminalize them, but never prompt.
+        public final List<OfferRecord> staleHistory = new ArrayList<>();
     }
 
     public static Plan reconcile(List<OfferRecord> persisted, List<OfferSignal> liveSlots, long now)
+    {
+        // No freshness gate: every non-terminal unmatched record is treated as offline-collected.
+        // Used by the preload pass, which terminalizes both buckets regardless.
+        return reconcile(persisted, liveSlots, now, Long.MIN_VALUE);
+    }
+
+    /**
+     * @param freshnessThresholdMillis a non-terminal unmatched record counts as a genuine offline
+     *     fill only if its last activity is at or after this cutoff; older records are leftovers
+     *     from prior sessions and go to {@link Plan#staleHistory} instead of driving a prompt.
+     */
+    public static Plan reconcile(List<OfferRecord> persisted, List<OfferSignal> liveSlots, long now,
+        long freshnessThresholdMillis)
     {
         Plan plan = new Plan();
         List<OfferRecord> remaining = new ArrayList<>(persisted);
@@ -48,7 +64,15 @@ public final class OfferReconciler
         // offline fills — including them re-flagged the whole backlog every login (false nag).
         for (OfferRecord r : remaining)
         {
-            if (!r.getState().isTerminal())
+            if (r.getState().isTerminal())
+            {
+                continue;
+            }
+            if (r.getEffectiveLastActivityAtMillis() < freshnessThresholdMillis)
+            {
+                plan.staleHistory.add(r);
+            }
+            else
             {
                 plan.offlineCollected.add(r);
             }

--- a/src/main/java/com/flipsmart/trading/OfferReconciler.java
+++ b/src/main/java/com/flipsmart/trading/OfferReconciler.java
@@ -44,7 +44,15 @@ public final class OfferReconciler
                 plan.minted.add(live);
             }
         }
-        plan.offlineCollected.addAll(remaining);
+        // Terminal (collected/cancelled-empty) records are already-reconciled history, not
+        // offline fills — including them re-flagged the whole backlog every login (false nag).
+        for (OfferRecord r : remaining)
+        {
+            if (!r.getState().isTerminal())
+            {
+                plan.offlineCollected.add(r);
+            }
+        }
         return plan;
     }
 

--- a/src/main/java/com/flipsmart/trading/TransactionLogger.java
+++ b/src/main/java/com/flipsmart/trading/TransactionLogger.java
@@ -120,7 +120,8 @@ public final class TransactionLogger
             .recommendedSellPrice(recPrice)
             .rsn(rsn)
             .totalQuantity(r.getTotalQuantity())
-            .idempotencyKey(key);
+            .idempotencyKey(key)
+            .offerId(r.getOfferId());
     }
 
     /**

--- a/src/test/java/com/flipsmart/GEHistoryServiceTest.java
+++ b/src/test/java/com/flipsmart/GEHistoryServiceTest.java
@@ -1,8 +1,14 @@
 package com.flipsmart;
 
+import com.flipsmart.domain.offer.OfferRecord;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Unit tests for {@link GEHistoryService}'s widget-text parsing helpers.
@@ -104,5 +110,45 @@ public class GEHistoryServiceTest
 	{
 		assertEquals(-1, GEHistoryService.parseLeadingTotalFromText(null));
 		assertEquals(-1, GEHistoryService.parseLeadingTotalFromText(""));
+	}
+
+	// ----- matchOfferId (#759 offer_id linkage) -----------------------
+
+	private static OfferRecord offer(long offerId, int itemId, boolean buy, int total, int price)
+	{
+		return OfferRecord.newOffer(offerId, 0, itemId, "i" + itemId, buy, total, price, 1L);
+	}
+
+	@Test
+	public void matchOfferId_uniqueMatchReturnsOfferId()
+	{
+		List<OfferRecord> candidates = Arrays.asList(
+			offer(42, 28924, false, 30000, 384),
+			offer(7, 4151, true, 5, 2_000_000));
+		assertEquals(Long.valueOf(42), GEHistoryService.matchOfferId(candidates, 28924, false, 384));
+	}
+
+	@Test
+	public void matchOfferId_ambiguousSameItemDirectionPriceReturnsNull()
+	{
+		List<OfferRecord> candidates = Arrays.asList(
+			offer(42, 28924, false, 30000, 384),
+			offer(43, 28924, false, 20000, 384));
+		assertNull(GEHistoryService.matchOfferId(candidates, 28924, false, 384));
+	}
+
+	@Test
+	public void matchOfferId_noMatchOnPriceOrDirectionReturnsNull()
+	{
+		List<OfferRecord> candidates = Collections.singletonList(offer(42, 28924, false, 30000, 384));
+		assertNull(GEHistoryService.matchOfferId(candidates, 28924, false, 999));
+		assertNull(GEHistoryService.matchOfferId(candidates, 28924, true, 384));
+	}
+
+	@Test
+	public void matchOfferId_sameOfferAcrossCollectionsIsNotAmbiguous()
+	{
+		OfferRecord same = offer(42, 28924, false, 30000, 384);
+		assertEquals(Long.valueOf(42), GEHistoryService.matchOfferId(Arrays.asList(same, same), 28924, false, 384));
 	}
 }

--- a/src/test/java/com/flipsmart/GEHistoryServiceTest.java
+++ b/src/test/java/com/flipsmart/GEHistoryServiceTest.java
@@ -1,6 +1,9 @@
 package com.flipsmart;
 
 import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.trading.OfferStore;
+import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -8,7 +11,14 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * Unit tests for {@link GEHistoryService}'s widget-text parsing helpers.
@@ -150,5 +160,40 @@ public class GEHistoryServiceTest
 	{
 		OfferRecord same = offer(42, 28924, false, 30000, 384);
 		assertEquals(Long.valueOf(42), GEHistoryService.matchOfferId(Arrays.asList(same, same), 28924, false, 384));
+	}
+
+	// ----- prompt de-nag: only prompt when GE data is genuinely missing (#759) -----
+
+	private ChatMessageManager chatMessageManager;
+
+	private GEHistoryService newService()
+	{
+		chatMessageManager = mock(ChatMessageManager.class);
+		return new GEHistoryService(
+			mock(Client.class),
+			mock(FlipSmartApiClient.class),
+			mock(PlayerSession.class),
+			chatMessageManager,
+			new OfferStore());
+	}
+
+	@Test
+	public void persistedStateWithoutOfflineFillsDoesNotPromptOrFlagBanner()
+	{
+		// Having tracked offers last session is NOT a reason to nag — only a
+		// genuinely-unverified offline fill is. No prompt, no overlay banner.
+		GEHistoryService svc = newService();
+		svc.setRecentlyPersistedOffers(Collections.singletonList(offer(42, 28924, false, 30000, 384)));
+		assertFalse(svc.hasUnverifiedOfflineFills());
+		verify(chatMessageManager, never()).queue(any());
+	}
+
+	@Test
+	public void genuineOfflineFillPromptsAndFlagsBanner()
+	{
+		GEHistoryService svc = newService();
+		svc.registerOfflineFill(28924);
+		assertTrue(svc.hasUnverifiedOfflineFills());
+		verify(chatMessageManager, times(1)).queue(any());
 	}
 }

--- a/src/test/java/com/flipsmart/OfferReconcilerTest.java
+++ b/src/test/java/com/flipsmart/OfferReconcilerTest.java
@@ -2,6 +2,7 @@ package com.flipsmart;
 
 import com.flipsmart.domain.offer.OfferRecord;
 import com.flipsmart.domain.offer.OfferSignal;
+import com.flipsmart.domain.offer.OfferState;
 import com.flipsmart.trading.OfferReconciler;
 import net.runelite.api.GrandExchangeOfferState;
 import org.junit.Test;
@@ -56,5 +57,39 @@ public class OfferReconcilerTest
 
         assertEquals(1, plan.offlineCollected.size());
         assertEquals(9L, plan.offlineCollected.get(0).getOfferId());
+    }
+
+    @Test
+    public void terminalPersistedRecord_isNotOfflineCollected()
+    {
+        // A COLLECTED record is already-reconciled history from a prior session;
+        // it must not be re-flagged as a fresh offline fill on every login.
+        OfferRecord collected = OfferRecord.newOffer(12L, 4, 555, "i555", true, 10, 100, NOW - 3000)
+            .withFill(10, 1000, OfferState.FILLED, NOW - 2500)
+            .withState(OfferState.COLLECTED, NOW - 2000);
+
+        OfferReconciler.Plan plan = OfferReconciler.reconcile(
+            Collections.singletonList(collected),
+            Collections.emptyList(), NOW);
+
+        assertTrue("terminal history must not drive an offline-fill prompt", plan.offlineCollected.isEmpty());
+    }
+
+    @Test
+    public void mixedHistory_onlyActiveNowGoneRecordIsOfflineCollected()
+    {
+        OfferRecord active = OfferRecord.newOffer(20L, 1, 100, "i100", true, 10, 100, NOW - 2000);
+        OfferRecord collected = OfferRecord.newOffer(21L, 2, 200, "i200", false, 5, 50, NOW - 3000)
+            .withFill(5, 250, OfferState.FILLED, NOW - 2800)
+            .withState(OfferState.COLLECTED, NOW - 2700);
+        OfferRecord cancelledEmpty = OfferRecord.newOffer(22L, 3, 300, "i300", true, 8, 80, NOW - 3000)
+            .withState(OfferState.CANCELLED_EMPTY, NOW - 2600);
+
+        OfferReconciler.Plan plan = OfferReconciler.reconcile(
+            java.util.Arrays.asList(active, collected, cancelledEmpty),
+            Collections.emptyList(), NOW);
+
+        assertEquals(1, plan.offlineCollected.size());
+        assertEquals(20L, plan.offlineCollected.get(0).getOfferId());
     }
 }

--- a/src/test/java/com/flipsmart/OfferReconcilerTest.java
+++ b/src/test/java/com/flipsmart/OfferReconcilerTest.java
@@ -92,4 +92,52 @@ public class OfferReconcilerTest
         assertEquals(1, plan.offlineCollected.size());
         assertEquals(20L, plan.offlineCollected.get(0).getOfferId());
     }
+
+    @Test
+    public void staleNonTerminalRecord_olderThanFreshness_isHistoryNotOfflineCollected()
+    {
+        // A non-terminal record last active before the freshness cutoff is a leftover from an
+        // older session (already known to the backend). It must not drive an offline-fill prompt;
+        // it belongs to staleHistory so the caller can terminalize it without nagging.
+        OfferRecord stale = OfferRecord.newOffer(30L, 1, 400, "i400", false, 3, 100, NOW - 10_000)
+            .withActivityAtMillis(NOW - 10_000);
+        long freshnessThreshold = NOW - 5_000;
+
+        OfferReconciler.Plan plan = OfferReconciler.reconcile(
+            Collections.singletonList(stale), Collections.emptyList(), NOW, freshnessThreshold);
+
+        assertTrue("stale leftover must not be an offline fill", plan.offlineCollected.isEmpty());
+        assertEquals(1, plan.staleHistory.size());
+        assertEquals(30L, plan.staleHistory.get(0).getOfferId());
+    }
+
+    @Test
+    public void recentNonTerminalRecord_newerThanFreshness_isOfflineCollected()
+    {
+        OfferRecord fresh = OfferRecord.newOffer(31L, 2, 500, "i500", false, 3, 100, NOW - 2_000)
+            .withActivityAtMillis(NOW - 2_000);
+        long freshnessThreshold = NOW - 5_000;
+
+        OfferReconciler.Plan plan = OfferReconciler.reconcile(
+            Collections.singletonList(fresh), Collections.emptyList(), NOW, freshnessThreshold);
+
+        assertEquals(1, plan.offlineCollected.size());
+        assertEquals(31L, plan.offlineCollected.get(0).getOfferId());
+        assertTrue(plan.staleHistory.isEmpty());
+    }
+
+    @Test
+    public void threeArgReconcile_appliesNoFreshnessGate()
+    {
+        // Back-compat: the 3-arg form (used by the preload pass, which terminalizes everything
+        // anyway) keeps treating every non-terminal unmatched record as offline-collected.
+        OfferRecord old = OfferRecord.newOffer(32L, 1, 600, "i600", false, 3, 100, NOW - 999_999)
+            .withActivityAtMillis(NOW - 999_999);
+
+        OfferReconciler.Plan plan = OfferReconciler.reconcile(
+            Collections.singletonList(old), Collections.emptyList(), NOW);
+
+        assertEquals(1, plan.offlineCollected.size());
+        assertTrue(plan.staleHistory.isEmpty());
+    }
 }

--- a/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
+++ b/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
@@ -198,6 +198,8 @@ public class OfflineSyncPersistenceTest
 	{
 		when(session.getRsn()).thenReturn("Zezima");
 		when(session.isOfflineSyncCompleted()).thenReturn(false);
+		// We've synced before (marker 500) and this fill is fresh since then (activity 2000).
+		configStore.put("offlineSyncAt_Zezima", "500");
 		// Item still in inventory (2 traded units), so the inventory gate allows the re-add.
 		when(activeFlipTracker.getInventoryCountForItem(111)).thenReturn(2);
 
@@ -239,6 +241,7 @@ public class OfflineSyncPersistenceTest
 	{
 		when(session.getRsn()).thenReturn("Zezima");
 		when(session.isOfflineSyncCompleted()).thenReturn(false);
+		configStore.put("offlineSyncAt_Zezima", "500"); // fresh since last sync (activity 2000)
 		when(activeFlipTracker.getInventoryCountForItem(4824)).thenReturn(0);
 
 		store.apply(sig(0, GrandExchangeOfferState.BUYING, 4824, 0, 10), 1000L);
@@ -263,6 +266,7 @@ public class OfflineSyncPersistenceTest
 	{
 		when(session.getRsn()).thenReturn("Zezima");
 		when(session.isOfflineSyncCompleted()).thenReturn(false);
+		configStore.put("offlineSyncAt_Zezima", "500"); // fresh since last sync (activity 2000)
 		when(activeFlipTracker.getInventoryCountForItem(4824)).thenReturn(7);
 
 		store.apply(sig(0, GrandExchangeOfferState.BUYING, 4824, 0, 10), 1000L);
@@ -327,6 +331,55 @@ public class OfflineSyncPersistenceTest
 
 		assertEquals("phantom collected item with terminal record + no inventory must be pruned", 1, removed);
 		verify(session, times(1)).removeCollectedItem(4824);
+	}
+
+	/**
+	 * A non-terminal persisted record last active BEFORE the previous sync is a leftover from an
+	 * earlier session (already backfilled) — relogging must not re-fire the "open GE History" prompt
+	 * for it. This is the false-nag the user hit: a relog with no new trades still prompted.
+	 */
+	@Test
+	public void staleOfflineRecordOlderThanLastSync_doesNotPrompt()
+	{
+		when(session.getRsn()).thenReturn("Zezima");
+		when(session.isOfflineSyncCompleted()).thenReturn(false);
+		// Last sync ran at 5000; this record's last activity (2000) predates it → already-known history.
+		configStore.put("offlineSyncAt_Zezima", "5000");
+
+		store.apply(sig(0, GrandExchangeOfferState.BUYING, 222, 0, 5), 1000L);
+		store.apply(sig(0, GrandExchangeOfferState.CANCELLED_BUY, 222, 2, 5), 2000L);
+		service.persistOfferState();
+		store.importRecords(Collections.emptyList());
+		when(client.getGrandExchangeOffers()).thenReturn(new GrandExchangeOffer[0]);
+
+		service.syncOfflineFills();
+
+		verify(geHistoryService, never()).registerOfflineFill(222);
+	}
+
+	/**
+	 * First sync for an account (no marker yet): the persisted blob predates the feature and is
+	 * already known to the backend, so nothing is prompted — and the marker is written so genuinely
+	 * new offline fills on later logins are detected.
+	 */
+	@Test
+	public void firstSyncWithNoMarker_suppressesPreExistingBlob_andWritesMarker()
+	{
+		when(session.getRsn()).thenReturn("Zezima");
+		when(session.isOfflineSyncCompleted()).thenReturn(false);
+		// No offlineSyncAt_Zezima marker present.
+
+		store.apply(sig(0, GrandExchangeOfferState.BUYING, 333, 0, 5), 1000L);
+		store.apply(sig(0, GrandExchangeOfferState.CANCELLED_BUY, 333, 2, 5), 2000L);
+		service.persistOfferState();
+		store.importRecords(Collections.emptyList());
+		when(client.getGrandExchangeOffers()).thenReturn(new GrandExchangeOffer[0]);
+
+		service.syncOfflineFills();
+
+		verify(geHistoryService, never()).registerOfflineFill(333);
+		assertTrue("a sync marker is written so later genuine fills are detected",
+			configStore.containsKey("offlineSyncAt_Zezima"));
 	}
 
 	@Test

--- a/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
+++ b/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.when;
 public class OfflineSyncPersistenceTest
 {
 	private static final String CONFIG_GROUP = "flipsmart";
+	private static final String SYNC_MARKER_ZEZIMA = "offlineSyncAt_Zezima";
 
 	private PlayerSession session;
 	private ConfigManager configManager;
@@ -199,7 +200,7 @@ public class OfflineSyncPersistenceTest
 		when(session.getRsn()).thenReturn("Zezima");
 		when(session.isOfflineSyncCompleted()).thenReturn(false);
 		// We've synced before (marker 500) and this fill is fresh since then (activity 2000).
-		configStore.put("offlineSyncAt_Zezima", "500");
+		configStore.put(SYNC_MARKER_ZEZIMA, "500");
 		// Item still in inventory (2 traded units), so the inventory gate allows the re-add.
 		when(activeFlipTracker.getInventoryCountForItem(111)).thenReturn(2);
 
@@ -241,7 +242,7 @@ public class OfflineSyncPersistenceTest
 	{
 		when(session.getRsn()).thenReturn("Zezima");
 		when(session.isOfflineSyncCompleted()).thenReturn(false);
-		configStore.put("offlineSyncAt_Zezima", "500"); // fresh since last sync (activity 2000)
+		configStore.put(SYNC_MARKER_ZEZIMA, "500"); // fresh since last sync (activity 2000)
 		when(activeFlipTracker.getInventoryCountForItem(4824)).thenReturn(0);
 
 		store.apply(sig(0, GrandExchangeOfferState.BUYING, 4824, 0, 10), 1000L);
@@ -266,7 +267,7 @@ public class OfflineSyncPersistenceTest
 	{
 		when(session.getRsn()).thenReturn("Zezima");
 		when(session.isOfflineSyncCompleted()).thenReturn(false);
-		configStore.put("offlineSyncAt_Zezima", "500"); // fresh since last sync (activity 2000)
+		configStore.put(SYNC_MARKER_ZEZIMA, "500"); // fresh since last sync (activity 2000)
 		when(activeFlipTracker.getInventoryCountForItem(4824)).thenReturn(7);
 
 		store.apply(sig(0, GrandExchangeOfferState.BUYING, 4824, 0, 10), 1000L);
@@ -344,7 +345,7 @@ public class OfflineSyncPersistenceTest
 		when(session.getRsn()).thenReturn("Zezima");
 		when(session.isOfflineSyncCompleted()).thenReturn(false);
 		// Last sync ran at 5000; this record's last activity (2000) predates it → already-known history.
-		configStore.put("offlineSyncAt_Zezima", "5000");
+		configStore.put(SYNC_MARKER_ZEZIMA, "5000");
 
 		store.apply(sig(0, GrandExchangeOfferState.BUYING, 222, 0, 5), 1000L);
 		store.apply(sig(0, GrandExchangeOfferState.CANCELLED_BUY, 222, 2, 5), 2000L);
@@ -379,7 +380,7 @@ public class OfflineSyncPersistenceTest
 
 		verify(geHistoryService, never()).registerOfflineFill(333);
 		assertTrue("a sync marker is written so later genuine fills are detected",
-			configStore.containsKey("offlineSyncAt_Zezima"));
+			configStore.containsKey(SYNC_MARKER_ZEZIMA));
 	}
 
 	@Test

--- a/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
+++ b/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
@@ -300,7 +300,12 @@ public class OfflineSyncPersistenceTest
 
 		service.persistOfferState();
 		store.importRecords(Collections.emptyList());
-		when(client.getGrandExchangeOffers()).thenReturn(new GrandExchangeOffer[0]);
+		// Live slots ARE readable (a different offer occupies slot 1), so reconcile can correctly
+		// classify the gone 4824 record as offline-collected and terminalize it.
+		ItemComposition comp999 = itemComp("i999");
+		when(itemManager.getItemComposition(999)).thenReturn(comp999);
+		GrandExchangeOffer live999 = geOffer(999, GrandExchangeOfferState.BUYING, 5, 100);
+		when(client.getGrandExchangeOffers()).thenReturn(new GrandExchangeOffer[]{null, live999});
 
 		service.preloadPersistedOffers();
 
@@ -381,6 +386,31 @@ public class OfflineSyncPersistenceTest
 		verify(geHistoryService, never()).registerOfflineFill(333);
 		assertTrue("a sync marker is written so later genuine fills are detected",
 			configStore.containsKey(SYNC_MARKER_ZEZIMA));
+	}
+
+	/**
+	 * Blob-growth guard (#759 release): at preload the GE slots are usually not loaded yet, so the
+	 * live snapshot is empty. Reconciling a still-live persisted offer against that empty snapshot
+	 * must NOT manufacture a terminal COLLECTED duplicate — doing so grew the persisted blob ~8
+	 * records every login. When slots are unreadable, classification is deferred to the +2s sync.
+	 */
+	@Test
+	public void preloadWithUnloadedSlots_doesNotManufactureTerminalDuplicate()
+	{
+		when(session.getRsn()).thenReturn("Zezima");
+
+		// A still-live BUY offer persisted from last session (NEW, slot 0).
+		store.apply(sig(0, GrandExchangeOfferState.BUYING, 7777, 0, 10), 1000L);
+		service.persistOfferState();
+		store.importRecords(Collections.emptyList());
+
+		// GE slots not loaded yet at preload time (the login-timing race) → empty snapshot.
+		when(client.getGrandExchangeOffers()).thenReturn(new GrandExchangeOffer[0]);
+
+		service.preloadPersistedOffers();
+
+		assertTrue("no COLLECTED duplicate manufactured when GE slots are unloaded",
+			store.forItem(7777).isEmpty());
 	}
 
 	@Test

--- a/src/test/java/com/flipsmart/TransactionLoggerTest.java
+++ b/src/test/java/com/flipsmart/TransactionLoggerTest.java
@@ -5,8 +5,11 @@ import com.flipsmart.domain.offer.OfferRecord;
 import com.flipsmart.domain.offer.OfferState;
 import com.flipsmart.domain.offer.OfferTransition;
 import com.flipsmart.trading.OfferEvent;
+import com.flipsmart.trading.OfferEventMapper;
+import com.flipsmart.trading.OfferStore;
 import com.flipsmart.trading.TransactionLogger;
 import com.flipsmart.trading.TransactionLogger.Type;
+import net.runelite.api.GrandExchangeOfferState;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -93,6 +96,36 @@ public class TransactionLoggerTest
         assertEquals(2, req.quantity);
         assertEquals(2_000_000, req.pricePerItem);
         assertEquals(RSN + ":5:1700000000000:FILL:2", req.idempotencyKey);
+    }
+
+    @Test
+    public void offlineCompletedTailInSlotOnLoginRecordsDelta()
+    {
+        // #759 case 1: a 30,000 sell partially filled to 20,907 online (persisted),
+        // then completed offline to 30,000. On next login the offer is still in its
+        // slot (OSRS does not auto-collect). With the persisted baseline preloaded
+        // into OfferStore, the login signal must record ONLY the 9,093 offline delta
+        // — not 0 (the loss this fix targets) and not 30,000 (a double count).
+        OfferStore store = new OfferStore();
+        TransactionLogger logger = newLogger(RSN);
+        store.addListener(logger::onOfferEvent);
+
+        // OfflineSyncService.preloadPersistedOffers seeds the store WITHOUT firing
+        // listeners (no spurious record); model that with importRecords.
+        OfferRecord persisted = OfferRecord
+            .newOffer(42L, 3, 28924, "Sunfire splinters", false, 30000, 384, 1700000000000L)
+            .withFill(20907, 20907L * 384, OfferState.PARTIAL_FILL, 1700000000500L);
+        store.importRecords(java.util.Collections.singletonList(persisted));
+
+        // Login burst: the offer now reads 30,000 sold (the tail filled offline).
+        store.apply(
+            OfferEventMapper.toSignal(3, GrandExchangeOfferState.SOLD, 28924,
+                "Sunfire splinters", 30000, 384, 30000, 30000L * 384),
+            1700000600000L);
+
+        TransactionRequest req = capture();
+        assertEquals(9093, req.quantity);
+        assertFalse(req.isBuy);
     }
 
     @Test

--- a/src/test/java/com/flipsmart/TransactionLoggerTest.java
+++ b/src/test/java/com/flipsmart/TransactionLoggerTest.java
@@ -126,6 +126,8 @@ public class TransactionLoggerTest
         TransactionRequest req = capture();
         assertEquals(9093, req.quantity);
         assertFalse(req.isBuy);
+        assertEquals(28924, req.itemId);
+        assertEquals(384, req.pricePerItem);
     }
 
     @Test

--- a/src/test/java/com/flipsmart/TransactionLoggerTest.java
+++ b/src/test/java/com/flipsmart/TransactionLoggerTest.java
@@ -129,6 +129,19 @@ public class TransactionLoggerTest
     }
 
     @Test
+    public void fillRecordsOfferIdFromRecord()
+    {
+        // #759: every recorded fill carries the OfferStore offerId so the backend
+        // can reconcile fills of the same offer per-offer (not summed at item level).
+        TransactionLogger logger = newLogger(RSN);
+        OfferRecord r = OfferRecord.newOffer(77, 3, 4151, "Abyssal whip", true, 5, 2_000_000, 1700000000000L)
+            .withFill(2, 4_000_000L, OfferState.PARTIAL_FILL, 1700000000500L);
+        logger.onOfferEvent(new OfferEvent(OfferTransition.Kind.FILLED_DELTA, r, 2, 4_000_000L));
+        TransactionRequest req = capture();
+        assertEquals(Long.valueOf(77), req.offerId);
+    }
+
+    @Test
     public void collectedAndNoneAndRejectedRecordNothing()
     {
         TransactionLogger logger = newLogger(RSN);

--- a/src/test/java/com/flipsmart/recommend/StaleOfferQueueTest.java
+++ b/src/test/java/com/flipsmart/recommend/StaleOfferQueueTest.java
@@ -1,0 +1,32 @@
+package com.flipsmart.recommend;
+
+import com.flipsmart.domain.offer.OfferRecord;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class StaleOfferQueueTest
+{
+	@Test
+	public void head_onEmptyQueue_returnsNullInsteadOfThrowing()
+	{
+		// The queue can be drained between an isEmpty() check and head() (the offer is
+		// cancelled/filled on another path), so head() must be null-safe rather than throw
+		// ArrayIndexOutOfBoundsException into the RuneLite client thread.
+		assertNull("head() on an empty queue must return null, not throw",
+			new StaleOfferQueue().head());
+	}
+
+	@Test
+	public void head_returnsFirstQueuedOffer_whenNonEmpty()
+	{
+		StaleOfferQueue queue = new StaleOfferQueue();
+		queue.addIfAbsent(OfferRecord.newOffer(1L, 0, 4151, "Abyssal whip", false, 1, 100, 1000L));
+
+		OfferRecord head = queue.head();
+		assertNotNull(head);
+		assertEquals(4151, head.getItemId());
+	}
+}


### PR DESCRIPTION
Part of Flip-Smart/flip-smart#759 — the **plugin half**. Pairs with backend PR Flip-Smart/flip-smart#793 (per-offer reconciliation + recent-window floor).

## What this delivers
1. **Verification (regression test)** — proves the post-#735 OfferStore pipeline already records the offline-completed tail of a bulk sell when the offer is still in-slot on login (records exactly the 9,093 delta, not 0 and not the full 30,000).
2. **Emit `offerId` on transactions** — every recorded fill carries the OfferStore `offerId` (serialized as `offer_id`) so the backend reconciles fills of the same GE offer per-offer instead of summing at item level.
3. **Link GE-History rows to offers** — `GEHistoryService.matchOfferId` conservatively resolves each History row to a tracked offer by `(itemId, isBuy, price)` and tags the backfill entry with its `offerId`, **only on a unique confident match** (any ambiguity / no-match → `null` → safe item-level fallback).
4. **Prompt de-nag** — the "open the GE History tab" chat prompt and overlay banner previously fired on **any** persisted offer state from the prior session (nagging every login). Now they fire **only when there's a genuinely-unverified offline fill** (`pendingOfflineFillItemIds`, populated by the reconciler for offers gone from their slot on login). `setRecentlyPersistedOffers` no longer prompts — it just feeds item-name + offerId resolution. Persisted state alone isn't missing data, since the OfferStore pipeline already records in-slot offline completions.
5. **Recency gate** — `OfflineSyncService` now skips persisted offer records whose last activity predates the most recent `offlineSyncAt_<RSN>` marker, routing them away from the prompt to avoid re-nagging on already-known history.
6. **Preload guard** — `reconcilePersistedIntoStore` now only terminalizes offline-collected records when the live GE-slot snapshot is actually readable (non-empty), deferring to the +2s offline sync otherwise. Prevents manufactured terminal duplicates when slots are unloaded at login.

## Why
Bulk sells were registering completed flips with a partial quantity (prod: Sunfire splinters 20,907 of 30,000) when an item had multiple concurrent/sequential offers — the item-level backfill couldn't tell them apart. Per-offer `offer_id` disambiguates precisely. And the offline-fill prompt was firing far more often than it should.

## Backwards compatibility
`offer_id` is optional everywhere; the backend ignores it when absent. The API (#793) leads the plugin by ~1-2 weeks for plugin-hub review — this code is inert until #793 is live, and old plugin versions keep working unchanged.

## Tests (`./gradlew build` green)
- `TransactionLoggerTest.offlineCompletedTailInSlotOnLoginRecordsDelta` — offline-tail verification.
- `TransactionLoggerTest.fillRecordsOfferIdFromRecord` — fills carry offerId.
- `GEHistoryServiceTest.matchOfferId_*` — unique / ambiguous / no-match / cross-collection duplicate.
- `GEHistoryServiceTest.persistedStateWithoutOfflineFillsDoesNotPromptOrFlagBanner` + `genuineOfflineFillPromptsAndFlagsBanner` — the de-nag.
- `OfflineSyncPersistenceTest.offlinePartialCancelRegistersSingleBackfillAtReconciledQty` + stale-history gate tests.
- `OfflineSyncPersistenceTest.preloadGuardDefersToBlobSyncWhenSlotsUnloaded` — preload guard.

### Codacy Quality Gate — fixed in this PR
- `71d5424` PMD GuardLogStatement `OfflineSyncService.java:402` — guarded `log.debug` call with `isDebugEnabled()` check
- `71d5424` PMD AvoidDuplicateLiterals `OfflineSyncPersistenceTest.java:202` — extracted repeated `"offlineSyncAt_Zezima"` to a named constant `SYNC_MARKER_ZEZIMA`
- `7711fb3` PMD GuardLogStatement `OfflineSyncService.java:298` — guarded new `log.debug` call in `reconcilePersistedIntoStore` with `isDebugEnabled()` check

### Codacy AI Reviewer — fixed in prior commit
- `b6a1f66` `TransactionLoggerTest.java:128` — extended assertions to verify `itemId` and `pricePerItem` on the offline-tail delta test (thread resolved)