### PR TITLE
Stamp round-trip id on GE transactions (#893)

### DIFF
--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -148,6 +148,9 @@ public class FlipSmartPlugin extends Plugin
 	private com.flipsmart.trading.OfferStore offerStore;
 
 	@Inject
+	private com.flipsmart.trading.RoundTripLedger roundTripLedger;
+
+	@Inject
 	private WebhookSyncService webhookSyncService;
 
 	@Inject
@@ -650,7 +653,7 @@ public class FlipSmartPlugin extends Plugin
 		manualAdjustmentTracker = serviceWiring.initializeManualAdjustmentTracker(this, config, flipAssistOverlay,
 			geSlotOverlay, inventoryHighlightOverlay, session, grandExchangeTracker, activeOfferAdvisorService, offerStore);
 		grandExchangeTracker.setOfferStore(offerStore);
-		serviceWiring.wireTransactionLogger(this, session, offerStore);
+		serviceWiring.wireTransactionLogger(this, session, offerStore, roundTripLedger);
 		serviceWiring.wireGrandExchangeTrackerCallbacks(this, grandExchangeTracker, autoRecommendService, geHistoryService,
 			offerStore, refreshCoalescer);
 

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -5,6 +5,7 @@ import com.flipsmart.domain.offer.OfferState;
 import com.flipsmart.trading.OfferEventMapper;
 import com.flipsmart.trading.OfferReconciler;
 import com.flipsmart.trading.OfferStore;
+import com.flipsmart.trading.RoundTripLedger;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -42,6 +43,7 @@ public class OfflineSyncService
 	private static final String COLLECTED_ITEMS_KEY_PREFIX = "collectedItems_";
 	private static final String COLLECTED_QUANTITIES_KEY_PREFIX = "collectedQuantities_";
 	private static final String COLLECTED_ITEMS_SAVED_AT_KEY_PREFIX = "collectedItemsSavedAt_";
+	private static final String ROUND_TRIP_LEDGER_KEY_PREFIX = "roundTripLedger_";
 	private static final String LAST_KNOWN_RSN_KEY = "lastKnownRsn";
 	// Wall-clock of the last completed offline sync, per RSN. A persisted offer is only a genuine
 	// offline fill if it was active since this marker; older leftovers are already-known history.
@@ -58,6 +60,7 @@ public class OfflineSyncService
 	private final GEHistoryService geHistoryService;
 	private final OfferStore offerStore;
 	private final ItemManager itemManager;
+	private final RoundTripLedger roundTripLedger;
 
 	/** Callback invoked after sync is complete (for scheduling post-sync tasks) */
 	private Runnable onSyncComplete;
@@ -72,7 +75,8 @@ public class OfflineSyncService
 		ActiveFlipTracker activeFlipTracker,
 		GEHistoryService geHistoryService,
 		OfferStore offerStore,
-		ItemManager itemManager)
+		ItemManager itemManager,
+		RoundTripLedger roundTripLedger)
 	{
 		this.session = session;
 		this.configManager = configManager;
@@ -83,6 +87,7 @@ public class OfflineSyncService
 		this.geHistoryService = geHistoryService;
 		this.offerStore = offerStore;
 		this.itemManager = itemManager;
+		this.roundTripLedger = roundTripLedger;
 	}
 
 	public void setOnSyncComplete(Runnable onSyncComplete)
@@ -237,6 +242,73 @@ public class OfflineSyncService
 			}
 		}
 
+		persistLedgerState(rsn);
+	}
+
+	/**
+	 * Persist the round-trip ledger's held-quantity/cycle state for {@code rsn} alongside
+	 * the offer state, so a restart resumes mid-cycle instead of losing the id and
+	 * splitting an in-progress position into a spurious new round trip.
+	 */
+	private void persistLedgerState(String rsn)
+	{
+		Map<Integer, RoundTripLedger.Entry> entries = roundTripLedger.export(rsn);
+		if (entries.isEmpty())
+		{
+			return;
+		}
+		try
+		{
+			configManager.setConfiguration(CONFIG_GROUP, ROUND_TRIP_LEDGER_KEY_PREFIX + rsn, gson.toJson(entries));
+		}
+		catch (Exception e)
+		{
+			log.error("Failed to persist round-trip ledger for {}: {}", rsn, e.getMessage());
+		}
+	}
+
+	/**
+	 * Restore the round-trip ledger's per-item state for {@code rsn}. When nothing was ever
+	 * persisted (first run of this feature on an account with an existing GE position), seed
+	 * conservatively from the store's currently-live unmatched buy fills instead of starting
+	 * blind at zero, so a restart doesn't collide a fresh cycle onto a stale in-flight buy.
+	 */
+	private void preloadLedgerState(String rsn)
+	{
+		if (rsn == null || !roundTripLedger.isEmpty(rsn))
+		{
+			return;
+		}
+		String json = configManager.getConfiguration(CONFIG_GROUP, ROUND_TRIP_LEDGER_KEY_PREFIX + rsn);
+		if (json != null && !json.isEmpty())
+		{
+			try
+			{
+				Type type = new TypeToken<Map<Integer, RoundTripLedger.Entry>>(){}.getType();
+				Map<Integer, RoundTripLedger.Entry> entries = gson.fromJson(json, type);
+				roundTripLedger.importState(rsn, entries);
+				return;
+			}
+			catch (Exception e)
+			{
+				log.debug("Ignoring unreadable persisted round-trip ledger for {} ({})", rsn, e.getMessage());
+			}
+		}
+		roundTripLedger.seedColdStart(rsn, liveUnmatchedBuys());
+	}
+
+	/** Currently-live buy offers with at least one filled unit — a stale unmatched position. */
+	private List<OfferRecord> liveUnmatchedBuys()
+	{
+		List<OfferRecord> out = new ArrayList<>();
+		for (OfferRecord r : offerStore.liveOffers())
+		{
+			if (r.isBuy() && r.getFilledQuantity() > 0)
+			{
+				out.add(r);
+			}
+		}
+		return out;
 	}
 
 	/**
@@ -255,10 +327,14 @@ public class OfflineSyncService
 		List<OfferRecord> persistedRecords = loadPersistedOfferRecords();
 		if (persistedRecords.isEmpty())
 		{
+			preloadLedgerState(resolvePersistenceRsn());
 			return;
 		}
 
 		reconcilePersistedIntoStore(persistedRecords);
+		// Runs after reconciliation so cold-start seeding (when there is no persisted
+		// ledger at all) sees the just-reattached live buys, not a pre-reconcile snapshot.
+		preloadLedgerState(resolvePersistenceRsn());
 
 		log.debug("Preloaded {} persisted offer records into store for timestamp preservation",
 			persistedRecords.size());

--- a/src/main/java/com/flipsmart/api/dto/TransactionRequest.java
+++ b/src/main/java/com/flipsmart/api/dto/TransactionRequest.java
@@ -16,6 +16,7 @@ public class TransactionRequest
 	public final Integer totalQuantity;
 	public final String idempotencyKey;
 	public final Long offerId;
+	public final Integer roundTripId;
 
 	private TransactionRequest(Builder builder)
 	{
@@ -30,6 +31,7 @@ public class TransactionRequest
 		this.totalQuantity = builder.totalQuantity;
 		this.idempotencyKey = builder.idempotencyKey;
 		this.offerId = builder.offerId;
+		this.roundTripId = builder.roundTripId;
 	}
 
 	public static Builder builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
@@ -50,6 +52,7 @@ public class TransactionRequest
 		private Integer totalQuantity;
 		private String idempotencyKey;
 		private Long offerId;
+		private Integer roundTripId;
 
 		private Builder(int itemId, String itemName, boolean isBuy, int quantity, int pricePerItem)
 		{
@@ -66,6 +69,7 @@ public class TransactionRequest
 		public Builder totalQuantity(Integer qty) { this.totalQuantity = qty; return this; }
 		public Builder idempotencyKey(String key) { this.idempotencyKey = key; return this; }
 		public Builder offerId(Long offerId) { this.offerId = offerId; return this; }
+		public Builder roundTripId(Integer roundTripId) { this.roundTripId = roundTripId; return this; }
 
 		public TransactionRequest build() { return new TransactionRequest(this); }
 	}

--- a/src/main/java/com/flipsmart/api/endpoints/TransactionEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/TransactionEndpoints.java
@@ -73,6 +73,10 @@ public class TransactionEndpoints
 		{
 			jsonBody.addProperty("offer_id", request.offerId);
 		}
+		if (request.roundTripId != null)
+		{
+			jsonBody.addProperty("round_trip_id", request.roundTripId);
+		}
 
 		RequestBody body = RequestBody.create(JSON, jsonBody.toString());
 

--- a/src/main/java/com/flipsmart/plugin/ServiceWiring.java
+++ b/src/main/java/com/flipsmart/plugin/ServiceWiring.java
@@ -15,6 +15,7 @@ import com.flipsmart.OfflineSyncService;
 import com.flipsmart.PlayerSession;
 import com.flipsmart.GrandExchangeTracker;
 import com.flipsmart.trading.OfferStore;
+import com.flipsmart.trading.RoundTripLedger;
 import com.flipsmart.trading.TransactionLogger;
 
 import javax.swing.SwingUtilities;
@@ -137,10 +138,11 @@ public class ServiceWiring
 	 * recording path. It must subscribe to the same OfferStore instance the tracker writes
 	 * to, so every state change the tracker applies is recorded exactly once.
 	 */
