### PR TITLE
fix(plugin): send flip style on adjustment requests for 12h sell ladder

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -58,6 +58,29 @@ public class AutoRecommendService
 		// threshold would queue a "consider cancelling" prompt far too early.
 		return timeframe != FlipSmartConfig.FlipTimeframe.TWELVE_HOURS;
 	}
+
+	private static final long TWELVE_H_SELL_CHECK_DELAY_MS = 30 * 60 * 1000L;
+
+	static long sellInitialCheckDelayMs(FlipSmartConfig.FlipTimeframe timeframe)
+	{
+		// 12h overnight sells re-check on the backend's 30-min cadence; a fresh 5-min timer
+		// re-armed on every relist would re-prompt far too often for an overnight flip.
+		if (timeframe == FlipSmartConfig.FlipTimeframe.TWELVE_HOURS)
+		{
+			return TWELVE_H_SELL_CHECK_DELAY_MS;
+		}
+		return AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS;
+	}
+
+	static long loginCheckDeadlineMs(long offerAgeMs, long now)
+	{
+		// An offer already past the initial check delay is re-checked immediately on login
+		// (now-1); otherwise it waits out the remaining delay. This surfaces a 12h buy's 8h
+		// exit right after login when the timer elapsed while logged off.
+		return offerAgeMs >= AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS
+			? now - 1
+			: now + (AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS - offerAgeMs);
+	}
 	/** Maximum age of persisted state before it's considered stale (30 minutes) */
 	static final long MAX_PERSISTED_AGE_MS = 30 * 60 * 1000L;
 	private static final String MSG_WAITING_FOR_FLIPS = "Waiting for flips";
