### PR TITLE
fix: honor GE tax-exempt list on sell offer-setup description (#904)

### DIFF
--- a/src/main/java/com/flipsmart/GeOfferDescriptionFormatter.java
+++ b/src/main/java/com/flipsmart/GeOfferDescriptionFormatter.java
@@ -103,18 +103,16 @@ public final class GeOfferDescriptionFormatter
 		int listedSellPrice,
 		int quantity)
 	{
-		StringBuilder sb = new StringBuilder();
-
-		// AC3 — Breakeven (fixed, depends only on recorded buy price + tax)
-		sb.append(formatBreakevenLine(itemId, recordedBuyPrice)).append("<br>");
-
-		// AC4 — Tax applied (dynamic with entered price+qty). Item-aware so
-		// tax-exempt-list items show 0 tax regardless of price.
 		int taxPerItem = calculateTaxPerItem(itemId, listedSellPrice);
-		sb.append(formatTaxLine(taxPerItem, quantity)).append("<br>");
 
-		// AC5 + AC6 — Your profit (dynamic with entered price+qty, color-coded)
-		sb.append(formatProfitLine(recordedBuyPrice, listedSellPrice, taxPerItem, quantity));
+		StringBuilder sb = new StringBuilder()
+			// AC3 — Breakeven (fixed, depends only on recorded buy price + tax)
+			.append(formatBreakevenLine(itemId, recordedBuyPrice)).append("<br>")
+			// AC4 — Tax applied (dynamic with entered price+qty). Item-aware so
+			// tax-exempt-list items show 0 tax regardless of price.
+			.append(formatTaxLine(taxPerItem, quantity)).append("<br>")
+			// AC5 + AC6 — Your profit (dynamic with entered price+qty, color-coded)
+			.append(formatProfitLine(recordedBuyPrice, listedSellPrice, taxPerItem, quantity));
 
 		return sb.toString();
 	}

--- a/src/main/java/com/flipsmart/GeOfferDescriptionFormatter.java
+++ b/src/main/java/com/flipsmart/GeOfferDescriptionFormatter.java
@@ -106,14 +106,12 @@ public final class GeOfferDescriptionFormatter
 		StringBuilder sb = new StringBuilder();
 
 		// AC3 — Breakeven (fixed, depends only on recorded buy price + tax)
-		sb.append(formatBreakevenLine(itemId, recordedBuyPrice));
-		sb.append("<br>");
+		sb.append(formatBreakevenLine(itemId, recordedBuyPrice)).append("<br>");
 
 		// AC4 — Tax applied (dynamic with entered price+qty). Item-aware so
 		// tax-exempt-list items show 0 tax regardless of price.
 		int taxPerItem = calculateTaxPerItem(itemId, listedSellPrice);
-		sb.append(formatTaxLine(taxPerItem, quantity));
-		sb.append("<br>");
+		sb.append(formatTaxLine(taxPerItem, quantity)).append("<br>");
 
 		// AC5 + AC6 — Your profit (dynamic with entered price+qty, color-coded)
 		sb.append(formatProfitLine(recordedBuyPrice, listedSellPrice, taxPerItem, quantity));

--- a/src/main/java/com/flipsmart/GeOfferDescriptionFormatter.java
+++ b/src/main/java/com/flipsmart/GeOfferDescriptionFormatter.java
@@ -87,6 +87,9 @@ public final class GeOfferDescriptionFormatter
 	 * the RuneLite-injected script that fires geSellExamineText is responsible
 	 * for invoking this on each rebuild.
 	 *
+	 * @param itemId           The item being sold, needed to honour the GE
+	 *                         tax-exempt list (bonds, darts, etc.) so exempt
+	 *                         items show pre-tax breakeven and profit.
 	 * @param recordedBuyPrice Player's recorded average buy price for the item,
 	 *                         or {@code null} if no buy history exists.
 	 * @param listedSellPrice  Currently entered sell price per item.
@@ -95,6 +98,7 @@ public final class GeOfferDescriptionFormatter
 	 *         color-coded profit lines separated by {@code <br>}.
 	 */
 	public static String formatSellDescription(
+		int itemId,
 		Integer recordedBuyPrice,
 		int listedSellPrice,
 		int quantity)