-	public void wireTransactionLogger(FlipSmartPlugin plugin, PlayerSession session, OfferStore offerStore)
+	public void wireTransactionLogger(FlipSmartPlugin plugin, PlayerSession session, OfferStore offerStore,
+		RoundTripLedger roundTripLedger)
 	{
 		TransactionLogger logger = new TransactionLogger(
-			plugin.getApiClient(), session, plugin::getCurrentRsnSafe);
+			plugin.getApiClient(), session, plugin::getCurrentRsnSafe, roundTripLedger);
 		offerStore.addListener(logger::onOfferEvent);
 	}
 

--- a/src/main/java/com/flipsmart/recommend/ActionResolver.java
+++ b/src/main/java/com/flipsmart/recommend/ActionResolver.java
@@ -30,12 +30,11 @@ public final class ActionResolver {
             if (!slotFree) {
                 break;
             }
-            // Quantity collected preemptively from an open trade (partial cancel) is sold
-            // before placing a new buy; a normally-completed buy does not jump that queue.
-            ActionKind kind = c.getOrigin() == CollectOrigin.PARTIAL_CANCEL
-                ? ActionKind.SELL_WAITING
-                : ActionKind.S3;
-            candidates.add(new ActionDecision(kind, ActionStep.LIST,
+            // A collected item that is meant to be sold takes priority over placing a
+            // new buy: the free slot should list what we already own rather than be
+            // consumed by a new buy that leaves the held item with nowhere to sell.
+            // Applies to both preemptive (partial-cancel) and normally-completed collects.
+            candidates.add(new ActionDecision(ActionKind.SELL_WAITING, ActionStep.LIST,
                 c.getItemId(), -1, c.getDetectedAtMillis()));
         }
 

--- a/src/main/java/com/flipsmart/trading/RoundTripLedger.java
+++ b/src/main/java/com/flipsmart/trading/RoundTripLedger.java
@@ -151,19 +151,25 @@ public final class RoundTripLedger
             {
                 return;
             }
-            Map<Integer, Entry> seeded = new HashMap<>();
-            for (OfferRecord r : liveUnmatchedBuys)
-            {
-                if (!r.isBuy() || r.getFilledQuantity() <= 0)
-                {
-                    continue;
-                }
-                seeded.computeIfAbsent(r.getItemId(), k -> new Entry(0, INITIAL_CYCLE_ID)).heldQuantity += r.getFilledQuantity();
-            }
+            Map<Integer, Entry> seeded = seedMapFrom(liveUnmatchedBuys);
             if (!seeded.isEmpty())
             {
                 byRsn.put(rsn, seeded);
             }
         }
+    }
+
+    private static Map<Integer, Entry> seedMapFrom(List<OfferRecord> liveUnmatchedBuys)
+    {
+        Map<Integer, Entry> seeded = new HashMap<>();
+        for (OfferRecord r : liveUnmatchedBuys)
+        {
+            if (!r.isBuy() || r.getFilledQuantity() <= 0)
+            {
+                continue;
+            }
+            seeded.computeIfAbsent(r.getItemId(), k -> new Entry(0, INITIAL_CYCLE_ID)).heldQuantity += r.getFilledQuantity();
+        }
+        return seeded;
     }
 }