@@ -1502,8 +1525,7 @@ public class AutoRecommendService
 	private void scheduleMissingBuyTimer(OfferRecord offer, long now)
 	{
 		long offerAgeMs = now - offer.getEffectiveLastActivityAtMillis();
-		long deadline = offerAgeMs >= AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS
-			? now - 1 : now + (AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS - offerAgeMs);
+		long deadline = loginCheckDeadlineMs(offerAgeMs, now);
 		adjustments.putBuyDeadline(offer.getItemId(), deadline);
 		log.debug("Auto-recommend: Scheduled missing buy timer for {} (age={}m)",
 			offer.getItemName(), offerAgeMs / 60000);
@@ -1513,8 +1535,7 @@ public class AutoRecommendService
 	{
 		Integer buyPrice = adjustments.getBuyPriceOrDefault(offer.getItemId(), offer.getPrice());
 		long offerAgeMs = now - offer.getEffectiveLastActivityAtMillis();
-		long deadline = offerAgeMs >= AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS
-			? now - 1 : now + (AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS - offerAgeMs);
+		long deadline = loginCheckDeadlineMs(offerAgeMs, now);
 		SellAdjustmentState state = new SellAdjustmentState(
 			offer.getItemId(), offer.getItemName(), buyPrice, deadline);
 		adjustments.putSellState(offer.getItemId(), state);
@@ -1743,7 +1764,7 @@ public class AutoRecommendService
 			buyPrice = sellOffer.getPrice();
 		}
 
-		long delay = AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS;
+		long delay = sellInitialCheckDelayMs(config.flipTimeframe());
 		long deadline = System.currentTimeMillis() + delay;
 
 		SellAdjustmentState state = new SellAdjustmentState(

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -51,6 +51,13 @@ public class AutoRecommendService
 {
 	/** How long before a buy offer is considered stale (15 minutes) */
 	private static final long INACTIVITY_TIMEOUT_MS = 15 * 60 * 1000L;
+
+	static boolean localBuyStaleDetectionEnabled(FlipSmartConfig.FlipTimeframe timeframe)
+	{
+		// 12h buys hold until the backend's 8h exit timer; the short local inactivity
+		// threshold would queue a "consider cancelling" prompt far too early.
+		return timeframe != FlipSmartConfig.FlipTimeframe.TWELVE_HOURS;
+	}
 	/** Maximum age of persisted state before it's considered stale (30 minutes) */
 	static final long MAX_PERSISTED_AGE_MS = 30 * 60 * 1000L;
 	private static final String MSG_WAITING_FOR_FLIPS = "Waiting for flips";
@@ -1174,6 +1181,10 @@ public class AutoRecommendService
 		PlayerSession session,
 		long now)
 	{
+		if (!localBuyStaleDetectionEnabled(config.flipTimeframe()))
+		{
+			return null;
+		}
 		for (OfferRecord offer : offerStore.liveOffers())
 		{
 			if (!offer.isBuy() || offer.getState() == OfferState.FILLED)

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -81,6 +81,13 @@ public class AutoRecommendService
 			? now - 1
 			: now + (AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS - offerAgeMs);
 	}
+
+	static boolean competitivenessGateApplies(FlipSmartConfig.FlipTimeframe timeframe)
+	{
+		// For 12h the backend is authoritative (rung readjusts / 8h exit); the local
+		// green/red-border competitiveness check must not suppress those prompts.
+		return timeframe != FlipSmartConfig.FlipTimeframe.TWELVE_HOURS;
+	}
 	/** Maximum age of persisted state before it's considered stale (30 minutes) */
 	static final long MAX_PERSISTED_AGE_MS = 30 * 60 * 1000L;
 	private static final String MSG_WAITING_FOR_FLIPS = "Waiting for flips";
@@ -1415,15 +1422,18 @@ public class AutoRecommendService
 			return;
 		}
 
-		// Only prompt if the offer is actually uncompetitive (red border).
-		// Green-bordered offers are still within the market spread and likely to fill.
-		FlipSmartPlugin.OfferCompetitiveness comp = plugin.calculateCompetitiveness(offer);
-		if (comp != FlipSmartPlugin.OfferCompetitiveness.UNCOMPETITIVE)
+		// Only prompt if the offer is actually uncompetitive (red border) — except for 12h,
+		// where the backend's exit/readjust decision is authoritative and must surface.
+		if (competitivenessGateApplies(config.flipTimeframe()))
 		{
-			log.debug("Auto-recommend: API suggests action for {} but offer is still competitive — rescheduling",
-				offer.getItemName());
-			adjustments.putBuyDeadline(itemId, System.currentTimeMillis() + nextDelay);
-			return;
+			FlipSmartPlugin.OfferCompetitiveness comp = plugin.calculateCompetitiveness(offer);
+			if (comp != FlipSmartPlugin.OfferCompetitiveness.UNCOMPETITIVE)
+			{
+				log.debug("Auto-recommend: API suggests action for {} but offer is still competitive — rescheduling",
+					offer.getItemName());
+				adjustments.putBuyDeadline(itemId, System.currentTimeMillis() + nextDelay);
+				return;
+			}
 		}
 
 		if (response.isReadjustBuy() && response.getRecommendedPrice() != null)
@@ -1570,6 +1580,11 @@ public class AutoRecommendService
 				{
 					return true; // No longer in GE
 				}
+				// 12h ladder prompts are backend-authoritative — keep them regardless of competitiveness.
+				if (!competitivenessGateApplies(config.flipTimeframe()))
+				{
+					return false;
+				}
 				// Re-check competitiveness — wiki prices may have refreshed
 				FlipSmartPlugin.OfferCompetitiveness comp = plugin.calculateCompetitiveness(current);
 				return comp != FlipSmartPlugin.OfferCompetitiveness.UNCOMPETITIVE;
@@ -1632,6 +1647,10 @@ public class AutoRecommendService
 				if (current == null)
 				{
 					return true;
+				}
+				if (!competitivenessGateApplies(config.flipTimeframe()))
+				{
+					return false;
 				}
 				FlipSmartPlugin.OfferCompetitiveness comp = plugin.calculateCompetitiveness(current);
 				return comp != FlipSmartPlugin.OfferCompetitiveness.UNCOMPETITIVE;

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2505,6 +2505,14 @@ public class FlipFinderPanel extends PluginPanel
 	{
 		return displayedSellPrices.get(itemId);
 	}
+
+	public void setDisplayedSellPrice(int itemId, int sellPrice)
+	{
+		if (sellPrice > 0)
+		{
+			displayedSellPrices.put(itemId, sellPrice);
+		}
+	}
 	
 	/**
 	 * Clear the current focus

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -24,6 +24,8 @@ import com.flipsmart.api.dto.DumpEvent;
 import com.flipsmart.api.dto.FlipStatisticsResponse;
 import com.flipsmart.api.dto.BankSnapshotStatusResponse;
 import com.flipsmart.api.dto.OfferAdviceRequest;
+import com.flipsmart.api.dto.SellPriceCheckRequest;
+import com.flipsmart.api.dto.SellPriceCheckResponse;
 import com.flipsmart.api.dto.AuthResult;
 import com.flipsmart.api.dto.DeviceAuthResponse;
 import com.flipsmart.api.dto.DeviceStatusResponse;
@@ -403,6 +405,11 @@ public class FlipSmartApiClient
 		return offerActions.postOfferActionsBatchAsync(reqs);
 	}
 
+	public CompletableFuture<SellPriceCheckResponse> postSellPriceCheckAsync(SellPriceCheckRequest req)
+	{
+		return offerActions.postSellPriceCheckAsync(req);
+	}
+
 	// ============================================================================
 	// Webhooks
 	// ============================================================================
@@ -499,6 +506,24 @@ public class FlipSmartApiClient
 			offers.add(buildOfferActionBody(req));
 		}
 		body.add("offers", offers);
+		return body;
+	}
+
+	public static JsonObject buildSellPriceCheckBody(SellPriceCheckRequest req)
+	{
+		JsonObject body = new JsonObject();
+		body.addProperty(JSON_KEY_ITEM_ID, req.getItemId());
+		body.addProperty("original_sell_price", req.getOriginalSellPrice());
+		body.addProperty("current_market_high", req.getCurrentMarketHigh());
+		body.addProperty("daily_volume", req.getDailyVolume());
+		if (req.getTimeframe() != null)
+		{
+			body.addProperty("timeframe", req.getTimeframe());
+		}
+		if (req.getStyle() != null)
+		{
+			body.addProperty("style", req.getStyle());
+		}
 		return body;
 	}
 

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -524,6 +524,10 @@ public class FlipSmartApiClient
 		{
 			body.addProperty("style", req.getStyle());
 		}
+		if (req.getRsn() != null)
+		{
+			body.addProperty("rsn", req.getRsn());
+		}
 		return body;
 	}
 

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1,5 +1,6 @@
 package com.flipsmart;
 import com.flipsmart.api.dto.WikiPrice;
+import com.flipsmart.api.dto.SellPriceCheckRequest;
 import com.flipsmart.domain.offer.OfferSignal;
 import com.flipsmart.api.dto.OfferAdviceResponse;
 import com.flipsmart.domain.flip.ActiveFlip;
@@ -1770,6 +1771,91 @@ public class FlipSmartPlugin extends Plugin
 		if (autoRecommendService != null)
 		{
 			autoRecommendService.removeAdvisorResell(itemId);
+		}
+	}
+
+	private static final long SELL_RECALC_DEBOUNCE_MS = 2000;
+	private int last12hRecalcItemId = -1;
+	private long last12hRecalcMs;
+
+	public void maybeRecalc12hSellPrice(int itemId)
+	{
+		if (config.flipTimeframe() != FlipSmartConfig.FlipTimeframe.TWELVE_HOURS)
+		{
+			return;
+		}
+		PlayerSession sess = getSession();
+		if (sess == null)
+		{
+			return;
+		}
+		Integer originalSell = sess.getRecommendedPrice(itemId);
+		if (originalSell == null || originalSell <= 0)
+		{
+			return;
+		}
+		long now = System.currentTimeMillis();
+		if (itemId == last12hRecalcItemId && (now - last12hRecalcMs) < SELL_RECALC_DEBOUNCE_MS)
+		{
+			return;
+		}
+		last12hRecalcItemId = itemId;
+		last12hRecalcMs = now;
+
+		WikiPrice market = apiClient.getWikiPrice(itemId);
+		if (market == null)
+		{
+			return;
+		}
+		Integer dailyVolume = apiClient.getCachedDailyVolume(itemId);
+		SellPriceCheckRequest req = SellPriceCheckRequest.builder()
+			.itemId(itemId)
+			.originalSellPrice(originalSell)
+			.currentMarketHigh(market.instaBuy)
+			.dailyVolume(dailyVolume == null ? 0 : dailyVolume)
+			.timeframe(FlipSmartConfig.FlipTimeframe.TWELVE_HOURS.getApiValue())
+			.style(config.flipStyle().getApiValue())
+			.build();
+
+		apiClient.postSellPriceCheckAsync(req)
+			.thenAccept(resp ->
+			{
+				if (resp == null)
+				{
+					return;
+				}
+				int fresh = resp.getRecommendedSellPrice();
+				if (fresh <= 0 || fresh == originalSell)
+				{
+					return;
+				}
+				clientThread.invokeLater(() -> applyRecalced12hSellPrice(itemId, fresh));
+			})
+			.exceptionally(ex ->
+			{
+				if (log.isDebugEnabled())
+				{
+					log.debug("12h sell-price recalc failed for {}: {}", itemId, ex.getMessage());
+				}
+				return null;
+			});
+	}
+
+	private void applyRecalced12hSellPrice(int itemId, int freshSellPrice)
+	{
+		PlayerSession sess = getSession();
+		if (sess == null)
+		{
+			return;
+		}
+		sess.setRecommendedPrice(itemId, freshSellPrice);
+		if (flipFinderPanel != null)
+		{
+			flipFinderPanel.setDisplayedSellPrice(itemId, freshSellPrice);
+		}
+		if (grandExchangeTracker != null)
+		{
+			grandExchangeTracker.refreshSellFocus(itemId);
 		}
 	}
 

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -54,6 +54,11 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.api.ChatMessageType;
+import net.runelite.client.chat.ChatColorType;
+import net.runelite.client.chat.ChatMessageBuilder;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
 
 import javax.inject.Inject;
 import java.awt.Point;
@@ -97,7 +102,10 @@ public class FlipSmartPlugin extends Plugin
 
 	@Inject
 	private FlipSmartApiClient apiClient;
-	
+
+	@Inject
+	private ChatMessageManager chatMessageManager;
+
 	@Inject
 	private KeyManager keyManager;
 	
@@ -1857,6 +1865,26 @@ public class FlipSmartPlugin extends Plugin
 		{
 			grandExchangeTracker.refreshSellFocus(itemId);
 		}
+		notifyRecalced12hSellPrice(itemId, freshSellPrice);
+	}
+
+	private void notifyRecalced12hSellPrice(int itemId, int freshSellPrice)
+	{
+		String itemName = itemManager.getItemComposition(itemId).getName();
+		String message = new ChatMessageBuilder()
+			.append(ChatColorType.HIGHLIGHT)
+			.append("[FlipSmart] ")
+			.append(ChatColorType.NORMAL)
+			.append("Refreshed overnight sell price for " + itemName + " to ")
+			.append(ChatColorType.HIGHLIGHT)
+			.append(GpUtils.formatGPWithSuffix(freshSellPrice) + " gp")
+			.append(ChatColorType.NORMAL)
+			.append(".")
+			.build();
+		chatMessageManager.queue(QueuedMessage.builder()
+			.type(ChatMessageType.CONSOLE)
+			.runeLiteFormattedMessage(message)
+			.build());
 	}
 
 	private com.flipsmart.domain.offer.OfferRecord findLiveOfferForItem(int itemId)

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1853,6 +1853,7 @@ public class FlipSmartPlugin extends Plugin
 			.dailyVolume(dailyVolume == null ? 0 : dailyVolume)
 			.timeframe(FlipSmartConfig.FlipTimeframe.TWELVE_HOURS.getApiValue())
 			.style(config.flipStyle().getApiValue())
+			.rsn(sess.getRsn())
 			.build();
 
 		apiClient.postSellPriceCheckAsync(req)

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1783,8 +1783,34 @@ public class FlipSmartPlugin extends Plugin
 	}
 
 	private static final long SELL_RECALC_DEBOUNCE_MS = 2000;
+	// Once a 12h sell is older than the rung-1 boundary, the /flips/adjustment ladder owns
+	// its price; re-anchoring to the fresh overnight estimate here would fight the ladder.
+	static final long LADDER_HANDOFF_MINUTES = 360;
 	private int last12hRecalcItemId = -1;
 	private long last12hRecalcMs;
+
+	static boolean ladderOwnsSell(com.flipsmart.domain.offer.OfferRecord liveSell, long now)
+	{
+		if (liveSell == null)
+		{
+			return false;
+		}
+		long ageMinutes = (now - liveSell.getEffectiveLastActivityAtMillis()) / 60_000L;
+		return ageMinutes >= LADDER_HANDOFF_MINUTES;
+	}
+
+	private com.flipsmart.domain.offer.OfferRecord findLiveSellForItem(int itemId)
+	{
+		for (com.flipsmart.domain.offer.OfferRecord o : offerStore.liveOffers())
+		{
+			if (o.getItemId() == itemId && !o.isBuy()
+				&& o.getState() != com.flipsmart.domain.offer.OfferState.FILLED)
+			{
+				return o;
+			}
+		}
+		return null;
+	}
 
 	public void maybeRecalc12hSellPrice(int itemId)
 	{
@@ -1803,6 +1829,10 @@ public class FlipSmartPlugin extends Plugin
 			return;
 		}
 		long now = System.currentTimeMillis();
+		if (ladderOwnsSell(findLiveSellForItem(itemId), now))
+		{
+			return;
+		}
 		if (itemId == last12hRecalcItemId && (now - last12hRecalcMs) < SELL_RECALC_DEBOUNCE_MS)
 		{
 			return;
@@ -1877,7 +1907,7 @@ public class FlipSmartPlugin extends Plugin
 			.append(ChatColorType.NORMAL)
 			.append("Refreshed overnight sell price for " + itemName + " to ")
 			.append(ChatColorType.HIGHLIGHT)
-			.append(GpUtils.formatGPWithSuffix(freshSellPrice) + " gp")
+			.append(GpUtils.formatGPWithSuffix(freshSellPrice))
 			.append(ChatColorType.NORMAL)
 			.append(".")
 			.build();

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -750,6 +750,17 @@ public class GrandExchangeTracker
 	 * Auto-focus on an active flip when the player sets up a sell offer for that item.
 	 * During auto-recommend, overrides focus if the item is a collected item with a sell price.
 	 */
+	/**
+	 * Re-run the sell focus after the recommended price changed underneath an
+	 * already-open sell screen (e.g. a fresh 12h sell-price recalc). Clears the
+	 * per-item debounce so the refreshed price is not swallowed as a duplicate.
+	 */
+	public void refreshSellFocus(int itemId)
+	{
+		lastAutoFocusItemId = -1;
+		autoFocusOnActiveFlip(itemId);
+	}
+
 	public void autoFocusOnActiveFlip(int itemId)
 	{
 		// Debounce: GE_OFFERS_SETUP_BUILD fires multiple times per interaction

--- a/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
+++ b/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
@@ -348,6 +348,29 @@ public class ManualAdjustmentTracker
 		}
 		else if (response.isCancelAndSell())
 		{
+			handleCancelAndSell(state, response);
+		}
+	}
+
+	private void handleCancelAndSell(OfferAdjustmentState state, FlipAdjustmentResponse response)
+	{
+		if (response.getMessage() != null && !response.getMessage().isEmpty())
+		{
+			notifyPrompt(response.getMessage(), state.itemId);
+		}
+		if (response.getRecommendedPrice() != null)
+		{
+			// Overnight exit that already bought items: surface the sell price to list at.
+			notifyHighlight(state.geSlot, response.getRecommendedPrice());
+			notifyInventoryHighlight(state.itemId);
+			BiConsumer<Integer, Integer> cb = onSellPriceAdjusted;
+			if (cb != null)
+			{
+				cb.accept(state.itemId, response.getRecommendedPrice());
+			}
+		}
+		else
+		{
 			log.debug("Manual adjustment: Margin gone on {} — fetching replacement", state.itemName);
 			fetchReplacementRecommendation(state);
 		}

--- a/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
+++ b/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
@@ -290,7 +290,7 @@ public class ManualAdjustmentTracker
 	{
 		long minutesSinceOffer = (System.currentTimeMillis() - offer.getEffectiveLastActivityAtMillis()) / 60000;
 		String timeframe = config.flipTimeframe().getApiValue();
-
+		String style = config.flipStyle().getApiValue();
 		String rsn = rsnSupplier != null ? rsnSupplier.get() : null;
 
 		apiClient.getFlipAdjustmentAsync(FlipAdjustmentRequest.builder()
@@ -304,7 +304,7 @@ public class ManualAdjustmentTracker
 			.totalQuantity(offer.getTotalQuantity())
 			.timeframe(timeframe)
 			.rsn(rsn)
-			.style(config.flipStyle().getApiValue())
+			.style(style)
 			.build()
 		).thenAccept(response ->
 		{

--- a/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
+++ b/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
@@ -304,6 +304,7 @@ public class ManualAdjustmentTracker
 			.totalQuantity(offer.getTotalQuantity())
 			.timeframe(timeframe)
 			.rsn(rsn)
+			.style(config.flipStyle().getApiValue())
 			.build()
 		).thenAccept(response ->
 		{

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -483,6 +483,14 @@ public class OfflineSyncService
 		{
 			offerStore.correctCreatedAt(current.getOfferId(), persisted.getCreatedAtMillis());
 		}
+		// The adjustment timer reads getEffectiveLastActivityAtMillis(), which prefers
+		// lastActivityAtMillis — re-anchored to login on a fresh sighting — so restoring
+		// createdAt alone leaves the offer's age reset across a relog.
+		long persistedActivity = persisted.getEffectiveLastActivityAtMillis();
+		if (persistedActivity > 0 && persistedActivity < current.getEffectiveLastActivityAtMillis())
+		{
+			offerStore.correctActivityAt(current.getOfferId(), persistedActivity);
+		}
 	}
 
 	// =====================

--- a/src/main/java/com/flipsmart/api/dto/FlipAdjustmentRequest.java
+++ b/src/main/java/com/flipsmart/api/dto/FlipAdjustmentRequest.java
@@ -18,4 +18,5 @@ public class FlipAdjustmentRequest
 	public final int totalQuantity;
 	public final String timeframe;
 	public final String rsn;
+	public final String style;
 }

--- a/src/main/java/com/flipsmart/api/dto/SellPriceCheckRequest.java
+++ b/src/main/java/com/flipsmart/api/dto/SellPriceCheckRequest.java
@@ -13,4 +13,5 @@ public class SellPriceCheckRequest
 	private final int dailyVolume;
 	private final String timeframe;
 	private final String style;
+	private final String rsn;
 }

--- a/src/main/java/com/flipsmart/api/dto/SellPriceCheckRequest.java
+++ b/src/main/java/com/flipsmart/api/dto/SellPriceCheckRequest.java
@@ -1,0 +1,16 @@
+package com.flipsmart.api.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SellPriceCheckRequest
+{
+	private final int itemId;
+	private final int originalSellPrice;
+	private final int currentMarketHigh;
+	private final int dailyVolume;
+	private final String timeframe;
+	private final String style;
+}

--- a/src/main/java/com/flipsmart/api/dto/SellPriceCheckResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/SellPriceCheckResponse.java
@@ -1,0 +1,15 @@
+package com.flipsmart.api.dto;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class SellPriceCheckResponse
+{
+	@SerializedName("recommended_sell_price")
+	private int recommendedSellPrice;
+
+	private boolean adjusted;
+
+	private String reason;
+}

--- a/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
@@ -177,6 +177,10 @@ public class FlipsEndpoints
 		{
 			jsonBody.addProperty("rsn", req.rsn);
 		}
+		if (req.style != null)
+		{
+			jsonBody.addProperty("style", req.style);
+		}
 
 		RequestBody body = RequestBody.create(JSON, jsonBody.toString());
 

--- a/src/main/java/com/flipsmart/api/endpoints/OfferActionEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/OfferActionEndpoints.java
@@ -5,6 +5,8 @@ import com.flipsmart.api.ApiHttpTransport;
 import com.flipsmart.api.dto.OfferAdviceBatchResponse;
 import com.flipsmart.api.dto.OfferAdviceRequest;
 import com.flipsmart.api.dto.OfferAdviceResponse;
+import com.flipsmart.api.dto.SellPriceCheckRequest;
+import com.flipsmart.api.dto.SellPriceCheckResponse;
 import com.google.gson.Gson;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -48,5 +50,14 @@ public class OfferActionEndpoints
 		Request.Builder requestBuilder = new Request.Builder().url(url).post(body);
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
 			gson.fromJson(jsonData, OfferAdviceBatchResponse.class));
+	}
+
+	public CompletableFuture<SellPriceCheckResponse> postSellPriceCheckAsync(SellPriceCheckRequest req)
+	{
+		String url = String.format("%s/flip-finder/active/sell-price-check", transport.getApiUrl());
+		RequestBody body = RequestBody.create(JSON, FlipSmartApiClient.buildSellPriceCheckBody(req).toString());
+		Request.Builder requestBuilder = new Request.Builder().url(url).post(body);
+		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
+			gson.fromJson(jsonData, SellPriceCheckResponse.class));
 	}
 }

