### PR TITLE
feat(plugin): trading-window settings cogwheel pop-out + FlipSmart overlay rename

### DIFF
--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -66,10 +66,10 @@ public class FlipAssistOverlay extends Overlay
 	private static final int STEP_INDICATOR_SIZE = 10;
 	
 	// Hint message
-	private static final String HINT_TITLE = "Flip Assist";
+	private static final String HINT_TITLE = "FlipSmart";
 	private static final String HINT_MESSAGE = "Click on a flip suggestion to start";
 	private static final String UPGRADE_MESSAGE = "Upgrade to Premium for more flip slots";
-	private static final String LOGIN_MESSAGE = "Log in to use Flip Assist";
+	private static final String LOGIN_MESSAGE = "Log in to use FlipSmart";
 	private static final String HISTORY_PROMPT_MESSAGE = "Open GE History tab to backfill recent trades";
 	private static final String MONITORING_MESSAGE = "Monitoring your flips";
 	
@@ -376,7 +376,7 @@ public class FlipAssistOverlay extends Overlay
 	/**
 	 * Render a small hint box with a title and message.
 	 * When an item icon is present, shows a two-line layout:
-	 *   "Flip Assist" title
+	 *   "FlipSmart" title
 	 *   "Collect items from GE" subtitle
 	 *   [icon] item name
 	 */

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1634,10 +1634,17 @@ public class FlipFinderPanel extends PluginPanel
 		}
 	}
 
-	/** Returns true if a recommendation passes the current profit filter. */
+	/** Returns true if a recommendation passes the current profit and volume filters. */
 	private boolean shouldDisplay(FlipRecommendation rec)
 	{
-		return FocusedFlip.calculateAdjustedProfit(rec, config.priceOffset()) >= config.minimumProfit();
+		return FocusedFlip.calculateAdjustedProfit(rec, config.priceOffset()) >= config.minimumProfit()
+			&& passesVolumeFilter(rec.getDailyVolume(), config.minimumVolume());
+	}
+
+	/** Returns true if a recommendation's daily volume meets the minimum-volume threshold. */
+	static boolean passesVolumeFilter(int dailyVolume, int minVolume)
+	{
+		return dailyVolume >= minVolume;
 	}
 
 	/** Returns the number of recommendations that pass the current profit filter. */

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -35,9 +35,9 @@ import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
@@ -83,7 +83,7 @@ public class FlipFinderPanel extends PluginPanel
 	private static final long SETTINGS_POPOUT_REOPEN_DEBOUNCE_MS = 200;
 	private static final int FILTER_SETTING_DEBOUNCE_MS = 300;
 
-	private final Map<String, Timer> filterSettingDebounceTimers = new HashMap<>();
+	private final Map<String, Timer> filterSettingDebounceTimers = new ConcurrentHashMap<>();
 
 	// Colors for focused/selected items
 	private static final Color COLOR_FOCUSED_BORDER = new Color(0, 200, 220);

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -303,18 +303,28 @@ public class FlipFinderPanel extends PluginPanel
 		// Logout button with compact styling
 		JButton logoutButton = new JButton("Logout");
 		logoutButton.setFocusable(false);
+		logoutButton.setFont(FONT_PLAIN_11);
 		logoutButton.setMargin(new Insets(2, 4, 2, 4));
 		logoutButton.addActionListener(e -> handleLogout());
 
 		// Refresh button with compact styling
 		refreshButton.setFocusable(false);
+		refreshButton.setFont(FONT_PLAIN_11);
 		refreshButton.setMargin(new Insets(2, 4, 2, 4));
 		refreshButton.addActionListener(e -> refresh(true));
+
+		JButton settingsButton = new JButton(new ImageIcon(PanelFormat.drawGearIcon(Color.LIGHT_GRAY, 12)));
+		settingsButton.setFocusable(false);
+		settingsButton.setFont(FONT_PLAIN_11);
+		settingsButton.setMargin(new Insets(1, 2, 1, 2));
+		settingsButton.setToolTipText("Quick settings");
+		settingsButton.addActionListener(e -> showSettingsPopout(settingsButton));
 
 		JPanel headerButtons = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 0));
 		headerButtons.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		headerButtons.add(logoutButton);
 		headerButtons.add(refreshButton);
