### PR TITLE
fix: drop stale entries from Active Flips tab (#914)

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -10,6 +10,7 @@ import com.flipsmart.api.dto.FlipStatisticsResponse;
 import com.flipsmart.api.dto.PluginSyncResponse;
 import com.flipsmart.domain.flip.FlipAnalysis;
 import com.flipsmart.domain.flip.ActiveFlip;
+import com.flipsmart.domain.flip.ActiveFlipDisplayFilter;
 import com.flipsmart.domain.flip.ActiveFlipLocalUpdater;
 import com.flipsmart.api.dto.BlocklistSummary;
 import com.flipsmart.domain.offer.OfferTransition;
@@ -1376,67 +1377,28 @@ public class FlipFinderPanel extends PluginPanel
 	}
 
 	/**
-	 * Show flips that are either currently in a GE slot / collected this
-	 * session, or had buy activity in the last 7 days (covers client-restart
-	 * scenarios, since collectedItemIds is session-only and GE tracking takes
-	 * time to repopulate). Stale-flip cleanup beyond that window is the
-	 * backend's job via /flips/cleanup. Null-safe: returns an empty list.
+	 * Keep only flips backed by live player state — an open GE offer, an item
+	 * collected this session, or an item held in the inventory — so completed,
+	 * cancelled, and collected trades drop off the tab immediately.
+	 * Null-safe: returns an empty list.
 	 */
 	private List<ActiveFlip> filterActiveFlips(List<ActiveFlip> activeFlips)
 	{
-		List<ActiveFlip> filtered = new ArrayList<>();
-		if (activeFlips == null)
+		List<ActiveFlip> filtered = ActiveFlipDisplayFilter.retain(
+			activeFlips, plugin.getActiveFlipItemIds(), plugin.getInventoryFlipItemIds());
+
+		if (activeFlips != null && log.isDebugEnabled())
 		{
-			return filtered;
-		}
-
-		java.util.Set<Integer> activeItemIds = plugin.getActiveFlipItemIds();
-		java.time.Instant sevenDaysAgo = java.time.Instant.now().minus(java.time.Duration.ofDays(7));
-
-		for (ActiveFlip flip : activeFlips)
-		{
-			boolean inGeOrCollected = activeItemIds.contains(flip.getItemId());
-			boolean isRecent = isFlipRecent(flip, sevenDaysAgo);
-
-			if (inGeOrCollected || isRecent)
+			for (ActiveFlip flip : activeFlips)
 			{
-				filtered.add(flip);
-				log.debug("Including flip: {} (inGE={}, recent={})",
-					flip.getItemName(), inGeOrCollected, isRecent);
-			}
-			else
-			{
-				log.debug("Filtering stale flip: {} (not in GE and older than 7 days)", flip.getItemName());
+				if (!filtered.contains(flip))
+				{
+					log.debug("Filtering stale flip: {} (not in GE, not collected, not in inventory)",
+						flip.getItemName());
+				}
 			}
 		}
 		return filtered;
-	}
-
-	/**
-	 * Prefers lastBuyTime over firstBuyTime. A missing or unparseable
-	 * timestamp is treated as recent so a flip is never hidden due to a data
-	 * gap rather than genuine staleness.
-	 */
-	private boolean isFlipRecent(ActiveFlip flip, java.time.Instant cutoff)
-	{
-		String timeStr = flip.getLastBuyTime();
-		if (timeStr == null || timeStr.isEmpty())
-		{
-			timeStr = flip.getFirstBuyTime();
-		}
-		if (timeStr == null || timeStr.isEmpty())
-		{
-			return true;
-		}
-
-		try
-		{
-			return java.time.Instant.parse(timeStr).isAfter(cutoff);
-		}
-		catch (Exception e)
-		{
-			return true;
-		}
 	}
 
 	/** Reflect the current active-flip/pending-order counts in the tab's status label. */

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1387,11 +1387,11 @@ public class FlipFinderPanel extends PluginPanel
 		List<ActiveFlip> filtered = ActiveFlipDisplayFilter.retain(
 			activeFlips, plugin.getActiveFlipItemIds(), plugin.getInventoryFlipItemIds());
 