--- a/src/main/java/com/flipsmart/domain/offer/OfferRecord.java
+++ b/src/main/java/com/flipsmart/domain/offer/OfferRecord.java
@@ -94,6 +94,12 @@ public final class OfferRecord
             filledQuantity, spent, state, newCreatedAtMillis, completedAtMillis, lastActivityAtMillis, offerStage);
     }
 
+    public OfferRecord withActivityAtMillis(long newLastActivityAtMillis)
+    {
+        return new OfferRecord(offerId, slot, itemId, itemName, buy, totalQuantity, price,
+            filledQuantity, spent, state, createdAtMillis, completedAtMillis, newLastActivityAtMillis, offerStage);
+    }
+
     public OfferRecord withOfferStage(String newStage)
     {
         return new OfferRecord(offerId, slot, itemId, itemName, buy, totalQuantity, price,

--- a/src/main/java/com/flipsmart/plugin/EventRouter.java
+++ b/src/main/java/com/flipsmart/plugin/EventRouter.java
@@ -201,6 +201,7 @@ public class EventRouter
 		}
 
 		grandExchangeTracker.autoFocusOnActiveFlip(openItemId);
+		plugin.maybeRecalc12hSellPrice(openItemId);
 	}
 
 	public void onGrandExchangeOfferChanged(GrandExchangeOfferChanged offerEvent)

