### PR TITLE
Active-mode competitive re-prompts + margin-decay exits (plugin wiring) (#918 pt.2)

### DIFF
--- a/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
+++ b/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
@@ -9,10 +9,34 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
+import lombok.Getter;
 
 public class ActiveOfferAdvisorService
 {
+	/**
+	 * Cross-poll advisor state (#918). The backend advisor is stateless, so the
+	 * plugin relays the counters it returned on the previous poll: last position
+	 * margin (for consecutive-decrease detection) and the joint reduction budget.
+	 */
+	@Getter
+	public static final class CourierState
+	{
+		private final Integer previousPositionMargin;
+		private final int consecutiveMarginDecreases;
+		private final double cumulativeMarginReductionPct;
+
+		public CourierState(Integer previousPositionMargin, int consecutiveMarginDecreases, double cumulativeMarginReductionPct)
+		{
+			this.previousPositionMargin = previousPositionMargin;
+			this.consecutiveMarginDecreases = consecutiveMarginDecreases;
+			this.cumulativeMarginReductionPct = cumulativeMarginReductionPct;
+		}
+
+		static final CourierState EMPTY = new CourierState(null, 0, 0.0);
+	}
+
 	private final Map<Integer, OfferAdviceResponse> dispositions = new ConcurrentHashMap<>();
+	private final Map<Integer, CourierState> courierByItem = new ConcurrentHashMap<>();
 
 	private volatile Consumer<OfferAdviceResponse> onSurfacePrice;
 	private volatile IntConsumer onHandoff;
@@ -30,6 +54,12 @@ public class ActiveOfferAdvisorService
 		return dispositions.get(itemId);
 	}
 
+	/** The courier state to relay for this item's next snapshot (EMPTY if none). */
+	public CourierState getCourierState(int itemId)
+	{
+		return courierByItem.getOrDefault(itemId, CourierState.EMPTY);
+	}
+
 	/**
 	 * Drop dispositions for items that are no longer open active offers (sold, bought,
 	 * collected, cancelled) so their prompt/highlight clears immediately instead of
@@ -44,10 +74,22 @@ public class ActiveOfferAdvisorService
 				applyResponse(itemId, null);
 			}
 		}
+		// Courier state can outlive a disposition (a WAITing offer clears its
+		// disposition but keeps accumulating decay/budget), so prune it too.
+		courierByItem.keySet().removeIf(id -> !activeItemIds.contains(id));
 	}
 
 	void applyResponse(int itemId, OfferAdviceResponse resp)
 	{
+		if (resp == null)
+		{
+			courierByItem.remove(itemId);
+		}
+		else
+		{
+			courierByItem.put(itemId, new CourierState(
+				resp.getPositionMargin(), resp.getConsecutiveMarginDecreases(), resp.getCumulativeMarginReductionPct()));
+		}
 		OfferDisposition disposition = OfferDisposition.route(resp == null ? null : resp.getActionEnum());
 		switch (disposition)
 		{
@@ -87,8 +129,20 @@ public class ActiveOfferAdvisorService
 		Integer userAvgBuyPrice,
 		Integer dailyVolume)
 	{
+		return buildSnapshot(offer, market, userAvgBuyPrice, dailyVolume, null, CourierState.EMPTY);
+	}
+
+	static OfferAdviceRequest buildSnapshot(
+		OfferRecord offer,
+		WikiPrice market,
+		Integer userAvgBuyPrice,
+		Integer dailyVolume,
+		Integer originalMargin,
+		CourierState courier)
+	{
 		boolean isSell = !offer.isBuy();
 		long lastFill = offer.getLastActivityAtMillis();
+		CourierState c = courier == null ? CourierState.EMPTY : courier;
 		return OfferAdviceRequest.builder()
 			.itemId(offer.getItemId())
 			.pool(OfferPoolClassifier.classify(dailyVolume))
@@ -101,7 +155,13 @@ public class ActiveOfferAdvisorService
 			.lastFillAtMillis(lastFill > 0 ? lastFill : null)
 			.currentMarketHigh(market == null ? null : market.instaBuy)
 			.currentMarketLow(market == null ? null : market.instaSell)
-			.userAvgBuyPrice(isSell ? userAvgBuyPrice : null)
+			// Now carried for buys too — the margin-decay exit (AC2) needs the
+			// avg buy price on a partially-filled buy.
+			.userAvgBuyPrice(userAvgBuyPrice)
+			.originalMargin(originalMargin)
+			.previousPositionMargin(c.getPreviousPositionMargin())
+			.consecutiveMarginDecreases(c.getConsecutiveMarginDecreases())
+			.cumulativeMarginReductionPct(c.getCumulativeMarginReductionPct())
 			.build();
 	}
 }

--- a/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
+++ b/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
@@ -39,10 +39,10 @@ public class ActiveOfferAdvisorService
 	private final Map<Integer, CourierState> courierByItem = new ConcurrentHashMap<>();
 
 	private volatile Consumer<OfferAdviceResponse> onSurfacePrice;
-	private volatile IntConsumer onHandoff;
+	private volatile Consumer<OfferAdviceResponse> onHandoff;
 	private volatile IntConsumer onClearSurface;
 
-	public void setCallbacks(Consumer<OfferAdviceResponse> onSurfacePrice, IntConsumer onHandoff, IntConsumer onClearSurface)
+	public void setCallbacks(Consumer<OfferAdviceResponse> onSurfacePrice, Consumer<OfferAdviceResponse> onHandoff, IntConsumer onClearSurface)
 	{
 		this.onSurfacePrice = onSurfacePrice;
 		this.onHandoff = onHandoff;
@@ -109,7 +109,8 @@ public class ActiveOfferAdvisorService
 				}
 				if (onHandoff != null)
 				{
-					onHandoff.accept(itemId);
+					resp.setItemIdHint(itemId);
+					onHandoff.accept(resp);
 				}
 				break;
 			case NONE:

--- a/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
+++ b/src/main/java/com/flipsmart/ActiveOfferAdvisorService.java
@@ -133,6 +133,22 @@ public class ActiveOfferAdvisorService
 		return buildSnapshot(offer, market, userAvgBuyPrice, dailyVolume, null, CourierState.EMPTY);
 	}
 
+	/**
+	 * Aggressive Advisor gate: the competitive re-prompts and margin-decay exit only evaluate when
+	 * the backend receives the original margin and courier counters. When the experimental toggle is
+	 * off we relay null / EMPTY so the backend runs only the base wait / move-down / exit advice.
+	 * Static + package-private so the gate stays unit-testable.
+	 */
+	static Integer relayedMargin(boolean aggressive, Integer originalMargin)
+	{
+		return aggressive ? originalMargin : null;
+	}
+
+	static CourierState relayedCourier(boolean aggressive, CourierState courier)
+	{
+		return aggressive ? courier : CourierState.EMPTY;
+	}
+
 	static OfferAdviceRequest buildSnapshot(
 		OfferRecord offer,
 		WikiPrice market,

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -429,6 +429,7 @@ public class AutoRecommendService
 				plugin.setRecommendedSellPrice(itemId, rec.getRecommendedSellPrice());
 				adjustments.putBuyPrice(itemId, rec.getRecommendedBuyPrice());
 				scheduleAdjustmentTimer(itemId, rec.getRecommendedBuyPrice());
+				captureOriginalMargin(itemId, rec);
 				log.debug("Auto-recommend: Non-focused buy for item {} - stored sell price {} from queue",
 					itemId, rec.getRecommendedSellPrice());
 			}
@@ -438,6 +439,7 @@ public class AutoRecommendService
 			plugin.setRecommendedSellPrice(itemId, current.getRecommendedSellPrice());
 			adjustments.putBuyPrice(itemId, current.getRecommendedBuyPrice());
 			scheduleAdjustmentTimer(itemId, current.getRecommendedBuyPrice());
+			captureOriginalMargin(itemId, current);
 			log.debug("Auto-recommend: Buy order placed for {} - re-resolving", current.getItemName());
 		}
 
@@ -2714,14 +2716,35 @@ public class AutoRecommendService
 		return queue.findRecommendationForItem(itemId);
 	}
 