+		headerButtons.add(settingsButton);
 
 		headerPanel.add(titleBox, BorderLayout.WEST);
 		headerPanel.add(headerButtons, BorderLayout.EAST);
@@ -450,15 +460,8 @@ public class FlipFinderPanel extends PluginPanel
 		});
 		skipButton.setVisible(false);
 
-		JButton settingsButton = new JButton(new ImageIcon(PanelFormat.drawGearIcon(Color.LIGHT_GRAY)));
-		settingsButton.setFocusable(false);
-		settingsButton.setMargin(new Insets(2, 4, 2, 4));
-		settingsButton.setToolTipText("Quick settings");
-		settingsButton.addActionListener(e -> showSettingsPopout(settingsButton));
-
 		JPanel styleRight = new JPanel(new FlowLayout(FlowLayout.RIGHT, 5, 0));
 		styleRight.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-		styleRight.add(settingsButton);
 		styleRight.add(autoRecommendButton);
 
 		styleRow.add(styleLeft, BorderLayout.WEST);

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -35,7 +35,9 @@ import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
@@ -79,6 +81,9 @@ public class FlipFinderPanel extends PluginPanel
 	private static final String MSG_LOGIN_TO_RUNESCAPE = "Log in to RuneScape";
 	private static final String MSG_LOGIN_INSTRUCTION = "<html><center>Log in to the game to get<br>flip suggestions and track your flips</center></html>";
 	private static final long SETTINGS_POPOUT_REOPEN_DEBOUNCE_MS = 200;
+	private static final int FILTER_SETTING_DEBOUNCE_MS = 300;
+
+	private final Map<String, Timer> filterSettingDebounceTimers = new HashMap<>();
 
 	// Colors for focused/selected items
 	private static final Color COLOR_FOCUSED_BORDER = new Color(0, 200, 220);
@@ -786,7 +791,7 @@ public class FlipFinderPanel extends PluginPanel
 		JSpinner spinner = new JSpinner(
 			new SpinnerNumberModel(config.minimumProfit(), 0, Integer.MAX_VALUE, 1000));
 		spinner.setToolTipText(FILTER_TOOLTIP);