--- a/src/main/java/com/flipsmart/trading/RoundTripLedger.java
+++ b/src/main/java/com/flipsmart/trading/RoundTripLedger.java
@@ -1,0 +1,136 @@
+package com.flipsmart.trading;
+
+import com.flipsmart.domain.offer.OfferRecord;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Singleton;
+
+/**
+ * Zero-crossing round-trip id ledger, keyed by (rsn, itemId).
+ *
+ * Tracks the running held quantity the plugin has observed (buys minus sells) and
+ * assigns a monotonic id to every fill between two zero-crossings, so the backend can
+ * match a sell to buys strictly within one round trip instead of across unrelated
+ * same-item positions. A full or over liquidation (held quantity returns to zero or
+ * below) closes the current cycle; whatever follows starts a new one.
+ */
+@Singleton
+public final class RoundTripLedger
+{
+    private static final int INITIAL_CYCLE_ID = 1;
+
+    /** Per-(rsn, itemId) state: quantity currently held and the active cycle id. */
+    public static final class Entry
+    {
+        public int heldQuantity;
+        public int cycleId;
+
+        public Entry()
+        {
+        }
+
+        public Entry(int heldQuantity, int cycleId)
+        {
+            this.heldQuantity = heldQuantity;
+            this.cycleId = cycleId;
+        }
+    }
+
+    private final Map<String, Map<Integer, Entry>> byRsn = new HashMap<>();
+
+    /**
+     * Apply a fill of {@code deltaQuantity} for (rsn, itemId) and return the round-trip
+     * id it belongs to. Returns {@code null} when {@code rsn} can't be resolved — the
+     * caller sends no id in that case rather than guess.
+     */
+    public synchronized Integer recordFill(String rsn, int itemId, boolean isBuy, int deltaQuantity)
+    {
+        if (rsn == null || rsn.isEmpty())
+        {
+            return null;
+        }
+        Entry e = entryFor(rsn, itemId);
+        e.heldQuantity += isBuy ? deltaQuantity : -deltaQuantity;
+        int roundTripId = e.cycleId;
+        if (e.heldQuantity <= 0)
+        {
+            e.cycleId++;
+            e.heldQuantity = 0;
+        }
+        return roundTripId;
+    }
+
+    /**
+     * The current round-trip id for (rsn, itemId) without mutating held quantity. Used to
+     * stamp zero-fill placement rows so they carry the same id their eventual fills will.
+     */
+    public synchronized Integer peekRoundTripId(String rsn, int itemId)
+    {
+        if (rsn == null || rsn.isEmpty())
+        {
+            return null;
+        }
+        return entryFor(rsn, itemId).cycleId;
+    }
+
+    private Entry entryFor(String rsn, int itemId)
+    {
+        return byRsn.computeIfAbsent(rsn, k -> new HashMap<>())
+            .computeIfAbsent(itemId, k -> new Entry(0, INITIAL_CYCLE_ID));
+    }
+
+    /** Snapshot of every itemId -> Entry tracked for {@code rsn}, for persistence. */
+    public synchronized Map<Integer, Entry> export(String rsn)
+    {
+        Map<Integer, Entry> existing = byRsn.get(rsn);
+        return existing == null ? Collections.emptyMap() : new HashMap<>(existing);
+    }
+
+    /** True when no state has ever been recorded for {@code rsn} (cold start / first run). */
+    public synchronized boolean isEmpty(String rsn)
+    {
+        return rsn == null || !byRsn.containsKey(rsn);
+    }
+
+    /** Replace all state for {@code rsn} with {@code entries} (e.g. restored from persistence). */
+    public synchronized void importState(String rsn, Map<Integer, Entry> entries)
+    {
+        if (rsn == null || rsn.isEmpty() || entries == null || entries.isEmpty())
+        {
+            return;
+        }
+        byRsn.put(rsn, new HashMap<>(entries));
+    }
+
+    /**
+     * Conservative cold-start seed, applied only when {@code rsn} has no ledger state at
+     * all — a genuine first run, e.g. this feature shipping to an account that already has
+     * an open GE position. Seeds held quantity per item from currently-live unmatched buy
+     * fills so the next sell of that pre-existing position doesn't collide with a fresh
+     * cycle that has never seen it.
+     */
+    public synchronized void seedColdStart(String rsn, List<OfferRecord> liveUnmatchedBuys)
+    {
+        if (rsn == null || rsn.isEmpty() || !isEmpty(rsn) || liveUnmatchedBuys == null || liveUnmatchedBuys.isEmpty())
+        {
+            return;
+        }
+        Map<Integer, Entry> seeded = new HashMap<>();
+        for (OfferRecord r : liveUnmatchedBuys)
+        {
+            if (!r.isBuy() || r.getFilledQuantity() <= 0)
+            {
+                continue;
+            }
+            seeded.computeIfAbsent(r.getItemId(), k -> new Entry(0, INITIAL_CYCLE_ID)).heldQuantity += r.getFilledQuantity();
+        }
+        if (!seeded.isEmpty())
+        {
+            byRsn.put(rsn, seeded);
+        }
+    }
+}

--- a/src/main/java/com/flipsmart/trading/RoundTripLedger.java
+++ b/src/main/java/com/flipsmart/trading/RoundTripLedger.java
@@ -40,6 +40,7 @@ public final class RoundTripLedger
         }
     }
 
+    private final Object lock = new Object();
     private final Map<String, Map<Integer, Entry>> byRsn = new HashMap<>();
 
     /**
@@ -47,34 +48,40 @@ public final class RoundTripLedger
      * id it belongs to. Returns {@code null} when {@code rsn} can't be resolved — the
      * caller sends no id in that case rather than guess.
      */
-    public synchronized Integer recordFill(String rsn, int itemId, boolean isBuy, int deltaQuantity)
+    public Integer recordFill(String rsn, int itemId, boolean isBuy, int deltaQuantity)
     {
-        if (rsn == null || rsn.isEmpty())
+        synchronized (lock)
         {
-            return null;
+            if (rsn == null || rsn.isEmpty())
+            {
+                return null;
+            }
+            Entry e = entryFor(rsn, itemId);
+            e.heldQuantity += isBuy ? deltaQuantity : -deltaQuantity;
+            int roundTripId = e.cycleId;
+            if (e.heldQuantity <= 0)
+            {
+                e.cycleId++;
+                e.heldQuantity = 0;
+            }
+            return roundTripId;
         }
-        Entry e = entryFor(rsn, itemId);
-        e.heldQuantity += isBuy ? deltaQuantity : -deltaQuantity;
-        int roundTripId = e.cycleId;
-        if (e.heldQuantity <= 0)
-        {
-            e.cycleId++;
-            e.heldQuantity = 0;
-        }
-        return roundTripId;
     }
 
     /**
      * The current round-trip id for (rsn, itemId) without mutating held quantity. Used to
      * stamp zero-fill placement rows so they carry the same id their eventual fills will.
      */
-    public synchronized Integer peekRoundTripId(String rsn, int itemId)
+    public Integer peekRoundTripId(String rsn, int itemId)
     {
-        if (rsn == null || rsn.isEmpty())
+        synchronized (lock)
         {
-            return null;
+            if (rsn == null || rsn.isEmpty())
+            {
+                return null;
+            }
+            return entryFor(rsn, itemId).cycleId;
         }
-        return entryFor(rsn, itemId).cycleId;
     }
 
     private Entry entryFor(String rsn, int itemId)
@@ -84,26 +91,35 @@ public final class RoundTripLedger
     }
 
     /** Snapshot of every itemId -> Entry tracked for {@code rsn}, for persistence. */