@@ -102,11 +106,12 @@ public final class GeOfferDescriptionFormatter
 		StringBuilder sb = new StringBuilder();
 
 		// AC3 — Breakeven (fixed, depends only on recorded buy price + tax)
-		sb.append(formatBreakevenLine(recordedBuyPrice));
+		sb.append(formatBreakevenLine(itemId, recordedBuyPrice));
 		sb.append("<br>");
 
-		// AC4 — Tax applied (dynamic with entered price+qty)
-		int taxPerItem = calculateTaxPerItem(listedSellPrice);
+		// AC4 — Tax applied (dynamic with entered price+qty). Item-aware so
+		// tax-exempt-list items show 0 tax regardless of price.
+		int taxPerItem = calculateTaxPerItem(itemId, listedSellPrice);
 		sb.append(formatTaxLine(taxPerItem, quantity));
 		sb.append("<br>");
 
@@ -116,14 +121,14 @@ public final class GeOfferDescriptionFormatter
 		return sb.toString();
 	}
 
-	static String formatBreakevenLine(Integer recordedBuyPrice)
+	static String formatBreakevenLine(int itemId, Integer recordedBuyPrice)
 	{
 		String label = colorTag(COLOR_LABEL) + "Breakeven: </col>";
 		if (recordedBuyPrice == null)
 		{
 			return label + "?";
 		}
-		int breakeven = calculateBreakevenPrice(recordedBuyPrice);
+		int breakeven = calculateBreakevenPrice(itemId, recordedBuyPrice);
 		return label + colorTag(COLOR_WHITE) + formatExact(breakeven) + " gp</col>";
 	}
 
@@ -165,14 +170,14 @@ public final class GeOfferDescriptionFormatter
 		return sb.toString();
 	}
 
-	static int calculateBreakevenPrice(int recordedBuyPrice)
+	static int calculateBreakevenPrice(int itemId, int recordedBuyPrice)
 	{
-		return GeTax.breakevenSellPrice(recordedBuyPrice);
+		return GeTax.breakevenSellPrice(itemId, recordedBuyPrice);
 	}
 
-	static int calculateTaxPerItem(int sellPrice)
+	static int calculateTaxPerItem(int itemId, int sellPrice)
 	{
-		return GeTax.taxFor(sellPrice);
+		return GeTax.taxFor(itemId, sellPrice);
 	}
 
 	private static String colorForProfit(long totalProfit)

--- a/src/main/java/com/flipsmart/GeOfferDescriptionService.java
+++ b/src/main/java/com/flipsmart/GeOfferDescriptionService.java
@@ -406,14 +406,14 @@ public class GeOfferDescriptionService
 		Integer recordedBuyPrice = BuyPriceLookup.findAverageBuyPrice(plugin.getCurrentActiveFlips(), itemId);
 		int sellPrice = Math.max(client.getVarbitValue(VarbitID.GE_NEWOFFER_PRICE), 0);
 		int quantity = Math.max(client.getVarbitValue(VarbitID.GE_NEWOFFER_QUANTITY), 0);
-		return GeOfferDescriptionFormatter.formatSellDescription(recordedBuyPrice, sellPrice, quantity);
+		return GeOfferDescriptionFormatter.formatSellDescription(itemId, recordedBuyPrice, sellPrice, quantity);
 	}
 
 	private String buildSellDescriptionStatic(int itemId, int listedPrice, int totalQuantity)
 	{
 		Integer recordedBuyPrice = BuyPriceLookup.findAverageBuyPrice(plugin.getCurrentActiveFlips(), itemId);
 		return GeOfferDescriptionFormatter.formatSellDescription(
-			recordedBuyPrice, Math.max(listedPrice, 0), Math.max(totalQuantity, 0));
+			itemId, recordedBuyPrice, Math.max(listedPrice, 0), Math.max(totalQuantity, 0));
 	}
 
 	private Integer lookupBuyLimit(int itemId)