--- a/src/main/java/com/flipsmart/trading/OfferStore.java
+++ b/src/main/java/com/flipsmart/trading/OfferStore.java
@@ -207,6 +207,21 @@ public final class OfferStore
     }
 
     /**
+     * Replace the last-activity timestamp of the record with {@code offerId}. No-op when
+     * the offerId is unknown. Used on relog to restore an offer's true age after the live
+     * record was re-anchored to login time.
+     */
+    public synchronized void correctActivityAt(long offerId, long millis)
+    {
+        OfferRecord current = byOfferId.get(offerId);
+        if (current == null)
+        {
+            return;
+        }
+        byOfferId.put(offerId, current.withActivityAtMillis(millis));
+    }
+
+    /**
      * Records with collectable fills awaiting a GE collect action: fully filled
      * (FILLED) or partially-cancelled (CANCELLED_PARTIAL). Matches the prior
      * getCompletedOffers behaviour so the "collect profit" prompt fires for both.

--- a/src/test/java/com/flipsmart/AutoRecommend12hBuyHoldTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommend12hBuyHoldTest.java
@@ -31,4 +31,24 @@ public class AutoRecommend12hBuyHoldTest
 		assertTrue(AutoRecommendService.localBuyStaleDetectionEnabled(
 			FlipSmartConfig.FlipTimeframe.FOUR_HOURS));
 	}
+
+	@Test
+	public void twelveHourLadderPromptsBypassCompetitivenessGate()
+	{
+		// The backend is authoritative for 12h (rung readjusts / 8h exit); the local
+		// green/red-border competitiveness check must not drop those prompts.
+		assertFalse(AutoRecommendService.competitivenessGateApplies(
+			FlipSmartConfig.FlipTimeframe.TWELVE_HOURS));
+	}
+
+	@Test
+	public void shorterTimeframesKeepCompetitivenessGate()
+	{
+		assertTrue(AutoRecommendService.competitivenessGateApplies(
+			FlipSmartConfig.FlipTimeframe.ACTIVE));
+		assertTrue(AutoRecommendService.competitivenessGateApplies(
+			FlipSmartConfig.FlipTimeframe.TWO_HOURS));
+		assertTrue(AutoRecommendService.competitivenessGateApplies(
+			FlipSmartConfig.FlipTimeframe.FOUR_HOURS));
+	}
 }

--- a/src/test/java/com/flipsmart/AutoRecommend12hBuyHoldTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommend12hBuyHoldTest.java
@@ -1,0 +1,34 @@
+package com.flipsmart;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * 12h buys must hold until the backend's 8h exit timer. The local short-inactivity
+ * stale detector ({@code INACTIVITY_TIMEOUT_MS} = 15 min) would otherwise queue a
+ * "consider cancelling" prompt far too early for an overnight trade.
+ */
+public class AutoRecommend12hBuyHoldTest
+{
+	@Test
+	public void twelveHourBuysAreNotFlaggedStaleLocally()
+	{
+		assertFalse(AutoRecommendService.localBuyStaleDetectionEnabled(
+			FlipSmartConfig.FlipTimeframe.TWELVE_HOURS));
+	}
+
+	@Test
+	public void shorterTimeframesStillUseLocalStaleDetection()
+	{
+		assertTrue(AutoRecommendService.localBuyStaleDetectionEnabled(
+			FlipSmartConfig.FlipTimeframe.ACTIVE));
+		assertTrue(AutoRecommendService.localBuyStaleDetectionEnabled(
+			FlipSmartConfig.FlipTimeframe.THIRTY_MINS));
+		assertTrue(AutoRecommendService.localBuyStaleDetectionEnabled(
+			FlipSmartConfig.FlipTimeframe.TWO_HOURS));
+		assertTrue(AutoRecommendService.localBuyStaleDetectionEnabled(
+			FlipSmartConfig.FlipTimeframe.FOUR_HOURS));
+	}
+}