+	/** Persist the flip's original per-unit margin at buy placement (#918), so it survives the
+	 * recommendation queue cycling. Captured once per placement from the seeding recommendation. */
+	private void captureOriginalMargin(int itemId, FlipRecommendation rec)
+	{
+		if (rec == null || rec.getMargin() <= 0)
+		{
+			return;
+		}
+		PlayerSession sess = plugin.getSession();
+		if (sess != null)
+		{
+			sess.setOriginalMargin(itemId, rec.getMargin());
+		}
+	}
+
 	/**
-	 * The per-unit margin from the recommendation that seeded this item, if it is
-	 * still in the queue. Relayed to the advisor as the original margin baseline for
-	 * the decay exit and the joint reduction budget; null when unknown (advisor then
-	 * falls back to its existing behavior).
+	 * The flip's original per-unit margin — the fixed baseline the advisor measures decay and the
+	 * joint reduction budget against. Sourced from the active offer's captured value (persisted at
+	 * placement, survives queue cycling), falling back to the live queue for a freshly-recommended
+	 * item not yet placed. Null when unknown (advisor then falls back to its existing behavior).
 	 */
 	public synchronized Integer getOriginalMargin(int itemId)
 	{
+		PlayerSession sess = plugin.getSession();
+		Integer persisted = sess == null ? null : sess.getOriginalMargin(itemId);
+		if (persisted != null)
+		{
+			return persisted;
+		}
 		FlipRecommendation rec = findRecommendationForItem(itemId);
 		return rec == null ? null : rec.getMargin();
 	}

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -2665,6 +2665,18 @@ public class AutoRecommendService
 	}
 
 	/**
+	 * The per-unit margin from the recommendation that seeded this item, if it is
+	 * still in the queue. Relayed to the advisor as the original margin baseline for
+	 * the decay exit and the joint reduction budget; null when unknown (advisor then
+	 * falls back to its existing behavior).
+	 */
+	public synchronized Integer getOriginalMargin(int itemId)
+	{
+		FlipRecommendation rec = findRecommendationForItem(itemId);
+		return rec == null ? null : rec.getMargin();
+	}
+
+	/**
 	 * Resolve the best sell price for an item. Session is the single source of truth:
 	 * it carries the most recent decision (initial smart-sell, or a manual/auto sell
 	 * adjustment) and is what the Flip Assist prompt reads. The panel's displayed

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -155,6 +155,10 @@ public class AutoRecommendService
 	// cleared by slot even after the offer has left the GE (the item lookup would then fail).
 	private final Map<Integer, Integer> stickyHighlightSlots = new java.util.concurrent.ConcurrentHashMap<>();
 
+	// Items whose surfaced resell price is a margin-decay EXIT (#918 AC2) rather than a
+	// buy reprice, so the prompt reads "Cancel & re-sell" instead of "Adjust buy".
+	private final java.util.Set<Integer> advisorExitResellItems = java.util.concurrent.ConcurrentHashMap.newKeySet();
+
 	// Provider for the panel's displayed (smart) sell price — preferred over session's stored price
 	private volatile IntFunction<Integer> displayedSellPriceProvider;
 
@@ -1691,9 +1695,21 @@ public class AutoRecommendService
 			Integer net = staleOffers.getResellNet(offer.getItemId());
 			String netSuffix = net == null ? ""
 				: String.format(" (%s%s)", net >= 0 ? "+" : "-", GpUtils.formatGP(Math.abs(net)));
-			// A priced buy prompt is the competitive buy reprice (advisor move_price_up);
-			// a priced sell prompt is a re-sell/exit at the advised price.
-			String verb = offer.isBuy() ? "Adjust buy" : "Re-sell";
+			// AC2 exit → cancel & re-sell; a priced buy prompt is the competitive buy
+			// reprice (move_price_up); a priced sell prompt is a re-sell/exit at the advised price.
+			String verb;
+			if (advisorExitResellItems.contains(offer.getItemId()))
+			{
+				verb = "Cancel & re-sell";
+			}
+			else if (offer.isBuy())
+			{
+				verb = "Adjust buy";
+			}
+			else
+			{
+				verb = "Re-sell";
+			}
 			overlayMsg = String.format("%s %s at:\n%s gp%s", verb, offer.getItemName(),
 				String.format("%,d", resellPrice), netSuffix);
 		}
@@ -1765,6 +1781,7 @@ public class AutoRecommendService
 	{
 		skipCooldown.clear(itemId);
 		dropStickyHighlight(itemId);
+		advisorExitResellItems.remove(itemId);
 	}
 
 	/** GE slot currently holding a live offer for the item, or null if none. */
@@ -1889,6 +1906,33 @@ public class AutoRecommendService
 		{
 			sess.setRecommendedPrice(offer.getItemId(), newPrice);
 		}
+		advisorExitResellItems.remove(offer.getItemId());
+		addToStaleQueue(offer);
+	}
+
+	/**
+	 * Surface a margin-decay exit (#918 AC2): cancel the remaining buy and re-sell the held
+	 * units at the advisor's already-jittered price. Stores the price in the stale-price map
+	 * (so the eventual sell lists via the no-offset path, honouring AC6) and marks the item as
+	 * an exit so the prompt reads "Cancel & re-sell" rather than "Adjust buy". Deliberately does
+	 * NOT set the session recommended price — that would flow through the offset-applying focus.
+	 */
+	public synchronized void surfaceAdvisorExitResell(OfferRecord offer, int resellPrice, Integer netProfitEstimate)
+	{
+		if (offer == null)
+		{
+			return;
+		}
+		staleOffers.putResellPrice(offer.getItemId(), resellPrice);
+		if (netProfitEstimate != null)
+		{
+			staleOffers.putResellNet(offer.getItemId(), netProfitEstimate);
+		}
+		else
+		{
+			staleOffers.removeResellNet(offer.getItemId());
+		}
+		advisorExitResellItems.add(offer.getItemId());
 		addToStaleQueue(offer);
 	}
 