-    public synchronized Map<Integer, Entry> export(String rsn)
+    public Map<Integer, Entry> export(String rsn)
     {
-        Map<Integer, Entry> existing = byRsn.get(rsn);
-        return existing == null ? Collections.emptyMap() : new HashMap<>(existing);
+        synchronized (lock)
+        {
+            Map<Integer, Entry> existing = byRsn.get(rsn);
+            return existing == null ? Collections.emptyMap() : new HashMap<>(existing);
+        }
     }
 
     /** True when no state has ever been recorded for {@code rsn} (cold start / first run). */
-    public synchronized boolean isEmpty(String rsn)
+    public boolean isEmpty(String rsn)
     {
-        return rsn == null || !byRsn.containsKey(rsn);
+        synchronized (lock)
+        {
+            return rsn == null || !byRsn.containsKey(rsn);
+        }
     }
 
     /** Replace all state for {@code rsn} with {@code entries} (e.g. restored from persistence). */
-    public synchronized void importState(String rsn, Map<Integer, Entry> entries)
+    public void importState(String rsn, Map<Integer, Entry> entries)
     {
-        if (rsn == null || rsn.isEmpty() || entries == null || entries.isEmpty())
+        synchronized (lock)
         {
-            return;
+            if (rsn == null || rsn.isEmpty() || entries == null || entries.isEmpty())
+            {
+                return;
+            }
+            byRsn.put(rsn, new HashMap<>(entries));
         }
-        byRsn.put(rsn, new HashMap<>(entries));
     }
 
     /**
@@ -113,24 +129,27 @@ public final class RoundTripLedger
      * fills so the next sell of that pre-existing position doesn't collide with a fresh
      * cycle that has never seen it.
      */
-    public synchronized void seedColdStart(String rsn, List<OfferRecord> liveUnmatchedBuys)
+    public void seedColdStart(String rsn, List<OfferRecord> liveUnmatchedBuys)
     {
-        if (rsn == null || rsn.isEmpty() || !isEmpty(rsn) || liveUnmatchedBuys == null || liveUnmatchedBuys.isEmpty())
+        synchronized (lock)
         {
-            return;
-        }
-        Map<Integer, Entry> seeded = new HashMap<>();
-        for (OfferRecord r : liveUnmatchedBuys)
-        {
-            if (!r.isBuy() || r.getFilledQuantity() <= 0)
+            if (rsn == null || rsn.isEmpty() || !isEmpty(rsn) || liveUnmatchedBuys == null || liveUnmatchedBuys.isEmpty())
             {
-                continue;
+                return;
             }
-            seeded.computeIfAbsent(r.getItemId(), k -> new Entry(0, INITIAL_CYCLE_ID)).heldQuantity += r.getFilledQuantity();
-        }
-        if (!seeded.isEmpty())
-        {
-            byRsn.put(rsn, seeded);
+            Map<Integer, Entry> seeded = new HashMap<>();
+            for (OfferRecord r : liveUnmatchedBuys)
+            {
+                if (!r.isBuy() || r.getFilledQuantity() <= 0)
+                {
+                    continue;
+                }
+                seeded.computeIfAbsent(r.getItemId(), k -> new Entry(0, INITIAL_CYCLE_ID)).heldQuantity += r.getFilledQuantity();
+            }
+            if (!seeded.isEmpty())
+            {
+                byRsn.put(rsn, seeded);
+            }
         }
     }
 }

--- a/src/main/java/com/flipsmart/trading/RoundTripLedger.java
+++ b/src/main/java/com/flipsmart/trading/RoundTripLedger.java
@@ -90,13 +90,27 @@ public final class RoundTripLedger
             .computeIfAbsent(itemId, k -> new Entry(0, INITIAL_CYCLE_ID));
     }
 
-    /** Snapshot of every itemId -> Entry tracked for {@code rsn}, for persistence. */
+    /**
+     * Snapshot of every itemId -> Entry tracked for {@code rsn}, for persistence. Entries are
+     * deep-copied so a later mutation via {@link #recordFill} can't race with serialization of
+     * this snapshot on another thread.
+     */
     public Map<Integer, Entry> export(String rsn)
     {
         synchronized (lock)
         {
             Map<Integer, Entry> existing = byRsn.get(rsn);
-            return existing == null ? Collections.emptyMap() : new HashMap<>(existing);
+            if (existing == null)
+            {
+                return Collections.emptyMap();
+            }
+            Map<Integer, Entry> copy = new HashMap<>();
+            for (Map.Entry<Integer, Entry> entry : existing.entrySet())
+            {
+                Entry source = entry.getValue();
+                copy.put(entry.getKey(), new Entry(source.heldQuantity, source.cycleId));
+            }
+            return copy;
         }
     }
 

--- a/src/main/java/com/flipsmart/trading/TransactionLogger.java
+++ b/src/main/java/com/flipsmart/trading/TransactionLogger.java
@@ -29,6 +29,7 @@ public final class TransactionLogger
     private final FlipSmartApiClient apiClient;
     private final PlayerSession session;
     private final Supplier<Optional<String>> rsnSupplier;
+    private final RoundTripLedger roundTripLedger;
 
     private final Set<String> seenKeys = Collections.synchronizedSet(
         Collections.newSetFromMap(
@@ -42,17 +43,18 @@ public final class TransactionLogger
             }));
 
     @Inject
-    public TransactionLogger(FlipSmartApiClient apiClient, PlayerSession session)
+    public TransactionLogger(FlipSmartApiClient apiClient, PlayerSession session, RoundTripLedger roundTripLedger)
     {
-        this(apiClient, session, session::getRsnSafe);
+        this(apiClient, session, session::getRsnSafe, roundTripLedger);
     }
 
     public TransactionLogger(FlipSmartApiClient apiClient, PlayerSession session,
-                             Supplier<Optional<String>> rsnSupplier)
+                             Supplier<Optional<String>> rsnSupplier, RoundTripLedger roundTripLedger)
     {
         this.apiClient = apiClient;
         this.session = session;
         this.rsnSupplier = rsnSupplier;
+        this.roundTripLedger = roundTripLedger;
     }
 
     public void onOfferEvent(OfferEvent e)
@@ -95,7 +97,10 @@ public final class TransactionLogger
         {
             return;
         }
-        apiClient.recordTransactionAsync(baseBuilder(r, 0, r.getPrice(), rsn, key).build());
+        // Zero-fill placement: peek the current cycle rather than recordFill, since no
+        // quantity actually moved and peeking must never trip a zero-crossing.
+        Integer roundTripId = roundTripLedger.peekRoundTripId(rsn, r.getItemId());
+        apiClient.recordTransactionAsync(baseBuilder(r, 0, r.getPrice(), rsn, key).roundTripId(roundTripId).build());
     }
 
     private void recordFill(com.flipsmart.domain.offer.OfferRecord r, int newlyFilled, long newlySpent)
