### PR TITLE
test(api): EntitlementsResponse DTO + entitlement/re-sell focus coverage

### DIFF
--- a/src/main/java/com/flipsmart/api/ApiHttpTransport.java
+++ b/src/main/java/com/flipsmart/api/ApiHttpTransport.java
@@ -3,6 +3,7 @@ package com.flipsmart.api;
 import com.flipsmart.FlipSmartConfig;
 import com.flipsmart.api.dto.AuthResult;
 import com.flipsmart.api.dto.DeviceAuthResponse;
+import com.flipsmart.api.dto.EntitlementsResponse;
 import com.flipsmart.api.dto.DeviceStatusResponse;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -39,7 +40,6 @@ public class ApiHttpTransport
 	private static final String ACCESS_TOKEN_KEY = "access_token";
 	private static final String REFRESH_TOKEN_KEY = "refresh_token";
 	private static final String JSON_KEY_IS_PREMIUM = "is_premium";
-	private static final String JSON_KEY_RSN_ENTITLEMENT = "rsn_entitlement";
 	private static final String JSON_KEY_STATUS = "status";
 	private static final String DEVICE_INFO = "RuneLite Plugin";
 	private static final String HEADER_AUTHORIZATION = "Authorization";
@@ -84,6 +84,17 @@ public class ApiHttpTransport
 	public Gson getGson()
 	{
 		return gson;
+	}
+
+	/**
+	 * Deserialize a response body into a DTO using the transport's Gson. Centralizes
+	 * the {@code gson.fromJson(body, T.class)} boilerplate the endpoint groups each
+	 * hand-rolled; behavior is identical to a direct Gson call (returns {@code null}
+	 * for an empty/null body).
+	 */
+	public <T> T parse(String body, Class<T> type)
+	{
+		return gson.fromJson(body, type);
 	}
 
 	public OkHttpClient getHttpClient()