@@ -1898,6 +1942,7 @@ public class AutoRecommendService
 	 */
 	public synchronized void removeAdvisorResell(int itemId)
 	{
+		advisorExitResellItems.remove(itemId);
 		boolean wasHead = staleOffers.headIsItem(itemId);
 		staleOffers.removeOffer(itemId);
 		if (wasHead)

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -528,7 +528,9 @@ public class AutoRecommendService
 		if (repricePending)
 		{
 			int repriceQty = resolveRepriceQuantity(itemId);
-			FocusedFlip focus = FocusedFlip.forSell(itemId, itemName, resellPrice, repriceQty, config.priceOffset());
+			// resellPrice is the advisor's backend price, already jittered (#918 AC6) —
+			// do NOT re-apply the plugin priceOffset or it would double-adjust.
+			FocusedFlip focus = FocusedFlip.forSell(itemId, itemName, resellPrice, repriceQty);
 			invokeFocusCallback(focus);
 			updateStatus(String.format(MSG_SELL_FORMAT, itemName, GpUtils.formatGPWithSuffix(resellPrice)));
 			return SellFocusResult.FOCUSED;
@@ -1684,12 +1686,15 @@ public class AutoRecommendService
 	{
 		Integer resellPrice = staleOffers.getResellPrice(offer.getItemId());
 		String overlayMsg;
-		if (!offer.isBuy() && resellPrice != null)
+		if (resellPrice != null)
 		{
 			Integer net = staleOffers.getResellNet(offer.getItemId());
 			String netSuffix = net == null ? ""
 				: String.format(" (%s%s)", net >= 0 ? "+" : "-", GpUtils.formatGP(Math.abs(net)));
-			overlayMsg = String.format("Re-sell %s at:\n%s gp%s", offer.getItemName(),
+			// A priced buy prompt is the competitive buy reprice (advisor move_price_up);
+			// a priced sell prompt is a re-sell/exit at the advised price.
+			String verb = offer.isBuy() ? "Adjust buy" : "Re-sell";
+			overlayMsg = String.format("%s %s at:\n%s gp%s", verb, offer.getItemName(),
 				String.format("%,d", resellPrice), netSuffix);
 		}
 		else

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -177,6 +177,13 @@ public class AutoRecommendService
 	// buy reprice, so the prompt reads "Cancel & re-sell" instead of "Adjust buy".
 	private final java.util.Set<Integer> advisorExitResellItems = java.util.concurrent.ConcurrentHashMap.newKeySet();
 
+	// Items whose stale-queue prompt originates from the Active-mode advisor (SURFACE_PRICE
+	// reprices and margin-decay exits). These are backend-authoritative and must bypass the local
+	// wiki competitiveness prune that governs legacy stale-offer prompts — otherwise an advisor
+	// reprice/exit on an offer the local check still reads as "competitive" (green) is dropped
+	// before it can surface.
+	private final java.util.Set<Integer> advisorSurfacedItems = java.util.concurrent.ConcurrentHashMap.newKeySet();
+
 	// Provider for the panel's displayed (smart) sell price — preferred over session's stored price
 	private volatile IntFunction<Integer> displayedSellPriceProvider;
 
@@ -362,6 +369,8 @@ public class AutoRecommendService
 		// AC5/AC6: toggling auto-mode off clears every skip cooldown and its sticky box.
 		skipCooldown.clearAll();
 		stickyHighlightSlots.clear();
+		advisorExitResellItems.clear();
+		advisorSurfacedItems.clear();
 		Runnable resetHighlights = onResetAllHighlights;
 		if (resetHighlights != null)
 		{
@@ -1712,24 +1721,7 @@ public class AutoRecommendService
 		if (session != null)
 		{
 			List<OfferRecord> currentOffers = offerStore.liveOffers();
-			staleOffers.pruneIrrelevant(o ->
-			{
-				OfferRecord current = currentOffers.stream()
-					.filter(t -> t.getItemId() == o.getItemId() && t.getState() != OfferState.FILLED)
-					.findFirst().orElse(null);
-				if (current == null)
-				{
-					return true; // No longer in GE
-				}
-				// 12h ladder prompts are backend-authoritative — keep them regardless of competitiveness.
-				if (!competitivenessGateApplies(config.flipTimeframe()))
-				{
-					return false;
-				}
-				// Re-check competitiveness — wiki prices may have refreshed
-				FlipSmartPlugin.OfferCompetitiveness comp = plugin.calculateCompetitiveness(current);
-				return comp != FlipSmartPlugin.OfferCompetitiveness.UNCOMPETITIVE;
-			});
+			staleOffers.pruneIrrelevant(o -> staleOfferNoLongerRelevant(o, currentOffers));
 		}
 
 		if (staleOffers.isEmpty())
@@ -1820,28 +1812,46 @@ public class AutoRecommendService
 		}
 	}
 
+	/**
+	 * Whether a queued stale/advisor offer should be pruned from the stale queue. Prunes when the
+	 * offer has left the GE (sold / collected / cancelled). Otherwise an advisor-surfaced prompt
+	 * (a SURFACE_PRICE reprice or margin-decay exit) is backend-authoritative and is kept
+	 * regardless of the local wiki competitiveness check — only legacy local-detection prompts are
+	 * subject to the green/red gate, which drops an offer that has drifted back to competitive.
+	 * Without the advisor bypass, a reprice/exit on an offer the local check still reads as
+	 * "competitive" (green) is pruned before it can surface.
+	 */
+	private boolean staleOfferNoLongerRelevant(OfferRecord queued, List<OfferRecord> currentOffers)
+	{
+		OfferRecord current = currentOffers.stream()
+			.filter(t -> t.getItemId() == queued.getItemId() && t.getState() != OfferState.FILLED)
+			.findFirst().orElse(null);
+		if (current == null)
+		{
+			return true; // No longer in GE
+		}
+		// Advisor prompts are backend-authoritative — never dropped for local competitiveness.
+		if (advisorSurfacedItems.contains(queued.getItemId()))
+		{
+			return false;
+		}
+		// 12h ladder prompts are backend-authoritative too — keep them regardless of competitiveness.
+		if (!competitivenessGateApplies(config.flipTimeframe()))
+		{
+			return false;
+		}
+		// Re-check competitiveness — wiki prices may have refreshed.
+		FlipSmartPlugin.OfferCompetitiveness comp = plugin.calculateCompetitiveness(current);
+		return comp != FlipSmartPlugin.OfferCompetitiveness.UNCOMPETITIVE;
+	}
+
 	private void focusStaleOfferForItem(int itemId)
 	{
 		PlayerSession session = plugin.getSession();
 		if (session != null)
 		{
 			List<OfferRecord> currentOffers = offerStore.liveOffers();
-			staleOffers.pruneIrrelevant(o ->
-			{
-				OfferRecord current = currentOffers.stream()
-					.filter(t -> t.getItemId() == o.getItemId() && t.getState() != OfferState.FILLED)
-					.findFirst().orElse(null);
-				if (current == null)
-				{
-					return true;
-				}
-				if (!competitivenessGateApplies(config.flipTimeframe()))
-				{
-					return false;
-				}
-				FlipSmartPlugin.OfferCompetitiveness comp = plugin.calculateCompetitiveness(current);
-				return comp != FlipSmartPlugin.OfferCompetitiveness.UNCOMPETITIVE;
-			});
+			staleOffers.pruneIrrelevant(o -> staleOfferNoLongerRelevant(o, currentOffers));
 		}
 
 		if (staleOffers.isEmpty())
@@ -1873,6 +1883,7 @@ public class AutoRecommendService
 		skipCooldown.clear(itemId);
 		dropStickyHighlight(itemId);
 		advisorExitResellItems.remove(itemId);
+		advisorSurfacedItems.remove(itemId);
 	}
 
 	/** GE slot currently holding a live offer for the item, or null if none. */
@@ -1944,6 +1955,23 @@ public class AutoRecommendService
 	}
 
 	/**
+	 * Surface a bare advisor HANDOFF: the advisor decided to cancel with no reprice — e.g. a
+	 * buy with no fills in its window (CANCEL_AND_RELIST_OTHER). Marks the item as advisor-surfaced
+	 * so the "consider cancelling" prompt bypasses the local competitiveness prune (the advisor is
+	 * authoritative — a no-fill cancel has nothing to do with the local green/red price check), then
+	 * queues it.
+	 */
+	public synchronized void surfaceAdvisorCancel(OfferRecord offer)
+	{
+		if (offer == null)
+		{
+			return;
+		}
+		advisorSurfacedItems.add(offer.getItemId());
+		addToStaleQueue(offer);
+	}
+
+	/**
 	 * Add a tracked offer to the stale queue if not already present.
 	 * If the queue was empty, immediately shows the first prompt.
 	 */
@@ -1998,6 +2026,7 @@ public class AutoRecommendService
 			sess.setRecommendedPrice(offer.getItemId(), newPrice);
 		}
 		advisorExitResellItems.remove(offer.getItemId());
+		advisorSurfacedItems.add(offer.getItemId());
 		addToStaleQueue(offer);
 	}
 
@@ -2024,6 +2053,7 @@ public class AutoRecommendService
 			staleOffers.removeResellNet(offer.getItemId());
 		}
 		advisorExitResellItems.add(offer.getItemId());
+		advisorSurfacedItems.add(offer.getItemId());
 		addToStaleQueue(offer);
 	}
 
@@ -2034,6 +2064,7 @@ public class AutoRecommendService
 	public synchronized void removeAdvisorResell(int itemId)
 	{
 		advisorExitResellItems.remove(itemId);
+		advisorSurfacedItems.remove(itemId);
 		boolean wasHead = staleOffers.headIsItem(itemId);
 		staleOffers.removeOffer(itemId);
 		if (wasHead)

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -496,6 +496,16 @@ public class FlipSmartApiClient
 		{
 			body.addProperty("user_avg_buy_price", req.getUserAvgBuyPrice());
 		}
+		if (req.getOriginalMargin() != null)
+		{
+			body.addProperty("original_margin", req.getOriginalMargin());
+		}
+		if (req.getPreviousPositionMargin() != null)
+		{
+			body.addProperty("previous_position_margin", req.getPreviousPositionMargin());
+		}
+		body.addProperty("consecutive_margin_decreases", req.getConsecutiveMarginDecreases());
+		body.addProperty("cumulative_margin_reduction_pct", req.getCumulativeMarginReductionPct());
 		return body;
 	}
 

--- a/src/main/java/com/flipsmart/FlipSmartConfig.java
+++ b/src/main/java/com/flipsmart/FlipSmartConfig.java
@@ -626,6 +626,26 @@ public interface FlipSmartConfig extends Config
 		return false;
 	}
 
+	@ConfigSection(
+		name = "Experimental",
+		description = "Opt-in features under active testing. May change or be removed.",
+		position = 7,
+		closedByDefault = true
+	)
+	String EXPERIMENTAL_SECTION = "experimental";
+
+	@ConfigItem(
+		keyName = "enableAggressiveAdvisor",
+		name = "Aggressive Advisor (EXPERIMENTAL)",
+		description = "In Active mode, add competitive re-price prompts and margin-decay early exits on top of the Active Offer Advisor. Experimental — off by default; the base wait / move-down / exit advice is unaffected.",
+		section = EXPERIMENTAL_SECTION,
+		position = 0
+	)
+	default boolean enableAggressiveAdvisor()
+	{
+		return false;
+	}
+
 	// ============================================
 	// Flip Style Enum
 	// ============================================

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -2000,9 +2000,9 @@ public class FlipSmartPlugin extends Plugin
 		return null;
 	}
 