--- a/src/main/java/com/flipsmart/util/GeTax.java
+++ b/src/main/java/com/flipsmart/util/GeTax.java
@@ -92,6 +92,11 @@ public final class GeTax
 		{
 			return true;
 		}
+		return isExemptItem(itemId);
+	}
+
+	private static boolean isExemptItem(int itemId)
+	{
 		return EXEMPT_ITEM_IDS.contains(itemId);
 	}
 
@@ -133,7 +138,7 @@ public final class GeTax
 	 */
 	public static int breakevenSellPrice(int itemId, int recordedBuyPrice)
 	{
-		if (EXEMPT_ITEM_IDS.contains(itemId))
+		if (isExemptItem(itemId))
 		{
 			return recordedBuyPrice;
 		}

--- a/src/main/java/com/flipsmart/util/GeTax.java
+++ b/src/main/java/com/flipsmart/util/GeTax.java
@@ -126,6 +126,21 @@ public final class GeTax
 	}
 
 	/**
+	 * Item-aware breakeven: for items on the tax-free list the flip breaks even
+	 * the moment the sell price covers the buy price (no tax to overcome), so
+	 * the breakeven is simply the recorded buy price. Otherwise defers to the
+	 * price-only calculation.
+	 */
+	public static int breakevenSellPrice(int itemId, int recordedBuyPrice)
+	{
+		if (EXEMPT_ITEM_IDS.contains(itemId))
+		{
+			return recordedBuyPrice;
+		}
+		return breakevenSellPrice(recordedBuyPrice);
+	}
+
+	/**
 	 * Smallest sell price S such that {@code S - taxFor(S) >= recordedBuyPrice},
 	 * i.e. the price at which a flip first breaks even after GE tax. Returns the
 	 * buy price unchanged for tax-exempt (&le; 50gp) inputs.

--- a/src/test/java/com/flipsmart/GeOfferDescriptionFormatterTest.java
+++ b/src/test/java/com/flipsmart/GeOfferDescriptionFormatterTest.java
@@ -1,0 +1,51 @@
+package com.flipsmart;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Covers the sell-offer description math, in particular that the GE tax-exempt
+ * item list is honoured on the offer-setup screen (issue #904 AC2). A previous
+ * version used the item-less {@link com.flipsmart.util.GeTax} overloads here,
+ * so exempt-list items (bonds, darts, arrows, cooked food, …) were shown with
+ * tax and an under-stated profit.
+ */
+public class GeOfferDescriptionFormatterTest
+{
+	private static final int ABYSSAL_WHIP_ID = 4151;       // taxable
+	private static final int OLD_SCHOOL_BOND_ID = 13190;   // tax-exempt list
+
+	@Test
+	public void taxableItemAppliesTaxToBreakevenAndProfit()
+	{
+		// Buy 100, sell 200, qty 1: tax = floor(200 * 0.02) = 4/item.
+		String out = GeOfferDescriptionFormatter.formatSellDescription(
+			ABYSSAL_WHIP_ID, 100, 200, 1);
+
+		assertTrue("taxable item should show non-zero tax", out.contains("Tax applied: </col>4 gp"));
+		// Breakeven must sit above the buy price to cover tax.
+		int breakeven = GeOfferDescriptionFormatter.calculateBreakevenPrice(ABYSSAL_WHIP_ID, 100);
+		assertTrue("taxable breakeven should exceed buy price", breakeven > 100);
+		// Profit = 200 - 100 - 4 = 96 (post-tax).
+		assertTrue("taxable profit is post-tax", out.contains("+96 gp"));
+	}
+
+	@Test
+	public void exemptListItemShowsNoTaxAndPreTaxProfit()
+	{
+		// Old school bond is on the exempt list; at any price it is never taxed.
+		String out = GeOfferDescriptionFormatter.formatSellDescription(
+			OLD_SCHOOL_BOND_ID, 8_000_000, 8_100_000, 1);
+
+		assertEquals("exempt-list item is never taxed",
+			0, GeOfferDescriptionFormatter.calculateTaxPerItem(OLD_SCHOOL_BOND_ID, 8_100_000));
+		assertTrue("tax line reads zero for exempt item", out.contains("Tax applied: </col>0 gp"));
+		// Breakeven for an exempt item is simply the buy price (no tax to cover).
+		assertEquals(8_000_000,
+			GeOfferDescriptionFormatter.calculateBreakevenPrice(OLD_SCHOOL_BOND_ID, 8_000_000));
+		// Profit is the raw margin: 8,100,000 - 8,000,000 = 100,000 (pre-tax).
+		assertTrue("exempt profit is pre-tax margin", out.contains("+100,000 gp"));
+	}
+}