@@ -107,7 +112,8 @@ public final class TransactionLogger
             return;
         }
         int pricePerItem = newlyFilled > 0 ? (int) (newlySpent / newlyFilled) : 0;
-        apiClient.recordTransactionAsync(baseBuilder(r, newlyFilled, pricePerItem, rsn, key).build());
+        Integer roundTripId = roundTripLedger.recordFill(rsn, r.getItemId(), r.isBuy(), newlyFilled);
+        apiClient.recordTransactionAsync(baseBuilder(r, newlyFilled, pricePerItem, rsn, key).roundTripId(roundTripId).build());
     }
 
     private TransactionRequest.Builder baseBuilder(com.flipsmart.domain.offer.OfferRecord r,

--- a/src/test/java/com/flipsmart/GrandExchangeTrackerCharacterizationTest.java
+++ b/src/test/java/com/flipsmart/GrandExchangeTrackerCharacterizationTest.java
@@ -71,7 +71,8 @@ public class GrandExchangeTrackerCharacterizationTest
 		// Recording now flows through the TransactionLogger listener on the store, exactly as
 		// production wires it. The apiClient mock + captor below capture the listener's calls.
 		com.flipsmart.trading.TransactionLogger logger =
-			new com.flipsmart.trading.TransactionLogger(apiClient, session, () -> java.util.Optional.of(RSN));
+			new com.flipsmart.trading.TransactionLogger(apiClient, session, () -> java.util.Optional.of(RSN),
+				new com.flipsmart.trading.RoundTripLedger());
 		store.addListener(logger::onOfferEvent);
 		activeFlipTracker = mock(ActiveFlipTracker.class);
 		itemManager = mock(ItemManager.class);

--- a/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
+++ b/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
@@ -94,7 +94,8 @@ public class OfflineSyncPersistenceTest
 			activeFlipTracker,
 			geHistoryService,
 			store,
-			itemManager);
+			itemManager,
+			new com.flipsmart.trading.RoundTripLedger());
 	}
 
 	@Test

--- a/src/test/java/com/flipsmart/TransactionLoggerTest.java
+++ b/src/test/java/com/flipsmart/TransactionLoggerTest.java
@@ -7,6 +7,7 @@ import com.flipsmart.domain.offer.OfferTransition;
 import com.flipsmart.trading.OfferEvent;
 import com.flipsmart.trading.OfferEventMapper;
 import com.flipsmart.trading.OfferStore;
+import com.flipsmart.trading.RoundTripLedger;
 import com.flipsmart.trading.TransactionLogger;
 import com.flipsmart.trading.TransactionLogger.Type;
 import net.runelite.api.GrandExchangeOfferState;
@@ -28,12 +29,14 @@ public class TransactionLoggerTest
 
     private FlipSmartApiClient apiClient;
     private PlayerSession session;