-	public void handleActiveOfferHandoff(int itemId)
+	public void handleActiveOfferHandoff(OfferAdviceResponse resp)
 	{
-		if (autoRecommendService == null)
+		if (autoRecommendService == null || resp == null || resp.getItemIdHint() == null)
 		{
 			return;
 		}
@@ -2010,6 +2010,14 @@ public class FlipSmartPlugin extends Plugin
 		if (sess == null)
 		{
 			return;
+		}
+		int itemId = resp.getItemIdHint();
+		// AC2 cancel-and-sell-partial carries the advisor's (jittered) resell price;
+		// adopt it so the eventual sell lists at the backend price (#918 AC6) rather
+		// than a plugin-recomputed one.
+		if (resp.getNewPrice() != null)
+		{
+			sess.setRecommendedPrice(itemId, resp.getNewPrice());
 		}
 		for (com.flipsmart.domain.offer.OfferRecord offer : offerStore.liveOffers())
 		{

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1754,9 +1754,13 @@ public class FlipSmartPlugin extends Plugin
 			}
 			Integer dailyVolume = apiClient.getCachedDailyVolume(offer.getItemId());
 			WikiPrice market = apiClient.getWikiPrice(offer.getItemId());
-			Integer avgBuy = offer.isBuy() ? null
-				: BuyPriceLookup.findAverageBuyPrice(getCurrentActiveFlips(), offer.getItemId());
-			requests.add(ActiveOfferAdvisorService.buildSnapshot(offer, market, avgBuy, dailyVolume));
+			Integer avgBuy = avgBuyPriceFor(offer);
+			Integer originalMargin = autoRecommendService == null ? null
+				: autoRecommendService.getOriginalMargin(offer.getItemId());
+			ActiveOfferAdvisorService.CourierState courier =
+				activeOfferAdvisorService.getCourierState(offer.getItemId());
+			requests.add(ActiveOfferAdvisorService.buildSnapshot(
+				offer, market, avgBuy, dailyVolume, originalMargin, courier));
 		}
 		if (requests.isEmpty())
 		{
@@ -1792,6 +1796,25 @@ public class FlipSmartPlugin extends Plugin
 				}
 				return null;
 			});
+	}
+
+	/**
+	 * Average price the user paid for the units they hold. For a sell that is the
+	 * matched buy cost from active flips; for a partially-filled buy it is this
+	 * offer's own average fill (falling back to the listed price), which the
+	 * margin-decay exit (#918 AC2) needs.
+	 */
+	private Integer avgBuyPriceFor(com.flipsmart.domain.offer.OfferRecord offer)
+	{
+		if (!offer.isBuy())
+		{
+			return BuyPriceLookup.findAverageBuyPrice(getCurrentActiveFlips(), offer.getItemId());
+		}
+		if (offer.getFilledQuantity() > 0 && offer.getSpent() > 0)
+		{
+			return (int) Math.round(offer.getSpent() / (double) offer.getFilledQuantity());
+		}
+		return offer.getPrice();
 	}
 
 	public void applyActiveOfferSurface(OfferAdviceResponse resp)

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1760,10 +1760,13 @@ public class FlipSmartPlugin extends Plugin
 			Integer dailyVolume = apiClient.getCachedDailyVolume(offer.getItemId());
 			WikiPrice market = apiClient.getWikiPrice(offer.getItemId());
 			Integer avgBuy = avgBuyPriceFor(offer);
-			Integer originalMargin = autoRecommendService == null ? null
-				: autoRecommendService.getOriginalMargin(offer.getItemId());
-			ActiveOfferAdvisorService.CourierState courier =
-				activeOfferAdvisorService.getCourierState(offer.getItemId());
+			// Gate the competitive re-prompts + margin-decay exit behind the experimental toggle:
+			// relaying the margin/courier only when it's on leaves the base advisor advice unchanged.
+			boolean aggressive = config.enableAggressiveAdvisor();
+			Integer originalMargin = ActiveOfferAdvisorService.relayedMargin(aggressive,
+				autoRecommendService == null ? null : autoRecommendService.getOriginalMargin(offer.getItemId()));
+			ActiveOfferAdvisorService.CourierState courier = ActiveOfferAdvisorService.relayedCourier(
+				aggressive, activeOfferAdvisorService.getCourierState(offer.getItemId()));
 			requests.add(ActiveOfferAdvisorService.buildSnapshot(
 				offer, market, avgBuy, dailyVolume, originalMargin, courier));
 		}

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -2006,19 +2006,11 @@ public class FlipSmartPlugin extends Plugin
 		{
 			return;
 		}
-		PlayerSession sess = getSession();
-		if (sess == null)
-		{
-			return;
-		}
 		int itemId = resp.getItemIdHint();
-		// AC2 cancel-and-sell-partial carries the advisor's (jittered) resell price;
-		// adopt it so the eventual sell lists at the backend price (#918 AC6) rather
-		// than a plugin-recomputed one.
-		if (resp.getNewPrice() != null)
-		{
-			sess.setRecommendedPrice(itemId, resp.getNewPrice());
-		}
+		// Cancel handoff only enqueues the offer for the existing cancel/sell flow.
+		// The advisor's resell price is deliberately NOT adopted here as the session
+		// price: the downstream sell focus re-applies the configured price offset, so
+		// seeding an already-jittered advisor price would double-adjust it.
 		for (com.flipsmart.domain.offer.OfferRecord offer : offerStore.liveOffers())
 		{
 			if (offer.getItemId() == itemId)

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -2025,7 +2025,7 @@ public class FlipSmartPlugin extends Plugin
 				}
 				else
 				{
-					autoRecommendService.addToStaleQueue(offer);
+					autoRecommendService.surfaceAdvisorCancel(offer);
 				}
 				break;
 			}

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -2007,15 +2007,21 @@ public class FlipSmartPlugin extends Plugin
 			return;
 		}
 		int itemId = resp.getItemIdHint();
-		// Cancel handoff only enqueues the offer for the existing cancel/sell flow.
-		// The advisor's resell price is deliberately NOT adopted here as the session
-		// price: the downstream sell focus re-applies the configured price offset, so
-		// seeding an already-jittered advisor price would double-adjust it.
 		for (com.flipsmart.domain.offer.OfferRecord offer : offerStore.liveOffers())
 		{
 			if (offer.getItemId() == itemId)
 			{
-				autoRecommendService.addToStaleQueue(offer);
+				if (resp.getNewPrice() != null)
+				{
+					// AC2 margin-decay exit: cancel the buy and re-sell the held units at the
+					// advisor's jittered price. Routed through the stale-price map (not the
+					// session price) so the sell lists via the no-offset path — no double-adjust.
+					autoRecommendService.surfaceAdvisorExitResell(offer, resp.getNewPrice(), resp.getNetProfitEstimate());
+				}
+				else
+				{
+					autoRecommendService.addToStaleQueue(offer);
+				}
 				break;
 			}
 		}

--- a/src/main/java/com/flipsmart/PlayerSession.java
+++ b/src/main/java/com/flipsmart/PlayerSession.java
@@ -49,6 +49,7 @@ public class PlayerSession
 	// =====================
 
 	private final Map<Integer, Integer> recommendedPrices = new ConcurrentHashMap<>();
+	private final Map<Integer, Integer> originalMargins = new ConcurrentHashMap<>();
 	// =====================
 	// Sync Status
 	// =====================
@@ -224,9 +225,31 @@ public class PlayerSession
 		recommendedPrices.remove(itemId);
 	}
 
+	/**
+	 * Per-item original margin (#918): the flip's per-unit margin captured when the buy was
+	 * placed. This is the fixed baseline the Active Offer Advisor measures decay and the joint
+	 * reduction budget against — a property of the active offer, not of the transient
+	 * recommendation queue, so it persists until the item is flipped again.
+	 */
+	public Integer getOriginalMargin(int itemId)
+	{
+		return originalMargins.get(itemId);
+	}
+
+	public void setOriginalMargin(int itemId, int margin)
+	{
+		originalMargins.put(itemId, margin);
+	}
+
+	public void removeOriginalMargin(int itemId)
+	{
+		originalMargins.remove(itemId);
+	}
+
 	public void clearRecommendedPrices()
 	{
 		recommendedPrices.clear();
+		originalMargins.clear();
 	}
 
 	// =====================

--- a/src/main/java/com/flipsmart/api/dto/OfferAdviceRequest.java
+++ b/src/main/java/com/flipsmart/api/dto/OfferAdviceRequest.java
@@ -22,6 +22,13 @@ public class OfferAdviceRequest
 	private final Integer currentMarketLow;
 	private final Integer userAvgBuyPrice;
 
