### PR TITLE
perf: dedupe RSN pushes per session; extend analysis cache TTL, coalesce in-flight fetches

### DIFF
--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -155,9 +155,9 @@ public class FlipSmartApiClient
 		transport.setAuthToken(token);
 	}
 
-	public void updateRSN(String rsn)
+	public CompletableFuture<Boolean> updateRSN(String rsn)
 	{
-		transport.updateRSN(rsn);
+		return transport.updateRSN(rsn);
 	}
 
 	public void clearAuth()

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -14,6 +14,7 @@ import com.flipsmart.util.GpUtils;
 import com.flipsmart.plugin.EventRouter;
 import com.flipsmart.plugin.PanelRefreshCoalescer;
 import com.flipsmart.plugin.PluginScheduler;
+import com.flipsmart.plugin.RsnSyncGate;
 import com.flipsmart.plugin.ServiceWiring;
 
 import com.google.gson.Gson;
@@ -197,6 +198,7 @@ public class FlipSmartPlugin extends Plugin
 	// populated, so syncRSN couldn't capture the current account's name. The
 	// onGameTick handler retries until it succeeds. Issue #556.
 	private volatile boolean rsnSyncPending;
+	private final RsnSyncGate rsnSyncGate = new RsnSyncGate();
 
 	// Cached world-type flag — updated on the client thread (WorldChanged, login) and read
 	// from any thread (Swing EDT, scheduler). Defaults to true so unlinked callers see more items.
@@ -1199,7 +1201,27 @@ public class FlipSmartPlugin extends Plugin
 		{
 			log.debug("RSN synced: {}", rsn);
 		}
-		apiClient.updateRSN(rsn);
+		pushRsnIfNeeded(rsn);
+	}
+
+	/**
+	 * Push the RSN to the backend only when it has not been confirmed pushed
+	 * this client session — LOGGED_IN fires on every world hop, not just logins.
+	 */
+	private void pushRsnIfNeeded(String rsn)
+	{
+		if (!rsnSyncGate.shouldPush(rsn))
+		{
+			log.debug("RSN already pushed this session, skipping: {}", rsn);
+			return;
+		}
+		apiClient.updateRSN(rsn).thenAccept(confirmed ->
+		{
+			if (Boolean.TRUE.equals(confirmed))
+			{
+				rsnSyncGate.markPushed(rsn);
+			}
+		});
 	}
 
 	/**
@@ -1448,7 +1470,9 @@ public class FlipSmartPlugin extends Plugin
 			if (session.getRsn() != null && !session.getRsn().isEmpty())
 			{
 				log.debug("Auth success callback - syncing RSN: {}", session.getRsn());
-				apiClient.updateRSN(session.getRsn());
+				// A fresh auth is a new backend session; the old pushed state no longer proves the binding exists
+				rsnSyncGate.reset();
+				pushRsnIfNeeded(session.getRsn());
 			}
 			else
 			{

--- a/src/main/java/com/flipsmart/api/ApiHttpTransport.java
+++ b/src/main/java/com/flipsmart/api/ApiHttpTransport.java
@@ -1086,13 +1086,15 @@ public class ApiHttpTransport
 	}
 
 	/**
-	 * Update the user's RuneScape Name on the server (async)
+	 * Update the user's RuneScape Name on the server (async).
+	 *
+	 * @return future completing true only when the server confirmed the update
 	 */