+    private RoundTripLedger roundTripLedger;
 
     @Before
     public void setUp()
     {
         apiClient = mock(FlipSmartApiClient.class);
         session = mock(PlayerSession.class);
+        roundTripLedger = new RoundTripLedger();
         when(apiClient.recordTransactionAsync(any(TransactionRequest.class)))
             .thenReturn(CompletableFuture.completedFuture(null));
         when(session.getRecommendedPrice(anyInt())).thenReturn(null);
@@ -42,7 +45,7 @@ public class TransactionLoggerTest
     private TransactionLogger newLogger(String rsn)
     {
         Supplier<Optional<String>> supplier = () -> Optional.of(rsn);
-        return new TransactionLogger(apiClient, session, supplier);
+        return new TransactionLogger(apiClient, session, supplier, roundTripLedger);
     }
 
     private TransactionRequest capture()
@@ -201,5 +204,90 @@ public class TransactionLoggerTest
         assertEquals(3, req.quantity);
         assertEquals(1500, req.pricePerItem);
         assertTrue(req.idempotencyKey.endsWith("FILL:3"));
+    }
+
+    // #893: every sent transaction is stamped with the round-trip id from the shared ledger.
+
+    @Test
+    public void twoCycleSequence_producesTwoDistinctRoundTripIds()
+    {
+        TransactionLogger logger = newLogger(RSN);
+        int itemId = 4151;
+
+        OfferRecord buyLow = OfferRecord.newOffer(1, 0, itemId, "Abyssal whip", true, 5, 1_000, 1L)
+            .withFill(5, 5_000L, OfferState.FILLED, 2L);
+        logger.onOfferEvent(new OfferEvent(OfferTransition.Kind.COMPLETED, buyLow, 5, 5_000L));
+
+        OfferRecord sellLow = OfferRecord.newOffer(2, 1, itemId, "Abyssal whip", false, 5, 1_200, 3L)
+            .withFill(5, 6_000L, OfferState.FILLED, 4L);
+        logger.onOfferEvent(new OfferEvent(OfferTransition.Kind.COMPLETED, sellLow, 5, 6_000L));
+
+        OfferRecord buyHigh = OfferRecord.newOffer(3, 0, itemId, "Abyssal whip", true, 5, 1_500, 5L)
+            .withFill(5, 7_500L, OfferState.FILLED, 6L);
+        logger.onOfferEvent(new OfferEvent(OfferTransition.Kind.COMPLETED, buyHigh, 5, 7_500L));
+
+        OfferRecord sellHigh = OfferRecord.newOffer(4, 1, itemId, "Abyssal whip", false, 5, 1_700, 7L)
+            .withFill(5, 8_500L, OfferState.FILLED, 8L);
+        logger.onOfferEvent(new OfferEvent(OfferTransition.Kind.COMPLETED, sellHigh, 5, 8_500L));
+
+        List<TransactionRequest> reqs = captureAll();
+        assertEquals(4, reqs.size());
+        Integer firstCycle = reqs.get(0).roundTripId;
+        Integer secondCycle = reqs.get(2).roundTripId;
+        assertEquals("buy and sell of the first lot share a round-trip id", firstCycle, reqs.get(1).roundTripId);
+        assertEquals("buy and sell of the second lot share a round-trip id", secondCycle, reqs.get(3).roundTripId);
+        assertNotEquals("the two round trips are distinct", firstCycle, secondCycle);
+    }
+
+    @Test
+    public void partialFillsWithinACycle_shareTheSameRoundTripId()
+    {
+        TransactionLogger logger = newLogger(RSN);
+        int itemId = 4151;
+
+        OfferRecord firstFill = OfferRecord.newOffer(1, 0, itemId, "Abyssal whip", true, 5, 1_000, 1L)
+            .withFill(2, 2_000L, OfferState.PARTIAL_FILL, 2L);
+        logger.onOfferEvent(new OfferEvent(OfferTransition.Kind.FILLED_DELTA, firstFill, 2, 2_000L));
+
+        OfferRecord secondFill = firstFill.withFill(5, 5_000L, OfferState.FILLED, 3L);
+        logger.onOfferEvent(new OfferEvent(OfferTransition.Kind.COMPLETED, secondFill, 3, 3_000L));
+
+        List<TransactionRequest> reqs = captureAll();
+        assertEquals(2, reqs.size());
+        assertEquals("both partial fills of the same buy share a round-trip id",
+            reqs.get(0).roundTripId, reqs.get(1).roundTripId);
+    }
+
+    @Test
+    public void relogMidCycle_preservesRoundTripIdFromPersistedLedgerState()
+    {
+        int itemId = 4151;
+
+        // First "session": a buy fill opens a cycle on the shared ledger.
+        TransactionLogger firstSession = newLogger(RSN);
+        OfferRecord buy = OfferRecord.newOffer(1, 0, itemId, "Abyssal whip", true, 5, 1_000, 1L)
+            .withFill(5, 5_000L, OfferState.FILLED, 2L);
+        firstSession.onOfferEvent(new OfferEvent(OfferTransition.Kind.COMPLETED, buy, 5, 5_000L));
+        Integer openCycleId = captureAll().get(0).roundTripId;
+
+        // Simulate a plugin restart: persist + restore the ledger, exactly as
+        // OfflineSyncService's persistLedgerState/preloadLedgerState round-trip it.
+        java.util.Map<Integer, RoundTripLedger.Entry> persisted = roundTripLedger.export(RSN);
+        RoundTripLedger restoredLedger = new RoundTripLedger();
+        restoredLedger.importState(RSN, persisted);
+
+        reset(apiClient);
+        when(apiClient.recordTransactionAsync(any(TransactionRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(null));
+        TransactionLogger secondSession = new TransactionLogger(apiClient, session,
+            () -> Optional.of(RSN), restoredLedger);
+
+        OfferRecord sell = OfferRecord.newOffer(2, 1, itemId, "Abyssal whip", false, 5, 1_200, 10L)
+            .withFill(5, 6_000L, OfferState.FILLED, 11L);
+        secondSession.onOfferEvent(new OfferEvent(OfferTransition.Kind.COMPLETED, sell, 5, 6_000L));
+
+        TransactionRequest sellReq = capture();
+        assertEquals("the id opened before the relog is preserved after restoring the ledger",
+            openCycleId, sellReq.roundTripId);
     }
 }

--- a/src/test/java/com/flipsmart/recommend/ActionResolverTest.java
+++ b/src/test/java/com/flipsmart/recommend/ActionResolverTest.java
@@ -79,11 +79,13 @@ public class ActionResolverTest {
         assertEquals(ActionKind.S3, resolver.resolve(in).getKind());
         assertEquals(ActionStep.COLLECT, resolver.resolve(in).getStep());
     }
-    @Test public void s3_fromCollectedCompletedBuyAwaitingList() {
+    @Test public void sellWaiting_fromCollectedCompletedBuyAwaitingList() {
+        // A collected completed buy awaiting sale lists at SELL_WAITING priority so it
+        // is offloaded before a new buy consumes the slot.
         ResolverInput in = base().filledSlotCount(7).collectedAwaitingList(Arrays.asList(
             new CollectedItem(32, CollectOrigin.COMPLETED_BUY, true, 5L))).build();
         ActionDecision d = resolver.resolve(in);
-        assertEquals(ActionKind.S3, d.getKind());
+        assertEquals(ActionKind.SELL_WAITING, d.getKind());
         assertEquals(ActionStep.LIST, d.getStep());
     }
     @Test public void s4_fromStaleSell() {
@@ -201,15 +203,17 @@ public class ActionResolverTest {
         assertEquals(ActionStep.LIST, d.getStep());
         assertEquals(71, d.getItemId());
     }
-    @Test public void completedBuyHeldItemDoesNotBeatNewBuy() {
-        // A normally-completed buy held for sale does NOT jump ahead of placing a new buy.
+    @Test public void completedBuyHeldItemBeatsNewBuy() {
+        // A normally-completed buy that has been collected for sale is listed before
+        // placing a new buy: the free slot lists the item we already own rather than
+        // being consumed by a new buy that leaves it nowhere to sell.
         ResolverInput in = base().filledSlotCount(7).surfaceableBuy(true, 99)
             .collectedAwaitingList(Arrays.asList(
                 new CollectedItem(71, CollectOrigin.COMPLETED_BUY, true, 5L))).build();
         ActionDecision d = resolver.resolve(in);
-        assertEquals(ActionKind.S2, d.getKind());
-        assertEquals(ActionStep.PLACE_BUY, d.getStep());
-        assertEquals(99, d.getItemId());
+        assertEquals(ActionKind.SELL_WAITING, d.getKind());
+        assertEquals(ActionStep.LIST, d.getStep());
+        assertEquals(71, d.getItemId());
     }
     @Test public void ac4_oldestPreemptiveSellTakesPriority() {
         // Two preemptively-collected items awaiting list → the one waiting longest surfaces first.

--- a/src/test/java/com/flipsmart/trading/RoundTripLedgerTest.java
+++ b/src/test/java/com/flipsmart/trading/RoundTripLedgerTest.java
@@ -1,0 +1,182 @@
+package com.flipsmart.trading;
+
+import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.domain.offer.OfferState;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class RoundTripLedgerTest
+{
+    private static final String RSN = "Zezima";
+    private static final int ITEM = 4151;
+
+    private RoundTripLedger ledger;
+
+    @Before
+    public void setUp()
+    {
+        ledger = new RoundTripLedger();
+    }
+
+    @Test
+    public void cleanTwoCycleSequence_producesTwoDistinctIds()
+    {
+        int buyLow = ledger.recordFill(RSN, ITEM, true, 10);
+        int sellLow = ledger.recordFill(RSN, ITEM, false, 10);
+        int buyHigh = ledger.recordFill(RSN, ITEM, true, 10);
+        int sellHigh = ledger.recordFill(RSN, ITEM, false, 10);
+
+        assertEquals("buy and sell of the same lot share the cycle", buyLow, sellLow);
+        assertEquals("buy and sell of the second lot share the cycle", buyHigh, sellHigh);
+        assertNotEquals("liquidating the first lot starts a new cycle for the second",
+            sellLow, buyHigh);
+    }
+
+    @Test
+    public void partialFillsWithinACycle_shareTheSameId()
+    {
+        int fill1 = ledger.recordFill(RSN, ITEM, true, 3);
+        int fill2 = ledger.recordFill(RSN, ITEM, true, 2);
+        int sellPartial = ledger.recordFill(RSN, ITEM, false, 4);
+        int sellRest = ledger.recordFill(RSN, ITEM, false, 1);
+
+        assertEquals(fill1, fill2);
+        assertEquals(fill1, sellPartial);
+        assertEquals(fill1, sellRest);
+    }
+
+    @Test
+    public void overSell_isTreatedAsLiquidationAndStartsNewCycle()
+    {
+        int buy = ledger.recordFill(RSN, ITEM, true, 5);
+        // Sells more than the ledger has recorded as held (e.g. externally-sourced stock) —
+        // still closes the cycle rather than leaving heldQuantity permanently negative.
+        int oversell = ledger.recordFill(RSN, ITEM, false, 8);
+        assertEquals(buy, oversell);
+
+        int nextBuy = ledger.recordFill(RSN, ITEM, true, 1);
+        assertNotEquals("the cycle after an over-sell is a fresh one", oversell, nextBuy);
+    }
+
+    @Test
+    public void differentItems_areTrackedIndependently()
+    {
+        int itemABuy = ledger.recordFill(RSN, ITEM, true, 5);
+        int itemBBuy = ledger.recordFill(RSN, 1305, true, 5);
+        assertEquals("a fresh item starts at the same initial cycle id as any other fresh item",
+            itemABuy, itemBBuy);
+
+        ledger.recordFill(RSN, ITEM, false, 5);
+        int itemBStillOpen = ledger.recordFill(RSN, 1305, true, 1);
+        assertEquals("liquidating item A must not roll item B's still-open cycle forward",
+            itemBBuy, itemBStillOpen);
+    }
+
+    @Test
+    public void nullOrEmptyRsn_returnsNullAndDoesNotThrow()
+    {
+        assertNull(ledger.recordFill(null, ITEM, true, 5));
+        assertNull(ledger.recordFill("", ITEM, true, 5));
+        assertNull(ledger.peekRoundTripId(null, ITEM));
+    }
+
+    @Test
+    public void peekRoundTripId_doesNotMutateHeldQuantityOrCycle()
+    {
+        int buy = ledger.recordFill(RSN, ITEM, true, 5);
+        Integer peeked = ledger.peekRoundTripId(RSN, ITEM);
+        assertEquals(Integer.valueOf(buy), peeked);
+
+        // Peeking repeatedly must never itself close the cycle.
+        ledger.peekRoundTripId(RSN, ITEM);
+        ledger.peekRoundTripId(RSN, ITEM);
+        int sell = ledger.recordFill(RSN, ITEM, false, 5);
+        assertEquals("cycle unaffected by peeks", buy, sell);
+    }
+
+    @Test
+    public void relogMidCycle_importedStatePreservesTheOpenId()
+    {
+        int buy = ledger.recordFill(RSN, ITEM, true, 7);
+
+        // Simulate a plugin restart: persist the entry, build a fresh ledger, restore it.
+        Map<Integer, RoundTripLedger.Entry> exported = ledger.export(RSN);
+        assertFalse(exported.isEmpty());
+
+        RoundTripLedger restarted = new RoundTripLedger();
+        restarted.importState(RSN, exported);
+
+        int sellAfterRelog = restarted.recordFill(RSN, ITEM, false, 7);
+        assertEquals("the id from before the relog is preserved on the imported ledger",
+            buy, sellAfterRelog);
+
+        int nextCycleBuy = restarted.recordFill(RSN, ITEM, true, 1);
+        assertNotEquals("a new cycle still starts correctly after the restored one closes",
+            sellAfterRelog, nextCycleBuy);
+    }
+
+    @Test
+    public void importState_withNullOrEmptyRsnOrEntries_isNoOp()
+    {
+        ledger.importState(null, Collections.singletonMap(ITEM, new RoundTripLedger.Entry(5, 1)));
+        ledger.importState(RSN, null);
+        ledger.importState(RSN, Collections.emptyMap());
+        assertTrue("no state materialized for RSN from any no-op import call", ledger.isEmpty(RSN));
+    }
+
+    @Test
+    public void seedColdStart_onlyAppliesWhenNoStateExistsYet()
+    {
+        OfferRecord liveBuy = OfferRecord.newOffer(1L, 0, ITEM, "Abyssal whip", true, 50, 1_000, 1_000L)
+            .withFill(30, 30_000L, OfferState.PARTIAL_FILL, 1_500L);
+
+        ledger.seedColdStart(RSN, Collections.singletonList(liveBuy));
+        assertFalse(ledger.isEmpty(RSN));
+
+        // A sell of exactly the seeded quantity closes the cycle immediately — proving the
+        // seed set heldQuantity to 30, not 0.
+        int seededCycle = ledger.peekRoundTripId(RSN, ITEM);
+        int sell = ledger.recordFill(RSN, ITEM, false, 30);
+        assertEquals(seededCycle, sell);
+
+        int afterSeededCycle = ledger.peekRoundTripId(RSN, ITEM);
+        assertNotEquals("selling the seeded amount closed the seeded cycle", seededCycle, afterSeededCycle);
+    }
+
+    @Test
+    public void seedColdStart_isNoOpWhenLedgerAlreadyHasState()
+    {
+        ledger.recordFill(RSN, ITEM, true, 5);
+        Map<Integer, RoundTripLedger.Entry> before = ledger.export(RSN);
+
+        OfferRecord liveBuy = OfferRecord.newOffer(1L, 0, ITEM, "Abyssal whip", true, 999, 1_000, 1_000L)
+            .withFill(999, 999_000L, OfferState.PARTIAL_FILL, 1_500L);
+        ledger.seedColdStart(RSN, Collections.singletonList(liveBuy));
+
+        assertEquals("an already-populated ledger is never overwritten by cold-start seeding",
+            before.get(ITEM).heldQuantity, ledger.export(RSN).get(ITEM).heldQuantity);
+    }
+
+    @Test
+    public void seedColdStart_ignoresSellRecordsAndZeroFillBuys()
+    {
+        OfferRecord sellRecord = OfferRecord.newOffer(2L, 1, ITEM, "Abyssal whip", false, 10, 1_000, 1_000L)
+            .withFill(10, 10_000L, OfferState.FILLED, 1_500L);
+        OfferRecord zeroFillBuy = OfferRecord.newOffer(3L, 2, 1305, "Dragon longsword", true, 10, 1_000, 1_000L);
+
+        ledger.seedColdStart(RSN, java.util.Arrays.asList(sellRecord, zeroFillBuy));
+        assertTrue("neither a sell nor an unfilled buy contributes held quantity",
+            ledger.isEmpty(RSN));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a zero-crossing position ledger (`RoundTripLedger`, keyed by `(rsn, itemId)`) that assigns a monotonic `round_trip_id` to every buy/sell fill between two full liquidations of a position, and stamps that id onto the transaction the plugin POSTs to the backend. This lets the backend match a sell to the buys from its own round trip instead of falling back to the oldest same-item buys, which could belong to an unrelated flip. This PR is the plugin half (workstream A) of issue #893; a separate backend PR implements the counterpart matching logic, and a further workstream B (sending the post-tax sell value) may follow later.

## Changes

### ✨ New Features
- `RoundTripLedger`: tracks held quantity per `(rsn, itemId)` as buys minus sells; a cycle id increments each time the position fully liquidates back to zero, so every fill in between shares one `round_trip_id`.
- `round_trip_id` is now stamped onto outgoing GE transaction payloads via `TransactionLogger` and threaded through `TransactionRequest` / `TransactionEndpoints`.
- Zero-fill offer placements peek the current round-trip id (without mutating held quantity) so they carry the same id their eventual fills will.

### ♻️ Refactoring
- `TransactionLogger` wiring updated so idempotency dedup runs **before** the ledger mutation — duplicate/replayed fills do not double-count into held quantity.
- `ServiceWiring` / `FlipSmartPlugin` updated to construct and inject `RoundTripLedger`.

### Persistence
- Ledger state is persisted per-RSN via `OfflineSyncService`, mirroring the existing `OfferStore` persistence pattern.
- Cold-start seed: on first load with no persisted ledger state for an RSN (e.g. this feature shipping to an account with an already-open GE position), the ledger seeds held quantity per item from currently-live unmatched buy fills rather than assuming a known position — a conservative default that avoids colliding a pre-existing position with a fresh cycle that has never seen it.

## Testing

### Automated Tests
- `./gradlew clean build` — BUILD SUCCESSFUL
- 451 tests, 0 failures, 0 errors
- New coverage: `RoundTripLedgerTest` (zero-crossing/cycle-increment behavior, cold-start seeding, persistence import/export) and expanded `TransactionLoggerTest` (round-trip id stamping, dedup-before-mutation ordering)

### Manual Testing
- [x] Open and fully close a single buy/sell cycle for one item in-game; confirm the transaction POST includes a `round_trip_id`.
- [x] Partially fill a buy, partially sell, then complete the round trip; confirm all fills in the cycle share the same `round_trip_id`.
- [x] Fully liquidate a position, then open a new position in the same item; confirm the second cycle gets a new (incremented) `round_trip_id`.
- [x] Restart the client mid-cycle and confirm ledger state (held quantity + cycle id) is restored from persistence rather than reset.
- [x] Log in on an account with an existing open GE position for the first time after this change ships; confirm cold-start seeding produces a sane held quantity instead of a false zero-crossing.

## API Changes

**Modified request payload** (additive, backward-compatible):
- `TransactionRequest`: new optional `round_trip_id` field. Serialized only when non-null, so older/other clients and the existing API contract are unaffected.

No endpoint signatures changed.

## Deployment Notes

- No new environment variables, dependencies, or configuration changes.
- No plugin-hub version bump required for this PR by itself; coordinate with the backend PR before this is user-facing in aggregate.
- Backend counterpart (separate PR on `flip-smart`) is required for the `round_trip_id` to actually affect sell-to-buy matching; until that ships, the field is sent but unused server-side.

## Checklist

- [x] Tests added/updated
- [x] Code follows style guidelines
- [x] Commit is clean and descriptive
- [x] No console/debug code left
- [x] Source comments free of issue-number references (LOC-budget scan run, clean)
- [ ] Reviewed by teammate

## Related Issues

Part of Flip-Smart/flip-smart#893

### 🩺 Codacy Quality Gate — fixed in this PR
- `e63cd78` `PMD_AvoidSynchronizedAtMethodLevel` `RoundTripLedger.java:50,71,87,94,100,116` — replaced method-level `synchronized` with a private lock object + block-level synchronization, so the singleton's monitor is no longer exposed to external callers

### 🩺 Codacy Quality Gate — dismissed via API (noise)
- `PMD_AvoidFieldNameMatchingMethodName` `TransactionRequest.java:55` — matches the fluent-Builder convention already used unflagged by 6 sibling fields in the same class
- `PMD_AvoidInstantiatingObjectsInLoops` `RoundTripLedger.java:129` — `computeIfAbsent` only allocates on cache miss, not per loop iteration
- `PMD_UseConcurrentHashMap` `RoundTripLedger.java:43,122` — map access is already fully guarded by the class's private lock; a concurrent map would be redundant
- `PMD_GuardLogStatement` `OfflineSyncService.java:266,294` — SLF4J parameterized logging already defers the format cost; matches the file's existing 20+ instance convention
- `Lizard_ccn-medium` `RoundTripLedger.java:116` — dismissed as documented complexity-warning noise, then independently resolved anyway via the extract-seed-helper commit below
- `PMD_UseConcurrentHashMap` / `PMD_AvoidInstantiatingObjectsInLoops` `RoundTripLedger.java:107,111` — re-flagged on the `export()` deep-copy loop itself; same false-positive classes as above (local map scoped to the lock, and object creation is the deep-copy's actual purpose)

### 🤖 Codacy AI Reviewer — fixed in this PR
- `8bcbf8d` `RoundTripLedger.java:116` — extracted the fill-aggregation loop out of `seedColdStart` into a static helper, dropping it under the complexity limit
- `e63cd78` `RoundTripLedger.java:50` — block-level lock replaces method-level `synchronized`
- `7a752d2` `RoundTripLedger.java:95` — `export()` now deep-copies each `Entry` so a concurrent `recordFill` can't mutate one mid-serialization

### 🤖 Codacy AI Reviewer — deferred (in-thread rationale)
- `RoundTripLedger.java:44` — unbounded ledger growth is a real long-term concern, but the suggested fix (pruning zero-quantity entries) would reset `cycleId` back to 1 on the item's next buy and reintroduce the exact round-trip collision bug this ledger exists to fix; needs a growth-cap design that preserves `cycleId` monotonicity, tracked as a follow-up rather than done here


### 🩺 Codacy — re-verified at fb427f7
No open signals: quality gate green (0 new issues), 0 outstanding AI Reviewer threads (all 4 replied + resolved above).


---

## Also in this PR — Flip Assist: prompt sell of a collected item before a new buy

Surfaced during #893 QA. A normally-completed buy that has been collected for sale
was ranked below placing a new buy (`S3` vs `S2`) in `ActionResolver`, so with one
free GE slot the plugin recommended a new buy — consuming the last slot and leaving
the just-collected item nowhere to sell. Collected-for-sale items (both preemptive
partial-cancel and normally-completed) now rank at `SELL_WAITING`, so the free slot
lists what we already own before opening a new position. Resolver tests updated to
pin the new priority. Verified in-game (client log: `resolver decision SELL_WAITING/LIST`
now wins over a surfaceable buy).