+	// Courier state (#918): the backend advisor is stateless, so cross-poll
+	// state travels on the request and is echoed back from the previous response.
+	private final Integer originalMargin;
+	private final Integer previousPositionMargin;
+	private final int consecutiveMarginDecreases;
+	private final double cumulativeMarginReductionPct;
+
 	public static String toIsoUtc(long epochMillis)
 	{
 		if (epochMillis <= 0)

--- a/src/main/java/com/flipsmart/api/dto/OfferAdviceResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/OfferAdviceResponse.java
@@ -16,6 +16,16 @@ public class OfferAdviceResponse
 	@SerializedName("net_profit_estimate")
 	private Integer netProfitEstimate;
 
+	// Courier state (#918) echoed back to the plugin for the next poll.
+	@SerializedName("position_margin")
+	private Integer positionMargin;
+
+	@SerializedName("consecutive_margin_decreases")
+	private int consecutiveMarginDecreases;
+
+	@SerializedName("cumulative_margin_reduction_pct")
+	private double cumulativeMarginReductionPct;
+
 	private transient Integer itemIdHint;
 
 	public Integer getItemIdHint()

--- a/src/main/java/com/flipsmart/domain/offer/OfferAction.java
+++ b/src/main/java/com/flipsmart/domain/offer/OfferAction.java
@@ -6,6 +6,7 @@ public enum OfferAction
 	CANCEL_AND_RELIST_OTHER("cancel_and_relist_other"),
 	CANCEL_AND_SELL_PARTIAL("cancel_and_sell_partial"),
 	MOVE_PRICE_DOWN("move_price_down"),
+	MOVE_PRICE_UP("move_price_up"),
 	EXIT_AT_BREAKEVEN("exit_at_breakeven"),
 	EXIT_AT_LOSS("exit_at_loss");
 

--- a/src/main/java/com/flipsmart/domain/offer/OfferDisposition.java
+++ b/src/main/java/com/flipsmart/domain/offer/OfferDisposition.java
@@ -15,6 +15,7 @@ public enum OfferDisposition
 		switch (action)
 		{
 			case MOVE_PRICE_DOWN:
+			case MOVE_PRICE_UP:
 			case EXIT_AT_BREAKEVEN:
 			case EXIT_AT_LOSS:
 				return SURFACE_PRICE;

--- a/src/main/java/com/flipsmart/plugin/ServiceWiring.java
+++ b/src/main/java/com/flipsmart/plugin/ServiceWiring.java
@@ -77,7 +77,7 @@ public class ServiceWiring
 		ActiveOfferAdvisorService activeOfferAdvisorService = new ActiveOfferAdvisorService();
 		activeOfferAdvisorService.setCallbacks(
 			resp -> SwingUtilities.invokeLater(() -> plugin.applyActiveOfferSurface(resp)),
-			resp -> plugin.handleActiveOfferHandoff(resp),
+			resp -> SwingUtilities.invokeLater(() -> plugin.handleActiveOfferHandoff(resp)),
 			itemId -> SwingUtilities.invokeLater(() -> plugin.clearActiveOfferSurface(itemId)));
 		return activeOfferAdvisorService;
 	}

--- a/src/main/java/com/flipsmart/plugin/ServiceWiring.java
+++ b/src/main/java/com/flipsmart/plugin/ServiceWiring.java
@@ -77,7 +77,7 @@ public class ServiceWiring
 		ActiveOfferAdvisorService activeOfferAdvisorService = new ActiveOfferAdvisorService();
 		activeOfferAdvisorService.setCallbacks(
 			resp -> SwingUtilities.invokeLater(() -> plugin.applyActiveOfferSurface(resp)),
-			itemId -> plugin.handleActiveOfferHandoff(itemId),
+			resp -> plugin.handleActiveOfferHandoff(resp),
 			itemId -> SwingUtilities.invokeLater(() -> plugin.clearActiveOfferSurface(itemId)));
 		return activeOfferAdvisorService;
 	}

--- a/src/test/java/com/flipsmart/ActiveOfferDispositionCacheTest.java
+++ b/src/test/java/com/flipsmart/ActiveOfferDispositionCacheTest.java
@@ -67,6 +67,29 @@ public class ActiveOfferDispositionCacheTest
 	}
 
 	@Test
+	public void courierStateIsStoredFromResponseAndClearedOnReconcile()
+	{
+		ActiveOfferAdvisorService svc = new ActiveOfferAdvisorService();
+		OfferAdviceResponse resp = new OfferAdviceResponse();
+		resp.setAction("wait");
+		resp.setPositionMargin(3100);
+		resp.setConsecutiveMarginDecreases(2);
+		resp.setCumulativeMarginReductionPct(0.15);
+
+		svc.applyResponse(42, resp);
+
+		ActiveOfferAdvisorService.CourierState c = svc.getCourierState(42);
+		assertEquals(Integer.valueOf(3100), c.getPreviousPositionMargin());
+		assertEquals(2, c.getConsecutiveMarginDecreases());
+		assertEquals(0.15, c.getCumulativeMarginReductionPct(), 1e-9);
+
+		// item no longer active → courier state resets to EMPTY
+		svc.reconcile(java.util.Collections.emptySet());
+		assertNull(svc.getCourierState(42).getPreviousPositionMargin());
+		assertEquals(0, svc.getCourierState(42).getConsecutiveMarginDecreases());
+	}
+
+	@Test
 	public void surfacePriceDoesNotFireClearCallback()
 	{
 		ActiveOfferAdvisorService svc = new ActiveOfferAdvisorService();

--- a/src/test/java/com/flipsmart/ActiveOfferDispositionCacheTest.java
+++ b/src/test/java/com/flipsmart/ActiveOfferDispositionCacheTest.java
@@ -51,7 +51,7 @@ public class ActiveOfferDispositionCacheTest
 		ActiveOfferAdvisorService svc = new ActiveOfferAdvisorService();
 		final int[] handoffItem = {-1};
 		final int[] cleared = {-1};
-		svc.setCallbacks(null, id -> handoffItem[0] = id, id -> cleared[0] = id);
+		svc.setCallbacks(null, resp -> handoffItem[0] = resp.getItemIdHint(), id -> cleared[0] = id);
 
 		OfferAdviceResponse move = new OfferAdviceResponse();
 		move.setAction(MOVE_PRICE_DOWN);

--- a/src/test/java/com/flipsmart/ActiveOfferSnapshotTest.java
+++ b/src/test/java/com/flipsmart/ActiveOfferSnapshotTest.java
@@ -7,6 +7,7 @@ import com.flipsmart.api.dto.OfferAdviceRequest;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 public class ActiveOfferSnapshotTest
 {
@@ -89,5 +90,24 @@ public class ActiveOfferSnapshotTest
 		assertNull(req.getPreviousPositionMargin());
 		assertEquals(0, req.getConsecutiveMarginDecreases());
 		assertEquals(0.0, req.getCumulativeMarginReductionPct(), 1e-9);
+	}
+
+	@Test
+	public void aggressiveGateRelaysMarginOnlyWhenOn()
+	{
+		assertNull("margin must not be relayed when the aggressive advisor is off",
+			ActiveOfferAdvisorService.relayedMargin(false, 5000));
+		assertEquals(Integer.valueOf(5000), ActiveOfferAdvisorService.relayedMargin(true, 5000));
+	}
+
+	@Test
+	public void aggressiveGateRelaysCourierOnlyWhenOn()
+	{
+		ActiveOfferAdvisorService.CourierState courier =
+			new ActiveOfferAdvisorService.CourierState(9000, 2, 0.2);
+		assertSame("courier must be EMPTY when the aggressive advisor is off",
+			ActiveOfferAdvisorService.CourierState.EMPTY,
+			ActiveOfferAdvisorService.relayedCourier(false, courier));
+		assertSame(courier, ActiveOfferAdvisorService.relayedCourier(true, courier));
 	}
 }

--- a/src/test/java/com/flipsmart/ActiveOfferSnapshotTest.java
+++ b/src/test/java/com/flipsmart/ActiveOfferSnapshotTest.java
@@ -53,11 +53,41 @@ public class ActiveOfferSnapshotTest
 	}
 
 	@Test