-		if (activeFlips != null && log.isDebugEnabled())
+		if (activeFlips != null)
 		{
 			for (ActiveFlip flip : activeFlips)
 			{
-				if (!filtered.contains(flip))
+				if (!filtered.contains(flip) && log.isDebugEnabled())
 				{
 					log.debug("Filtering stale flip: {} (not in GE, not collected, not in inventory)",
 						flip.getItemName());

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -210,6 +210,11 @@ public class FlipSmartPlugin extends Plugin
 	// Cached GE location flag — updated each game tick on the client thread.
 	private volatile boolean atGrandExchange = false;
 
+	// Canonical item ids currently held in the inventory. Maintained on the client
+	// thread (inventory ItemContainerChanged) and read from the Swing EDT by the
+	// Active Flips display filter, so it must stay thread-safe.
+	private final java.util.Set<Integer> inventoryFlipItemIds = java.util.concurrent.ConcurrentHashMap.newKeySet();
+
 	// Track login to avoid recording existing offers as new transactions
 	private static final int GE_LOGIN_BURST_WINDOW = 3; // ticks
 
@@ -588,7 +593,19 @@ public class FlipSmartPlugin extends Plugin
 		itemIds.addAll(session.getCollectedItemIds());
 		return itemIds;
 	}
-	
+
+	/**
+	 * Canonical item ids currently held in the inventory, as a thread-safe snapshot
+	 * maintained on the client thread. Read from the Swing EDT by the Active Flips
+	 * display filter to keep collected-but-unsold flips visible across a client
+	 * restart (when session-only collected state is lost) without reading the game
+	 * client off-thread.
+	 */
+	public java.util.Set<Integer> getInventoryFlipItemIds()
+	{
+		return inventoryFlipItemIds;
+	}
+
 	/**
 	 * Get all active flip item IDs including items in inventory.
 	 * This is used for filtering active flips display to show items the player
@@ -1537,19 +1554,27 @@ public class FlipSmartPlugin extends Plugin
 		if (inventory == null)
 		{
 			session.setCashStack(0);
+			inventoryFlipItemIds.clear();
 			return;
 		}
 
 		int totalCash = 0;
 		Item[] items = inventory.getItems();
 
+		java.util.Set<Integer> currentInventoryIds = new java.util.HashSet<>();
 		for (Item item : items)
 		{
 			if (item.getId() == COINS_ITEM_ID)
 			{
 				totalCash += item.getQuantity();
 			}
+			if (item.getId() > 0)
+			{
+				currentInventoryIds.add(itemManager.canonicalize(item.getId()));
+			}
 		}
+		inventoryFlipItemIds.retainAll(currentInventoryIds);
+		inventoryFlipItemIds.addAll(currentInventoryIds);
 
 		if (totalCash != session.getCurrentCashStack())
 		{

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -210,10 +210,11 @@ public class FlipSmartPlugin extends Plugin
 	// Cached GE location flag — updated each game tick on the client thread.
 	private volatile boolean atGrandExchange = false;
 
-	// Canonical item ids currently held in the inventory. Maintained on the client
-	// thread (inventory ItemContainerChanged) and read from the Swing EDT by the
-	// Active Flips display filter, so it must stay thread-safe.
-	private final java.util.Set<Integer> inventoryFlipItemIds = java.util.concurrent.ConcurrentHashMap.newKeySet();
+	// Canonical item ids currently held in the inventory. Rebuilt on the client
+	// thread (inventory ItemContainerChanged) and published as one volatile swap to
+	// an immutable set, so the Swing EDT reader in the Active Flips filter always
+	// sees a complete snapshot, never a partially-rebuilt set.
+	private volatile java.util.Set<Integer> inventoryFlipItemIds = java.util.Collections.emptySet();
 
 	// Track login to avoid recording existing offers as new transactions
 	private static final int GE_LOGIN_BURST_WINDOW = 3; // ticks
@@ -1554,7 +1555,7 @@ public class FlipSmartPlugin extends Plugin
 		if (inventory == null)
 		{
 			session.setCashStack(0);
-			inventoryFlipItemIds.clear();
+			inventoryFlipItemIds = java.util.Collections.emptySet();
 			return;
 		}
 
@@ -1573,8 +1574,7 @@ public class FlipSmartPlugin extends Plugin
 				currentInventoryIds.add(itemManager.canonicalize(item.getId()));
 			}
 		}
-		inventoryFlipItemIds.retainAll(currentInventoryIds);
-		inventoryFlipItemIds.addAll(currentInventoryIds);
+		inventoryFlipItemIds = java.util.Collections.unmodifiableSet(currentInventoryIds);
 
 		if (totalCash != session.getCurrentCashStack())
 		{

--- a/src/main/java/com/flipsmart/domain/flip/ActiveFlipDisplayFilter.java
+++ b/src/main/java/com/flipsmart/domain/flip/ActiveFlipDisplayFilter.java
@@ -1,0 +1,55 @@
+package com.flipsmart.domain.flip;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Decides which backend active flips are actually still in progress for the
+ * logged-in player, so the Active Flips tab mirrors the real GE window rather
+ * than lingering on completed, cancelled, or collected trades.
+ *
+ * A flip is retained only when its item is backed by live player state: an open
+ * GE buy/sell offer, an item collected this session and awaiting sale, or an
+ * item currently held in the inventory. The previous "bought within 7 days"
+ * recency rule kept fully-sold flips visible for days and is deliberately gone —
+ * activeness is a function of present state, not of how recently a buy happened.
+ */
+public final class ActiveFlipDisplayFilter
+{
+	private ActiveFlipDisplayFilter()
+	{
+	}
+
+	/**
+	 * @param flips            active flips reported by the backend (may be null)
+	 * @param activeItemIds    item ids in a live GE offer or collected this session
+	 * @param inventoryItemIds item ids currently in the player's inventory
+	 * @return the flips whose item is present in live player state, in input order
+	 */
+	public static List<ActiveFlip> retain(List<ActiveFlip> flips, Set<Integer> activeItemIds,
+		Set<Integer> inventoryItemIds)
+	{
+		List<ActiveFlip> retained = new ArrayList<>();
+		if (flips == null)
+		{
+			return retained;
+		}
+		for (ActiveFlip flip : flips)
+		{
+			if (isBackedByLiveState(flip, activeItemIds, inventoryItemIds))
+			{
+				retained.add(flip);
+			}
+		}
+		return retained;
+	}
+
+	private static boolean isBackedByLiveState(ActiveFlip flip, Set<Integer> activeItemIds,
+		Set<Integer> inventoryItemIds)
+	{
+		int itemId = flip.getItemId();
+		return (activeItemIds != null && activeItemIds.contains(itemId))
+			|| (inventoryItemIds != null && inventoryItemIds.contains(itemId));
+	}
+}

--- a/src/main/java/com/flipsmart/recommend/ActionKind.java
+++ b/src/main/java/com/flipsmart/recommend/ActionKind.java
@@ -1,7 +1,10 @@
 package com.flipsmart.recommend;
 
 public enum ActionKind {
-    // Priority is by ordinal (lowest wins). SELL_WAITING sits above S2 so an item
-    // collected preemptively from an open trade is sold before placing a new buy.
-    S1, SELL_WAITING, S2, S3, S4, S5, S6, IDLE
+    // Priority is by ordinal (lowest wins). SELL_WAITING and S3 both sit above S2 so
+    // the collect->sell pipeline for an item we already own is finished before capital
+    // is deployed into a new buy: SELL_WAITING lists an already-collected item, and S3
+    // collects a completed buy (which then becomes a SELL_WAITING) — both ahead of the
+    // S2 new buy.
+    S1, SELL_WAITING, S3, S2, S4, S5, S6, IDLE
 }

--- a/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
@@ -64,8 +64,10 @@ public class AutoRecommendDispatchTest {
     }
 
     @Test
-    public void emptySlotWithBuyChoosesS2OverCompletedBuyCollection() {
-        // product-confirmed inversion: fill empty slot before collecting a completed buy
+    public void emptySlotCollectsCompletedBuyBeforeNewBuy() {
+        // Product decision (#914): collect a completed buy (so it can then be sold) before
+        // a new buy consumes the freed slot. Free slot + surfaceable buy (21) + a completed
+        // buy (31) awaiting collection → collect 31, not buy 21.
         when(plugin.getFilledGESlotCount()).thenReturn(7);
         OfferRecord filledBuy = OfferRecord
             .newOffer(1, 0, 31, "boughtItem", true, 10, 100, 0L)
@@ -74,8 +76,9 @@ public class AutoRecommendDispatchTest {
 
         ActionDecision d = service.resolveAndApply(-1);
 
-        assertEquals(ActionKind.S2, d.getKind());
-        assertEquals(21, d.getItemId());
+        assertEquals(ActionKind.S3, d.getKind());
+        assertEquals(ActionStep.COLLECT, d.getStep());
+        assertEquals(31, d.getItemId());
     }
 
     @Test

--- a/src/test/java/com/flipsmart/domain/flip/ActiveFlipDisplayFilterTest.java
+++ b/src/test/java/com/flipsmart/domain/flip/ActiveFlipDisplayFilterTest.java
@@ -1,0 +1,100 @@
+package com.flipsmart.domain.flip;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Covers issue #914: the Active Flips tab must drop completed / cancelled /
+ * collected trades and only show flips backed by live player state.
+ */
+public class ActiveFlipDisplayFilterTest
+{
+	private static ActiveFlip flip(int itemId, String name)
+	{
+		ActiveFlip f = new ActiveFlip();
+		f.setItemId(itemId);
+		f.setItemName(name);
+		return f;
+	}
+
+	private static Set<Integer> setOf(int... ids)
+	{
+		Set<Integer> set = new HashSet<>();
+		for (int id : ids)
+		{
+			set.add(id);
+		}
+		return set;
+	}
+
+	@Test
+	public void retainsFlipWithOpenGeOfferOrCollectedThisSession()
+	{
+		ActiveFlip inGe = flip(1, "In GE");
+		List<ActiveFlip> result = ActiveFlipDisplayFilter.retain(
+			Collections.singletonList(inGe), setOf(1), Collections.emptySet());
+
+		assertEquals(Collections.singletonList(inGe), result);
+	}
+
+	@Test
+	public void retainsFlipHeldInInventory()
+	{
+		ActiveFlip inInventory = flip(2, "Awaiting sale");
+		List<ActiveFlip> result = ActiveFlipDisplayFilter.retain(
+			Collections.singletonList(inInventory), Collections.emptySet(), setOf(2));
+
+		assertEquals(Collections.singletonList(inInventory), result);
+	}
+
+	@Test
+	public void excludesCompletedFlipAbsentFromAllLiveState()
+	{
+		// Swamp Tar sold and collected: no open offer, not collected this session, not in inventory.
+		ActiveFlip soldSwampTar = flip(1939, "Swamp tar");
+		List<ActiveFlip> result = ActiveFlipDisplayFilter.retain(
+			Collections.singletonList(soldSwampTar), Collections.emptySet(), Collections.emptySet());
+
+		assertTrue("A sold/collected flip must not linger", result.isEmpty());
+	}
+
+	@Test
+	public void keepsOnlyLiveFlipsFromAMixedList()
+	{
+		ActiveFlip inGe = flip(1, "In GE");
+		ActiveFlip inInventory = flip(2, "Inventory");
+		ActiveFlip stale = flip(3, "Stale");
+		List<ActiveFlip> flips = Arrays.asList(inGe, stale, inInventory);
+
+		List<ActiveFlip> result = ActiveFlipDisplayFilter.retain(
+			flips, setOf(1), setOf(2));
+
+		// Stale dropped; survivors keep their input order.
+		assertEquals(Arrays.asList(inGe, inInventory), result);
+	}
+
+	@Test
+	public void nullFlipListReturnsEmpty()
+	{
+		assertTrue(ActiveFlipDisplayFilter.retain(null, setOf(1), setOf(2)).isEmpty());
+	}
+
+	@Test
+	public void nullStateSetsAreTreatedAsEmpty()
+	{
+		ActiveFlip anyFlip = flip(1, "Any");
+		Set<Integer> none = null;
+		List<ActiveFlip> result = ActiveFlipDisplayFilter.retain(
+			Collections.singletonList(anyFlip), none, none);
+
+		assertTrue(result.isEmpty());
+	}
+}

--- a/src/test/java/com/flipsmart/recommend/ActionResolverTest.java
+++ b/src/test/java/com/flipsmart/recommend/ActionResolverTest.java
@@ -111,10 +111,16 @@ public class ActionResolverTest {
             .staleOffers(Arrays.asList(staleBuyPartial(0, 11, 5L))).build();
         assertEquals(ActionKind.S1, resolver.resolve(in).getKind());
     }
-    @Test public void s2_preempts_s3() {  // product-confirmed: fill empty slot before collecting buy
+    @Test public void s3_preempts_s2() {
+        // Product decision (#914): a completed buy awaiting collection is collected (so it
+        // can then be sold) before a new buy consumes the freed slot. A free slot plus a
+        // surfaceable buy must not pull us off collecting the item we already own.
         ResolverInput in = base().filledSlotCount(7).surfaceableBuy(true, 99)
             .completedAwaitingCollection(Arrays.asList(filledBuy(0, 31, 5L))).build();
-        assertEquals(ActionKind.S2, resolver.resolve(in).getKind());
+        ActionDecision d = resolver.resolve(in);
+        assertEquals(ActionKind.S3, d.getKind());
+        assertEquals(ActionStep.COLLECT, d.getStep());
+        assertEquals(31, d.getItemId());
     }
     @Test public void s3_preempts_s4() {
         ResolverInput in = base()


### PR DESCRIPTION
## Summary

The Active Flips tab was showing stale entries (e.g. sold-and-collected items lingering for days). Product suspected the backend, but the backend was already correct — the bug is plugin-only. This PR replaces the plugin's client-side 7-day recency heuristic with a live-state check, so a flip is displayed only while it's actually backed by real player state (an open GE offer, a collected-this-session item, or an item held in inventory).

## Changes

### 🐛 Bug Fixes
- Removed the client-side `isFlipRecent()` 7-day recency heuristic in `FlipFinderPanel.filterActiveFlips()` that kept completed/sold/cancelled flips visible for days after they left the GE window (the reported Swamp Tar case).
- Active Flips now reflects live player state instead of a time-based approximation, so completed flips disappear immediately on the next refresh trigger.

### ✨ New Features
- Added `ActiveFlipDisplayFilter.retain(flips, activeItemIds, inventoryItemIds)` — a small, pure, unit-tested class encoding the retention rule: keep a flip only if its item has an open GE buy/sell offer, was collected this session, or is currently held in inventory. Null-safe, preserves input order.
- `FlipSmartPlugin` now maintains a thread-safe canonical inventory item-id snapshot (`inventoryFlipItemIds`, a `ConcurrentHashMap` key set) updated on the client thread inside `updateCashStack()` (inventory `ItemContainerChanged`). The Swing EDT filter reads this snapshot rather than touching the game client off-thread. This inventory signal also replaces what the 7-day window was crudely approximating: keeping collected-but-unsold flips visible across a client restart, when session-only collected state is lost.

### ♻️ Refactoring
- `filterActiveFlips()` now delegates to `ActiveFlipDisplayFilter.retain(...)`; the old inline filtering loop and the `isFlipRecent` time-window method are both removed. Net LOC-negative change in `FlipFinderPanel.java`.

## Root Cause (investigation)

The full active-flips data flow was traced end-to-end:
- The plugin's Active Flips tab is populated from the backend (`/transactions/active-flips` and the bundled `/plugin/sync`). The backend's `active_buy_filter()` (`app/endpoints/transactions.py`) already excludes fully-sold, dismissed, and cancelled-empty flips — a flip drops out the moment `quantity - quantity_sold <= 0`. There is no 7-day recency window on the backend, and it caps active flips at 8 per RSN.
- The staleness came entirely from the plugin's own display filter, `FlipFinderPanel.filterActiveFlips()`, which retained a flip if it was in the GE/collected set **or** had buy activity within the last 7 days (`isFlipRecent`). A completed/sold flip could therefore linger in the UI for days after leaving the GE window, matching the reported screenshots.

## Testing

### Automated Tests
- Added `ActiveFlipDisplayFilterTest` (6 cases): retains a flip with an open GE offer, retains a flip held in inventory, excludes a sold/collected flip absent from all live state (the Swamp Tar case), keeps input order across a mixed retained/dropped list, and null-safety for both a null flip list and null state sets.
- `./gradlew build` passes locally (compiles, runs the full test suite, and checkstyle).

### Manual Testing (in-game — plugin behavior can't be driven by browser QA)
- [x] Complete a flip fully (buy, then sell and collect) at the GE. Confirm the item disappears from Active Flips immediately, without a manual reload.
- [x] Cancel an offer with 0 fills — confirm it's removed from Active Flips.
- [x] Buy an item, collect it to inventory, leave it unsold — confirm it stays in Active Flips (in-progress). Then sell + collect it and confirm it disappears.
- [x] Confirm Active Flips never shows more entries than trades in the GE window.
- [x] Restart the client mid-flip (item in inventory awaiting sale) — confirm it still appears after relogging.

## Acceptance Criteria Mapping

- **AC1** (collected/completed removed): a sold+collected item is in no live state → filtered out.
- **AC2** (cancelled removed): cancelled-with-no-remaining is dismissed on the backend and absent from live state → removed; a cancel that leaves items in inventory correctly stays visible until sold.
- **AC3** (adjusted re-syncs): partial fills / quantity changes already fire `syncActiveFlipAsync` + a panel refresh; the re-render now uses the corrected filter.
- **AC4** (re-confirm full set on events): `refreshActiveFlips()` re-fetches the full backend list and re-filters against the full live-state set on every adjust/cancel/collect event.
- **AC5** (≤ GE window, max 8): the backend caps active flips at 8/RSN and the plugin filter only ever removes entries — it never adds beyond the backend list.
- **AC6** (no manual refresh needed): refresh already fires automatically on the trigger events; the display filter was the only defect.

## Deployment Notes

- No environment variables, dependencies, or configuration changes.
- No backend changes required — this is a plugin-only fix.
- No database migrations.
- Ships on the normal RuneLite Plugin Hub release cadence.

## Checklist

- [x] Tests added/updated
- [x] Code follows style guidelines (checkstyle passes via `./gradlew build`)
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left (existing `log.debug` calls only, gated appropriately)
- [x] No issue-number references or narrative comments added to plugin source (LOC-budget discipline)
- [ ] In-game manual QA performed (see Manual Testing checklist above)
- [ ] Reviewed by teammate

## Related Issues

Closes Flip-Smart/flip-smart#914

### 🩺 Codacy Quality Gate — fixed in this PR
- `4654101` PMD_category_java_bestpractices_GuardLogStatement `src/main/java/com/flipsmart/FlipFinderPanel.java:1396` — moved the `log.isDebugEnabled()` guard onto the innermost `if` directly wrapping `log.debug(...)`, matching the existing `OfflineSyncService.java` idiom (PMD only inspects the nearest enclosing `if` of the log call).

### 🤖 Codacy AI Reviewer
No open `@codacy-production[bot]` review comments on this PR at time of resolution.


---

## Folded-in fix: collect a completed buy before a new buy (#914 edge case)

While QA'ing the Active Flips fix in-game, a related auto-recommend edge case surfaced and was confirmed from the client log: when a GE slot opened while a bought item was still sitting **uncollected**, the overlay nudged a **new buy** instead of collecting the item you already own (which then needs selling).

**Root cause (confirmed via client-log repro):**
```
resolver input  filled=7/8  collected=0  completed=2   (a completed BUY awaiting collection)
resolver decision  S2/PLACE_BUY                        (recommended a new buy)
```
The action-priority resolver ranked `S2` (place a new buy) **above** `S3` (collect a completed buy). The end-to-end collect→sell flow still worked because a separate direct path (`onOfferCollected`) forces the sell focus the moment you actually collect — which masked the wrong nudge.

**Fix:** Reordered the `ActionKind` tiers so `S3` (collect a completed buy) sits **above** `S2` (place a new buy), mirroring the existing `SELL_WAITING > S2` rule. The full collect→sell pipeline for items you already own now precedes deploying capital into new buys. This reverses the earlier product-confirmed `s2 > s3` decision at the product owner's request; the two tests that encoded it (`ActionResolverTest.s2_preempts_s3`, `AutoRecommendDispatchTest.emptySlotWithBuyChoosesS2OverCompletedBuyCollection`) were updated to assert the new behavior.

**Tests:** `./gradlew build` (full suite + checkstyle) passes. Resolver-tier coverage updated: `s3_preempts_s2` and `emptySlotCollectsCompletedBuyBeforeNewBuy` now assert collect-before-buy.

### Manual QA (in-game, new behavior)
- [ ] With a free GE slot and a completed buy still uncollected, confirm the overlay says "Collect &lt;item&gt;" (not "Buy &lt;new item&gt;").
- [ ] After collecting, confirm it prompts to sell the collected item, then only recommends a new buy once nothing is left to collect/sell.