-	public void updateRSN(String rsn)
+	public CompletableFuture<Boolean> updateRSN(String rsn)
 	{
 		if (rsn == null || rsn.isEmpty())
 		{
-			return;
+			return CompletableFuture.completedFuture(false);
 		}
 
 		String apiUrl = getApiUrl();
@@ -1102,7 +1104,7 @@ public class ApiHttpTransport
 			.url(url)
 			.put(RequestBody.create(JSON, ""));
 
-		executeAuthenticatedAsync(requestBuilder, jsonData ->
+		return executeAuthenticatedAsync(requestBuilder, jsonData ->
 		{
 			log.debug("Successfully updated RSN to: {}", rsn);
 			return true;

--- a/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
@@ -13,41 +13,59 @@ import okhttp3.RequestBody;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
 
 import static com.flipsmart.api.ApiHttpTransport.JSON;
 import static com.flipsmart.api.ApiHttpTransport.urlEncode;
 
 /**
  * Item analysis, flip recommendations and flip-adjustment endpoints.
- * Owns the per-item analysis cache.
+ * Owns the per-item analysis cache. Analysis feeds slow-moving card display
+ * fields (buy limit, liquidity, risk), so a long TTL is acceptable; live
+ * prices on cards come from the active-flips payload, not from here.
  */
 public class FlipsEndpoints
 {
 	private static final String JSON_KEY_ITEM_ID = "item_id";
-	private static final long CACHE_DURATION_MS = 180_000; // 3 minute cache
+	static final long CACHE_DURATION_MS = 900_000;
 
 	private final ApiHttpTransport transport;
+	private final LongSupplier clock;
 
 	// Cache to avoid spamming the API
 	private final Map<Integer, CachedAnalysis> analysisCache = new ConcurrentHashMap<>();
+	private final Map<Integer, CompletableFuture<FlipAnalysis>> inFlightAnalysis = new ConcurrentHashMap<>();
 
 	public FlipsEndpoints(ApiHttpTransport transport)
 	{
+		this(transport, System::currentTimeMillis);
+	}
+
+	FlipsEndpoints(ApiHttpTransport transport, LongSupplier clock)
+	{
 		this.transport = transport;
+		this.clock = clock;
 	}
 
 	/**
-	 * Fetch item analysis from the API asynchronously
+	 * Fetch item analysis from the API asynchronously. Served from the per-item
+	 * cache while fresh; concurrent requests for the same item share one call.
 	 */
 	public CompletableFuture<FlipAnalysis> getItemAnalysisAsync(int itemId)
 	{
-		// Check cache first
 		CachedAnalysis cached = analysisCache.get(itemId);
-		if (cached != null && !cached.isExpired())
+		if (cached != null && !cached.isExpired(clock.getAsLong()))
 		{
 			return CompletableFuture.completedFuture(cached.getAnalysis());
 		}
 
+		CompletableFuture<FlipAnalysis> future = inFlightAnalysis.computeIfAbsent(itemId, this::fetchItemAnalysis);
+		future.whenComplete((analysis, error) -> inFlightAnalysis.remove(itemId, future));
+		return future;
+	}
+
+	private CompletableFuture<FlipAnalysis> fetchItemAnalysis(int itemId)
+	{
 		String apiUrl = transport.getApiUrl();
 		String url = String.format("%s/analysis/%d?timeframe=1h", apiUrl, itemId);
 
@@ -58,8 +76,11 @@ public class FlipsEndpoints
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
 		{
 			FlipAnalysis analysis = transport.parse(jsonData, FlipAnalysis.class);
-			removeExpiredCacheEntries();
-			analysisCache.put(itemId, new CachedAnalysis(analysis));
+			if (analysis != null)
+			{
+				removeExpiredCacheEntries();
+				analysisCache.put(itemId, new CachedAnalysis(analysis, clock.getAsLong()));
+			}
 			return analysis;
 		});
 	}
@@ -210,7 +231,8 @@ public class FlipsEndpoints
 	 */
 	private void removeExpiredCacheEntries()
 	{
-		analysisCache.entrySet().removeIf(entry -> entry.getValue().isExpired());
+		long now = clock.getAsLong();
+		analysisCache.entrySet().removeIf(entry -> entry.getValue().isExpired(now));
 	}
 
 	/**
@@ -221,10 +243,10 @@ public class FlipsEndpoints
 		private final FlipAnalysis analysis;
 		private final long timestamp;
 
-		CachedAnalysis(FlipAnalysis analysis)
+		CachedAnalysis(FlipAnalysis analysis, long now)
 		{
 			this.analysis = analysis;
-			this.timestamp = System.currentTimeMillis();
+			this.timestamp = now;
 		}
 
 		FlipAnalysis getAnalysis()
@@ -232,9 +254,9 @@ public class FlipsEndpoints
 			return analysis;
 		}
 
-		boolean isExpired()
+		boolean isExpired(long now)
 		{
-			return System.currentTimeMillis() - timestamp > CACHE_DURATION_MS;
+			return now - timestamp > CACHE_DURATION_MS;
 		}
 	}
 }

--- a/src/main/java/com/flipsmart/plugin/RsnSyncGate.java
+++ b/src/main/java/com/flipsmart/plugin/RsnSyncGate.java
@@ -9,7 +9,7 @@ package com.flipsmart.plugin;
  */
 public class RsnSyncGate
 {
-	private volatile String lastPushedRsn;
+	private volatile String lastPushedRsn = "";
 
 	public boolean shouldPush(String rsn)
 	{
@@ -24,6 +24,6 @@ public class RsnSyncGate
 	/** Forget the pushed state so the next sync pushes again (e.g. after re-auth). */
 	public void reset()
 	{
-		lastPushedRsn = null;
+		lastPushedRsn = "";
 	}
 }

--- a/src/main/java/com/flipsmart/plugin/RsnSyncGate.java
+++ b/src/main/java/com/flipsmart/plugin/RsnSyncGate.java
@@ -1,0 +1,29 @@
+package com.flipsmart.plugin;
+
+/**
+ * Deduplicates RSN pushes to the backend. The RSN sync path fires on every
+ * LOGGED_IN transition — including every world hop — but the backend only
+ * needs to hear about an RSN it has not been told about this client session.
+ * Callers mark a push only after the backend confirms it, so a failed push
+ * is retried on the next login transition.
+ */
+public class RsnSyncGate
+{
+	private volatile String lastPushedRsn;
+
+	public boolean shouldPush(String rsn)
+	{
+		return rsn != null && !rsn.isEmpty() && !rsn.equals(lastPushedRsn);
+	}
+
+	public void markPushed(String rsn)
+	{
+		lastPushedRsn = rsn;
+	}
+
+	/** Forget the pushed state so the next sync pushes again (e.g. after re-auth). */
+	public void reset()
+	{
+		lastPushedRsn = null;
+	}
+}

--- a/src/test/java/com/flipsmart/api/endpoints/FlipsEndpointsAnalysisCacheTest.java
+++ b/src/test/java/com/flipsmart/api/endpoints/FlipsEndpointsAnalysisCacheTest.java
@@ -1,0 +1,156 @@
+package com.flipsmart.api.endpoints;
+
+import com.flipsmart.api.ApiHttpTransport;
+import com.flipsmart.domain.flip.FlipAnalysis;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the analysis-cache contract behind getItemAnalysisAsync: fresh entries
+ * are served without a network call, concurrent misses share one in-flight
+ * request, expiry triggers a refetch, and null (failed) results are never
+ * cached.
+ */
+public class FlipsEndpointsAnalysisCacheTest
+{
+	private static final int ITEM_ID = 4151;
+	private static final String JSON_BODY = "{}";
+
+	private final long[] now = {0L};
+	private final List<PendingRequest> requests = new ArrayList<>();
+	private ApiHttpTransport transport;
+	private FlipsEndpoints endpoints;
+	private FlipAnalysis parsed;
+
+	private static class PendingRequest
+	{
+		final Function<String, FlipAnalysis> handler;
+		final CompletableFuture<FlipAnalysis> future = new CompletableFuture<>();
+
+		PendingRequest(Function<String, FlipAnalysis> handler)
+		{
+			this.handler = handler;
+		}
+
+		void completeWithBody(String body)
+		{
+			future.complete(handler.apply(body));
+		}
+	}
+
+	@Before
+	@SuppressWarnings("unchecked")
+	public void setUp()
+	{
+		transport = mock(ApiHttpTransport.class);
+		parsed = new FlipAnalysis();
+		when(transport.getApiUrl()).thenReturn("http://localhost:8000");
+		when(transport.parse(anyString(), eq(FlipAnalysis.class))).thenReturn(parsed);
+		when(transport.executeAuthenticatedAsync(any(), any(Function.class))).thenAnswer(invocation ->
+		{
+			PendingRequest pending = new PendingRequest(invocation.getArgument(1));
+			requests.add(pending);
+			return pending.future;
+		});
+		endpoints = new FlipsEndpoints(transport, () -> now[0]);
+	}
+
+	@Test
+	public void freshCacheEntryIsServedWithoutNetworkCall()
+	{
+		endpoints.getItemAnalysisAsync(ITEM_ID);
+		requests.get(0).completeWithBody(JSON_BODY);
+
+		FlipAnalysis second = endpoints.getItemAnalysisAsync(ITEM_ID).join();
+
+		assertEquals("cached result must not trigger a second request", 1, requests.size());
+		assertSame(parsed, second);
+	}
+
+	@Test
+	public void concurrentMissesShareOneInFlightRequest()
+	{
+		CompletableFuture<FlipAnalysis> first = endpoints.getItemAnalysisAsync(ITEM_ID);
+		CompletableFuture<FlipAnalysis> second = endpoints.getItemAnalysisAsync(ITEM_ID);
+
+		assertEquals("coalesced callers must share the single in-flight call", 1, requests.size());
+		requests.get(0).completeWithBody(JSON_BODY);
+		assertSame(parsed, first.join());
+		assertSame(parsed, second.join());
+	}
+
+	@Test
+	public void expiredEntryTriggersRefetch()
+	{
+		endpoints.getItemAnalysisAsync(ITEM_ID);
+		requests.get(0).completeWithBody(JSON_BODY);
+
+		now[0] = FlipsEndpoints.CACHE_DURATION_MS + 1;
+		endpoints.getItemAnalysisAsync(ITEM_ID);
+
+		assertEquals(2, requests.size());
+	}
+
+	@Test
+	public void entryJustInsideTtlStillServedFromCache()
+	{
+		endpoints.getItemAnalysisAsync(ITEM_ID);
+		requests.get(0).completeWithBody(JSON_BODY);
+
+		now[0] = FlipsEndpoints.CACHE_DURATION_MS;
+		endpoints.getItemAnalysisAsync(ITEM_ID);
+
+		assertEquals(1, requests.size());
+	}
+
+	@Test
+	public void nullResultIsNotCachedAndNextCallRetries()
+	{
+		when(transport.parse(anyString(), eq(FlipAnalysis.class))).thenReturn(null);
+
+		CompletableFuture<FlipAnalysis> first = endpoints.getItemAnalysisAsync(ITEM_ID);
+		requests.get(0).completeWithBody(JSON_BODY);
+		assertNull(first.join());
+
+		endpoints.getItemAnalysisAsync(ITEM_ID);
+		assertEquals("a null result must not poison the cache", 2, requests.size());
+	}
+
+	@Test
+	public void completedInFlightEntryIsReleased()
+	{
+		endpoints.getItemAnalysisAsync(ITEM_ID);
+		requests.get(0).completeWithBody(JSON_BODY);
+		now[0] = FlipsEndpoints.CACHE_DURATION_MS + 1;
+
+		CompletableFuture<FlipAnalysis> refetched = endpoints.getItemAnalysisAsync(ITEM_ID);
+
+		assertEquals("expired entry must start a new request, not reuse the finished one", 2, requests.size());
+		assertFalse(refetched.isDone());
+		requests.get(1).completeWithBody(JSON_BODY);
+		assertTrue(refetched.isDone());
+	}
+
+	@Test
+	public void differentItemsDoNotShareInFlightRequests()
+	{
+		endpoints.getItemAnalysisAsync(ITEM_ID);
+		endpoints.getItemAnalysisAsync(ITEM_ID + 1);
+
+		assertEquals(2, requests.size());
+	}
+}

--- a/src/test/java/com/flipsmart/plugin/RsnSyncGateTest.java
+++ b/src/test/java/com/flipsmart/plugin/RsnSyncGateTest.java
@@ -1,0 +1,67 @@
+package com.flipsmart.plugin;
+
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RsnSyncGateTest
+{
+	private static final String RSN_A = "PlayerOne";
+	private static final String RSN_B = "PlayerTwo";
+
+	@Test
+	public void pushesAnRsnItHasNeverSeen()
+	{
+		assertTrue(new RsnSyncGate().shouldPush(RSN_A));
+	}
+
+	@Test
+	public void suppressesRepeatPushOfConfirmedRsn()
+	{
+		RsnSyncGate gate = new RsnSyncGate();
+		gate.markPushed(RSN_A);
+		assertFalse("world hops re-trigger sync; a confirmed RSN must not re-push", gate.shouldPush(RSN_A));
+	}
+
+	@Test
+	public void pushesAgainWhenRsnChanges()
+	{
+		RsnSyncGate gate = new RsnSyncGate();
+		gate.markPushed(RSN_A);
+		assertTrue(gate.shouldPush(RSN_B));
+	}
+
+	@Test
+	public void unconfirmedPushStaysEligibleForRetry()
+	{
+		RsnSyncGate gate = new RsnSyncGate();
+		assertTrue(gate.shouldPush(RSN_A));
+		assertTrue("no markPushed happened, so the next transition must retry", gate.shouldPush(RSN_A));
+	}
+
+	@Test
+	public void resetForcesRepush()
+	{
+		RsnSyncGate gate = new RsnSyncGate();
+		gate.markPushed(RSN_A);
+		gate.reset();
+		assertTrue(gate.shouldPush(RSN_A));
+	}
+
+	@Test
+	public void neverPushesNullOrEmpty()
+	{
+		RsnSyncGate gate = new RsnSyncGate();
+		assertFalse(gate.shouldPush(null));
+		assertFalse(gate.shouldPush(""));
+	}
+
+	@Test
+	public void accountSwitchBackAndForthPushesEachSwitch()
+	{
+		RsnSyncGate gate = new RsnSyncGate();
+		gate.markPushed(RSN_A);
+		gate.markPushed(RSN_B);
+		assertTrue(gate.shouldPush(RSN_A));
+	}
+}


### PR DESCRIPTION
## Summary

Two independent plugin-only hygiene fixes that each cut a top-offending API call rate. RSN push dedupe removes redundant `PUT /auth/rsn` calls fired on every world hop (~53k/day fleet-wide), and the analysis-fetch cache change extends TTL and coalesces concurrent requests to cut `GET /analysis/{item_id}` volume, the single highest server-time endpoint (~1.4M calls/week). No backend changes are required for either fix.

## Changes

### ⚡ Performance

- **RSN push dedupe (`RsnSyncGate`)**: `syncRSN()` previously called `apiClient.updateRSN()` unconditionally on every `LOGGED_IN` game-state transition, including plain world hops. A new `com.flipsmart.plugin.RsnSyncGate` suppresses pushes for an RSN already confirmed-pushed this client session. `markPushed` only fires on a server-confirmed success (`transport.updateRSN` now returns `CompletableFuture<Boolean>` instead of `void`), so a failed push remains eligible for retry on the next transition. The panel's Discord auth-success callback resets the gate so a fresh binding re-pushes immediately. Expected: `PUT /auth/rsn` drops from one-per-world-hop to roughly one per login session / RSN change (~70-95% cut against a 368,640-call/7d Sentry baseline).
- **Analysis fetch reduction (`FlipsEndpoints`)**: `CACHE_DURATION_MS` raised from 180,000 to 900,000 (3 min → 15 min) — the fields this feeds (buy limit, liquidity, risk) are slow-moving display data; live card prices already come from the active-flips payload, not this endpoint. Added in-flight request coalescing so concurrent cache misses for the same item share a single request instead of fanning out. Failed (null) results are no longer cached — previously a null could be cached and pin a broken card for the full TTL, which matters more now that the TTL is 5x longer. Added an injectable clock (`LongSupplier`) for deterministic tests, mirroring the existing `ApiBackoffGate` pattern. Expected: ~80% fewer analysis fetches per user, stacking on top of the refresh-count reduction already shipped in #841.

### ✅ Tests

- `RsnSyncGateTest` — 7 new tests covering push/skip/retry-on-failure/reset behavior.
- `FlipsEndpointsAnalysisCacheTest` — 7 new tests covering TTL expiry, in-flight coalescing, and null-result non-caching.

## Testing

### Automated Tests
- ✅ `./gradlew clean build` → BUILD SUCCESSFUL
- ✅ 430 tests total / 0 failures / 0 errors (14 new: 7 `RsnSyncGateTest` + 7 `FlipsEndpointsAnalysisCacheTest`)

### Manual Testing (in-game, via `~/.runelite/logs/client.log`)
- [ ] Log in → exactly one "Successfully updated RSN to:" line; world-hop several times → "RSN already pushed this session, skipping" debug lines, NO further `/auth/rsn` PUTs.
- [ ] Switch to a different character → one new RSN push for the new name.
- [ ] With active flips on the panel, watch refreshes for >3 minutes → analysis fetches for the same items do NOT recur every 3 minutes (previously they did); a given item refetches at most every 15 minutes.

## API Changes

None — plugin-only change. No backend endpoints added, modified, or removed.

## SonarCloud

This repo has no GitHub Actions workflow configured to trigger per-branch/PR SonarCloud analysis (`gh api repos/Flip-Smart/flip-smart-runelite-plugin/actions/workflows` returns 0 workflows). Only `master` has ever been analyzed (last analysis 2026-06-02, pre-existing 2 bugs / 58 code smells, unrelated to this diff). No fresh scan is available for this branch; not treated as a blocker.

## Codacy

### 🩺 Codacy Quality Gate — fixed in this PR
- `d7651de` `PMD_category_java_errorprone_NullAssignment` `src/main/java/com/flipsmart/plugin/RsnSyncGate.java:27` — swapped the `reset()`/field-init sentinel from `null` to `""` (an RSN is never empty, so behavior is unchanged) to drop the explicit null-assignment PMD flagged.

### 🤖 Codacy AI Reviewer
No open `@codacy-production[bot]` review comments on this PR (verified directly via `gh api repos/.../pulls/172/comments`, 0 returned).

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: None
- [ ] Requires database migration: No (plugin-only, no backend touched)

## Checklist

- [x] Tests added/updated
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] No issue-number references or narrative comments in plugin source (verified via grep against the diff)
- [ ] In-game manual QA (see checklist above)
- [ ] Reviewed by teammate

## Related Issues

Closes Flip-Smart/flip-smart#844

