### PR TITLE
Add skip cooldown to prevent immediate re-appearance of skipped Flip Assist items

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -92,7 +92,6 @@ public class AutoRecommendService
 	/** Maximum age of persisted state before it's considered stale (30 minutes) */
 	static final long MAX_PERSISTED_AGE_MS = 30 * 60 * 1000L;
 	private static final String MSG_WAITING_FOR_FLIPS = "Waiting for flips";
-	private static final String MSG_QUEUE_DEPLETED = "Item queue depleted - refresh for more recommendations";
 	private static final String MSG_SELL_FORMAT = "Auto: Sell %s @ %s";
 	private static final String MSG_BUY_FORMAT = "Auto: Buy %s @ %s";
 
@@ -1023,25 +1022,6 @@ public class AutoRecommendService
 			}
 		}
 		return -1;
-	}
-
-	/**
-	 * True when the buy queue still holds items that would be surfaceable were it not for
-	 * their skip cooldown — i.e. the queue is "depleted" only because everything is snoozed
-	 * (AC3), not genuinely empty. Distinguishes the refresh-me state from the ordinary
-	 * all-listed / waiting-for-sells state.
-	 */
-	private boolean allSurfaceableBuysCoolingDown()
-	{
-		List<FlipRecommendation> view = queue.view();
-		Set<Integer> active = plugin.getActiveFlipItemIds();
-		int offset = config.priceOffset();
-		int minProfit = config.minimumProfit();
-		boolean surfaceableIgnoringCooldown =
-			firstAvailableBuyIndex(view, active, -1, offset, minProfit) >= 0;
-		boolean surfaceableWithCooldown =
-			firstAvailableBuyIndex(view, active, -1, offset, minProfit, skipCooldown::isCoolingDown) >= 0;
-		return surfaceableIgnoringCooldown && !surfaceableWithCooldown;
 	}
 
 	private boolean isUserBusy()
@@ -2386,20 +2366,15 @@ public class AutoRecommendService
 			{
 				focusNextCollectedItemSell();
 			}
-			else if (allSurfaceableBuysCoolingDown())
-			{
-				// AC3: items remain but every one is inside its skip cooldown. Tell the user
-				// to refresh rather than auto-refreshing into the same still-cooling list.
-				invokeFocusCallback(null);
-				updateStatus("Auto: Item queue depleted");
-				invokeOverlayMessageCallback(MSG_QUEUE_DEPLETED);
-			}
 			else
 			{
-				// Clear focus so stale buy/sell overlay doesn't persist
+				// Queue exhausted (all listed, or all remaining items are inside their skip
+				// cooldown) — pull a fresh, shuffled recommendation list and continue on that.
+				// The skip cooldown survives the refresh, so just-skipped items stay suppressed
+				// in the new list while new items surface.
 				invokeFocusCallback(null);
-				updateStatus("Auto: All recommendations listed");
-				invokeOverlayMessageCallback("All flips listed - waiting for sells");
+				updateStatus("Auto: Finding more recommendations");
+				invokeOverlayMessageCallback("Finding more recommendations...");
 
 				Runnable exhaustedCallback = onQueueExhausted;
 				if (exhaustedCallback != null)
@@ -2782,13 +2757,6 @@ public class AutoRecommendService
 				updateStatus("Auto: Collect profit from GE");
 				invokeOverlayMessageCallback("Collect profit from GE");
 			}