-		spinner.addChangeListener(e -> applyFilterSetting(
+		spinner.addChangeListener(e -> applyFilterSettingDebounced(
 			CONFIG_KEY_MIN_PROFIT, (Integer) spinner.getValue()));
 
 		row.add(label);
@@ -807,7 +812,7 @@ public class FlipFinderPanel extends PluginPanel
 		JSpinner spinner = new JSpinner(
 			new SpinnerNumberModel(config.minimumVolume(), 0, Integer.MAX_VALUE, 100));
 		spinner.setToolTipText(FILTER_TOOLTIP);
-		spinner.addChangeListener(e -> applyFilterSetting(
+		spinner.addChangeListener(e -> applyFilterSettingDebounced(
 			CONFIG_KEY_MIN_VOLUME, (Integer) spinner.getValue()));
 
 		row.add(label);
@@ -837,6 +842,22 @@ public class FlipFinderPanel extends PluginPanel
 	{
 		configManager.setConfiguration(CONFIG_GROUP, key, value);
 		populateRecommendations(new ArrayList<>(currentRecommendations));
+	}
+
+	// Coalesces rapid spinner adjustments (e.g. holding the up/down arrows)
+	// into a single config save + re-populate after the user pauses.
+	private void applyFilterSettingDebounced(String key, int value)
+	{
+		Timer existing = filterSettingDebounceTimers.get(key);
+		if (existing != null && existing.isRunning())
+		{
+			existing.stop();
+		}
+
+		Timer timer = new Timer(FILTER_SETTING_DEBOUNCE_MS, e -> applyFilterSetting(key, value));
+		timer.setRepeats(false);
+		timer.start();
+		filterSettingDebounceTimers.put(key, timer);
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -29,6 +29,8 @@ import net.runelite.client.util.LinkBrowser;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -44,6 +46,11 @@ public class FlipFinderPanel extends PluginPanel
 	private static final String CONFIG_KEY_FLIP_STYLE = "flipStyle";
 	private static final String CONFIG_KEY_FLIP_TIMEFRAME = "flipTimeframe";
 	private static final String CONFIG_KEY_COMPLETED_SORT = "completedSort";
+	private static final String CONFIG_KEY_MIN_PROFIT = "minProfit";
+	private static final String CONFIG_KEY_MIN_VOLUME = "minVolume";
+	private static final String CONFIG_KEY_ENABLE_FLIP_ASSISTANT = "enableFlipAssistant";
+	private static final String FILTER_TOOLTIP =
+		"Adding a minimum filter may limit the number of results you see.";
 
 	/** Sort options for the Completed tab. Recency is the default (AC9). */
 	private enum CompletedSort
@@ -443,8 +450,15 @@ public class FlipFinderPanel extends PluginPanel
 		});
 		skipButton.setVisible(false);
 
+		JButton settingsButton = new JButton(new ImageIcon(PanelFormat.drawGearIcon(Color.LIGHT_GRAY)));
+		settingsButton.setFocusable(false);
+		settingsButton.setMargin(new Insets(2, 4, 2, 4));
+		settingsButton.setToolTipText("Quick settings");
+		settingsButton.addActionListener(e -> showSettingsPopout(settingsButton));
+
 		JPanel styleRight = new JPanel(new FlowLayout(FlowLayout.RIGHT, 5, 0));
 		styleRight.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		styleRight.add(settingsButton);
 		styleRight.add(autoRecommendButton);
 
 		styleRow.add(styleLeft, BorderLayout.WEST);
@@ -705,6 +719,120 @@ public class FlipFinderPanel extends PluginPanel
 		mainPanel.add(topPanel, BorderLayout.NORTH);
 		mainPanel.add(tabbedPane, BorderLayout.CENTER);
 		mainPanel.add(footerPanel, BorderLayout.SOUTH);
+	}
+
+	private long settingsPopupClosedAt = 0L;
+
+	private void showSettingsPopout(JComponent anchor)
+	{
+		// A click on the gear while the pop-out is open first dismisses it
+		// (light-weight popups close on any outside press), so without this
+		// guard the same click would immediately reopen it.
+		if (System.currentTimeMillis() - settingsPopupClosedAt < 200)
+		{
+			return;
+		}
+
+		JPopupMenu popup = new JPopupMenu();
+		popup.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		popup.addPopupMenuListener(new PopupMenuListener()
+		{
+			@Override
+			public void popupMenuWillBecomeVisible(PopupMenuEvent e)
+			{
+			}
+
+			@Override
+			public void popupMenuWillBecomeInvisible(PopupMenuEvent e)
+			{
+				settingsPopupClosedAt = System.currentTimeMillis();
+			}
+
+			@Override
+			public void popupMenuCanceled(PopupMenuEvent e)
+			{
+			}
+		});
+
+		JPanel body = new JPanel();
+		body.setLayout(new BoxLayout(body, BoxLayout.Y_AXIS));
+		body.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		body.setBorder(new EmptyBorder(8, 10, 8, 10));
+
+		body.add(buildMinProfitRow());
+		body.add(Box.createVerticalStrut(6));
+		body.add(buildMinVolumeRow());
+		body.add(Box.createVerticalStrut(6));
+		body.add(buildHideButtonsRow());
+
+		popup.add(body);
+		popup.show(anchor, 0, anchor.getHeight());
+	}
+
+	private JPanel buildMinProfitRow()
+	{
+		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
+		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+		JLabel label = new JLabel("Min Profit: ");
+		label.setForeground(Color.LIGHT_GRAY);
+		label.setFont(FONT_PLAIN_12);
+		label.setToolTipText(FILTER_TOOLTIP);
+
+		JSpinner spinner = new JSpinner(
+			new SpinnerNumberModel(config.minimumProfit(), 0, Integer.MAX_VALUE, 1000));
+		spinner.setToolTipText(FILTER_TOOLTIP);
+		spinner.addChangeListener(e -> applyFilterSetting(
+			CONFIG_KEY_MIN_PROFIT, (Integer) spinner.getValue()));
+
+		row.add(label);
+		row.add(spinner);
+		return row;
+	}
+
+	private JPanel buildMinVolumeRow()
+	{
+		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
+		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+		JLabel label = new JLabel("Min Volume: ");
+		label.setForeground(Color.LIGHT_GRAY);
+		label.setFont(FONT_PLAIN_12);
+		label.setToolTipText(FILTER_TOOLTIP);
+
+		JSpinner spinner = new JSpinner(
+			new SpinnerNumberModel(config.minimumVolume(), 0, Integer.MAX_VALUE, 100));
+		spinner.setToolTipText(FILTER_TOOLTIP);
+		spinner.addChangeListener(e -> applyFilterSetting(
+			CONFIG_KEY_MIN_VOLUME, (Integer) spinner.getValue()));
+
+		row.add(label);
+		row.add(spinner);
+		return row;
+	}
+
+	private JPanel buildHideButtonsRow()
+	{
+		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
+		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+		JCheckBox hide = new JCheckBox("Hide FlipSmart Buttons");
+		hide.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		hide.setForeground(Color.LIGHT_GRAY);
+		hide.setFont(FONT_PLAIN_12);
+		hide.setFocusable(false);
+		hide.setSelected(!config.enableFlipAssistant());
+		hide.addActionListener(e -> configManager.setConfiguration(
+			CONFIG_GROUP, CONFIG_KEY_ENABLE_FLIP_ASSISTANT, !hide.isSelected()));
+
+		row.add(hide);
+		return row;
+	}
+
+	private void applyFilterSetting(String key, int value)
+	{
+		configManager.setConfiguration(CONFIG_GROUP, key, value);
+		populateRecommendations(new ArrayList<>(currentRecommendations));
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -78,7 +78,8 @@ public class FlipFinderPanel extends PluginPanel
 	private static final String RISK_NA = "Risk: N/A";
 	private static final String MSG_LOGIN_TO_RUNESCAPE = "Log in to RuneScape";
 	private static final String MSG_LOGIN_INSTRUCTION = "<html><center>Log in to the game to get<br>flip suggestions and track your flips</center></html>";
-	
+	private static final long SETTINGS_POPOUT_REOPEN_DEBOUNCE_MS = 200;
+
 	// Colors for focused/selected items
 	private static final Color COLOR_FOCUSED_BORDER = new Color(0, 200, 220);
 	private static final Color COLOR_FOCUSED_BG = new Color(0, 60, 70);
@@ -724,14 +725,14 @@ public class FlipFinderPanel extends PluginPanel
 		mainPanel.add(footerPanel, BorderLayout.SOUTH);
 	}
 
-	private long settingsPopupClosedAt = 0L;
+	private long settingsPopupClosedAt;
 
 	private void showSettingsPopout(JComponent anchor)
 	{
 		// A click on the gear while the pop-out is open first dismisses it
 		// (light-weight popups close on any outside press), so without this
 		// guard the same click would immediately reopen it.
-		if (System.currentTimeMillis() - settingsPopupClosedAt < 200)
+		if (System.currentTimeMillis() - settingsPopupClosedAt < SETTINGS_POPOUT_REOPEN_DEBOUNCE_MS)
 		{
 			return;
 		}

--- a/src/main/java/com/flipsmart/FlipSmartConfig.java
+++ b/src/main/java/com/flipsmart/FlipSmartConfig.java
@@ -168,6 +168,18 @@ public interface FlipSmartConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "minVolume",
+		name = "Minimum Volume",
+		description = "Hide recommendations with daily trade volume below this value",
+		section = flipFinderSection,
+		position = 5
+	)
+	default int minimumVolume()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
 		keyName = "cashstackOverrideEnabled",
 		name = "Cashstack Override",
 		description = "Override your in-game cashstack with a fixed amount. The plugin will suggest flips based on this value instead of your actual inventory cash. Supports shorthand input: e.g. 500k, 2.5m, 10M.",

--- a/src/main/java/com/flipsmart/FlipSmartConfig.java
+++ b/src/main/java/com/flipsmart/FlipSmartConfig.java
@@ -172,7 +172,7 @@ public interface FlipSmartConfig extends Config
 		name = "Minimum Volume",
 		description = "Hide recommendations with daily trade volume below this value",
 		section = flipFinderSection,
-		position = 5
+		position = 9
 	)
 	default int minimumVolume()
 	{

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -230,6 +230,47 @@ public final class PanelFormat
 	}
 
 	/**
+	 * Draw a gear/cogwheel icon onto a 14x14 image with the given color.
+	 */
+	public static BufferedImage drawGearIcon(Color color)
+	{
+		int size = 14;
+		BufferedImage icon = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = icon.createGraphics();
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+		g.setColor(color);
+		g.setStroke(new BasicStroke(2f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+
+		double cx = size / 2.0;
+		double cy = size / 2.0;
+		double toothTip = size / 2.0 - 1.0;
+		double body = toothTip - 2.5;
+		int teeth = 8;
+
+		for (int i = 0; i < teeth; i++)
+		{
+			double a = Math.PI * 2 * i / teeth;
+			int x1 = (int) Math.round(cx + Math.cos(a) * body);
+			int y1 = (int) Math.round(cy + Math.sin(a) * body);
+			int x2 = (int) Math.round(cx + Math.cos(a) * toothTip);
+			int y2 = (int) Math.round(cy + Math.sin(a) * toothTip);
+			g.drawLine(x1, y1, x2, y2);
+		}
+
+		int bodyDia = (int) Math.round(body * 2);
+		g.fillOval((int) Math.round(cx - body), (int) Math.round(cy - body), bodyDia, bodyDia);
+
+		double hole = body * 0.45;
+		int holeDia = (int) Math.round(hole * 2);
+		g.setComposite(AlphaComposite.Clear);
+		g.fillOval((int) Math.round(cx - hole), (int) Math.round(cy - hole), holeDia, holeDia);
+
+		g.dispose();
+		return icon;
+	}
+
+	/**
 	 * Draw a ban/circle-slash icon onto a 14x14 image with the given color.
 	 */
 	public static BufferedImage drawBlockIcon(Color color)

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -232,9 +232,8 @@ public final class PanelFormat
 	/**
 	 * Draw a gear/cogwheel icon onto a 14x14 image with the given color.
 	 */
-	public static BufferedImage drawGearIcon(Color color)
+	public static BufferedImage drawGearIcon(Color color, int size)
 	{
-		int size = 14;
 		BufferedImage icon = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
 		Graphics2D g = icon.createGraphics();
 		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -230,7 +230,7 @@ public final class PanelFormat
 	}
 
 	/**
-	 * Draw a gear/cogwheel icon onto a 14x14 image with the given color.
+	 * Draw a gear/cogwheel icon onto a {@code size}x{@code size} image with the given color.
 	 */
 	public static BufferedImage drawGearIcon(Color color, int size)
 	{

--- a/src/test/java/com/flipsmart/GearIconTest.java
+++ b/src/test/java/com/flipsmart/GearIconTest.java
@@ -1,0 +1,23 @@
+package com.flipsmart;
+
+import com.flipsmart.ui.panel.PanelFormat;
+
+import org.junit.Test;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class GearIconTest
+{
+	@Test
+	public void drawsNonNullFixedSizeIcon()
+	{
+		BufferedImage icon = PanelFormat.drawGearIcon(Color.WHITE);
+		assertNotNull(icon);
+		assertEquals(14, icon.getWidth());
+		assertEquals(14, icon.getHeight());
+	}
+}

--- a/src/test/java/com/flipsmart/GearIconTest.java
+++ b/src/test/java/com/flipsmart/GearIconTest.java
@@ -15,9 +15,9 @@ public class GearIconTest
 	@Test
 	public void drawsNonNullFixedSizeIcon()
 	{
-		BufferedImage icon = PanelFormat.drawGearIcon(Color.WHITE);
+		BufferedImage icon = PanelFormat.drawGearIcon(Color.WHITE, 12);
 		assertNotNull(icon);
-		assertEquals(14, icon.getWidth());
-		assertEquals(14, icon.getHeight());
+		assertEquals(12, icon.getWidth());
+		assertEquals(12, icon.getHeight());
 	}
 }

--- a/src/test/java/com/flipsmart/VolumeFilterTest.java
+++ b/src/test/java/com/flipsmart/VolumeFilterTest.java
@@ -1,0 +1,29 @@
+package com.flipsmart;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class VolumeFilterTest
+{
+	@Test
+	public void volumeAtOrAboveThresholdPasses()
+	{
+		assertTrue(FlipFinderPanel.passesVolumeFilter(1000, 500));
+		assertTrue(FlipFinderPanel.passesVolumeFilter(500, 500));
+	}
+
+	@Test
+	public void volumeBelowThresholdFails()
+	{
+		assertFalse(FlipFinderPanel.passesVolumeFilter(499, 500));
+	}
+
+	@Test
+	public void zeroThresholdPassesEverything()
+	{
+		assertTrue(FlipFinderPanel.passesVolumeFilter(0, 0));
+		assertTrue(FlipFinderPanel.passesVolumeFilter(1, 0));
+	}
+}


### PR DESCRIPTION
## Summary

Adds a settings cogwheel pop-out to the Flip Finder panel header so players can adjust quick filters (Minimum Profit, Minimum Volume, Hide FlipSmart Buttons) without leaving the panel, and renames the user-facing in-game overlay label from "Flip Assist" to "FlipSmart" for brand consistency.

## Changes

### ✨ New Features
- Settings cogwheel (⚙) button added to the Flip Finder panel header, beside the existing Refresh button.
- Clicking the gear opens a quick-settings pop-out (JPopupMenu) exposing three live-applying settings — no save button required:
  - **Minimum Profit** — bound to the existing `minProfit` config.
  - **Minimum Volume** — new `minVolume` config (default 0), filters recommendations by `dailyVolume`.
  - **Hide FlipSmart Buttons** — checkbox bound to the existing `enableFlipAssistant` config (inverted: checking it hides the in-game Flip Assist screen).
- Both numeric fields show a hover tooltip: "Adding a minimum filter may limit the number of results you see."

### ♻️ Refactoring
- Moved the settings gear beside Refresh (rather than the Style/Timeframe row) per product-owner direction, since the header is static across panel states.
- Shrunk the gear icon and lightened the header button font for visual consistency with the existing Refresh control.

### 🎨 UI/UX
- Renamed the user-facing in-game overlay label "Flip Assist" → "FlipSmart" in `FlipAssistOverlay` (the `HINT_TITLE` constant and the login prompt text). Display-string-only rename — internal class/method/identifier names are unchanged.

## Testing

### Automated Tests
- ✅ `./gradlew build` passing (compile + checkstyle + unit tests)
- ✅ New unit tests: `VolumeFilterTest`, `GearIconTest`

### Manual QA Test Plan (in-game, RuneLite client)
RuneLite is a desktop Java client, not browser-driven, so there are no automated Playwright/browser tests possible for this repo. The following is verified manually in-game:

- [x] AC1: Gear icon appears in the panel header beside Refresh, matches the existing control aesthetic, and does not disrupt the header layout. (Placed in the header rather than the Style/Timeframe row per product-owner direction — the header is static across panel states.) — confirmed in-game during development.
- [ ] AC2: Clicking the gear opens a pop-out containing Minimum Profit, Minimum Volume, and Hide FlipSmart Buttons controls.
- [ ] AC3: Minimum Profit filters out low-profit recommendations immediately.
- [ ] AC4: Minimum Volume filters out low-daily-volume recommendations immediately.
- [ ] AC5: Hovering either numeric field shows the tooltip "Adding a minimum filter may limit the number of results you see."
- [ ] AC6: Hide FlipSmart Buttons hides the in-game Flip Assist screen and persists across sessions, staying in sync with the config-panel "Enable Flip Assistant" setting.
- [ ] AC7: The pop-out closes on outside click and on a second gear click; all changes apply immediately with no save button.
- [ ] AC8: The in-game overlay title reads "FlipSmart", and the login prompt reads "Log in to use FlipSmart".

## API Changes

N/A — this is a plugin-only change; no backend API touched.

## Database Changes

N/A — no backend/database involved.

## Deployment Notes

- Ships via the normal RuneLite Plugin Hub release/pin-update process, not a direct deploy.
- No environment variables or configuration changes needed.
- No new dependencies.

## Checklist

- [x] Tests added/updated
- [x] Code follows style guidelines (checkstyle passing)
- [x] Commits are clean and descriptive
- [x] No debug code left
- [x] Types are correct
- [ ] Reviewed by teammate

## Related Issues

Closes Flip-Smart/flip-smart#723

## 🩺 Codacy Quality Gate — fixed in this PR
- `4cfecb3` PMD_AvoidLiteralsInIfCondition / PMD_RedundantFieldInitializer `FlipFinderPanel.java:727,734` — extracted `SETTINGS_POPOUT_REOPEN_DEBOUNCE_MS` constant; removed redundant `= 0L` field initializer.
- `6d87c50` `FlipFinderPanel.java:789` — debounced the Min Profit / Min Volume spinner change listeners (300ms, per-key `Timer`) so rapid adjustment no longer fires a config save + full recommendation re-populate on every increment.
- `9b3e2a8` `PanelFormat.java:232` — updated stale Javadoc on `drawGearIcon` to reference the dynamic `size` parameter instead of a fixed 14x14.
- `c6c0900` `FlipSmartConfig.java:175` — moved `minVolume`'s config `position` from 5 to 9 to resolve a collision with `flipFinderRefreshMinutes` (also position 5).
- `c57a23f` `FlipFinderPanel.java:86` — swapped the new debounce-timer field from `HashMap` to `ConcurrentHashMap` per PMD `UseConcurrentHashMap`, consistent with existing `displayedSellPrices` field convention in this file.

## 🤖 Codacy AI Reviewer — fixed in this PR
- `4cfecb3` `FlipFinderPanel.java:734` (+ duplicate at :731) — magic number `200` extracted to a named constant.
- `4cfecb3` `FlipFinderPanel.java:727` (+ duplicate at :724) — removed redundant field initializer.
- `6d87c50` `FlipFinderPanel.java:789` — debounced spinner writes to avoid excessive disk I/O / UI churn on rapid adjustment.
- `9b3e2a8` `PanelFormat.java:232` — corrected stale Javadoc size reference.
- `c6c0900` `FlipSmartConfig.java:175` (+ duplicate) — resolved duplicate config `position`.

## 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `FlipFinderPanel.java:828` — `enableFlipAssistant()` is defined in `FlipSmartConfig.java:379`; the reviewed diff hunk simply didn't include that part of the file. Confirmed no compile error via `./gradlew compileJava`.

## 🤖 Codacy AI Reviewer — deferred (in-thread rationale)
- `FlipFinderPanel.java:461` — comment anchored to an earlier revision; the gear button was already moved out of `styleRight`/`styleRow` into the header (beside Refresh) in a prior commit on this branch, before this Codacy pass ran.