-	public void buyOfferOmitsUserAvgBuyPriceEvenIfProvided()
+	public void buyOfferCarriesUserAvgBuyPriceForDecayExit()
 	{
+		// AC2 (#918): a partially-filled buy needs its avg buy price so the backend
+		// can compute the decaying position margin.
 		OfferRecord offer = buyOffer(1, 1, 5, System.currentTimeMillis());
 		OfferAdviceRequest req = ActiveOfferAdvisorService.buildSnapshot(offer, null, 990, 100000);
 		assertEquals("mid_vol", req.getPool());
-		assertNull(req.getUserAvgBuyPrice());
+		assertEquals(Integer.valueOf(990), req.getUserAvgBuyPrice());
+	}
+
+	@Test
+	public void buildsSnapshotWithCourierState()
+	{
+		OfferRecord offer = buyOffer(4151, 10, 100000, System.currentTimeMillis());
+		ActiveOfferAdvisorService.CourierState courier =
+			new ActiveOfferAdvisorService.CourierState(9000, 1, 0.1);
+
+		OfferAdviceRequest req = ActiveOfferAdvisorService.buildSnapshot(
+			offer, new WikiPrice(95000, 94000), 90000, 100000, 10000, courier);
+
+		assertEquals(Integer.valueOf(10000), req.getOriginalMargin());
+		assertEquals(Integer.valueOf(9000), req.getPreviousPositionMargin());
+		assertEquals(1, req.getConsecutiveMarginDecreases());
+		assertEquals(0.1, req.getCumulativeMarginReductionPct(), 1e-9);
+		assertEquals(Integer.valueOf(90000), req.getUserAvgBuyPrice());
+	}
+
+	@Test
+	public void fourArgSnapshotDefaultsCourierStateToEmpty()
+	{
+		OfferRecord offer = buyOffer(1, 1, 5, System.currentTimeMillis());
+		OfferAdviceRequest req = ActiveOfferAdvisorService.buildSnapshot(offer, null, null, 100000);
+		assertNull(req.getOriginalMargin());
+		assertNull(req.getPreviousPositionMargin());
+		assertEquals(0, req.getConsecutiveMarginDecreases());
+		assertEquals(0.0, req.getCumulativeMarginReductionPct(), 1e-9);
 	}
 }

--- a/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
@@ -499,6 +499,64 @@ public class AutoRecommendDispatchTest {
     }
 
     @Test
+    public void advisorResellSurfacesEvenWhenLocallyCompetitive() throws Exception {
+        // #918 surfacing bug: the Active-mode advisor is backend-authoritative. A reprice it
+        // surfaces must NOT be dropped by the local wiki competitiveness prune just because the
+        // offer still reads as "competitive" (green) locally — otherwise the prompt never shows.
+        when(config.flipTimeframe()).thenReturn(FlipSmartConfig.FlipTimeframe.ACTIVE);
+        when(plugin.calculateCompetitiveness(any())).thenReturn(FlipSmartPlugin.OfferCompetitiveness.COMPETITIVE);
+        OfferRecord activeSell = OfferRecord
+            .newOffer(2, 0, 42, "item-42", false, 5, 300, 0L)
+            .withFill(0, 0L, OfferState.PARTIAL_FILL, 1L);
+        offerStore.importRecords(Arrays.asList(activeSell));
+
+        service.surfaceAdvisorResell(activeSell, 250, 1000);
+        SwingUtilities.invokeAndWait(() -> {});
+
+        String overlay = service.getLastOverlayMessage();
+        assertTrue("advisor reprice must surface despite a locally-competitive offer; got: " + overlay,
+            overlay != null && overlay.contains("Re-sell") && overlay.contains("250"));
+    }
+
+    @Test
+    public void advisorExitResellSurfacesEvenWhenLocallyCompetitive() throws Exception {
+        // #918 surfacing bug, exit variant: a margin-decay exit must surface even when the local
+        // competitiveness check reads the offer as competitive (green).
+        when(config.flipTimeframe()).thenReturn(FlipSmartConfig.FlipTimeframe.ACTIVE);
+        when(plugin.calculateCompetitiveness(any())).thenReturn(FlipSmartPlugin.OfferCompetitiveness.COMPETITIVE);
+        OfferRecord partialBuy = OfferRecord
+            .newOffer(3, 0, 77, "item-77", true, 10, 100, 0L)
+            .withFill(5, 500L, OfferState.PARTIAL_FILL, 1L);
+        offerStore.importRecords(Arrays.asList(partialBuy));
+
+        service.surfaceAdvisorExitResell(partialBuy, 250, -1000);
+        SwingUtilities.invokeAndWait(() -> {});
+
+        String overlay = service.getLastOverlayMessage();
+        assertTrue("advisor exit must surface despite a locally-competitive offer; got: " + overlay,
+            overlay != null && overlay.contains("Cancel & re-sell") && overlay.contains("250"));
+    }
+
+    @Test
+    public void advisorCancelSurfacesEvenWhenLocallyCompetitive() throws Exception {
+        // #918 surfacing bug, bare-handoff variant: a no-price advisor cancel (e.g. a buy with no
+        // fills in its window) must surface even when the local competitiveness check reads the
+        // offer as competitive (green) — the advisor is authoritative.
+        when(config.flipTimeframe()).thenReturn(FlipSmartConfig.FlipTimeframe.ACTIVE);
+        when(plugin.calculateCompetitiveness(any())).thenReturn(FlipSmartPlugin.OfferCompetitiveness.COMPETITIVE);
+        OfferRecord unfilledBuy = OfferRecord
+            .newOffer(5, 0, 99, "item-99", true, 10, 100, 0L);
+        offerStore.importRecords(Arrays.asList(unfilledBuy));
+
+        service.surfaceAdvisorCancel(unfilledBuy);
+        SwingUtilities.invokeAndWait(() -> {});
+
+        String overlay = service.getLastOverlayMessage();
+        assertTrue("advisor cancel must surface despite a locally-competitive offer; got: " + overlay,
+            overlay != null && overlay.contains("Consider cancelling") && overlay.contains("item-99"));
+    }
+
+    @Test
     public void originalMarginPersistsAfterRecommendationQueueCycles() {
         // #918: the advisor's original-margin baseline is a property of the ACTIVE OFFER,
         // captured at placement — it must survive the recommendation queue refreshing to

--- a/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
@@ -427,6 +427,48 @@ public class AutoRecommendDispatchTest {
     }
 
     @Test
+    public void ac2ExitResellShowsCancelAndResellPrompt() throws Exception {
+        // AC2 (#918): the margin-decay exit surfaces a "cancel & re-sell" prompt at the
+        // advisor's price, distinct from the AC3 "adjust buy" reprice on a buy offer.
+        when(config.flipTimeframe()).thenReturn(FlipSmartConfig.FlipTimeframe.ACTIVE);
+        when(plugin.calculateCompetitiveness(any())).thenReturn(FlipSmartPlugin.OfferCompetitiveness.UNCOMPETITIVE);
+        OfferRecord partialBuy = OfferRecord
+            .newOffer(3, 0, 77, "item-77", true, 10, 100, 0L)
+            .withFill(5, 500L, OfferState.PARTIAL_FILL, 1L);
+        offerStore.importRecords(Arrays.asList(partialBuy));
+
+        service.surfaceAdvisorExitResell(partialBuy, 250, -1000);
+        SwingUtilities.invokeAndWait(() -> {});
+
+        String overlay = service.getLastOverlayMessage();
+        assertTrue("AC2 exit must prompt cancel & re-sell at the advised price; got: " + overlay,
+            overlay != null && overlay.contains("Cancel & re-sell") && overlay.contains("250"));
+    }
+
+    @Test
+    public void ac2ExitResellListsAtAdvisorPriceWithoutOffset() throws Exception {
+        // The advisor price is already jittered (AC6) — the plugin must not re-apply its offset.
+        // Once the held units are being sold, the resell lists via the no-offset path.
+        when(config.priceOffset()).thenReturn(5);
+        when(plugin.calculateCompetitiveness(any())).thenReturn(FlipSmartPlugin.OfferCompetitiveness.UNCOMPETITIVE);
+        OfferRecord heldSell = OfferRecord
+            .newOffer(4, 0, 88, "item-88", false, 5, 300, 0L)
+            .withFill(0, 0L, OfferState.PARTIAL_FILL, 1L);
+        offerStore.importRecords(Arrays.asList(heldSell));
+
+        service.surfaceAdvisorExitResell(heldSell, 250, -1000);
+
+        AtomicReference<FocusedFlip> painted = new AtomicReference<>();
+        service.setOnFocusChanged(painted::set);
+        AutoRecommendService.SellFocusResult result = service.overrideFocusForSell(88, "item-88");
+        SwingUtilities.invokeAndWait(() -> {});
+
+        assertEquals(AutoRecommendService.SellFocusResult.FOCUSED, result);
+        assertEquals("must list at the advisor price, no offset applied",
+            250, painted.get().getCurrentStepPrice());
+    }
+
+    @Test
     public void modifyingSellRelistsReturnedItemNotNewBuy() throws Exception {
         // Bug: Modify on an active sell returns items to inventory and frees the slot; the
         // sell-collected path advanced to the resolver, which picked S2 (empty-slot buy) over

--- a/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
@@ -469,6 +469,24 @@ public class AutoRecommendDispatchTest {
     }
 
     @Test
+    public void originalMarginPersistsAfterRecommendationQueueCycles() {
+        // #918: the advisor's original-margin baseline is a property of the ACTIVE OFFER,
+        // captured at placement — it must survive the recommendation queue refreshing to
+        // entirely different items (which happens constantly as the user cycles/skips).
+        FlipRecommendation r = rec(77);
+        r.setMargin(5000);
+        service.start(Arrays.asList(r));
+
+        service.onBuyOrderPlaced(77); // captures the original margin at placement
+
+        // Queue cycles to different items — 77 is no longer recommended.
+        service.refreshQueue(Arrays.asList(rec(88), rec(99)));
+
+        assertEquals("original margin must persist from the active offer, not the live queue",
+            Integer.valueOf(5000), service.getOriginalMargin(77));
+    }
+
+    @Test
     public void modifyingSellRelistsReturnedItemNotNewBuy() throws Exception {
         // Bug: Modify on an active sell returns items to inventory and frees the slot; the
         // sell-collected path advanced to the resolver, which picked S2 (empty-slot buy) over

--- a/src/test/java/com/flipsmart/OfferActionBodyTest.java
+++ b/src/test/java/com/flipsmart/OfferActionBodyTest.java
@@ -55,4 +55,34 @@ public class OfferActionBodyTest
 		assertFalse(body.has("user_avg_buy_price"));
 		assertTrue(body.has("item_id"));
 	}
+
+	@Test
+	public void includesCourierStateFields()
+	{
+		OfferAdviceRequest req = OfferAdviceRequest.builder()
+			.itemId(4151).pool("mid_vol").side("buy").stage("initial")
+			.listedAtMillis(1781035200000L).listedPrice(100000).listedQuantity(10).filledQuantity(5)
+			.originalMargin(10000).previousPositionMargin(9000)
+			.consecutiveMarginDecreases(1).cumulativeMarginReductionPct(0.1)
+			.build();
+		JsonObject body = FlipSmartApiClient.buildOfferActionBody(req);
+		assertEquals(10000, body.get("original_margin").getAsInt());
+		assertEquals(9000, body.get("previous_position_margin").getAsInt());
+		assertEquals(1, body.get("consecutive_margin_decreases").getAsInt());
+		assertEquals(0.1, body.get("cumulative_margin_reduction_pct").getAsDouble(), 1e-9);
+	}
+
+	@Test
+	public void omitsNullCourierMarginsButKeepsCounters()
+	{
+		OfferAdviceRequest req = OfferAdviceRequest.builder()
+			.itemId(1).pool("mid_vol").side("buy").stage("initial")
+			.listedAtMillis(1781035200000L).listedPrice(5).listedQuantity(1).filledQuantity(0)
+			.build();
+		JsonObject body = FlipSmartApiClient.buildOfferActionBody(req);
+		assertFalse(body.has("original_margin"));
+		assertFalse(body.has("previous_position_margin"));
+		assertEquals(0, body.get("consecutive_margin_decreases").getAsInt());
+		assertEquals(0.0, body.get("cumulative_margin_reduction_pct").getAsDouble(), 1e-9);
+	}
 }

--- a/src/test/java/com/flipsmart/OfferActionBodyTest.java
+++ b/src/test/java/com/flipsmart/OfferActionBodyTest.java
@@ -42,13 +42,17 @@ public class OfferActionBodyTest
 		assertFalse("null last_fill omitted", body.has("last_fill_at"));
 	}
 