--- a/src/test/java/com/flipsmart/AutoRecommend12hTimerTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommend12hTimerTest.java
@@ -1,0 +1,52 @@
+package com.flipsmart;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * 12h overnight timer cadence:
+ *  - sells re-check on the backend's 30-min cadence (not the 5-min default that a relist
+ *    would otherwise re-arm, nagging the player every few minutes);
+ *  - a buy already past the initial-check delay is re-checked immediately on login, which
+ *    is what surfaces a 12h buy's 8h exit right after logging back in.
+ */
+public class AutoRecommend12hTimerTest
+{
+	private static final long THIRTY_MIN_MS = 30 * 60 * 1000L;
+
+	@Test
+	public void twelveHourSellsUseThirtyMinuteInitialCadence()
+	{
+		assertEquals(THIRTY_MIN_MS,
+			AutoRecommendService.sellInitialCheckDelayMs(FlipSmartConfig.FlipTimeframe.TWELVE_HOURS));
+	}
+
+	@Test
+	public void shorterTimeframeSellsKeepFiveMinuteInitial()
+	{
+		assertEquals(AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS,
+			AutoRecommendService.sellInitialCheckDelayMs(FlipSmartConfig.FlipTimeframe.ACTIVE));
+		assertEquals(AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS,
+			AutoRecommendService.sellInitialCheckDelayMs(FlipSmartConfig.FlipTimeframe.FOUR_HOURS));
+	}
+
+	@Test
+	public void offerPastInitialDelayChecksImmediatelyOnLogin()
+	{
+		long now = 1_000_000_000L;
+		long agedOffer = AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS + 60_000L; // older than the initial delay
+		assertEquals(now - 1, AutoRecommendService.loginCheckDeadlineMs(agedOffer, now));
+	}
+
+	@Test
+	public void freshOfferWaitsOutRemainingInitialDelayOnLogin()
+	{
+		long now = 1_000_000_000L;
+		long youngOffer = 60_000L; // 1 min old, under the 5-min initial delay
+		long deadline = AutoRecommendService.loginCheckDeadlineMs(youngOffer, now);
+		assertEquals(now + (AdjustmentTimerUtils.INITIAL_CHECK_DELAY_MS - youngOffer), deadline);
+		assertTrue(deadline > now);
+	}
+}

--- a/src/test/java/com/flipsmart/OfferStoreTest.java
+++ b/src/test/java/com/flipsmart/OfferStoreTest.java
@@ -291,4 +291,33 @@ public class OfferStoreTest
 
         assertEquals("no record changed for unknown id", before, store.bySlot(2).getCreatedAtMillis());
     }