### PR DESCRIPTION
## Summary

The GE sell offer-setup description computed tax and breakeven using item-less `GeTax` overloads, so tax-exempt items (bonds, darts, arrows, cooked food, teleport tablets, etc.) were shown with GE tax wrongly deducted and an understated profit. This threads the item id through the sell-description formatter so exempt items correctly show 0 tax, a breakeven equal to the buy price, and pre-tax profit, while taxable items are unaffected.

## Changes

### 🐛 Bug Fixes
- `GeOfferDescriptionFormatter.formatSellDescription` now accepts an `itemId` parameter and uses it to compute both the breakeven line and the tax line, so tax-exempt items no longer have GE tax wrongly deducted on the offer-setup screen.
- `GeOfferDescriptionService` passes `itemId` through both call sites (`buildSellDescription` and `buildSellDescriptionStatic`) to the formatter.

### ♻️ Refactoring
- Added `GeTax.breakevenSellPrice(int itemId, int buyPrice)` overload that returns the buy price directly for exempt-list items (no tax to cover) and otherwise defers to the existing price-only calculation.

### 🗄️ Database Changes
N/A — plugin-only change, no backend/database impact.

### 📝 Documentation
- Updated Javadoc on `formatSellDescription` and added Javadoc on the new `GeTax.breakevenSellPrice(int, int)` overload.

## Testing

### Automated Tests
- ✅ New `GeOfferDescriptionFormatterTest` (2 tests): taxable item still applies post-tax deduction to breakeven/profit; exempt-list item shows 0 tax, breakeven == buy price, and pre-tax profit.
- ✅ Full `./gradlew clean build` passes (compile, test, check, assemble all green).

### Manual Testing
- [x] Open a sell offer for a tax-exempt item (e.g. Old school bond) in-game and confirm the offer-setup description shows "Tax applied: 0 gp", a breakeven price equal to the buy price, and pre-tax profit.
- [x] Open a sell offer for a normal taxable item and confirm it still shows post-tax numbers (tax deducted, breakeven reflecting tax).

## API Changes

N/A — plugin-only change, no backend API impact.

## Frontend Impact

N/A — plugin-only change.

## Database Migrations

N/A.

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: None
- [ ] Requires database migration: No

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (Javadoc)
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by teammate

## Related Issues

Part of Flip-Smart/flip-smart#904

## Screenshots

N/A — no UI layout change; text content of the existing offer-setup description changes for tax-exempt items only. Manual in-game testing steps above cover verification.

### 🩺 Codacy Quality Gate — fixed in this PR
- `51799f1`, `57389b7` PMD_ConsecutiveAppendsShouldReuse `GeOfferDescriptionFormatter.java` — first pass chained the breakeven/tax append pairs; the gate re-flagged the tax/profit pair (only a comment separated them), so a follow-up fully chained all three `StringBuilder.append` calls in `formatSellDescription` into one statement.
- `7203333` (consistency, flagged only via AI Reviewer, not a gate finding) `GeTax.java:136` — extracted private `isExemptItem(itemId)` helper shared by `isExempt(itemId, sellPrice)` and `breakevenSellPrice(itemId, recordedBuyPrice)` to remove duplicated `EXEMPT_ITEM_IDS.contains(itemId)` logic.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `51799f1`, `57389b7` `GeOfferDescriptionFormatter.java:109` — chained consecutive `StringBuilder.append` calls (same finding as the PMD gate issue above).
- `7203333` `GeTax.java:136` — use a shared `isExemptItem(itemId)` helper instead of duplicating `EXEMPT_ITEM_IDS.contains(itemId)`.