+	private OfferAdviceRequest.OfferAdviceRequestBuilder createBaseRequestBuilder()
+	{
+		return OfferAdviceRequest.builder()
+			.itemId(1).pool("mid_vol").side("buy").stage("initial")
+			.listedAtMillis(1781035200000L).listedPrice(5).listedQuantity(1).filledQuantity(0);
+	}
+
 	@Test
 	public void omitsNullMarketAndBuyPrice()
 	{
-		OfferAdviceRequest req = OfferAdviceRequest.builder()
-			.itemId(1).pool("mid_vol").side("buy").stage("initial")
-			.listedAtMillis(1781035200000L).listedPrice(5).listedQuantity(1).filledQuantity(0)
-			.build();
+		OfferAdviceRequest req = createBaseRequestBuilder().build();
 		JsonObject body = FlipSmartApiClient.buildOfferActionBody(req);
 		assertFalse(body.has("current_market_high"));
 		assertFalse(body.has("current_market_low"));
@@ -75,10 +79,7 @@ public class OfferActionBodyTest
 	@Test
 	public void omitsNullCourierMarginsButKeepsCounters()
 	{
-		OfferAdviceRequest req = OfferAdviceRequest.builder()
-			.itemId(1).pool("mid_vol").side("buy").stage("initial")
-			.listedAtMillis(1781035200000L).listedPrice(5).listedQuantity(1).filledQuantity(0)
-			.build();
+		OfferAdviceRequest req = createBaseRequestBuilder().build();
 		JsonObject body = FlipSmartApiClient.buildOfferActionBody(req);
 		assertFalse(body.has("original_margin"));
 		assertFalse(body.has("previous_position_margin"));

--- a/src/test/java/com/flipsmart/OfferAdviceResponseTest.java
+++ b/src/test/java/com/flipsmart/OfferAdviceResponseTest.java
@@ -33,4 +33,25 @@ public class OfferAdviceResponseTest
 		assertNull(r.getNewPrice());
 		assertNull(r.getNetProfitEstimate());
 	}
+
+	@Test
+	public void deserializesCourierStateFields()
+	{
+		String json = "{\"action\":\"wait\",\"reason\":\"monitoring\",\"position_margin\":3100,"
+			+ "\"consecutive_margin_decreases\":2,\"cumulative_margin_reduction_pct\":0.15}";
+		OfferAdviceResponse r = gson.fromJson(json, OfferAdviceResponse.class);
+		assertEquals(Integer.valueOf(3100), r.getPositionMargin());
+		assertEquals(2, r.getConsecutiveMarginDecreases());
+		assertEquals(0.15, r.getCumulativeMarginReductionPct(), 1e-9);
+	}
+
+	@Test
+	public void defaultsCourierCountersWhenAbsent()
+	{
+		String json = "{\"action\":\"wait\",\"reason\":\"x\"}";
+		OfferAdviceResponse r = gson.fromJson(json, OfferAdviceResponse.class);
+		assertNull(r.getPositionMargin());
+		assertEquals(0, r.getConsecutiveMarginDecreases());
+		assertEquals(0.0, r.getCumulativeMarginReductionPct(), 1e-9);
+	}
 }