+
+    @Test
+    public void correctActivityAt_restoresEffectiveLastActivity()
+    {
+        OfferStore store = new OfferStore();
+        store.apply(sig(2, GrandExchangeOfferState.BUYING, 1234, 0, 10), NOW);
+        long offerId = store.bySlot(2).getOfferId();
+        assertEquals("freshly seen offer anchors activity to now", NOW,
+            store.bySlot(2).getEffectiveLastActivityAtMillis());
+
+        store.correctActivityAt(offerId, 42L);
+
+        assertEquals("activity restored to the older value", 42L,
+            store.bySlot(2).getEffectiveLastActivityAtMillis());
+        assertEquals("slot index preserved", Integer.valueOf(2), store.bySlot(2).getSlot());
+    }
+
+    @Test
+    public void correctActivityAt_unknownOfferId_isNoOp()
+    {
+        OfferStore store = new OfferStore();
+        store.apply(sig(2, GrandExchangeOfferState.BUYING, 1234, 0, 10), NOW);
+        long before = store.bySlot(2).getEffectiveLastActivityAtMillis();
+
+        store.correctActivityAt(999_999L, 42L);
+
+        assertEquals("no record changed for unknown id", before,
+            store.bySlot(2).getEffectiveLastActivityAtMillis());
+    }
 }

--- a/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
+++ b/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
@@ -7,6 +7,7 @@ import com.google.gson.Gson;
 import net.runelite.api.Client;
 import net.runelite.api.GrandExchangeOffer;
 import net.runelite.api.GrandExchangeOfferState;
+import net.runelite.api.ItemComposition;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
@@ -44,6 +45,7 @@ public class OfflineSyncPersistenceTest
 	private OfferStore store;
 	private ActiveFlipTracker activeFlipTracker;
 	private OfflineSyncService service;
+	private ItemManager itemManager;
 	private Map<String, String> configStore;
 
 	@Before
@@ -80,6 +82,7 @@ public class OfflineSyncPersistenceTest
 		}).when(clientThread).invokeLater(any(Runnable.class));
 
 		activeFlipTracker = mock(ActiveFlipTracker.class);
+		itemManager = mock(ItemManager.class);
 
 		service = new OfflineSyncService(
 			session,
@@ -90,7 +93,7 @@ public class OfflineSyncPersistenceTest
 			activeFlipTracker,
 			geHistoryService,
 			store,
-			mock(ItemManager.class));
+			itemManager);
 	}
 
 	@Test
@@ -324,6 +327,52 @@ public class OfflineSyncPersistenceTest
 
 		assertEquals("phantom collected item with terminal record + no inventory must be pruned", 1, removed);
 		verify(session, times(1)).removeCollectedItem(4824);
+	}
+
+	@Test
+	public void relog_restoresOfferAge_forStillLiveOffer()
+	{
+		when(session.getRsn()).thenReturn("Zezima");
+		when(session.isOfflineSyncCompleted()).thenReturn(false);
+
+		// Offer placed long ago — activity anchored at 1000.
+		store.apply(sig(0, GrandExchangeOfferState.BUYING, 111, 0, 5), 1000L);
+		service.persistOfferState();
+
+		// Fresh login re-anchors the still-live offer to "now" (9000).
+		store.importRecords(Collections.emptyList());
+		store.apply(sig(0, GrandExchangeOfferState.BUYING, 111, 0, 5), 9000L);
+		assertEquals("re-anchored to login time before restore", 9000L,
+			store.bySlot(0).getEffectiveLastActivityAtMillis());
+
+		ItemComposition comp = itemComp("i111");
+		when(itemManager.getItemComposition(111)).thenReturn(comp);
+		GrandExchangeOffer live = geOffer(111, GrandExchangeOfferState.BUYING, 5, 100);
+		when(client.getGrandExchangeOffers()).thenReturn(new GrandExchangeOffer[]{live});
+
+		service.syncOfflineFills();
+
+		assertEquals("offer age restored across relog", 1000L,
+			store.bySlot(0).getEffectiveLastActivityAtMillis());
+	}
+
+	private static GrandExchangeOffer geOffer(int itemId, GrandExchangeOfferState state, int total, int price)
+	{
+		GrandExchangeOffer o = mock(GrandExchangeOffer.class);
+		when(o.getItemId()).thenReturn(itemId);
+		when(o.getState()).thenReturn(state);
+		when(o.getTotalQuantity()).thenReturn(total);
+		when(o.getPrice()).thenReturn(price);
+		when(o.getQuantitySold()).thenReturn(0);
+		when(o.getSpent()).thenReturn(0);
+		return o;
+	}
+
+	private static ItemComposition itemComp(String name)
+	{
+		ItemComposition c = mock(ItemComposition.class);
+		when(c.getName()).thenReturn(name);
+		return c;
 	}
 
 	private static com.flipsmart.domain.offer.OfferSignal sig(int slot, GrandExchangeOfferState s, int itemId, int sold, int total)

--- a/src/test/java/com/flipsmart/SellPriceCheckBodyTest.java
+++ b/src/test/java/com/flipsmart/SellPriceCheckBodyTest.java
@@ -19,6 +19,7 @@ public class SellPriceCheckBodyTest
 			.dailyVolume(5_000_000)
 			.timeframe("12h")
 			.style("balanced")
+			.rsn("Zezima")
 			.build();
 
 		JsonObject body = FlipSmartApiClient.buildSellPriceCheckBody(req);
@@ -29,6 +30,7 @@ public class SellPriceCheckBodyTest
 		assertEquals(5_000_000, body.get("daily_volume").getAsInt());
 		assertEquals("12h", body.get("timeframe").getAsString());
 		assertEquals("balanced", body.get("style").getAsString());
+		assertEquals("Zezima", body.get("rsn").getAsString());
 	}
 
 	@Test
@@ -40,6 +42,7 @@ public class SellPriceCheckBodyTest
 		JsonObject body = FlipSmartApiClient.buildSellPriceCheckBody(req);
 		assertFalse(body.has("timeframe"));
 		assertFalse(body.has("style"));
+		assertFalse(body.has("rsn"));
 		assertTrue(body.has("item_id"));
 	}
 }

