### PR TITLE
feat(plugin): move duplicated flip settings to single source of truth (side panel)

### DIFF
--- a/src/main/java/com/flipsmart/FlipSmartConfig.java
+++ b/src/main/java/com/flipsmart/FlipSmartConfig.java
@@ -112,7 +112,8 @@ public interface FlipSmartConfig extends Config
 		name = "Flip Style",
 		description = "Your preferred flipping style: Conservative (safer, faster fills), Balanced (mix of both), Aggressive (higher profit, slower fills)",
 		section = flipFinderSection,
-		position = 2
+		position = 2,
+		hidden = true
 	)
 	default FlipStyle flipStyle()
 	{
@@ -124,7 +125,8 @@ public interface FlipSmartConfig extends Config
 		name = "Timeframe",
 		description = "Target flip timeframe: Active (standard recommendations), or time-optimized profiles (30m, 2h, 4h, 12h)",
 		section = flipFinderSection,
-		position = 3
+		position = 3,
+		hidden = true
 	)
 	default FlipTimeframe flipTimeframe()
 	{
@@ -160,7 +162,8 @@ public interface FlipSmartConfig extends Config
 		name = "Minimum Profit",
 		description = "Hide recommendations with total profit below this value (in GP)",
 		section = flipFinderSection,
-		position = 4
+		position = 4,
+		hidden = true
 	)
 	default int minimumProfit()
 	{
@@ -172,7 +175,8 @@ public interface FlipSmartConfig extends Config
 		name = "Minimum Volume",
 		description = "Hide recommendations with daily trade volume below this value",
 		section = flipFinderSection,
-		position = 9
+		position = 9,
+		hidden = true
 	)
 	default int minimumVolume()
 	{


### PR DESCRIPTION
## Summary

Removes settings from the RuneLite plugin's config panel that were duplicated with side-panel controls, so each setting lives in exactly one place going forward.

## Changes

### 🐛 Bug Fixes / ♻️ Refactoring
- Removes four settings from the plugin's config panel that were duplicated between the plugin settings panel and the side panel: **Min Profit**, **Min Volume**, **Flip Style**, **Timeframe**. These now live exclusively in the side panel.
- Settings-only items with no side-panel equivalent are unchanged and remain visible in the plugin config panel: **Recommendations limit**, **Refresh interval**, **F2P mode**, **Cashstack override**.
- Implementation approach: sets `hidden = true` on the four `@ConfigItem` annotations rather than deleting the config accessors. This removes the fields from the RuneLite config UI while keeping the config keys registered under the hood, so:
  - The side-panel controls that read via `config.minimumProfit()` / `config.flipStyle()` (and the analogous volume/timeframe getters) keep working unchanged.
  - Writes via `configManager.setConfiguration(...)` from the side panel continue to persist correctly.
  - The recommendation filtering logic is untouched — this is a UI-surface-only change.
- This follows the existing `hidden = true` precedent already used in the same file for `email`/`password`/`refreshToken`.
- Note: `dumpAlertMinProfit` (a separate, distinct dump-alert setting unrelated to the duplicated four) was intentionally left untouched.
- Existing users are unaffected data-wise: their saved config values persist under the same keys; they'll now edit those values from the side panel instead of the plugin settings panel.

## Testing

### Automated Tests
- ✅ `./gradlew clean build` — BUILD SUCCESSFUL, 7 actionable tasks executed (compile, test, check, assemble all passed)
- No automated test coverage for config UI visibility (RuneLite `@ConfigItem` hidden-flag behavior isn't unit-testable outside the client) — verification is manual, per the checklist below

### Manual Testing
- [x] Open the FlipSmart plugin's RuneLite config panel and confirm Min Profit, Min Volume, Flip Style, and Timeframe no longer appear as options.
- [x] Confirm Recommendations limit, Refresh interval, F2P mode, and Cashstack override still appear in the plugin config panel (unchanged).
- [x] Confirm the side-panel dropdowns/filter gear pop-out still correctly read the current Min Profit / Min Volume / Flip Style / Timeframe values.
- [x] Change values via the side panel, restart the RuneLite client, and confirm the values persisted (survives client restart).

## Deployment Notes

- No environment variables added or changed.
- No new dependencies.
- No configuration or migration changes.
- Plugin-only Java source change; no API or database surface.

## Checklist

- [x] Manual testing checklist included above (no automated UI test coverage possible)
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console/debug code left
- [x] Config keys preserved for backward compatibility with existing saved values
- [ ] Reviewed by teammate

## Related Issues

Closes Flip-Smart/flip-smart#873


### 🩺 Codacy
No open signals at `e8c7ab1` — quality gate green (0 new issues), 0 AI Reviewer comments.
