### PR TITLE
chore(motd): fetch MOTD once on login instead of polling every 60s

### DIFF
--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -643,7 +643,6 @@ public class FlipSmartPlugin extends Plugin
 
 		// Start dump alert service
 		dumpAlertService.start();
-		motdService.start();
 
 		// Sync webhook config to backend if configured
 		webhookSyncService.syncIfChanged();
@@ -809,7 +808,6 @@ public class FlipSmartPlugin extends Plugin
 
 		// Stop dump alert service
 		dumpAlertService.stop();
-		motdService.stop();
 
 		// Stop auto-recommend service and timer
 		scheduler.stopAutoRecommendRefreshTimer();

--- a/src/main/java/com/flipsmart/MotdService.java
+++ b/src/main/java/com/flipsmart/MotdService.java
@@ -2,7 +2,6 @@ package com.flipsmart;
 import com.flipsmart.api.dto.MotdChannelData;
 import com.flipsmart.api.dto.MotdResponse;
 
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
@@ -16,24 +15,18 @@ import net.runelite.client.config.ConfigManager;
 import javax.inject.Inject;
 import java.awt.Color;
 import javax.inject.Singleton;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 
 /**
- * Polls /motd at 60s and posts the plugin channel's message to the chatbox
- * once per version per client. Subscribes to game-state LOGGED_IN to surface
- * any unseen MOTD on login between polls.
+ * Fetches /motd once per login (game-state LOGGED_IN) and posts the plugin
+ * channel's message to the chatbox at most once per version per client. No
+ * background polling: a message set while a player is already logged in
+ * surfaces on their next login.
  */
-@Slf4j
 @Singleton
 public class MotdService
 {
 	private static final String CONFIG_GROUP = "flipsmart";
 	private static final String LAST_SHOWN_KEY = "motd.lastShownVersion";
-	private static final long POLL_INTERVAL_SECONDS = 60L;
-	private static final long INITIAL_DELAY_SECONDS = 5L;
 
 	private final Client client;
 	private final FlipSmartConfig config;
@@ -41,9 +34,6 @@ public class MotdService
 	private final ChatMessageManager chatMessageManager;
 	private final ClientThread clientThread;
 	private final ConfigManager configManager;
-
-	private ScheduledExecutorService executor;
-	private ScheduledFuture<?> pollingTask;
 
 	private MotdResponse latest;
 
@@ -62,41 +52,6 @@ public class MotdService
 		this.chatMessageManager = chatMessageManager;
 		this.clientThread = clientThread;
 		this.configManager = configManager;
-	}
-
-	public void start()
-	{
-		stop();
-		executor = Executors.newSingleThreadScheduledExecutor();
-		pollingTask = executor.scheduleAtFixedRate(this::poll,
-			INITIAL_DELAY_SECONDS, POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
-		log.debug("MotdService started ({}s interval)", POLL_INTERVAL_SECONDS);
-	}
-
-	public void stop()
-	{
-		if (pollingTask != null)
-		{
-			pollingTask.cancel(false);
-			pollingTask = null;
-		}
-		if (executor != null)
-		{
-			executor.shutdownNow();
-			executor = null;
-		}
-	}
-
-	private void poll()
-	{
-		try
-		{
-			apiClient.getMotdAsync().thenAccept(this::handleResponse);
-		}
-		catch (Exception e)
-		{
-			log.debug("MOTD poll error: {}", e.getMessage());
-		}
 	}
 
 	/** Visible for testing. */


### PR DESCRIPTION
## Summary

Product decided the plugin should fetch MOTD only once per login rather than polling every 60 seconds. This eliminates a large volume of redundant API calls across all logged-in users. A message published while a player is already in-game will surface on their next login. The version-based dedup (persisted `motd.lastShownVersion`) is unchanged, so a given message still posts to chat at most once per (client, version) — world-hops and reconnects stay quiet.

This is part of a coordinated MOTD DB-load reduction effort:
- API PR #802 (`flip-smart`): made `/motd` cache-absorbed and fixed a session leak
- Webapp PR (parallel): lengthened the web UI poll to 5 minutes

## Changes

### ♻️ Refactoring
- `MotdService.java`: removed the `ScheduledExecutorService`, the 60s `poll()` loop, `start()`/`stop()` lifecycle methods, the `POLL_INTERVAL_SECONDS` / `INITIAL_DELAY_SECONDS` constants, and now-unused `java.util.concurrent.*` imports and `@Slf4j`. `onLogin()` (wired to `LOGGED_IN` game-state via `EventRouter`) now drives all MOTD fetches directly.
- `FlipSmartPlugin.java`: removed the `motdService.start()` call in `startUp()` and `motdService.stop()` call in `shutDown()`.
- Net diff: ~51 deletions, 4 insertions — reduces Plugin Hub LOC footprint.

## Testing

### Automated Tests
- BUILD SUCCESSFUL — full Gradle test suite green (`./gradlew test`)
- `MotdServiceTest` exercises `handleResponse()` and `onLogin()` directly; constructor signature unchanged, no test changes needed.

### Manual Testing
- [ ] Log in to OSRS with the plugin active — MOTD fetch fires once, message appears in chat if unseen for this version
- [ ] World-hop / reconnect — no duplicate MOTD message (version dedup suppresses it)
- [ ] Log out and back in — MOTD fires again on login (already-seen version stays silent)
- [ ] Verify no repeated API calls to `/motd` while logged in (no 60s polling)

## Deployment Notes

- No configuration changes required
- No migration needed
- No new dependencies
- Backend must have PR #802 merged and deployed for the cache-absorbed `/motd` endpoint, but the plugin change is backward-compatible with the old endpoint

## Checklist

- [x] Tests passing (`./gradlew test`)
- [x] No `java.util.concurrent.*` imports remain in `MotdService`
- [x] No GitHub issue-ref comments (`// #123`, `// Issue #N`) in Java source
- [x] `start()`/`stop()` calls removed from plugin lifecycle
- [x] Version dedup logic (`motd.lastShownVersion`) untouched
- [x] Net change is a deletion — good for Plugin Hub LOC budget
- [x] No `.claude/`, `CLAUDE.md`, or Claude config added to this repo

## Related

Related to Flip-Smart/flip-smart#802 (API: cache-absorb `/motd` + session leak fix)

---

## Codacy Quality Gate

**Result: PASS** — 0 new issues, 7 fixed (net removal PR). Gate was green on first analysis (no action required).

## Codacy AI Reviewer

**1 comment processed**

| Disposition | Count |
|---|---|
| False positives (rebutted in-thread) | 1 |

- `MotdService.java:20` — Codacy flagged `onLogin()` as dead code / never called. False positive: the method is wired through the existing EventBus chain unchanged by this PR (`FlipSmartPlugin.onGameStateChanged` @Subscribe at line 837 → `eventRouter.onGameStateChanged` at line 839 → `EventRouter.onGameStateChanged` at line 114 calls `plugin.getMotdService().onLogin()` at line 136 on every `LOGGED_IN` transition). MotdServiceTest exercises this path; all tests pass. Thread replied and resolved.