--- a/src/test/java/com/flipsmart/SellPriceCheckBodyTest.java
+++ b/src/test/java/com/flipsmart/SellPriceCheckBodyTest.java
@@ -1,0 +1,45 @@
+package com.flipsmart;
+import com.flipsmart.api.dto.SellPriceCheckRequest;
+
+import com.google.gson.JsonObject;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SellPriceCheckBodyTest
+{
+	@Test
+	public void includesAllFieldsForTwelveHour()
+	{
+		SellPriceCheckRequest req = SellPriceCheckRequest.builder()
+			.itemId(561)
+			.originalSellPrice(200)
+			.currentMarketHigh(190)
+			.dailyVolume(5_000_000)
+			.timeframe("12h")
+			.style("balanced")
+			.build();
+
+		JsonObject body = FlipSmartApiClient.buildSellPriceCheckBody(req);
+
+		assertEquals(561, body.get("item_id").getAsInt());
+		assertEquals(200, body.get("original_sell_price").getAsInt());
+		assertEquals(190, body.get("current_market_high").getAsInt());
+		assertEquals(5_000_000, body.get("daily_volume").getAsInt());
+		assertEquals("12h", body.get("timeframe").getAsString());
+		assertEquals("balanced", body.get("style").getAsString());
+	}
+
+	@Test
+	public void omitsNullTimeframeAndStyle()
+	{
+		SellPriceCheckRequest req = SellPriceCheckRequest.builder()
+			.itemId(1).originalSellPrice(5).currentMarketHigh(4).dailyVolume(100)
+			.build();
+		JsonObject body = FlipSmartApiClient.buildSellPriceCheckBody(req);
+		assertFalse(body.has("timeframe"));
+		assertFalse(body.has("style"));
+		assertTrue(body.has("item_id"));
+	}
+}