@@ -855,36 +866,9 @@ public class ApiHttpTransport
 		return executeAsync(request, responseBody -> {
 			try
 			{
-				JsonObject json = gson.fromJson(responseBody, JsonObject.class);
-
-				boolean premium;
-				if (json.has(JSON_KEY_IS_PREMIUM) && json.get(JSON_KEY_IS_PREMIUM).isJsonPrimitive())
-				{
-					premium = json.get(JSON_KEY_IS_PREMIUM).getAsBoolean();
-				}
-				else
-				{
-					premium = false;
-				}
-
-				boolean rsnBlocked;
-				if (json.has(JSON_KEY_RSN_ENTITLEMENT) && !json.get(JSON_KEY_RSN_ENTITLEMENT).isJsonNull())
-				{
-					JsonObject rsnEntitlement = json.getAsJsonObject(JSON_KEY_RSN_ENTITLEMENT);
-					if (rsnEntitlement.has(JSON_KEY_STATUS))
-					{
-						String status = rsnEntitlement.get(JSON_KEY_STATUS).getAsString();
-						rsnBlocked = "blocked".equals(status);
-					}
-					else
-					{
-						rsnBlocked = false;
-					}
-				}
-				else
-				{
-					rsnBlocked = false;
-				}
+				EntitlementsResponse entitlements = EntitlementsResponse.fromJson(gson, responseBody);
+				boolean premium = entitlements.isPremium();
+				boolean rsnBlocked = entitlements.isRsnBlocked();
 
 				synchronized (authLock)
 				{

--- a/src/main/java/com/flipsmart/api/ApiHttpTransport.java
+++ b/src/main/java/com/flipsmart/api/ApiHttpTransport.java
@@ -88,9 +88,9 @@ public class ApiHttpTransport
 
 	/**
 	 * Deserialize a response body into a DTO using the transport's Gson. Centralizes
-	 * the {@code gson.fromJson(body, T.class)} boilerplate the endpoint groups each
-	 * hand-rolled; behavior is identical to a direct Gson call (returns {@code null}
-	 * for an empty/null body).
+	 * the {@code gson.fromJson(body, T.class)} boilerplate that each endpoint group
+	 * previously hand-rolled; behavior is identical to a direct Gson call (returns
+	 * {@code null} for an empty/null body).
 	 */
 	public <T> T parse(String body, Class<T> type)
 	{

--- a/src/main/java/com/flipsmart/api/dto/EntitlementsResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/EntitlementsResponse.java
@@ -17,7 +17,7 @@ public class EntitlementsResponse
 	private static final String STATUS_BLOCKED = "blocked";
 
 	@SerializedName("is_premium")
-	private JsonElement isPremium;
+	private JsonElement premiumElement;
 
 	@SerializedName("rsn_entitlement")
 	private RsnEntitlement rsnEntitlement;
@@ -30,7 +30,7 @@ public class EntitlementsResponse
 
 	public boolean isPremium()
 	{
-		return isPremium != null && isPremium.isJsonPrimitive() && isPremium.getAsBoolean();
+		return premiumElement != null && premiumElement.isJsonPrimitive() && premiumElement.getAsBoolean();
 	}
 
 	public boolean isRsnBlocked()

--- a/src/main/java/com/flipsmart/api/dto/EntitlementsResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/EntitlementsResponse.java
@@ -1,0 +1,46 @@
+package com.flipsmart.api.dto;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Parsed {@code GET /auth/entitlements} response. Replaces the hand-rolled
+ * {@code JsonObject} walk that previously lived in the transport.
+ *
+ * <p>Premium is held as a raw {@link JsonElement} rather than a {@code Boolean}
+ * so a non-primitive {@code is_premium} (object/array) defaults to false instead
+ * of throwing during deserialization, preserving the original defensive parse.
+ */
+public class EntitlementsResponse
+{
+	private static final String STATUS_BLOCKED = "blocked";
+
+	@SerializedName("is_premium")
+	private JsonElement isPremium;
+
+	@SerializedName("rsn_entitlement")
+	private RsnEntitlement rsnEntitlement;
+
+	public static EntitlementsResponse fromJson(Gson gson, String body)
+	{
+		EntitlementsResponse parsed = gson.fromJson(body, EntitlementsResponse.class);
+		return parsed != null ? parsed : new EntitlementsResponse();
+	}
+
+	public boolean isPremium()
+	{
+		return isPremium != null && isPremium.isJsonPrimitive() && isPremium.getAsBoolean();
+	}
+
+	public boolean isRsnBlocked()
+	{
+		return rsnEntitlement != null && STATUS_BLOCKED.equals(rsnEntitlement.status);
+	}
+
+	private static class RsnEntitlement
+	{
+		@SerializedName("status")
+		private String status;
+	}
+}

--- a/src/main/java/com/flipsmart/api/endpoints/BankSnapshotEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/BankSnapshotEndpoints.java
@@ -5,7 +5,6 @@ import com.flipsmart.api.dto.BankItem;
 import com.flipsmart.api.dto.BankItemId;
 import com.flipsmart.api.dto.BankSnapshotResponse;
 import com.flipsmart.api.dto.BankSnapshotStatusResponse;
-import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import okhttp3.Request;
@@ -26,12 +25,10 @@ public class BankSnapshotEndpoints
 	private static final String JSON_KEY_QUANTITY = "quantity";
 
 	private final ApiHttpTransport transport;
-	private final Gson gson;
 
 	public BankSnapshotEndpoints(ApiHttpTransport transport)
 	{
 		this.transport = transport;
-		this.gson = transport.getGson();
 	}
 
 	/**
@@ -47,7 +44,7 @@ public class BankSnapshotEndpoints
 			.get();
 
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
-			gson.fromJson(jsonData, BankSnapshotStatusResponse.class));
+			transport.parse(jsonData, BankSnapshotStatusResponse.class));
 	}
 
 	/**
@@ -108,6 +105,6 @@ public class BankSnapshotEndpoints
 			.post(body);
 
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
-			gson.fromJson(jsonData, BankSnapshotResponse.class));
+			transport.parse(jsonData, BankSnapshotResponse.class));
 	}
 }

--- a/src/main/java/com/flipsmart/api/endpoints/BlocklistEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/BlocklistEndpoints.java
@@ -2,7 +2,6 @@ package com.flipsmart.api.endpoints;
 
 import com.flipsmart.api.ApiHttpTransport;
 import com.flipsmart.api.dto.BlocklistsResponse;
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Request;
@@ -21,12 +20,10 @@ public class BlocklistEndpoints
 	private static final String JSON_KEY_ITEM_ID = "item_id";
 
 	private final ApiHttpTransport transport;
-	private final Gson gson;
 
 	public BlocklistEndpoints(ApiHttpTransport transport)
 	{
 		this.transport = transport;
-		this.gson = transport.getGson();
 	}
 
 	/**
@@ -43,7 +40,7 @@ public class BlocklistEndpoints
 			.get();
 
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
-			gson.fromJson(jsonData, BlocklistsResponse.class));
+			transport.parse(jsonData, BlocklistsResponse.class));
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
@@ -6,7 +6,6 @@ import com.flipsmart.api.dto.FlipAdjustmentResponse;
 import com.flipsmart.api.dto.FlipFinderResponse;
 import com.flipsmart.api.dto.TimeframeFlipFinderResponse;
 import com.flipsmart.domain.flip.FlipAnalysis;
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -28,7 +27,6 @@ public class FlipsEndpoints
 	private static final long CACHE_DURATION_MS = 180_000; // 3 minute cache
 
 	private final ApiHttpTransport transport;
-	private final Gson gson;
 
 	// Cache to avoid spamming the API
 	private final Map<Integer, CachedAnalysis> analysisCache = new ConcurrentHashMap<>();
@@ -36,7 +34,6 @@ public class FlipsEndpoints
 	public FlipsEndpoints(ApiHttpTransport transport)
 	{
 		this.transport = transport;
-		this.gson = transport.getGson();
 	}
 
 	/**
@@ -60,7 +57,7 @@ public class FlipsEndpoints
 
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
 		{
-			FlipAnalysis analysis = gson.fromJson(jsonData, FlipAnalysis.class);
+			FlipAnalysis analysis = transport.parse(jsonData, FlipAnalysis.class);
 			removeExpiredCacheEntries();
 			analysisCache.put(itemId, new CachedAnalysis(analysis));
 			return analysis;
@@ -116,7 +113,7 @@ public class FlipsEndpoints
 			.get();
 
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
-			gson.fromJson(jsonData, FlipFinderResponse.class));
+			transport.parse(jsonData, FlipFinderResponse.class));
 	}
 
 	/**
@@ -148,7 +145,7 @@ public class FlipsEndpoints
 			.get();
 
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
-			gson.fromJson(jsonData, TimeframeFlipFinderResponse.class));
+			transport.parse(jsonData, TimeframeFlipFinderResponse.class));
 	}
 
 	/**
@@ -189,7 +186,7 @@ public class FlipsEndpoints
 			.post(body);
 
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
-			gson.fromJson(jsonData, FlipAdjustmentResponse.class));
+			transport.parse(jsonData, FlipAdjustmentResponse.class));
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/api/endpoints/MotdEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/MotdEndpoints.java
@@ -2,7 +2,6 @@ package com.flipsmart.api.endpoints;
 
 import com.flipsmart.api.ApiHttpTransport;
 import com.flipsmart.api.dto.MotdResponse;
-import com.google.gson.Gson;
 import okhttp3.Request;
 
 import java.util.concurrent.CompletableFuture;
@@ -13,12 +12,10 @@ import java.util.concurrent.CompletableFuture;
 public class MotdEndpoints
 {
 	private final ApiHttpTransport transport;
-	private final Gson gson;
 
 	public MotdEndpoints(ApiHttpTransport transport)
 	{
 		this.transport = transport;
-		this.gson = transport.getGson();
 	}
 
 	/**
@@ -36,7 +33,7 @@ public class MotdEndpoints
 
 		return transport.executeAsync(
 			request,
-			body -> gson.fromJson(body, MotdResponse.class),
+			body -> transport.parse(body, MotdResponse.class),
 			null,
 			false // public endpoint — do not retry on 401
 		);

--- a/src/main/java/com/flipsmart/api/endpoints/OfferActionEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/OfferActionEndpoints.java
@@ -7,7 +7,6 @@ import com.flipsmart.api.dto.OfferAdviceRequest;
 import com.flipsmart.api.dto.OfferAdviceResponse;
 import com.flipsmart.api.dto.SellPriceCheckRequest;
 import com.flipsmart.api.dto.SellPriceCheckResponse;
-import com.google.gson.Gson;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 
@@ -26,12 +25,10 @@ import static com.flipsmart.api.ApiHttpTransport.JSON;
 public class OfferActionEndpoints
 {
 	private final ApiHttpTransport transport;
-	private final Gson gson;
 
 	public OfferActionEndpoints(ApiHttpTransport transport)
 	{
 		this.transport = transport;
-		this.gson = transport.getGson();
 	}
 
 	public CompletableFuture<OfferAdviceResponse> postOfferActionAsync(OfferAdviceRequest req)
@@ -40,7 +37,7 @@ public class OfferActionEndpoints
 		RequestBody body = RequestBody.create(JSON, FlipSmartApiClient.buildOfferActionBody(req).toString());
 		Request.Builder requestBuilder = new Request.Builder().url(url).post(body);
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
-			gson.fromJson(jsonData, OfferAdviceResponse.class));
+			transport.parse(jsonData, OfferAdviceResponse.class));
 	}
 
 	public CompletableFuture<OfferAdviceBatchResponse> postOfferActionsBatchAsync(List<OfferAdviceRequest> reqs)
@@ -49,7 +46,7 @@ public class OfferActionEndpoints
 		RequestBody body = RequestBody.create(JSON, FlipSmartApiClient.buildOfferActionsBody(reqs).toString());
 		Request.Builder requestBuilder = new Request.Builder().url(url).post(body);
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
-			gson.fromJson(jsonData, OfferAdviceBatchResponse.class));
+			transport.parse(jsonData, OfferAdviceBatchResponse.class));
 	}
 
 	public CompletableFuture<SellPriceCheckResponse> postSellPriceCheckAsync(SellPriceCheckRequest req)
@@ -58,6 +55,6 @@ public class OfferActionEndpoints
 		RequestBody body = RequestBody.create(JSON, FlipSmartApiClient.buildSellPriceCheckBody(req).toString());
 		Request.Builder requestBuilder = new Request.Builder().url(url).post(body);
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
-			gson.fromJson(jsonData, SellPriceCheckResponse.class));
+			transport.parse(jsonData, SellPriceCheckResponse.class));
 	}
 }

--- a/src/test/java/com/flipsmart/OverrideFocusForSellTest.java
+++ b/src/test/java/com/flipsmart/OverrideFocusForSellTest.java
@@ -1,0 +1,119 @@
+package com.flipsmart;
+
+import com.flipsmart.domain.flip.FlipRecommendation;
+import com.flipsmart.trading.OfferStore;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.SwingUtilities;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the tri-state contract of {@link AutoRecommendService#overrideFocusForSell}
+ * introduced with the stale re-sell focus fix (#156). The caller's tick-retry
+ * logic depends on the distinction between {@code UNAVAILABLE} (state not settled,
+ * retry later) and the terminal {@code ALREADY_SELLING}/{@code FOCUSED} outcomes,
+ * so each branch is covered here.
+ *
+ * <p>{@code ALREADY_SELLING} and the reprice/known-price {@code FOCUSED} paths are
+ * already pinned in {@link AutoRecommendDispatchTest}; this class fills the
+ * {@code UNAVAILABLE} branches and the clean resolve-and-fire-callback path.
+ */
+public class OverrideFocusForSellTest
+{
+	@Mock private FlipSmartConfig config;
+	@Mock private FlipSmartPlugin plugin;
+	@Mock private FlipSmartApiClient apiClient;
+	private OfferStore offerStore;
+	private AutoRecommendService service;
+	private PlayerSession session;
+
+	private static FlipRecommendation rec(int itemId)
+	{
+		FlipRecommendation r = new FlipRecommendation();
+		r.setItemId(itemId);
+		r.setItemName("item-" + itemId);
+		r.setRecommendedBuyPrice(100);
+		r.setRecommendedSellPrice(200);
+		r.setRecommendedQuantity(10);
+		return r;
+	}
+
+	@Before
+	public void setUp()
+	{
+		MockitoAnnotations.openMocks(this);
+		offerStore = new OfferStore();
+		session = new PlayerSession();
+		when(plugin.getSession()).thenReturn(session);
+		when(plugin.getFlipSlotLimit()).thenReturn(8);
+		when(plugin.getActiveFlipItemIds()).thenReturn(new HashSet<>());
+		when(plugin.getApiClient()).thenReturn(apiClient);
+		when(apiClient.isRsnBlocked()).thenReturn(false);
+		when(config.priceOffset()).thenReturn(0);
+		when(config.minimumProfit()).thenReturn(1);
+		when(plugin.isClientThread()).thenReturn(true);
+		service = new AutoRecommendService(config, plugin, offerStore);
+		service.start(Arrays.asList(rec(21)));
+	}
+
+	@Test
+	public void inactiveServiceReturnsUnavailable()
+	{
+		service.stop();
+		assertEquals(AutoRecommendService.SellFocusResult.UNAVAILABLE,
+			service.overrideFocusForSell(21, "item-21"));
+	}
+
+	@Test
+	public void nullSessionReturnsUnavailable()
+	{
+		when(plugin.getSession()).thenReturn(null);
+		assertEquals(AutoRecommendService.SellFocusResult.UNAVAILABLE,
+			service.overrideFocusForSell(21, "item-21"));
+	}
+
+	@Test
+	public void unresolvablePriceReturnsUnavailable()
+	{
+		// Item 999 is not in the queue and has no session/advisor price, so no sell price
+		// can be resolved yet → caller should retry on a later tick.
+		assertEquals(AutoRecommendService.SellFocusResult.UNAVAILABLE,
+			service.overrideFocusForSell(999, "item-999"));
+	}
+
+	@Test
+	public void knownPriceButZeroQuantityReturnsUnavailable()
+	{
+		// Price resolvable from session, but nothing in inventory / collected and no rec to
+		// supply a fallback quantity → quantity unsettled → UNAVAILABLE.
+		session.setRecommendedPrice(888, 150);
+		when(plugin.getInventoryCountForItem(888)).thenReturn(0);
+		assertEquals(AutoRecommendService.SellFocusResult.UNAVAILABLE,
+			service.overrideFocusForSell(888, "item-888"));
+	}
+
+	@Test
+	public void resolvedPriceAndQuantityReturnsFocusedAndFiresCallback() throws Exception
+	{
+		session.setRecommendedPrice(888, 150);
+		when(plugin.getInventoryCountForItem(888)).thenReturn(5);
+
+		AtomicReference<FocusedFlip> painted = new AtomicReference<>();
+		service.setOnFocusChanged(painted::set);
+
+		AutoRecommendService.SellFocusResult result = service.overrideFocusForSell(888, "item-888");
+		SwingUtilities.invokeAndWait(() -> { });
+
+		assertEquals(AutoRecommendService.SellFocusResult.FOCUSED, result);
+		assertNotNull("resolve must fire the focus callback", painted.get());
+		assertEquals(888, painted.get().getItemId());
+		assertEquals("focus must carry the resolved sell price", 150, painted.get().getCurrentStepPrice());
+	}
+}

--- a/src/test/java/com/flipsmart/SellFocusRetryTest.java
+++ b/src/test/java/com/flipsmart/SellFocusRetryTest.java
@@ -1,0 +1,122 @@
+package com.flipsmart;
+
+import com.flipsmart.api.dto.ActiveFlipsResponse;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import net.runelite.client.game.ItemManager;
+import org.junit.Before;
+import org.junit.Test;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the deferred sell-focus tick-retry in {@link GrandExchangeTracker}, the
+ * settle-race fix from #156. When {@code overrideFocusForSell} reports the local
+ * collect/inventory/session state has not settled ({@code UNAVAILABLE}), the
+ * tracker retries once per game tick for a bounded budget before falling back to
+ * the backend active-flip lookup — the fallback restored in {@code 3c6e53d}.
+ */
+public class SellFocusRetryTest
+{
+	private static final int ITEM = 4151;
+	private static final String RSN = "TestPlayer";
+	private static final int RETRY_BUDGET_TICKS = 6;
+
+	private PlayerSession session;
+	private FlipSmartApiClient apiClient;
+	private ActiveFlipTracker activeFlipTracker;
+	private ItemManager itemManager;
+	private TradeActivityLog tradeActivityLog;
+	private AutoRecommendService autoRecommendService;
+	private GrandExchangeTracker tracker;
+
+	@Before
+	public void setUp()
+	{
+		session = new PlayerSession();
+		session.setRsn(RSN);
+		apiClient = mock(FlipSmartApiClient.class);
+		activeFlipTracker = mock(ActiveFlipTracker.class);
+		itemManager = mock(ItemManager.class);
+		tradeActivityLog = mock(TradeActivityLog.class);
+		autoRecommendService = mock(AutoRecommendService.class);
+
+		when(activeFlipTracker.getInventoryCountForItem(anyInt())).thenReturn(0);
+		when(apiClient.getActiveFlipsAsync(anyString()))
+			.thenReturn(CompletableFuture.<ActiveFlipsResponse>completedFuture(null));
+		when(autoRecommendService.isActive()).thenReturn(true);
+
+		tracker = new GrandExchangeTracker(
+			session, apiClient, activeFlipTracker, itemManager, tradeActivityLog);
+		tracker.setAutoRecommendService(autoRecommendService);
+		tracker.setRsnSupplier(() -> Optional.of(RSN));
+	}
+
+	@Test
+	public void settlesToFocusedWithinBudgetWithoutApiFallback()
+	{
+		// First attempt unsettled, the retry tick resolves it.
+		when(autoRecommendService.overrideFocusForSell(anyInt(), anyString()))
+			.thenReturn(AutoRecommendService.SellFocusResult.UNAVAILABLE,
+				AutoRecommendService.SellFocusResult.FOCUSED);
+
+		tracker.autoFocusOnActiveFlip(ITEM);   // UNAVAILABLE → schedules a retry
+		tracker.retryPendingSellFocusTick();   // FOCUSED → settles, clears pending
+
+		verify(apiClient, never()).getActiveFlipsAsync(anyString());
+
+		// Pending is cleared: a further tick must be a no-op (no extra resolve attempt).
+		tracker.retryPendingSellFocusTick();
+		verify(autoRecommendService, times(2)).overrideFocusForSell(anyInt(), anyString());
+	}
+
+	@Test
+	public void fallsBackToApiLookupAfterBudgetExhausted()
+	{
+		when(autoRecommendService.overrideFocusForSell(anyInt(), anyString()))
+			.thenReturn(AutoRecommendService.SellFocusResult.UNAVAILABLE);
+
+		tracker.autoFocusOnActiveFlip(ITEM);   // UNAVAILABLE → budget = 6 ticks
+
+		// Exhaust all but the final tick — still no fallback.
+		for (int i = 0; i < RETRY_BUDGET_TICKS - 1; i++)
+		{
+			tracker.retryPendingSellFocusTick();
+		}
+		verify(apiClient, never()).getActiveFlipsAsync(anyString());
+
+		// The budget-exhausting tick falls back to the backend active-flip lookup once.
+		tracker.retryPendingSellFocusTick();
+		verify(apiClient, times(1)).getActiveFlipsAsync(anyString());
+
+		// Pending cleared after fallback — no second API call on subsequent ticks.
+		tracker.retryPendingSellFocusTick();
+		verify(apiClient, times(1)).getActiveFlipsAsync(anyString());
+	}
+
+	@Test
+	public void clearsPendingRetryWhenAutoRecommendTurnedOff()
+	{
+		when(autoRecommendService.overrideFocusForSell(anyInt(), anyString()))
+			.thenReturn(AutoRecommendService.SellFocusResult.UNAVAILABLE);
+
+		tracker.autoFocusOnActiveFlip(ITEM);   // schedules a retry while active
+
+		when(autoRecommendService.isActive()).thenReturn(false);
+		tracker.retryPendingSellFocusTick();   // auto-recommend off → drop the pending retry
+
+		verify(apiClient, never()).getActiveFlipsAsync(anyString());
+		// Only the initial autoFocus attempt ran; the off-tick must not re-resolve.
+		verify(autoRecommendService, times(1)).overrideFocusForSell(anyInt(), anyString());
+
+		// Pending was actually cleared: re-enabling and ticking again is a no-op.
+		when(autoRecommendService.isActive()).thenReturn(true);
+		tracker.retryPendingSellFocusTick();
+		verify(autoRecommendService, times(1)).overrideFocusForSell(anyInt(), anyString());
+	}
+}

--- a/src/test/java/com/flipsmart/api/ApiHttpTransportParseTest.java
+++ b/src/test/java/com/flipsmart/api/ApiHttpTransportParseTest.java
@@ -1,0 +1,51 @@
+package com.flipsmart.api;
+
+import com.flipsmart.FlipSmartConfig;
+import com.flipsmart.api.dto.OfferAdviceResponse;
+import com.google.gson.Gson;
+import okhttp3.OkHttpClient;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Pins the shared {@link ApiHttpTransport#parse(String, Class)} helper that
+ * replaces the per-endpoint {@code gson.fromJson(body, T.class)} boilerplate.
+ * It is a thin delegate to the transport's Gson, so it must behave exactly as a
+ * direct {@code gson.fromJson} call — including returning {@code null} for an
+ * empty/null body.
+ */
+public class ApiHttpTransportParseTest
+{
+	private ApiHttpTransport transport;
+
+	@Before
+	public void setUp()
+	{
+		transport = new ApiHttpTransport(
+			mock(OkHttpClient.class), new Gson(), mock(FlipSmartConfig.class));
+	}
+
+	@Test
+	public void parseDeserializesDtoBody()
+	{
+		OfferAdviceResponse r = transport.parse(
+			"{\"action\":\"wait\",\"reason\":\"hold\"}", OfferAdviceResponse.class);
+		assertEquals("wait", r.getAction());
+		assertEquals("hold", r.getReason());
+	}
+
+	@Test
+	public void parseReturnsNullForEmptyBody()
+	{
+		assertNull(transport.parse("", OfferAdviceResponse.class));
+	}
+
+	@Test
+	public void parseReturnsNullForNullBody()
+	{
+		assertNull(transport.parse(null, OfferAdviceResponse.class));
+	}
+}

--- a/src/test/java/com/flipsmart/api/dto/EntitlementsResponseTest.java
+++ b/src/test/java/com/flipsmart/api/dto/EntitlementsResponseTest.java
@@ -1,0 +1,118 @@
+package com.flipsmart.api.dto;
+
+import com.google.gson.Gson;
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Pins the defensive entitlement-parsing behavior extracted from
+ * {@code ApiHttpTransport.fetchEntitlementsAsync}. The branches below mirror the
+ * exact hand-rolled guards that were in the transport: premium defaults to false
+ * unless {@code is_premium} is a JSON primitive that reads truthy; an rsn is
+ * blocked only when {@code rsn_entitlement.status == "blocked"}; everything is
+ * safe on null/missing values.
+ */
+public class EntitlementsResponseTest
+{
+	private final Gson gson = new Gson();
+
+	private EntitlementsResponse parse(String json)
+	{
+		return EntitlementsResponse.fromJson(gson, json);
+	}
+
+	// ---- premium branches ----
+
+	@Test
+	public void premiumTrueWhenIsPremiumTrue()
+	{
+		assertTrue(parse("{\"is_premium\":true}").isPremium());
+	}
+
+	@Test
+	public void premiumFalseWhenIsPremiumFalse()
+	{
+		assertFalse(parse("{\"is_premium\":false}").isPremium());
+	}
+
+	@Test
+	public void premiumFalseWhenIsPremiumMissing()
+	{
+		assertFalse(parse("{}").isPremium());
+	}
+
+	@Test
+	public void premiumFalseWhenIsPremiumNonPrimitive()
+	{
+		// A non-primitive (object) is_premium must default to false WITHOUT throwing,
+		// so the rest of the payload (rsn_entitlement) is still evaluated.
+		EntitlementsResponse r = parse("{\"is_premium\":{},\"rsn_entitlement\":{\"status\":\"blocked\"}}");
+		assertFalse(r.isPremium());
+		assertTrue("non-primitive premium must not abort rsn parsing", r.isRsnBlocked());
+	}
+
+	@Test
+	public void premiumFalseWhenIsPremiumNull()
+	{
+		assertFalse(parse("{\"is_premium\":null}").isPremium());
+	}
+
+	// ---- rsn-entitlement branches ----
+
+	@Test
+	public void rsnBlockedWhenStatusBlocked()
+	{
+		assertTrue(parse("{\"rsn_entitlement\":{\"status\":\"blocked\"}}").isRsnBlocked());
+	}
+
+	@Test
+	public void rsnNotBlockedWhenStatusOther()
+	{
+		assertFalse(parse("{\"rsn_entitlement\":{\"status\":\"active\"}}").isRsnBlocked());
+	}
+
+	@Test
+	public void rsnNotBlockedWhenStatusMissing()
+	{
+		assertFalse(parse("{\"rsn_entitlement\":{}}").isRsnBlocked());
+	}
+
+	@Test
+	public void rsnNotBlockedWhenEntitlementNull()
+	{
+		assertFalse(parse("{\"rsn_entitlement\":null}").isRsnBlocked());
+	}
+
+	@Test
+	public void rsnNotBlockedWhenEntitlementMissing()
+	{
+		assertFalse(parse("{}").isRsnBlocked());
+	}
+
+	// ---- whole-body safety ----
+
+	@Test
+	public void emptyBodyIsSafeBothFalse()
+	{
+		EntitlementsResponse r = parse("");
+		assertFalse(r.isPremium());
+		assertFalse(r.isRsnBlocked());
+	}
+
+	@Test
+	public void nullBodyIsSafeBothFalse()
+	{
+		EntitlementsResponse r = parse(null);
+		assertFalse(r.isPremium());
+		assertFalse(r.isRsnBlocked());
+	}
+
+	@Test
+	public void premiumAndBlockedTogether()
+	{
+		EntitlementsResponse r = parse("{\"is_premium\":true,\"rsn_entitlement\":{\"status\":\"blocked\"}}");
+		assertTrue(r.isPremium());
+		assertTrue(r.isRsnBlocked());
+	}
+}

--- a/src/test/java/com/flipsmart/api/dto/SeamDtoDeserializationTest.java
+++ b/src/test/java/com/flipsmart/api/dto/SeamDtoDeserializationTest.java
@@ -1,0 +1,107 @@
+package com.flipsmart.api.dto;
+
+import com.google.gson.Gson;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Round-trip deserialization coverage for the endpoint-group response DTOs the
+ * #731 split exposed (now parsed via {@code ApiHttpTransport.parse}). These pin
+ * the snake_case wire-key → field mappings so a renamed {@code @SerializedName}
+ * or field can't silently drop data from a response.
+ */
+public class SeamDtoDeserializationTest
+{
+	private final Gson gson = new Gson();
+
+	@Test
+	public void flipStatisticsResponseMapsSnakeCaseKeys()
+	{
+		String json = "{\"total_flips\":42,\"successful_flips\":30,\"total_profit\":1500000,"
+			+ "\"success_rate\":0.714,\"average_roi\":12.5}";
+		FlipStatisticsResponse r = gson.fromJson(json, FlipStatisticsResponse.class);
+		assertEquals(42, r.getTotalFlips());
+		assertEquals(30, r.getSuccessfulFlips());
+		assertEquals(1500000, r.getTotalProfit());
+		assertEquals(0.714, r.getSuccessRate(), 1e-9);
+		assertEquals(12.5, r.getAverageRoi(), 1e-9);
+	}
+
+	@Test
+	public void flipFinderResponseMapsKeysNestedSubscriptionAndRecommendations()
+	{
+		String json = "{\"flip_style\":\"high_volume\",\"cash_stack\":50000000,"
+			+ "\"per_slot_budget\":6250000.0,\"total_items_analyzed\":3500,"
+			+ "\"items_matching_criteria\":120,"
+			+ "\"recommendations\":[{\"item_id\":4151,\"item_name\":\"Abyssal whip\"}],"
+			+ "\"subscription\":{\"tier\":\"premium\",\"recommendation_limit\":50,"
+			+ "\"recommendations_returned\":40}}";
+		FlipFinderResponse r = gson.fromJson(json, FlipFinderResponse.class);
+		assertEquals("high_volume", r.getFlipStyle());
+		assertEquals(Integer.valueOf(50000000), r.getCashStack());
+		assertEquals(Double.valueOf(6250000.0), r.getPerSlotBudget());
+		assertEquals(3500, r.getTotalItemsAnalyzed());
+		assertEquals(120, r.getItemsMatchingCriteria());
+		assertEquals(1, r.getRecommendations().size());
+		assertEquals(4151, r.getRecommendations().get(0).getItemId());
+		assertEquals("premium", r.getSubscription().getTier());
+		assertEquals(Integer.valueOf(50), r.getSubscription().getRecommendationLimit());
+		assertTrue("premium-tier subscription must read as premium", r.isPremium());
+	}
+
+	@Test
+	public void flipFinderResponseNonPremiumTierIsNotPremium()
+	{
+		String json = "{\"subscription\":{\"tier\":\"free\"}}";
+		FlipFinderResponse r = gson.fromJson(json, FlipFinderResponse.class);
+		assertFalse(r.isPremium());
+	}
+
+	@Test
+	public void flipFinderResponseMissingSubscriptionIsNotPremium()
+	{
+		FlipFinderResponse r = gson.fromJson("{\"flip_style\":\"balanced\"}", FlipFinderResponse.class);
+		assertFalse("absent subscription must not throw and must read as non-premium", r.isPremium());
+	}
+
+	@Test
+	public void completedFlipsResponseMapsListAndCount()
+	{
+		String json = "{\"count\":2,\"flips\":["
+			+ "{\"id\":1,\"item_id\":4151,\"item_name\":\"Abyssal whip\",\"quantity\":1},"
+			+ "{\"id\":2,\"item_id\":1305,\"item_name\":\"Dragon longsword\",\"quantity\":5}]}";
+		CompletedFlipsResponse r = gson.fromJson(json, CompletedFlipsResponse.class);
+		assertEquals(2, r.getCount());
+		assertEquals(2, r.getFlips().size());
+		assertEquals(4151, r.getFlips().get(0).getItemId());
+	}
+
+	@Test
+	public void blocklistsResponseMapsListCountAndNestedSnakeCaseKeys()
+	{
+		String json = "{\"count\":1,\"blocklists\":[{\"id\":7,\"name\":\"My list\","
+			+ "\"description\":\"d\",\"item_count\":3,\"share_id\":\"abc\",\"is_public\":true}]}";
+		BlocklistsResponse r = gson.fromJson(json, BlocklistsResponse.class);
+		assertEquals(1, r.getCount());
+		assertEquals(1, r.getBlocklists().size());
+		BlocklistSummary s = r.getBlocklists().get(0);
+		assertEquals(7, s.getId());
+		assertEquals(3, s.getItemCount());
+		assertEquals("abc", s.getShareId());
+		assertTrue(s.isPublic());
+	}
+
+	@Test
+	public void bankSnapshotStatusResponseMapsSnakeCaseKeys()
+	{
+		String json = "{\"can_snapshot\":false,\"next_snapshot_available\":\"2026-07-01T00:00:00Z\","
+			+ "\"hours_until_available\":4.5,\"message\":\"rate limited\"}";
+		BankSnapshotStatusResponse r = gson.fromJson(json, BankSnapshotStatusResponse.class);
+		assertFalse(r.isCanSnapshot());
+		assertEquals("2026-07-01T00:00:00Z", r.getNextSnapshotAvailable());
+		assertEquals(Double.valueOf(4.5), r.getHoursUntilAvailable());
+		assertEquals("rate limited", r.getMessage());
+	}
+}


### PR DESCRIPTION
## Summary

Introduces `EntitlementsResponse` DTO + static mapper, replacing the hand-rolled `JsonObject` walk in `ApiHttpTransport.fetchEntitlementsAsync` with a characterization-pinned identical implementation. Adds 31 new unit tests covering entitlement parsing edge cases, stale re-sell focus tri-state branches, tick-retry guard regressions, and seam-DTO round-trips from the #731 redesign. No production behavior changes — the refactor is fully pinned by the new test suite.

## Changes

### ♻️ Refactoring
- New `com.flipsmart.api.dto.EntitlementsResponse` DTO with static `fromJson` mapper replaces the inline `JsonObject` walk in `ApiHttpTransport.fetchEntitlementsAsync`; `is_premium` held as a raw `JsonElement` so a non-primitive value safely defaults to `false` (no behavioral change)
- Removed now-unused `JSON_KEY_RSN_ENTITLEMENT` constant from `ApiHttpTransport`
- Added `ApiHttpTransport.parse(body, Class)` helper (behavior-neutral Gson delegate); adopted in pure-DTO endpoint groups (Motd/BankSnapshot/Blocklist/Flips/OfferAction), dropping their redundant `gson` field

### ✅ Tests — +31 unit tests
- `EntitlementsResponseTest` (13 tests): pins every premium branch (`true`/`false`/missing/non-primitive/`null`) and rsn-entitlement branch (blocked/non-blocked/missing-status/null/missing-key) + null/empty-body safety
- `OverrideFocusForSellTest` (5 tests): covers `overrideFocusForSell` tri-state UNAVAILABLE branches (inactive, null session, unresolvable price, zero quantity) and the clean FOCUSED-fires-callback path
- `SellFocusRetryTest` (3 tests): pins `GrandExchangeTracker` tick-retry — settles to FOCUSED within budget without API fallback; falls back to `tryAsyncSellFocus`/`getActiveFlipsAsync` exactly on budget exhaustion (guards the `3c6e53d` regression); clears pending retry when auto-recommend is turned off
- `ApiHttpTransportParseTest` (3 tests): covers the new `parse` helper
- `SeamDtoDeserializationTest` (7 tests): round-trip coverage for the #731 seam response DTOs (`FlipStatistics`/`FlipFinder`/`CompletedFlips`/`Blocklists`/`BankSnapshotStatus`), pinning snake_case wire-key mappings

## Testing

### Automated Tests
- `./gradlew build` — 324 tests, 0 failures, 0 errors
- Checkstyle: no violations
- All tests UP-TO-DATE after full build

### Manual Testing
- No production behavior change; manual testing not required for this PR

### Acceptance Criteria
- [x] `EntitlementsResponse` DTO + mapper replaces manual `JsonObject` parsing (behavior identical, pinned by test suite)
- [x] Unit tests cover all premium branches (`true`/`false`/missing/non-primitive/`null`) and all rsn-entitlement branches
- [x] `SellFocusRetryTest` guards the `3c6e53d` regression (budget-exhaustion fallback path)
- [x] `./gradlew build` green — 324 tests pass
- [x] No issue-ref comments in plugin main source (LOC budget — verified by diff scan)

## Deployment Notes

- No migration required
- No new dependencies
- No environment variable changes
- Pure test/refactor PR — no behavioral change to ship separately

## Checklist

- [x] Tests added — 31 new unit tests
- [x] No console.log / debug code left
- [x] Source comments clean (no issue refs in `src/main/java/`, test javadoc is exempt)
- [x] Commits are clean and descriptive
- [x] Build passes locally

## Related Issues

Closes Flip-Smart/flip-smart#750

---

## 🤖 Codacy AI Reviewer — 4 comments processed

| Disposition | File | Note |
|---|---|---|
| Fixed (ac3f377) | `EntitlementsResponse.java:20` | Renamed field `isPremium` → `premiumElement` to resolve `PMD_AvoidFieldNameMatchingMethodName` |
| False Positive | `SellFocusRetryTest.java:30` | `PMD_SingularField` does not account for JUnit `@Before` / Mockito fixture lifecycle |
| Fixed (46ea3f5) | `ApiHttpTransport.java:91` | Rephrased incomplete Javadoc sentence for grammatical clarity |
| False Positive | `ApiHttpTransport.java:43` | `JSON_KEY_IS_PREMIUM` (line 507) and `JSON_KEY_STATUS` (line 1011) are actively used; only `JSON_KEY_RSN_ENTITLEMENT` was removed |

## 🩺 Codacy Quality Gate — 6 issues resolved

| Disposition | Count | Rule | Files |
|---|---|---|---|
| Fixed (ac3f377) | 1 | `PMD_AvoidFieldNameMatchingMethodName` | `EntitlementsResponse.java` |
| Dismissed | 5 | `PMD_SingularField` | `SellFocusRetryTest.java` (×4), `OverrideFocusForSellTest.java` (×1) — false positives in JUnit/Mockito test fixture context |