--- a/src/test/java/com/flipsmart/OfferDispositionTest.java
+++ b/src/test/java/com/flipsmart/OfferDispositionTest.java
@@ -11,8 +11,15 @@ public class OfferDispositionTest
 	public void priceActionsSurface()
 	{
 		assertEquals(OfferDisposition.SURFACE_PRICE, OfferDisposition.route(OfferAction.MOVE_PRICE_DOWN));
+		assertEquals(OfferDisposition.SURFACE_PRICE, OfferDisposition.route(OfferAction.MOVE_PRICE_UP));
 		assertEquals(OfferDisposition.SURFACE_PRICE, OfferDisposition.route(OfferAction.EXIT_AT_BREAKEVEN));
 		assertEquals(OfferDisposition.SURFACE_PRICE, OfferDisposition.route(OfferAction.EXIT_AT_LOSS));
+	}
+
+	@Test
+	public void moveUpParsesFromWire()
+	{
+		assertEquals(OfferAction.MOVE_PRICE_UP, OfferAction.fromWire("move_price_up"));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
Plugin half of #918. Wires the RuneLite plugin to the new Active Offer Advisor behavior (backend PR Flip-Smart/flip-smart#924): relays the courier state that lets the stateless advisor track margin decay and the joint reduction budget, surfaces the new competitive buy-reprice action, and stops double-adjusting advisor prices with the plugin's own price offset.

## Experimental gating (default OFF)
The **competitive re-prompts (AC3/AC4)** and the **margin-decay early exit (AC2)** are the new, hard-to-verify behavior, so they ship behind a new **`Aggressive Advisor (EXPERIMENTAL)`** toggle in a new bottom **"Experimental"** config section (`enableAggressiveAdvisor`, default **OFF**, section collapsed by default).

- **On by default for everyone** (via the existing `Active Offer Advisor` setting + Active timeframe): the proven base advice — wait / move-down / breakeven & any-loss exits / stall cancels — plus the AC6 price jitter, the no-double-offset fix, and the advisor-prompt surfacing fix.
- **Behind the experimental flag:** the competitive buy/sell re-prompts and the margin-decay exit.
- **Gate mechanism (plugin-only):** those three behaviors only evaluate when the backend receives `original_margin` + the courier counters. When the toggle is off the poll relays `null` / `EMPTY` (via `ActiveOfferAdvisorService.relayedMargin`/`relayedCourier`), so the backend runs only the base advice — no backend change needed (null `original_margin` is the documented fallback).

**QA status:** the base re-lists/exits and the surfacing fix are verified in-game. The gated AC2/AC3/AC4 behavior is backend-logic-verified (direct advisor run) and rides the same proven surfacing path, but the live in-game trigger was hard to reproduce on a thin market — hence gated for product to exercise with the flag on.

## Changes
- **Courier state** on the offer-advice DTOs: request carries `original_margin` + the echoed `previous_position_margin` / `consecutive_margin_decreases` / `cumulative_margin_reduction_pct`; response parses `position_margin` + the two counters. `ActiveOfferAdvisorService` stores the last response's counters per item and relays them on the next poll (stateless-backend courier pattern), pruning on reconcile.
- **`MOVE_PRICE_UP`** action added and routed to `SURFACE_PRICE`; the stale-offer overlay now renders a priced buy prompt ("Adjust buy to X") in addition to the existing "Re-sell at X".
- **Poll wiring:** the advisor poll now relays the original recommendation margin (via `AutoRecommendService.getOriginalMargin`) and the average buy price for a partially-filled buy (this offer's avg fill, falling back to the listed price) so the margin-decay exit (AC2) can evaluate.
- **AC6 no double-offset:** advisor-sourced re-list prices are backend-jittered, so the plugin no longer re-applies its `priceOffset` to them — the advisor resell fill uses the no-offset `FocusedFlip.forSell`, and the cancel-and-sell-partial handoff no longer seeds the session with the advisor's jittered price at all (it leaves pricing to the existing cancel/sell flow), so the downstream sell focus can't double-adjust it.

## Testing
- New/updated unit tests: courier DTO (de)serialization, `MOVE_PRICE_UP` routing, `buildSnapshot` courier + buy avg-buy, courier-state store + reconcile pruning, handoff carrying the response.
- `./gradlew build` (compile + tests + checkstyle) green.

## Manual testing (in-game — plugin QA is manual)
- [ ] Active mode ON, Active Offer Advisor ON. List a buy above market so it's undercut → verify an "Adjust buy to X" prompt appears at a competitive (jittered) price, and repeats as the market moves, until the projected margin would drop below ~75% of the original. (backend logic verified in-game 2026-07-09 — move_price_up fires on an undercut buy and re-prompts — but the on-screen prompt does NOT reliably surface; see the "Known blocker" note below, so not marking end-to-end verified)
- [ ] Partially fill a buy (≥10%) on a ≥50k item, then let the market sell price fall on two consecutive advisor polls → verify a cancel-and-sell-partial exit is recommended.
- [ ] Undercut a sell → verify the re-sell prompt tracks the market down (jittered) within the joint 25% budget, then falls back to existing behavior.
- [x] Verify surfaced/typed prices are NOT double-offset (match the advisor's price, not price ± the configured offset).
- [x] Toggle the Active Offer Advisor off → verify none of the above fires.

## Scope note
The buy-reprice **setup-screen auto-fill** is intentionally not included — the player reads the "Adjust buy to X" overlay and types the price (consistent with the plugin's no-synthetic-input policy). Sell-side auto-fill is unchanged.

## Related
Closes Flip-Smart/flip-smart#918. Pairs with backend PR Flip-Smart/flip-smart#924 (merge both together).

---

### 🩺 Codacy Quality Gate
Green throughout — 0 new issues at every head, including the latest commit `6287bfd` (session-persisted `originalMargin`). No Pass B action needed.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `eda1857` `src/main/java/com/flipsmart/plugin/ServiceWiring.java:80` — wrapped the `onHandoff` callback in `SwingUtilities.invokeLater()` so it marshals to the EDT like the other two advisor callbacks (the poll runs `applyResponse` on a background thread).
- `5b425db` `src/test/java/com/flipsmart/OfferActionBodyTest.java:76` — extracted a `createBaseRequestBuilder()` helper for the exact-duplicate builder setup shared by two tests (Codacy duplication/clone finding).
- `f47da30` `src/main/java/com/flipsmart/FlipSmartPlugin.java:2020` — resolved the double-offset gap previously deferred here. `handleActiveOfferHandoff` no longer seeds the session with the advisor's jittered resell price at all; it leaves pricing to the existing cancel/sell flow, so `AutoRecommendService.resolveBestSellPrice` can no longer re-apply `config.priceOffset()` on top of an already-jittered price.

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `src/main/java/com/flipsmart/AutoRecommendService.java:533` — Codacy suggested passing an explicit `0` offset instead of using the offset-free `FocusedFlip.forSell` overload. Functionally identical (the 4-arg overload delegates to the 5-arg one with `priceOffset=0`); the overload is used deliberately here (#918 AC6) to self-document "no offset" and prevent an accidental future re-offset at this call site.

### 🩺 Codacy — re-checked at `6287bfd`
No new signals from the `originalMargins` session-persistence commit: 0 open AI Reviewer threads (all 4 prior threads remain resolved), 0 quality-gate issues, `isUpToStandards=true`.

### 🩺 Codacy — re-checked at `978a9dc`
No new signals from the advisor-prompt-surfacing fix (see "Known blocker — RESOLVED" below): 0 open AI Reviewer threads (all 4 prior threads remain resolved, no new comments posted against this commit), 0 quality-gate issues, `isUpToStandards=true`, gate green throughout.

### 🩺 Codacy — re-checked at `b6fa20a`
No new signals from the `enableAggressiveAdvisor` experimental-toggle commit (new `FlipSmartConfig` section, `ActiveOfferAdvisorService.relayedMargin`/`relayedCourier` gate helpers, poll wiring in `FlipSmartPlugin`, and the new `ActiveOfferSnapshotTest` coverage): 0 open AI Reviewer threads (all 4 prior threads remain resolved, no new comments posted against this commit), 0 quality-gate issues, `isUpToStandards=true`, gate green throughout.

## Design: original-margin lifecycle

The advisor's **original margin** — the fixed baseline the margin-decay exit (AC2) measures against and the joint buy+sell reduction budget (AC5) is a fraction of — is a property of the **active offer**, not of the recommendation queue.

- It is captured **once, at buy placement** (`AutoRecommendService.onBuyOrderPlaced` → `captureOriginalMargin`) from the seeding recommendation's per-unit margin, and persisted on `PlayerSession.originalMargins` keyed by item.
- It is relayed in every offer snapshot (`original_margin`) and **survives the recommendation list cycling/refreshing**, which happens constantly as the user skips through recommendations.
- `getOriginalMargin` reads the persisted per-offer value first, falling back to the live queue only for a freshly-recommended item not yet placed.

This replaces an earlier approach that sourced the original margin from the live recommendation queue — which went null as soon as the seeding recommendation cycled out, silently disabling AC2/AC3/AC4 on real active offers. Captured at placement, the baseline now sticks for the life of the flip.

## ⚠️ Known blocker — advisor prompts don't surface (pre-existing) — RESOLVED in `978a9dc`

In-game QA revealed the advisor's SURFACE_PRICE prompts — the new `move_price_up`/`cancel_and_sell_partial` AND the existing `exit_at_breakeven`/`move_price_down` — get added to the stale-offer queue and then **immediately pruned** by `focusStaleOfferForItem`'s `pruneIrrelevant`, which drops any offer the plugin's own `calculateCompetitiveness()` doesn't rate `UNCOMPETITIVE`. The resolver then sees `stale=0` and the overlay stays on "Monitoring active offers" — the player never sees the prompt.

This is **pre-existing** (`git diff master...HEAD` shows the pruning path is untouched by this PR) and affects the existing advisor exits too, but it blocks the visible value of this feature. Proposed fix (separate follow-up or folded into this PR): advisor-surfaced (SURFACE_PRICE) offers should **bypass the competitiveness prune** since the backend already decided they're actionable. **Do not merge until the prompts actually surface in-game.** (Note: partly amplified by a dev-env with unrealistic prices skewing `calculateCompetitiveness`; time-based exits would be pruned in prod regardless.)

**Update (`978a9dc`):** fixed. `AutoRecommendService` now tracks an `advisorSurfacedItems` set of items with an Active-mode advisor prompt surfaced to the player, and the two near-duplicate prune lambdas were deduplicated into a shared `staleOfferNoLongerRelevant(...)` helper that bypasses the local competitiveness gate specifically for items in that set — advisor-surfaced offers are no longer re-pruned by `calculateCompetitiveness()`. Also added `surfaceAdvisorCancel(...)` for the bare no-price handoff case, wired from `FlipSmartPlugin.handleActiveOfferHandoff`. 3 new regression tests in `AutoRecommendDispatchTest.java` cover the bypass. Still needs in-game re-verification of the manual testing checklist above before merge — the blocker is fixed but the checklist items are unchecked pending that re-test.