-		}
-		else if (hasAvailableGESlots() && allSurfaceableBuysCoolingDown())
-		{
-			// AC3: a slot is free but every remaining recommendation is snoozed by a skip
-			// cooldown — prompt a manual refresh instead of silently showing "Waiting".
-			updateStatus("Auto: Item queue depleted");
-			invokeOverlayMessageCallback(MSG_QUEUE_DEPLETED);
 		}
 		else if (adjustments.hasBuyDeadlines() || adjustments.hasSellStates())
 		{

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -14,6 +14,7 @@ import com.flipsmart.recommend.CollectedItem;
 import com.flipsmart.recommend.RecommendationQueue;
 import com.flipsmart.recommend.ActionStep;
 import com.flipsmart.recommend.ResolverInput;
+import com.flipsmart.recommend.SkipCooldownTracker;
 import com.flipsmart.recommend.StaleOfferQueue;
 import com.flipsmart.trading.OfferStore;
 import com.flipsmart.util.GpUtils;
@@ -91,6 +92,7 @@ public class AutoRecommendService
 	/** Maximum age of persisted state before it's considered stale (30 minutes) */
 	static final long MAX_PERSISTED_AGE_MS = 30 * 60 * 1000L;
 	private static final String MSG_WAITING_FOR_FLIPS = "Waiting for flips";
+	private static final String MSG_QUEUE_DEPLETED = "Item queue depleted - refresh for more recommendations";
 	private static final String MSG_SELL_FORMAT = "Auto: Sell %s @ %s";
 	private static final String MSG_BUY_FORMAT = "Auto: Buy %s @ %s";
 
@@ -109,6 +111,10 @@ public class AutoRecommendService
 	private final AdjustmentService adjustments = new AdjustmentService();
 
 	private final ActionResolver actionResolver = new ActionResolver();
+
+	// 5-minute per-item skip window: a skipped buy/action is held out of auto-surfacing
+	// so it does not immediately re-appear. Cleared on auto-mode toggle, survives refreshes.
+	private final SkipCooldownTracker skipCooldown = new SkipCooldownTracker();
 
 	private final List<Runnable> deferredActions = new ArrayList<>();
 
@@ -135,6 +141,20 @@ public class AutoRecommendService
 	// Clears all GE slot adjustment highlights when the stale-offer queue drains,
 	// so a slot highlight never lingers without a matching prompt.
 	private volatile Runnable onClearAllHighlights;
+
+	// Sticky highlight callbacks (keyed by GE slot): keep a skipped-but-cooling action's
+	// orange box lit across focus changes, and drop it when the cooldown ends or the offer
+	// is acted on.
+	private volatile java.util.function.IntConsumer onStickyHighlight;
+	private volatile java.util.function.IntConsumer onClearStickyHighlight;
+
+	// Full highlight reset (transient + sticky) used when auto-mode stops.
+	private volatile Runnable onResetAllHighlights;
+
+	// Items whose orange box is kept sticky because their action was skipped and is still
+	// cooling. Maps itemId -> the GE slot recorded at skip time, so the sticky box can be
+	// cleared by slot even after the offer has left the GE (the item lookup would then fail).
+	private final Map<Integer, Integer> stickyHighlightSlots = new java.util.concurrent.ConcurrentHashMap<>();
 
 	// Provider for the panel's displayed (smart) sell price — preferred over session's stored price
 	private volatile IntFunction<Integer> displayedSellPriceProvider;
@@ -212,6 +232,21 @@ public class AutoRecommendService
 	public void setOnClearAllHighlights(Runnable callback)
 	{
 		this.onClearAllHighlights = callback;
+	}
+
+	public void setOnStickyHighlight(java.util.function.IntConsumer callback)
+	{
+		this.onStickyHighlight = callback;
+	}
+
+	public void setOnClearStickyHighlight(java.util.function.IntConsumer callback)
+	{
+		this.onClearStickyHighlight = callback;
+	}
+
+	public void setOnResetAllHighlights(Runnable callback)
+	{
+		this.onResetAllHighlights = callback;
 	}
 
 	public void setDisplayedSellPriceProvider(IntFunction<Integer> provider)
@@ -306,6 +341,14 @@ public class AutoRecommendService
 		adjustments.clear();
 		staleOffers.clear();
 		deferredActions.clear();
+		// AC5/AC6: toggling auto-mode off clears every skip cooldown and its sticky box.
+		skipCooldown.clearAll();
+		stickyHighlightSlots.clear();
+		Runnable resetHighlights = onResetAllHighlights;
+		if (resetHighlights != null)
+		{
+			resetHighlights.run();
+		}
 		PlayerSession session = plugin.getSession();
 		if (session != null)
 		{
@@ -367,6 +410,7 @@ public class AutoRecommendService
 	{
 		staleOffers.removePrompted(itemId);
 		staleOffers.removeOffer(itemId);
+		resolveActedItem(itemId);
 		if (!active)
 		{
 			return;
@@ -571,6 +615,9 @@ public class AutoRecommendService
 			return;
 		}
 
+		// Re-listing a skipped/uncompetitive sell resolves its maintenance action (AC8 path).
+		resolveActedItem(itemId);
+
 		PlayerSession session = plugin.getSession();
 		if (session != null)
 		{
@@ -620,6 +667,7 @@ public class AutoRecommendService
 		}
 		staleOffers.removePrompted(itemId);
 		staleOffers.removeOffer(itemId);
+		resolveActedItem(itemId);
 		if (!active)
 		{
 			return;
@@ -717,6 +765,7 @@ public class AutoRecommendService
 	public synchronized void onOfferCollected(int itemId, boolean wasBuy, String itemName, int quantity)
 	{
 		staleOffers.removeOffer(itemId);
+		resolveActedItem(itemId);
 		if (!active)
 		{
 			return;
@@ -824,6 +873,9 @@ public class AutoRecommendService
 
 	ActionDecision resolveAndApply(int excludeItemId)
 	{
+		// Retire any sticky boxes whose cooldown lapsed or whose offer is gone before we
+		// decide what to surface (cheap no-op when nothing is sticky).
+		reconcileStickyHighlights();
 		ActionDecision decision = actionResolver.resolve(buildResolverInput(excludeItemId));
 		log.debug("Auto-recommend: resolver decision {}/{} item={} slot={}",
 			decision.getKind(), decision.getStep(), decision.getItemId(), decision.getSlot());
@@ -943,17 +995,53 @@ public class AutoRecommendService
 		int priceOffset,
 		int minProfit)
 	{
+		return firstAvailableBuyIndex(queue, activeItemIds, excludeItemId, priceOffset, minProfit, id -> false);
+	}
+
+	/**
+	 * As above, but also skips items inside their post-skip cooldown window so a skipped
+	 * buy does not immediately re-appear (AC1/AC2) — including when the queue was just
+	 * refreshed from the backend (AC4).
+	 */
+	static int firstAvailableBuyIndex(
+		List<FlipRecommendation> queue,
+		Set<Integer> activeItemIds,
+		int excludeItemId,
+		int priceOffset,
+		int minProfit,
+		java.util.function.IntPredicate isCoolingDown)
+	{
 		for (int i = 0; i < queue.size(); i++)
 		{
 			FlipRecommendation rec = queue.get(i);
 			if (rec.getItemId() != excludeItemId
 				&& !activeItemIds.contains(rec.getItemId())
+				&& !isCoolingDown.test(rec.getItemId())
 				&& FocusedFlip.calculateAdjustedProfit(rec, priceOffset) >= minProfit)
 			{
 				return i;
 			}
 		}
 		return -1;
+	}
+
+	/**
+	 * True when the buy queue still holds items that would be surfaceable were it not for
+	 * their skip cooldown — i.e. the queue is "depleted" only because everything is snoozed
+	 * (AC3), not genuinely empty. Distinguishes the refresh-me state from the ordinary
+	 * all-listed / waiting-for-sells state.
+	 */
+	private boolean allSurfaceableBuysCoolingDown()
+	{
+		List<FlipRecommendation> view = queue.view();
+		Set<Integer> active = plugin.getActiveFlipItemIds();
+		int offset = config.priceOffset();
+		int minProfit = config.minimumProfit();
+		boolean surfaceableIgnoringCooldown =
+			firstAvailableBuyIndex(view, active, -1, offset, minProfit) >= 0;
+		boolean surfaceableWithCooldown =
+			firstAvailableBuyIndex(view, active, -1, offset, minProfit, skipCooldown::isCoolingDown) >= 0;
+		return surfaceableIgnoringCooldown && !surfaceableWithCooldown;
 	}
 
 	private boolean isUserBusy()
@@ -1685,11 +1773,95 @@ public class AutoRecommendService
 	}
 
 	/**
+	 * The player placed/cancelled/collected an offer for this item, so any skip cooldown and
+	 * sticky box for it are now moot — drop them immediately rather than waiting for expiry.
+	 */
+	private void resolveActedItem(int itemId)
+	{
+		skipCooldown.clear(itemId);
+		dropStickyHighlight(itemId);
+	}
+
+	/** GE slot currently holding a live offer for the item, or null if none. */
+	private Integer slotForLiveItem(int itemId)
+	{
+		for (OfferRecord o : offerStore.liveOffers())
+		{
+			if (o.getItemId() == itemId && o.getSlot() != null)
+			{
+				return o.getSlot();
+			}
+		}
+		return null;
+	}
+
+	/** Track a skipped action's item and light its sticky orange box (AC7). */
+	private void keepStickyHighlight(int itemId)
+	{
+		Integer slot = slotForLiveItem(itemId);
+		if (slot == null)
+		{
+			return;
+		}
+		stickyHighlightSlots.put(itemId, slot);
+		java.util.function.IntConsumer cb = onStickyHighlight;
+		if (cb != null)
+		{
+			cb.accept(slot);
+		}
+	}
+
+	/** Stop tracking a sticky item and drop its orange box by the slot recorded at skip time. */
+	private void dropStickyHighlight(int itemId)
+	{
+		Integer slot = stickyHighlightSlots.remove(itemId);
+		if (slot != null)
+		{
+			java.util.function.IntConsumer cb = onClearStickyHighlight;
+			if (cb != null)
+			{
+				cb.accept(slot);
+			}
+		}
+	}
+
+	/**
+	 * Drop sticky boxes whose reason has passed: the cooldown expired, or the offer is no
+	 * longer a live, unfilled GE offer (acted on / collected / cancelled). An expired
+	 * still-uncompetitive offer is re-surfaced by the normal adjustment-timer path once its
+	 * cooldown lifts, which restores a live (transient) highlight.
+	 */
+	private void reconcileStickyHighlights()
+	{
+		if (stickyHighlightSlots.isEmpty())
+		{
+			return;
+		}
+		List<OfferRecord> live = offerStore.liveOffers();
+		for (Integer itemId : new java.util.ArrayList<>(stickyHighlightSlots.keySet()))
+		{
+			boolean cooling = skipCooldown.isCoolingDown(itemId);
+			boolean stillLiveOffer = live.stream()
+				.anyMatch(o -> o.getItemId() == itemId && o.getState() != OfferState.FILLED);
+			if (!cooling || !stillLiveOffer)
+			{
+				dropStickyHighlight(itemId);
+			}
+		}
+	}
+
+	/**
 	 * Add a tracked offer to the stale queue if not already present.
 	 * If the queue was empty, immediately shows the first prompt.
 	 */
 	void addToStaleQueue(OfferRecord offer)
 	{
+		if (skipCooldown.isCoolingDown(offer.getItemId()))
+		{
+			// Snoozed by a recent skip — don't re-prompt until the cooldown lifts.
+			return;
+		}
+
 		StaleOfferQueue.AddResult result = staleOffers.addIfAbsent(offer);
 		if (result == StaleOfferQueue.AddResult.ALREADY_PRESENT)
 		{
@@ -2165,6 +2337,11 @@ public class AutoRecommendService
 		if (!staleOffers.isEmpty())
 		{
 			OfferRecord skipped = staleOffers.removeHead();
+			// Hold the action out of auto-surfacing for the cooldown, but keep its orange
+			// box lit (AC7) — the trade still needs maintenance — and its session sell
+			// price intact so a manual GE pull-up still shows the re-adjusted price (AC8).
+			skipCooldown.skip(skipped.getItemId());
+			keepStickyHighlight(skipped.getItemId());
 			log.debug("Auto-recommend: User skipped stale offer prompt for {}", skipped.getItemName());
 			focusNextAvailableAction();
 			return;
@@ -2176,6 +2353,7 @@ public class AutoRecommendService
 		{
 			PlayerSession session = plugin.getSession();
 			log.debug("Auto-recommend: User skipped collected item sell prompt for item {}", collectedId);
+			skipCooldown.skip(collectedId);
 			session.removeCollectedItem(collectedId);
 			focusedCollectedItemId = -1;
 			focusNextAvailableAction();
@@ -2183,6 +2361,11 @@ public class AutoRecommendService
 		}
 
 		log.debug("Auto-recommend: User skipped current recommendation");
+		FlipRecommendation skippedBuy = queue.getCurrentRecommendation();
+		if (skippedBuy != null)
+		{
+			skipCooldown.skip(skippedBuy.getItemId());
+		}
 		advanceToNext();
 	}
 
@@ -2194,13 +2377,22 @@ public class AutoRecommendService
 		queue.skipToNextSurfaceable(
 			plugin.getActiveFlipItemIds(),
 			next -> FocusedFlip.calculateAdjustedProfit(next, priceOffset),
-			minProfit);
+			minProfit,
+			skipCooldown::isCoolingDown);
 
 		if (queue.cursorBeyondEnd())
 		{
 			if (hasCollectedItemsToSell())
 			{
 				focusNextCollectedItemSell();
+			}
+			else if (allSurfaceableBuysCoolingDown())
+			{
+				// AC3: items remain but every one is inside its skip cooldown. Tell the user
+				// to refresh rather than auto-refreshing into the same still-cooling list.
+				invokeFocusCallback(null);
+				updateStatus("Auto: Item queue depleted");
+				invokeOverlayMessageCallback(MSG_QUEUE_DEPLETED);
 			}
 			else
 			{
@@ -2591,6 +2783,13 @@ public class AutoRecommendService
 				invokeOverlayMessageCallback("Collect profit from GE");
 			}
 		}
+		else if (hasAvailableGESlots() && allSurfaceableBuysCoolingDown())
+		{
+			// AC3: a slot is free but every remaining recommendation is snoozed by a skip
+			// cooldown — prompt a manual refresh instead of silently showing "Waiting".
+			updateStatus("Auto: Item queue depleted");
+			invokeOverlayMessageCallback(MSG_QUEUE_DEPLETED);
+		}
 		else if (adjustments.hasBuyDeadlines() || adjustments.hasSellStates())
 		{
 			// Offers are being monitored for staleness — don't say "Waiting for flips"
@@ -2792,7 +2991,7 @@ public class AutoRecommendService
 		int surfaceableItemId = -1;
 		List<FlipRecommendation> view = queue.view();
 		int idx = firstAvailableBuyIndex(view, plugin.getActiveFlipItemIds(),
-			excludeItemId, config.priceOffset(), config.minimumProfit());
+			excludeItemId, config.priceOffset(), config.minimumProfit(), skipCooldown::isCoolingDown);
 		if (idx >= 0 && idx < view.size())
 		{
 			hasSurfaceable = true;
@@ -2802,7 +3001,11 @@ public class AutoRecommendService
 		int filledSlots = plugin.getFilledGESlotCount();
 		int slotLimit = plugin.getFlipSlotLimit();
 		List<OfferRecord> completed = offerStore.completedAwaitingCollection();
-		List<OfferRecord> staleSnapshot = staleOffers.snapshot();
+		// Drop any cooling-down stale offers so a skipped reprice/cancel action is not
+		// re-surfaced by the resolver until its cooldown lifts (AC6).
+		List<OfferRecord> staleSnapshot = staleOffers.snapshot().stream()
+			.filter(o -> !skipCooldown.isCoolingDown(o.getItemId()))
+			.collect(java.util.stream.Collectors.toList());
 		if (logInput)
 		{
 			log.debug("Auto-recommend: resolver input filled={}/{} surfaceableBuy={} (item={}, idx={}) queue={} active={} collected={} stale={} completed={}",

--- a/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
@@ -69,6 +69,12 @@ public class GrandExchangeSlotOverlay extends Overlay
 	// Slots with pending adjustment recommendations (slot -> recommended price)
 	private final java.util.Map<Integer, Integer> adjustmentHighlights = new java.util.concurrent.ConcurrentHashMap<>();
 
+	// Slots whose orange box must persist across focus changes because the player skipped
+	// their maintenance action and it is still within its cooldown. Transient clears
+	// (clearAllAdjustmentHighlights) deliberately leave these alone; they are dropped only
+	// when the cooldown expires or the offer is acted on / leaves the GE.
+	private final java.util.Set<Integer> stickyAdjustmentSlots = java.util.concurrent.ConcurrentHashMap.newKeySet();
+
 	private final Client client;
 	private final FlipSmartConfig config;
 	private final FlipSmartPlugin plugin;
@@ -105,11 +111,39 @@ public class GrandExchangeSlotOverlay extends Overlay
 	}
 
 	/**
-	 * Clear all adjustment highlights (e.g., on logout).
+	 * Clear all transient adjustment highlights (e.g., on a focus change). Sticky
+	 * highlights kept for a skipped-but-cooling action are intentionally preserved.
 	 */
 	public void clearAllAdjustmentHighlights()
 	{
 		adjustmentHighlights.clear();
+	}
+
+	/**
+	 * Keep a slot's orange box lit across focus changes while its skipped action cools
+	 * down.
+	 */
+	public void setStickyAdjustmentHighlight(int slot)
+	{
+		stickyAdjustmentSlots.add(slot);
+	}
+
+	/**
+	 * Drop the sticky highlight for a slot (cooldown expired, or the offer was acted on).
+	 */
+	public void clearStickyAdjustmentHighlight(int slot)
+	{
+		stickyAdjustmentSlots.remove(slot);
+	}
+
+	/**
+	 * Full reset of every highlight, transient and sticky (e.g., on logout or when
+	 * auto-mode stops).
+	 */
+	public void resetAllHighlights()
+	{
+		adjustmentHighlights.clear();
+		stickyAdjustmentSlots.clear();
 	}
 
 	/**
@@ -271,7 +305,7 @@ public class GrandExchangeSlotOverlay extends Overlay
 									GrandExchangeOffer offer, FlipSmartPlugin.OfferCompetitiveness competitiveness, int slot)
 	{
 		// Draw colored border around the entire slot
-		boolean hasAdjustment = adjustmentHighlights.containsKey(slot);
+		boolean hasAdjustment = adjustmentHighlights.containsKey(slot) || stickyAdjustmentSlots.contains(slot);
 		if (hasAdjustment)
 		{
 			drawOrangeGlow(graphics, bounds);

--- a/src/main/java/com/flipsmart/plugin/ServiceWiring.java
+++ b/src/main/java/com/flipsmart/plugin/ServiceWiring.java
@@ -58,6 +58,9 @@ public class ServiceWiring
 		autoRecommendService.setDisplayedSellPriceProvider(itemId -> plugin.getFlipFinderPanel() != null ? plugin.getFlipFinderPanel().getDisplayedSellPrice(itemId) : null);
 		autoRecommendService.setOnStaleOfferPrompted(plugin::highlightSlotForItem);
 		autoRecommendService.setOnClearAllHighlights(geSlotOverlay::clearAllAdjustmentHighlights);
+		autoRecommendService.setOnStickyHighlight(geSlotOverlay::setStickyAdjustmentHighlight);
+		autoRecommendService.setOnClearStickyHighlight(geSlotOverlay::clearStickyAdjustmentHighlight);
+		autoRecommendService.setOnResetAllHighlights(geSlotOverlay::resetAllHighlights);
 		flipAssistOverlay.setOnStepChanged(autoRecommendService::onOverlayStepChanged);
 		return autoRecommendService;
 	}

--- a/src/main/java/com/flipsmart/recommend/RecommendationQueue.java
+++ b/src/main/java/com/flipsmart/recommend/RecommendationQueue.java
@@ -224,11 +224,25 @@ public final class RecommendationQueue
 		ToIntFunction<FlipRecommendation> profitFn,
 		int minProfit)
 	{
+		skipToNextSurfaceable(activeItemIds, profitFn, minProfit, id -> false);
+	}
+
+	/**
+	 * As above, but also skips items inside their post-skip cooldown so the cursor never
+	 * lands on a recently-skipped item (AC2).
+	 */
+	public void skipToNextSurfaceable(
+		Set<Integer> activeItemIds,
+		ToIntFunction<FlipRecommendation> profitFn,
+		int minProfit,
+		java.util.function.IntPredicate isCoolingDown)
+	{
 		currentIndex++;
 		while (currentIndex < recommendations.size())
 		{
 			FlipRecommendation next = recommendations.get(currentIndex);
 			if (!activeItemIds.contains(next.getItemId())
+				&& !isCoolingDown.test(next.getItemId())
 				&& profitFn.applyAsInt(next) >= minProfit)
 			{
 				break;

--- a/src/main/java/com/flipsmart/recommend/SkipCooldownTracker.java
+++ b/src/main/java/com/flipsmart/recommend/SkipCooldownTracker.java
@@ -1,0 +1,90 @@
+package com.flipsmart.recommend;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.LongSupplier;
+
+/**
+ * Tracks a short per-item "leave me alone" window after a Flip Assist skip.
+ *
+ * When the player skips a recommendation or an action in auto-mode, that item is
+ * held out of auto-surfacing for {@link #COOLDOWN_MS} so it does not immediately
+ * re-appear on the next GE event, game tick, or Flip Finder refresh. Suppression is
+ * intentionally limited to auto-surfacing — the passive orange highlight and a manual
+ * GE offer-screen pull-up are unaffected.
+ *
+ * The window survives Flip Finder refreshes (the map is never touched by a refresh)
+ * and is cleared only by natural expiry or an auto-mode toggle off-and-on via
+ * {@link #clearAll()}. The clock is injectable so the cooldown can be unit-tested
+ * without wall-clock sleeps.
+ */
+public class SkipCooldownTracker
+{
+	/** How long a skipped item stays out of auto-surfacing (5 minutes). */
+	public static final long COOLDOWN_MS = 5 * 60 * 1000L;
+
+	/** Housekeeping cap; expired entries are pruned lazily well before this. */
+	private static final int MAX_ENTRIES = 500;
+
+	/** itemId -> wall-clock instant at which the cooldown expires. */
+	private final Map<Integer, Long> cooldownUntilMillis = new HashMap<>();
+
+	private final LongSupplier clock;
+
+	public SkipCooldownTracker()
+	{
+		this(System::currentTimeMillis);
+	}
+
+	/** Test seam: inject a deterministic clock. */
+	SkipCooldownTracker(LongSupplier clock)
+	{
+		this.clock = clock;
+	}
+
+	/** Start (or restart) the cooldown window for an item. */
+	public void skip(int itemId)
+	{
+		long now = clock.getAsLong();
+		cooldownUntilMillis.put(itemId, now + COOLDOWN_MS);
+		if (cooldownUntilMillis.size() > MAX_ENTRIES)
+		{
+			pruneExpired();
+		}
+	}
+
+	/** True while the item is inside its skip window. Expires lazily on read. */
+	public boolean isCoolingDown(int itemId)
+	{
+		Long until = cooldownUntilMillis.get(itemId);
+		if (until == null)
+		{
+			return false;
+		}
+		if (clock.getAsLong() >= until)
+		{
+			cooldownUntilMillis.remove(itemId);
+			return false;
+		}
+		return true;
+	}
+
+	/** Drop the cooldown for a single item — used when the player acts on it. */
+	public void clear(int itemId)
+	{
+		cooldownUntilMillis.remove(itemId);
+	}
+
+	/** Drop every cooldown — used when auto-mode is toggled off and back on. */
+	public void clearAll()
+	{
+		cooldownUntilMillis.clear();
+	}
+
+	/** Remove entries whose window has elapsed. */
+	public void pruneExpired()
+	{
+		long now = clock.getAsLong();
+		cooldownUntilMillis.entrySet().removeIf(entry -> now >= entry.getValue());
+	}
+}

--- a/src/main/java/com/flipsmart/recommend/SkipCooldownTracker.java
+++ b/src/main/java/com/flipsmart/recommend/SkipCooldownTracker.java
@@ -1,7 +1,7 @@
 package com.flipsmart.recommend;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.LongSupplier;
 
 /**
@@ -27,7 +27,7 @@ public class SkipCooldownTracker
 	private static final int MAX_ENTRIES = 500;
 
 	/** itemId -> wall-clock instant at which the cooldown expires. */
-	private final Map<Integer, Long> cooldownUntilMillis = new HashMap<>();
+	private final Map<Integer, Long> cooldownUntilMillis = new ConcurrentHashMap<>();
 
 	private final LongSupplier clock;
 

--- a/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
@@ -539,4 +539,39 @@ public class AutoRecommendDispatchTest {
         assertTrue("overlay must mention item-200, not profit; got: " + overlay,
             overlay != null && overlay.contains("item-200"));
     }
+
+    // AC1/AC2 (#919): a skipped buy is snoozed for its cooldown, so the next resolve
+    // surfaces a different item instead of re-recommending the one just skipped.
+    @Test
+    public void skippedBuyIsSnoozedAndNextItemSurfaces() {
+        when(plugin.getFilledGESlotCount()).thenReturn(7); // one free slot
+        service.start(Arrays.asList(rec(21), rec(22)));
+
+        ActionDecision first = service.resolveAndApply(-1);
+        assertEquals(ActionStep.PLACE_BUY, first.getStep());
+        assertEquals(21, first.getItemId());
+
+        service.skip(); // skip 21 -> 5-minute cooldown
+
+        ActionDecision afterSkip = service.resolveAndApply(-1);
+        assertEquals(ActionStep.PLACE_BUY, afterSkip.getStep());
+        assertEquals("skipped 21 is snoozed; 22 surfaces instead", 22, afterSkip.getItemId());
+    }
+
+    // AC5 (#919): toggling auto-mode off and back on clears the skip cooldown, so a
+    // previously-skipped item becomes eligible again.
+    @Test
+    public void togglingAutoModeClearsSkipCooldown() {
+        when(plugin.getFilledGESlotCount()).thenReturn(7);
+        service.start(Arrays.asList(rec(21), rec(22)));
+        service.resolveAndApply(-1);
+        service.skip(); // 21 cooling
+
+        service.stop();                                    // toggle OFF
+        service.start(Arrays.asList(rec(21), rec(22)));    // toggle ON
+
+        ActionDecision d = service.resolveAndApply(-1);
+        assertEquals(ActionStep.PLACE_BUY, d.getStep());
+        assertEquals("cooldown cleared on toggle; 21 surfaces again", 21, d.getItemId());
+    }
 }

--- a/src/test/java/com/flipsmart/AutoRecommendFreeSlotBuyTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendFreeSlotBuyTest.java
@@ -118,4 +118,34 @@ public class AutoRecommendFreeSlotBuyTest
 
 		assertEquals(-1, idx);
 	}
+
+	// AC1/AC2/AC4: an item inside its skip cooldown is passed over even though it is
+	// otherwise surfaceable, so a skipped buy does not immediately re-appear (including
+	// after a backend refresh that still lists it).
+	@Test
+	public void skipsCoolingDownItem()
+	{
+		List<FlipRecommendation> queue = Arrays.asList(
+			profitable(1001), profitable(2002), profitable(3003));
+		Set<Integer> cooling = new HashSet<>(Collections.singletonList(1001));
+
+		int idx = AutoRecommendService.firstAvailableBuyIndex(
+			queue, NONE_ACTIVE, NO_EXCLUDE, 0, 1, cooling::contains);
+
+		assertEquals("skips the cooling item, picks the next", 1, idx);
+	}
+
+	// When every remaining item is cooling down the scan reports nothing surfaceable,
+	// which is what drives the AC3 "queue depleted" message.
+	@Test
+	public void returnsMinusOneWhenAllCoolingDown()
+	{
+		List<FlipRecommendation> queue = Arrays.asList(profitable(1001), profitable(2002));
+		Set<Integer> cooling = new HashSet<>(Arrays.asList(1001, 2002));
+
+		int idx = AutoRecommendService.firstAvailableBuyIndex(
+			queue, NONE_ACTIVE, NO_EXCLUDE, 0, 1, cooling::contains);
+
+		assertEquals(-1, idx);
+	}
 }

--- a/src/test/java/com/flipsmart/AutoRecommendFreeSlotBuyTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendFreeSlotBuyTest.java
@@ -136,7 +136,7 @@ public class AutoRecommendFreeSlotBuyTest
 	}
 
 	// When every remaining item is cooling down the scan reports nothing surfaceable,
-	// which is what drives the AC3 "queue depleted" message.
+	// which is what makes the exhausted queue pull a fresh recommendation list (AC3).
 	@Test
 	public void returnsMinusOneWhenAllCoolingDown()
 	{

--- a/src/test/java/com/flipsmart/recommend/RecommendationQueueTest.java
+++ b/src/test/java/com/flipsmart/recommend/RecommendationQueueTest.java
@@ -199,6 +199,25 @@ public class RecommendationQueueTest
 	}
 
 	@Test
+	public void skipToNextSurfaceableSkipsCoolingDownItems()
+	{
+		RecommendationQueue q = new RecommendationQueue();
+		FlipRecommendation surfaceable = rec(14, 500);
+		q.replace(Arrays.asList(rec(11, 500), rec(12, 500), rec(13, 500), surfaceable));
+		q.setCurrentIndex(0); // currently on item 11
+
+		// items 12 and 13 were recently skipped (cooling) → cursor lands on 14 (AC2).
+		q.skipToNextSurfaceable(
+			Collections.emptySet(),
+			FlipRecommendation::getRecommendedSellPrice,
+			100,
+			id -> id == 12 || id == 13);
+
+		assertEquals(3, q.getCurrentIndex());
+		assertSame(surfaceable, q.getCurrentRecommendation());
+	}
+
+	@Test
 	public void skipToNextSurfaceableRunsOffEndWhenNoneQualify()
 	{
 		RecommendationQueue q = new RecommendationQueue();

--- a/src/test/java/com/flipsmart/recommend/SkipCooldownTrackerTest.java
+++ b/src/test/java/com/flipsmart/recommend/SkipCooldownTrackerTest.java
@@ -1,0 +1,131 @@
+package com.flipsmart.recommend;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Covers the 5-minute skip window used by Flip Assist (#919): a skipped item is held
+ * out of auto-surfacing for {@link SkipCooldownTracker#COOLDOWN_MS}, the window expires
+ * lazily, an auto-mode toggle clears every window, and distinct items are independent.
+ */
+public class SkipCooldownTrackerTest
+{
+	private static final int ITEM = 4151;
+	private static final int OTHER_ITEM = 561;
+
+	private long now;
+	private SkipCooldownTracker tracker;
+
+	@Before
+	public void setUp()
+	{
+		now = 1_000_000L;
+		tracker = new SkipCooldownTracker(() -> now);
+	}
+
+	/** AC1/AC6: a freshly skipped item is inside its window. */
+	@Test
+	public void skippedItemIsCoolingDown()
+	{
+		tracker.skip(ITEM);
+
+		assertTrue(tracker.isCoolingDown(ITEM));
+	}
+
+	/** An item that was never skipped is not cooling down. */
+	@Test
+	public void unseenItemIsNotCoolingDown()
+	{
+		assertFalse(tracker.isCoolingDown(ITEM));
+	}
+
+	/** The window holds right up to the 5-minute boundary. */
+	@Test
+	public void stillCoolingJustBeforeExpiry()
+	{
+		tracker.skip(ITEM);
+
+		now += SkipCooldownTracker.COOLDOWN_MS - 1;
+
+		assertTrue(tracker.isCoolingDown(ITEM));
+	}
+
+	/** At/after the boundary the item is eligible again. */
+	@Test
+	public void expiresAtBoundary()
+	{
+		tracker.skip(ITEM);
+
+		now += SkipCooldownTracker.COOLDOWN_MS;
+
+		assertFalse(tracker.isCoolingDown(ITEM));
+	}
+
+	/** Acting on a skipped item clears only that item's window. */
+	@Test
+	public void clearReleasesOnlyTheGivenItem()
+	{
+		tracker.skip(ITEM);
+		tracker.skip(OTHER_ITEM);
+
+		tracker.clear(ITEM);
+
+		assertFalse(tracker.isCoolingDown(ITEM));
+		assertTrue(tracker.isCoolingDown(OTHER_ITEM));
+	}
+
+	/** AC5/AC6: toggling auto-mode clears every window. */
+	@Test
+	public void clearAllReleasesEveryItem()
+	{
+		tracker.skip(ITEM);
+		tracker.skip(OTHER_ITEM);
+
+		tracker.clearAll();
+
+		assertFalse(tracker.isCoolingDown(ITEM));
+		assertFalse(tracker.isCoolingDown(OTHER_ITEM));
+	}
+
+	/** Skipping one item does not suppress another. */
+	@Test
+	public void distinctItemsAreIndependent()
+	{
+		tracker.skip(ITEM);
+
+		assertTrue(tracker.isCoolingDown(ITEM));
+		assertFalse(tracker.isCoolingDown(OTHER_ITEM));
+	}
+
+	/** Re-skipping refreshes the window from the new skip instant. */
+	@Test
+	public void reSkipExtendsWindow()
+	{
+		tracker.skip(ITEM);
+
+		now += SkipCooldownTracker.COOLDOWN_MS - 1_000;
+		tracker.skip(ITEM);
+		now += 2_000;
+
+		// Would have expired under the first skip; the second skip keeps it cooling.
+		assertTrue(tracker.isCoolingDown(ITEM));
+	}
+
+	/** pruneExpired drops elapsed windows and keeps live ones. */
+	@Test
+	public void pruneExpiredDropsOnlyElapsedWindows()
+	{
+		tracker.skip(ITEM);
+		now += SkipCooldownTracker.COOLDOWN_MS - 1_000;
+		tracker.skip(OTHER_ITEM);
+
+		now += 2_000; // ITEM elapsed, OTHER_ITEM still live
+		tracker.pruneExpired();
+
+		assertFalse(tracker.isCoolingDown(ITEM));
+		assertTrue(tracker.isCoolingDown(OTHER_ITEM));
+	}
+}


### PR DESCRIPTION
## Summary

Adds a 5-minute skip cooldown so skipped items/actions don't immediately re-appear in Flip Assist auto-mode. Implements all 8 acceptance criteria from the linked issue; this is a plugin-only change (no backend changes) — AC4's intent ("skipped items shouldn't reappear even after a backend refresh") is satisfied client-side by suppressing recently-skipped items from the refreshed recommendation list rather than by any API change.

## Changes

### ✨ New Features
- New `SkipCooldownTracker` (`com.flipsmart.recommend`) — per-item 5-minute cooldown window, with an injectable clock for testability, lazy expiry (no background sweep thread), `clearAll()` for auto-mode toggle resets, and `clear(item)` for when an item is acted on.
- `AutoRecommendService.skip()` now stamps the cooldown for the skipped buy, the skipped stale-offer action, or the skipped collected-sell.
- When the skip queue is exhausted because every remaining item is snoozed by the cooldown, the skip-button path auto-refreshes with a fresh shuffled list and continues on it (via the existing `onQueueExhausted` → `refreshRecommendations(true)` → `refreshQueue` hook). The cooldown persists across the refresh, so just-skipped items stay suppressed in the new list while new items surface — the user keeps flowing with no dead-end (AC3).
- Skipped actions retain their orange highlight box via a new sticky highlight added to `GrandExchangeSlotOverlay` that survives GE focus changes (`clearAllAdjustmentHighlights` leaves the sticky box in place; `resetAllHighlights` on plugin stop clears it). The sticky highlight is tracked by GE slot so it clears correctly even after the offer leaves the Grand Exchange, and the session's last-known sell price is retained so that manually reopening the GE offer screen for that item still shows the re-adjusted price (AC7, AC8).

### ♻️ Refactoring
- Buy re-appearance is blocked at both places a buy candidate can resurface: the resolver's `firstAvailableBuyIndex` scan (which starts back at index 0) and `RecommendationQueue.skipToNextSurfaceable`'s monotonic skip cursor — so a skipped buy stays hidden even if a price re-adjustment/re-listing or a fresh backend refresh restarts the candidate queue (covers AC1, AC2, and the client-side intent of AC4).
- Stale/action re-prompt is blocked by filtering cooling items out of the resolver's stale-offer snapshot and gating `addToStaleQueue` (AC6).
- Cooldown state persists across both manual and the 2-minute auto Flip Finder refresh; it is cleared only by natural 5-minute expiry or by toggling auto-mode off then on (AC5).
- Acting on an item (buy placed, offer cancelled, sell collected, or a stale sell re-listed) clears both its cooldown and its sticky highlight box immediately.

## Testing

### Automated Tests
- ✅ `SkipCooldownTrackerTest` — covers cooling state, expiry boundary, `clear`, `clearAll`, pruning, and independence between items, using the injected clock.
- ✅ `AutoRecommendFreeSlotBuyTest` — verifies the buy scan skips cooling items and returns -1 when all candidates are cooling.
- ✅ `RecommendationQueueTest` — verifies the skip cursor skips cooling items.
- ✅ `AutoRecommendDispatchTest` — verifies a skipped buy is snoozed and the next item surfaces; verifies toggling auto-mode clears the cooldown.
- ✅ `./gradlew clean build` (compile + full test suite) green — 477 tests, 0 failures, 0 errors.

### Manual Testing
- [x] Auto-mode ON. Skip a recommended buy -> verify it does not re-appear on the next prompt; a different item is shown instead.
- [ ] Skip several items until the queue is exhausted -> verify it automatically pulls a fresh list and continues, and the items you just skipped do NOT come back in the new list (they stay suppressed until their 5-minute cooldown expires).
- [x] Skip a reprice/cancel action on a stale sell -> verify the orange box stays on that slot, and the action is not re-prompted for 5 minutes.
- [x] With a skipped action's cooldown active, manually open the GE offer screen for that item -> verify it still shows the re-adjusted price.
- [x] Toggle auto-mode OFF then ON -> verify previously-skipped items become eligible again immediately.
- [ ] Wait out the 5-minute cooldown -> verify skipped items/actions return to the rotation.

_(Manual testing above is pending — to be completed in-game by a human.)_

## API Changes

None — plugin-only change, no backend/API modifications.

## Database Migrations

Not applicable.

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: None
- [ ] Requires database migration: No

Standard plugin release via Plugin Hub cadence once merged.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (n/a)
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by [teammate]

## Related Issues

Closes Flip-Smart/flip-smart#919

### 🩺 Codacy Quality Gate — fixed in this PR
- `4eed1b8` PMD_UseConcurrentHashMap `src/main/java/com/flipsmart/recommend/SkipCooldownTracker.java:30` — swapped `HashMap` for `ConcurrentHashMap` on the itemId→cooldown-expiry map.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `4eed1b8` `src/main/java/com/flipsmart/recommend/SkipCooldownTracker.java:30` — swapped `HashMap` for `ConcurrentHashMap` (same fix as the quality-gate finding above).

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `src/main/java/com/flipsmart/AutoRecommendService.java:147` — fully-qualified `java.util.function.IntConsumer` matches the existing `onStaleOfferPrompted` field a few lines above (pre-existing on master), so it's consistent with its immediate sibling rather than inconsistent with the codebase; left as-is.