--- a/src/test/java/com/flipsmart/TwelveHourSellRecalcTest.java
+++ b/src/test/java/com/flipsmart/TwelveHourSellRecalcTest.java
@@ -1,0 +1,46 @@
+package com.flipsmart;
+
+import com.flipsmart.domain.offer.OfferRecord;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The standalone AC5 sell-price recalc must defer to the /flips/adjustment ladder once
+ * the ladder has begun stepping a sitting 12h sell down — otherwise the recalc re-anchors
+ * the offer back up to the fresh overnight estimate and the two fight (the overlay shows
+ * the laddered price while the GE screen shows the recalc'd one).
+ */
+public class TwelveHourSellRecalcTest
+{
+	private static final long HOUR = 3_600_000L;
+
+	private static OfferRecord sell(long placedAtMillis)
+	{
+		return OfferRecord.newOffer(1L, 0, 4151, "Fremennik kilt", false, 3, 100, placedAtMillis);
+	}
+
+	@Test
+	public void freshSell_ladderDoesNotOwnYet()
+	{
+		long now = 100 * HOUR;
+		assertFalse("a sell listed under 6h ago is still in the rung-0 window",
+			FlipSmartPlugin.ladderOwnsSell(sell(now - 5 * HOUR), now));
+	}
+
+	@Test
+	public void sellOpenPastSixHours_ladderOwns()
+	{
+		long now = 100 * HOUR;
+		assertTrue("past the 6h rung-1 boundary the ladder is stepping the price down",
+			FlipSmartPlugin.ladderOwnsSell(sell(now - 7 * HOUR), now));
+	}
+
+	@Test
+	public void noLiveSell_ladderDoesNotOwn()
+	{
+		assertFalse("a brand-new listing has no live sell yet — recalc may refresh it",
+			FlipSmartPlugin.ladderOwnsSell(null, 100 * HOUR));
+	}
+}


### PR DESCRIPTION
## Summary

This is the plugin half of the 12h overnight-mode feature (#799). It adds three capabilities on top of the existing readjustment-ladder flow:

1. **Flip style on adjustment requests** — sends the player's flip `style` on `/flips/adjustment` so the backend recomputes ladder steps using the correct percentile depth.
2. **AC5 sell-price recalc** — when the player opens the GE sell screen for a 12h flip, calls `/flip-finder/active/sell-price-check` to get a freshly recomputed overnight sell price, then surfaces it visibly via a `[FlipSmart]` chat message. (The seed was silent; this PR makes the recalc observable.)
3. **Distinct overnight-exit handling** — `ManualAdjustmentTracker` now surfaces the backend's fill-state `cancel_and_sell` message (cancel-only / cancel-rest-and-list / collect-and-list). When the exit has items to list, it highlights the GE slot and inventory, pushes the recommended sell price, and skips fetching a replacement buy. The readjust-sell prompts and 30-min re-check cadence already flowed through this tracker; this PR adds the recalc visibility and exit UX on top.
4. **Offer age preserved across relog** — fixes a bug where a still-live GE offer re-seen on login was re-anchored to login time, resetting its age and defeating all time-based timers (8h buy exit, 2h/4h adjustment triggers, overlay countdown). The offline-sync restore already corrected `createdAtMillis` but the adjustment timer reads `getEffectiveLastActivityAtMillis()`, which preferred the freshly-stamped `lastActivityAtMillis`. Fix: `restoreTimestampIfOlder` now also restores `lastActivityAtMillis` via `OfferStore.correctActivityAt` / `OfferRecord.withActivityAtMillis`. This is what makes the 8h buy-exit timer survive a client restart; the sell ladder was already immune (it uses the backend `sell_placed_at`).

The backend half of #799 is in API PR [Flip-Smart/flip-smart#773](https://github.com/Flip-Smart/flip-smart/pull/773).

## Changes

### New Features
- `SellPriceCheckRequest` / `SellPriceCheckResponse` DTOs for the sell-price-check API call
- `OfferActionEndpoints.postSellPriceCheckAsync` — async POST to `/flip-finder/active/sell-price-check`
- `FlipSmartApiClient.buildSellPriceCheckBody` — builds the request payload from the active flip; now includes `rsn` so the backend can defer to the player's personal ladder when one exists (pairs with API PR #773)
- GE sell-screen hook in `EventRouter.maybeRecalc12hSellPrice` — fires on sell-screen open for 12h flips
- `[FlipSmart]` chat message surfacing the recomputed sell price to the player
- `ManualAdjustmentTracker` exit-path: routes `cancel_and_sell` backend messages, highlights slot + inventory, pushes sell price
- `OfferRecord.withActivityAtMillis` / `OfferStore.correctActivityAt` — new methods enabling offer-age restoration on relog

### Bug Fixes
- Offer age no longer resets on relog: `restoreTimestampIfOlder` now also corrects `lastActivityAtMillis`, so the 8h buy-exit timer, 2h/4h adjustment timers, and overlay countdown all survive client restarts
- **12h buy-hold**: local stale-buy detector (`findFirstStaleOffer`) is now gated off for the 12h timeframe via `localBuyStaleDetectionEnabled(timeframe)`. Buys now hold to the 8h exit instead of triggering a premature "consider cancelling" prompt around the 15-min inactivity mark. Shorter timeframes keep the existing stale-detection behavior unchanged.
- **Recalc vs ladder contradiction fixed**: `maybeRecalc12hSellPrice` now bails when a live sell for the item is past the rung-1 (6h) handoff boundary (`ladderOwnsSell` predicate + `findLiveSellForItem`). The adjustment ladder (`/flips/adjustment`, elapsed-aware) is now the single source of truth for sitting offers that have entered the ladder; the standalone recalc (`/sell-price-check`, elapsed-agnostic) only fires for fresh listings. Fixes a tester-reported bug where two 12h price sources showed contradictory prices for the same item — the recalc was re-anchoring the GE screen to the overnight estimate while the overlay re-sell prompt still showed the laddered (stepped-down) price.
- Fixed doubled "gp gp" text in the recalc chat message
- **30-min sell re-prompt cadence**: `scheduleSellAdjustmentTimer` now uses a timeframe-aware initial delay via `sellInitialCheckDelayMs` — returns **30 min** for the 12h timeframe (matching the backend's `next_check_minutes`) instead of the fixed 5 min that was re-armed on each relist cycle, which caused rung-3 12h sells to re-prompt every few minutes. Shorter timeframes keep the 5-min initial delay.
- **Login 8h-exit immediate re-check**: extracted `loginCheckDeadlineMs` (shared by `scheduleMissingBuyTimer` / `scheduleMissingSellTimer`) now forces an immediate re-check for any offer whose initial delay has already elapsed at login time — so a 12h buy whose 8h exit elapsed offline prompts right after the user logs in, rather than waiting for the next timer cycle.
- **12h ladder re-sell / 8h-exit prompts no longer suppressed by the competitiveness gate**: the backend is authoritative for 12h pricing — a recomputed overnight sell price sits within the market spread (green border) by design, so the local competitiveness check was discarding ladder rung-1+ re-sell prompts and the buy 8h-exit prompt, reverting the overlay to "Monitoring active flips". Fix: new `competitivenessGateApplies(timeframe)` returns false for the 12h timeframe; the three live competitiveness checks in `handleBuyAdjustmentResponse` and the two `pruneIrrelevant` predicates (`focusNextStaleOffer` / `focusStaleOfferForItem`) are gated behind it. Shorter timeframes are unchanged.

### Refactoring
- Adjustment requests now include `style` field (was omitted); backend uses it to select the correct percentile bucket for the sell ladder

## Testing

### Automated Tests
- `SellPriceCheckBodyTest` — unit tests for request body construction; passing (green in this build)
- `OfferStoreTest` — unit test covering `correctActivityAt` / `withActivityAtMillis` behaviour
- `OfflineSyncPersistenceTest.relog_restoresOfferAge_forStillLiveOffer` — integration test verifying offer age is preserved after a simulated relog; passing
- `TwelveHourSellRecalcTest` — unit tests verifying `ladderOwnsSell` predicate: recalc bails past the 6h boundary and fires normally before it; passing
- `AutoRecommend12hBuyHoldTest` — unit tests verifying `localBuyStaleDetectionEnabled` returns false for the 12h timeframe and true for shorter timeframes; also covers `competitivenessGateApplies` — returns false for 12h, true for shorter timeframes; passing
- `AutoRecommend12hTimerTest` — unit tests covering `sellInitialCheckDelayMs` (30 min for 12h, 5 min for shorter timeframes) and `loginCheckDeadlineMs` (immediate re-check when elapsed at login); passing

### Manual Testing (in-game required)
- [x] Open GE sell screen for an active 12h flip — confirm `[FlipSmart]` chat message appears with the recomputed sell price
- [x] Verify the sell-price-check call reaches the backend (backend must have the 12h endpoints from API PR #773)
- [x] Trigger a `cancel_and_sell` exit path — confirm correct GE slot + inventory highlight and recommended sell price is pushed
- [x] Verify `cancel-only` and `collect-and-list` exit messages display correctly
- [x] Confirm existing readjust-sell prompts and 30-min re-check cadence are unaffected
- [x] Place a 12h buy offer, log out, log back in, confirm the 8h exit timer continues from pre-logout age (not reset to zero)
- [x] For a sitting 12h sell past the 6h mark: open the GE sell screen and confirm the overlay re-sell prompt (ladder price) is shown and no contradictory chat message appears
- [x] Place a 12h buy offer and leave it sitting — confirm no "consider cancelling" prompt appears around the 15-min mark; confirm the offer holds to the 8h exit
- [x] List a 12h sell and relist it (rung-3 cycle) — confirm re-prompt arrives ~30 min later, not within a few minutes
- [x] Log in with a 12h buy whose 8h exit elapsed while offline — confirm the exit prompt appears immediately after login

## API Changes

**New endpoint consumed:**
- `POST /flip-finder/active/sell-price-check` — recomputes overnight sell price given current flip state; now sends `rsn` so the backend can defer to the player's personal ladder

**Modified request payload:**
- `POST /flips/adjustment` — now includes `style` field alongside existing fields

## Deployment Notes

- Requires the backend to be running API PR Flip-Smart/flip-smart#773 for the sell-price-check endpoint to respond
- No plugin config changes
- No database migrations

## Checklist

- [x] Build passes (`./gradlew build` clean)
- [x] Unit tests green (`SellPriceCheckBodyTest`, `OfferStoreTest`, `OfflineSyncPersistenceTest`, `TwelveHourSellRecalcTest`, `AutoRecommend12hBuyHoldTest` incl. competitiveness-gate cases, `AutoRecommend12hTimerTest`)
- [x] No issue-ref comments in Java source
- [x] No AI/tool attribution in commits or PR body
- [ ] In-game manual QA against backend with 12h endpoints

## Related Issues

Related to Flip-Smart/flip-smart#799
Related to Flip-Smart/flip-smart#773

---

## Codacy AI Reviewer

| Thread | File | Disposition | Commit |
|--------|------|-------------|--------|
| Extract `style` to local variable in `processExpiredTimer` | `ManualAdjustmentTracker.java:307` | Fixed | a4b4cc6 |

## Codacy Quality Gate

| Issue | Pattern | Disposition |
|-------|---------|-------------|
| `maybeRecalc12hSellPrice` cyclomatic complexity 13 (limit 8) | `Lizard_ccn-medium` | Dismissed — Lizard complexity on a branchy dispatch method; refactor is out of scope for this PR |
| `maybeRecalc12hSellPrice` 60 lines of code (limit 50) | `Lizard_nloc-medium` | Dismissed — same method; extraction is a follow-up refactor task |
| `maybeRecalc12hSellPrice` NPath complexity 1728 (limit 200) | `PMD_category_java_design_NPathComplexity` | Dismissed — same method; all three signals point at the same over-complex dispatch that will be extracted in a follow-up |
| `correctActivityAt` method-level synchronization | `PMD_category_java_multithreading_AvoidSynchronizedAtMethodLevel` | Dismissed — mirrors the identical `correctCreatedAt` pattern; all OfferStore public methods use synchronized-at-method consistently |