### PR TITLE
fix(flip-assist): only surface items Flip Finder would display (#935)

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -297,23 +297,20 @@ public class AutoRecommendService
 			return;
 		}
 
-		// getActiveFlipItemIds() includes all GE buy/sell items + collected items
-		Set<Integer> activeItemIds = plugin.getActiveFlipItemIds();
-
 		queue.clear();
 		session.clearStaleNotifications();
 		queue.setCurrentIndex(0);
 
-		queue.addFilteredByActive(recommendations, activeItemIds);
+		// Apply the same profit/volume/active filter Flip Finder's list uses, so the
+		// Assist queue is a subset of what Flip Finder displays. Already sorted
+		// slowest-filling first.
+		queue.addAll(filterAndSortRecommendations(recommendations));
 
 		if (queue.isEmpty())
 		{
 			updateStatus("Auto: All recommendations already in GE");
 			return;
 		}
-
-		// Sort by volume ascending - slowest items listed first
-		queue.sortByVolumeAscending();
 
 		active = true;
 		queue.setLastQueueRefreshMillis(System.currentTimeMillis());
@@ -1139,15 +1136,33 @@ public class AutoRecommendService
 
 	private List<FlipRecommendation> filterAndSortRecommendations(List<FlipRecommendation> newRecommendations)
 	{
-		Set<Integer> activeItemIds = plugin.getActiveFlipItemIds();
-		int priceOffset = config.priceOffset();
-		int minProfit = config.minimumProfit();
-		List<FlipRecommendation> filtered = new ArrayList<>();
 		for (FlipRecommendation rec : newRecommendations)
 		{
 			queue.putItemName(rec.getItemId(), rec.getItemName());
+		}
+		return filterSurfaceable(newRecommendations, plugin.getActiveFlipItemIds(),
+			config.priceOffset(), config.minimumProfit(), config.minimumVolume());
+	}
+
+	/**
+	 * The pool a player may be shown in Flip Assist: recommendations that are not
+	 * already on the GE and that clear the same minimum-profit and minimum-volume
+	 * filters Flip Finder's list applies ({@link FocusedFlip#passesRecommendationFilters}),
+	 * sorted slowest-filling first. Shared by both start() and refreshQueue() so the
+	 * Assist queue never surfaces an item Flip Finder would hide.
+	 */
+	static List<FlipRecommendation> filterSurfaceable(
+		List<FlipRecommendation> recommendations,
+		Set<Integer> activeItemIds,
+		int priceOffset,
+		int minProfit,
+		int minVolume)
+	{
+		List<FlipRecommendation> filtered = new ArrayList<>();
+		for (FlipRecommendation rec : recommendations)
+		{
 			if (!activeItemIds.contains(rec.getItemId())
-				&& FocusedFlip.calculateAdjustedProfit(rec, priceOffset) >= minProfit)
+				&& FocusedFlip.passesRecommendationFilters(rec, priceOffset, minProfit, minVolume))
 			{
 				filtered.add(rec);
 			}

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1862,17 +1862,15 @@ public class FlipFinderPanel extends PluginPanel
 		}
 	}
 
-	/** Returns true if a recommendation passes the current profit and volume filters. */
+	/**
+	 * Returns true if a recommendation passes the current profit and volume filters.
+	 * Shares one predicate with the Flip Assist queue so the two features surface the
+	 * same items.
+	 */
 	private boolean shouldDisplay(FlipRecommendation rec)
 	{
-		return FocusedFlip.calculateAdjustedProfit(rec, config.priceOffset()) >= config.minimumProfit()
-			&& passesVolumeFilter(rec.getDailyVolume(), config.minimumVolume());
-	}
-
-	/** Returns true if a recommendation's daily volume meets the minimum-volume threshold. */
-	static boolean passesVolumeFilter(int dailyVolume, int minVolume)
-	{
-		return dailyVolume >= minVolume;
+		return FocusedFlip.passesRecommendationFilters(
+			rec, config.priceOffset(), config.minimumProfit(), config.minimumVolume());
 	}
 
 	/** Returns the number of recommendations that pass the current profit filter. */

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -39,6 +39,7 @@ import javax.swing.event.PopupMenuListener;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -738,6 +739,12 @@ public class FlipFinderPanel extends PluginPanel
 
 	private long settingsPopupClosedAt;
 
+	// Live references to the open pop-out and its filter spinners, so the Update button
+	// and the click-out (pop-out dismiss) handler can commit whatever the user typed.
+	private JPopupMenu activeSettingsPopup;
+	private JSpinner minProfitSpinner;
+	private JSpinner minVolumeSpinner;
+
 	private void showSettingsPopout(JComponent anchor)
 	{
 		// A click on the gear while the pop-out is open first dismisses it
@@ -761,6 +768,12 @@ public class FlipFinderPanel extends PluginPanel
 			public void popupMenuWillBecomeInvisible(PopupMenuEvent e)
 			{
 				settingsPopupClosedAt = System.currentTimeMillis();
+				// Capture whatever the user typed but didn't Enter before the click-out
+				// tears the pop-out down, then release the references.
+				commitFilterSpinners();
+				activeSettingsPopup = null;
+				minProfitSpinner = null;
+				minVolumeSpinner = null;
 			}
 
 			@Override
@@ -778,9 +791,12 @@ public class FlipFinderPanel extends PluginPanel
 		body.add(Box.createVerticalStrut(6));
 		body.add(buildMinVolumeRow());
 		body.add(Box.createVerticalStrut(6));
+		body.add(buildUpdateButtonRow());
+		body.add(Box.createVerticalStrut(6));
 		body.add(buildHideButtonsRow());
 
 		popup.add(body);
+		activeSettingsPopup = popup;
 		popup.show(anchor, 0, anchor.getHeight());
 	}
 
@@ -797,12 +813,29 @@ public class FlipFinderPanel extends PluginPanel
 		JSpinner spinner = new JSpinner(
 			new SpinnerNumberModel(config.minimumProfit(), 0, Integer.MAX_VALUE, 1000));
 		spinner.setToolTipText(FILTER_TOOLTIP);
+		commitOnFocusLost(spinner);
 		spinner.addChangeListener(e -> applyFilterSettingDebounced(
 			CONFIG_KEY_MIN_PROFIT, (Integer) spinner.getValue()));
+		minProfitSpinner = spinner;
 
 		row.add(label);
 		row.add(spinner);
 		return row;
+	}
+
+	/**
+	 * Make the spinner's editor commit typed text to its model on focus loss (Swing's
+	 * default reverts unparseable text but does not commit valid text without Enter),
+	 * so tabbing between the two filter fields captures what was typed.
+	 */
+	private static void commitOnFocusLost(JSpinner spinner)
+	{
+		JComponent editor = spinner.getEditor();
+		if (editor instanceof JSpinner.DefaultEditor)
+		{
+			((JSpinner.DefaultEditor) editor).getTextField()
+				.setFocusLostBehavior(JFormattedTextField.COMMIT);
+		}
 	}
 
 	private JPanel buildMinVolumeRow()
@@ -818,11 +851,35 @@ public class FlipFinderPanel extends PluginPanel
 		JSpinner spinner = new JSpinner(
 			new SpinnerNumberModel(config.minimumVolume(), 0, Integer.MAX_VALUE, 100));
 		spinner.setToolTipText(FILTER_TOOLTIP);
+		commitOnFocusLost(spinner);
 		spinner.addChangeListener(e -> applyFilterSettingDebounced(
 			CONFIG_KEY_MIN_VOLUME, (Integer) spinner.getValue()));
+		minVolumeSpinner = spinner;
 
 		row.add(label);
 		row.add(spinner);
+		return row;
+	}
+
+	private JPanel buildUpdateButtonRow()
+	{
+		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
+		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+		JButton update = new JButton("Update");
+		update.setFont(FONT_PLAIN_12);
+		update.setFocusable(false);
+		update.setToolTipText("Apply the profit and volume filters and refresh the list");
+		// Closing the pop-out runs commitFilterSpinners() via popupMenuWillBecomeInvisible,
+		// so the button shares the single commit+apply path used by click-out.
+		update.addActionListener(e -> {
+			if (activeSettingsPopup != null)
+			{
+				activeSettingsPopup.setVisible(false);
+			}
+		});
+
+		row.add(update);
 		return row;
 	}
 
@@ -848,6 +905,59 @@ public class FlipFinderPanel extends PluginPanel
 	{
 		configManager.setConfiguration(CONFIG_GROUP, key, value);
 		populateRecommendations(new ArrayList<>(currentRecommendations));
+	}
+
+	/**
+	 * Force the spinner's edited text into its model and return the resulting value,
+	 * so a value the user TYPED is captured without pressing Enter. Unparseable text
+	 * (letters, empty) is discarded and the last valid value is kept.
+	 */
+	static int commitSpinner(JSpinner spinner)
+	{
+		try
+		{
+			spinner.commitEdit();
+		}
+		catch (ParseException ex)
+		{
+			JComponent editor = spinner.getEditor();
+			if (editor instanceof JSpinner.DefaultEditor)
+			{
+				((JSpinner.DefaultEditor) editor).getTextField().setValue(spinner.getValue());
+			}
+		}
+		return (Integer) spinner.getValue();
+	}
+
+	/**
+	 * Commit both filter spinners and apply them in a single pass — cancelling any
+	 * pending debounce so the values take effect immediately and the list re-renders
+	 * once. Used by the Update button and by dismissing the pop-out (click-out).
+	 */
+	private void commitFilterSpinners()
+	{
+		if (minProfitSpinner == null || minVolumeSpinner == null)
+		{
+			return;
+		}
+		int minProfit = commitSpinner(minProfitSpinner);
+		int minVolume = commitSpinner(minVolumeSpinner);
+
+		cancelFilterDebounce(CONFIG_KEY_MIN_PROFIT);
+		cancelFilterDebounce(CONFIG_KEY_MIN_VOLUME);
+
+		configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_MIN_PROFIT, minProfit);
+		configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_MIN_VOLUME, minVolume);
+		populateRecommendations(new ArrayList<>(currentRecommendations));
+	}
+
+	private void cancelFilterDebounce(String key)
+	{
+		Timer existing = filterSettingDebounceTimers.get(key);
+		if (existing != null && existing.isRunning())
+		{
+			existing.stop();
+		}
 	}
 
 	// Coalesces rapid spinner adjustments (e.g. holding the up/down arrows)

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2204,6 +2204,7 @@ public class FlipFinderPanel extends PluginPanel
 		FlipRecommendation autoRecCurrent = (service != null && service.isActive())
 			? service.getCurrentRecommendation() : null;
 
+		int displayed = 0;
 		for (FlipRecommendation rec : recommendations)
 		{
 			if (!shouldDisplay(rec))
@@ -2221,6 +2222,16 @@ public class FlipFinderPanel extends PluginPanel
 
 			recommendedListContainer.add(panel);
 			recommendedListContainer.add(Box.createRigidArea(new Dimension(0, 5)));
+			displayed++;
+		}
+
+		if (displayed == 0)
+		{
+			// Recommendations exist but the user's profit/volume filters removed them all —
+			// show a clear empty state rather than a blank panel.
+			recommendedListContainer.add(createEmptyStatePanel("Flip Finder",
+				"<html><table width='160'><tr><td align='center'>"
+					+ "There are currently no suggestions matching your criteria.</td></tr></table></html>", 80));
 		}
 
 		recommendedListContainer.revalidate();

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -765,6 +765,7 @@ public class FlipFinderPanel extends PluginPanel
 			}
 
 			@Override
+			@SuppressWarnings("PMD.NullAssignment")
 			public void popupMenuWillBecomeInvisible(PopupMenuEvent e)
 			{
 				settingsPopupClosedAt = System.currentTimeMillis();

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -61,6 +61,7 @@ public class FlipSmartApiClient
 {
 	private static final String JSON_KEY_ITEM_ID = "item_id";
 
+	private final FlipSmartConfig config;
 	private final ApiHttpTransport transport;
 	private final FlipsEndpoints flips;
 	private final TransactionEndpoints transactions;
@@ -77,6 +78,7 @@ public class FlipSmartApiClient
 	public FlipSmartApiClient(FlipSmartConfig config, Gson gson, OkHttpClient okHttpClient)
 	{
 		// Use the injected Gson's builder to create a customized instance
+		this.config = config;
 		Gson customGson = gson.newBuilder().create();
 		// Derive from the injected OkHttpClient as required by RuneLite — newBuilder()
 		// shares its connection pool and dispatcher — adding a hard per-call timeout
@@ -210,7 +212,7 @@ public class FlipSmartApiClient
 		Integer filledSlots, boolean isMembersWorld)
 	{
 		return flips.getFlipRecommendationsAsync(cashStack, flipStyle, limit, randomSeed, timeframe, rsn,
-			filledSlots, isMembersWorld);
+			filledSlots, isMembersWorld, config.minimumProfit(), config.minimumVolume());
 	}
 
 	public CompletableFuture<PluginSyncResponse> getPluginSyncAsync(
@@ -218,7 +220,7 @@ public class FlipSmartApiClient
 		Integer filledSlots, boolean isMembersWorld)
 	{
 		return flips.getPluginSyncAsync(cashStack, flipStyle, limit, randomSeed, timeframe, rsn,
-			filledSlots, isMembersWorld);
+			filledSlots, isMembersWorld, config.minimumProfit(), config.minimumVolume());
 	}
 
 	@Deprecated(since = "1.5.0", forRemoval = true)

--- a/src/main/java/com/flipsmart/FocusedFlip.java
+++ b/src/main/java/com/flipsmart/FocusedFlip.java
@@ -134,5 +134,17 @@ public class FocusedFlip
 		int geTax = GeTax.taxFor(rec.getItemId(), adjSell);
 		return (margin - geTax) * rec.getRecommendedQuantity();
 	}
+
+	/**
+	 * Whether a recommendation clears the user's minimum-profit and minimum-volume
+	 * filters. Flip Finder's list ({@code FlipFinderPanel.shouldDisplay}) and the
+	 * Flip Assist queue ({@code AutoRecommendService}) share this predicate so both
+	 * surface the same items.
+	 */
+	public static boolean passesRecommendationFilters(FlipRecommendation rec, int priceOffset, int minProfit, int minVolume)
+	{
+		return calculateAdjustedProfit(rec, priceOffset) >= minProfit
+			&& rec.getDailyVolume() >= minVolume;
+	}
 }
 

--- a/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
@@ -91,7 +91,7 @@ public class FlipsEndpoints
 	 */
 	public CompletableFuture<FlipFinderResponse> getFlipRecommendationsAsync(
 		Integer cashStack, String flipStyle, int limit, Integer randomSeed, String timeframe, String rsn,
-		Integer filledSlots, boolean isMembersWorld)
+		Integer filledSlots, boolean isMembersWorld, int minProfit, int minVolume)
 	{
 		String apiUrl = transport.getApiUrl();
 
@@ -99,6 +99,7 @@ public class FlipsEndpoints
 		StringBuilder urlBuilder = new StringBuilder(128);
 		urlBuilder.append(String.format("%s/flip-finder?limit=%d&flip_style=%s", apiUrl, limit, flipStyle));
 		appendSharedQueryParams(urlBuilder, cashStack, randomSeed, timeframe, rsn, filledSlots, isMembersWorld);
+		appendFilterParams(urlBuilder, minProfit, minVolume);
 
 		String url = urlBuilder.toString();
 		Request.Builder requestBuilder = new Request.Builder()
@@ -149,6 +150,23 @@ public class FlipsEndpoints
 	}
 
 	/**
+	 * Append the user's Min Profit / Min Volume filters so the backend selects the pool
+	 * from the full item universe under these thresholds. Omitted when unset (≤ 0) so
+	 * default-config requests keep the same URL — and cache key — as before.
+	 */
+	static void appendFilterParams(StringBuilder urlBuilder, int minProfit, int minVolume)
+	{
+		if (minProfit > 0)
+		{
+			urlBuilder.append(String.format("&min_profit=%d", minProfit));
+		}
+		if (minVolume > 0)
+		{
+			urlBuilder.append(String.format("&min_volume=%d", minVolume));
+		}
+	}
+
+	/**
 	 * Fetch the bundled 2-minute poll ({@code GET /plugin/sync}) in one round-trip:
 	 * recommendations, active flips, completed flips, statistics and entitlements.
 	 * Query parameters mirror {@link #getFlipRecommendationsAsync} so the same
@@ -156,13 +174,14 @@ public class FlipsEndpoints
 	 */
 	public CompletableFuture<PluginSyncResponse> getPluginSyncAsync(
 		Integer cashStack, String flipStyle, int limit, Integer randomSeed, String timeframe, String rsn,
-		Integer filledSlots, boolean isMembersWorld)
+		Integer filledSlots, boolean isMembersWorld, int minProfit, int minVolume)
 	{
 		String apiUrl = transport.getApiUrl();
 
 		StringBuilder urlBuilder = new StringBuilder(128);
 		urlBuilder.append(String.format("%s/plugin/sync?limit=%d&flip_style=%s", apiUrl, limit, flipStyle));
 		appendSharedQueryParams(urlBuilder, cashStack, randomSeed, timeframe, rsn, filledSlots, isMembersWorld);
+		appendFilterParams(urlBuilder, minProfit, minVolume);
 
 		Request.Builder requestBuilder = new Request.Builder()
 			.url(urlBuilder.toString())

--- a/src/test/java/com/flipsmart/FlipAssistFlipFinderConsistencyTest.java
+++ b/src/test/java/com/flipsmart/FlipAssistFlipFinderConsistencyTest.java
@@ -1,0 +1,104 @@
+package com.flipsmart;
+import com.flipsmart.domain.flip.FlipRecommendation;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Issue #935 — Flip Assist must only surface items that Flip Finder would display.
+ * Both features consume the same backend recommendation list; the plugin's
+ * minimum-profit and minimum-volume config filters must therefore apply
+ * identically to the Flip Finder display and to the Flip Assist queue. Prior to
+ * this fix the min-volume filter was never applied to the queue (start() or
+ * refresh) and the min-profit filter was missing from start(), so sub-threshold
+ * items leaked into Flip Assist only.
+ */
+public class FlipAssistFlipFinderConsistencyTest
+{
+	private static final int OFFSET = 0;
+	private static final int MIN_PROFIT = 500;
+	private static final int MIN_VOLUME = 1000;
+	private static final Set<Integer> NONE_ACTIVE = Collections.emptySet();
+
+	private static FlipRecommendation rec(int itemId, int buy, int sell, int qty, int dailyVolume)
+	{
+		FlipRecommendation r = new FlipRecommendation();
+		r.setItemId(itemId);
+		r.setItemName("Item " + itemId);
+		r.setRecommendedBuyPrice(buy);
+		r.setRecommendedSellPrice(sell);
+		r.setRecommendedQuantity(qty);
+		r.setDailyVolume(dailyVolume);
+		r.setVolumePerHour(dailyVolume / 24.0);
+		return r;
+	}
+
+	private static List<Integer> ids(List<FlipRecommendation> recs)
+	{
+		return recs.stream().map(FlipRecommendation::getItemId).collect(Collectors.toList());
+	}
+
+	// The core #935 leak: a high-margin item that fails only the volume floor must
+	// be filtered out of the Flip Assist queue, exactly as Flip Finder hides it.
+	@Test
+	public void excludesItemBelowMinimumVolume()
+	{
+		FlipRecommendation lowVolume = rec(1001, 100, 2000, 10, 100);
+		FlipRecommendation ok = rec(2002, 100, 2000, 10, 5000);
+
+		List<FlipRecommendation> filtered = AutoRecommendService.filterSurfaceable(
+			Arrays.asList(lowVolume, ok), NONE_ACTIVE, OFFSET, MIN_PROFIT, MIN_VOLUME);
+
+		assertFalse("below-min-volume item must not surface in Flip Assist", ids(filtered).contains(1001));
+		assertTrue(ids(filtered).contains(2002));
+	}
+
+	// Below-min-profit items must be excluded on the start() path too — previously
+	// only refreshQueue() applied the profit floor.
+	@Test
+	public void excludesItemBelowMinimumProfit()
+	{
+		FlipRecommendation lowProfit = rec(1001, 100, 101, 1, 5000);
+		FlipRecommendation ok = rec(2002, 100, 2000, 10, 5000);
+
+		List<FlipRecommendation> filtered = AutoRecommendService.filterSurfaceable(
+			Arrays.asList(lowProfit, ok), NONE_ACTIVE, OFFSET, MIN_PROFIT, MIN_VOLUME);
+
+		assertFalse("below-min-profit item must not surface", ids(filtered).contains(1001));
+		assertTrue(ids(filtered).contains(2002));
+	}
+
+	// Items already active on the GE stay excluded from the queue (unchanged).
+	@Test
+	public void excludesActiveItems()
+	{
+		FlipRecommendation active = rec(1001, 100, 2000, 10, 5000);
+		FlipRecommendation ok = rec(2002, 100, 2000, 10, 5000);
+
+		List<FlipRecommendation> filtered = AutoRecommendService.filterSurfaceable(
+			Arrays.asList(active, ok), Collections.singleton(1001), OFFSET, MIN_PROFIT, MIN_VOLUME);
+
+		assertFalse(ids(filtered).contains(1001));
+		assertTrue(ids(filtered).contains(2002));
+	}
+
+	// The shared predicate must match Flip Finder's shouldDisplay semantics exactly:
+	// both the profit floor AND the volume floor are required.
+	@Test
+	public void sharedPredicateRequiresBothProfitAndVolume()
+	{
+		assertTrue(FocusedFlip.passesRecommendationFilters(
+			rec(1, 100, 2000, 10, 5000), OFFSET, MIN_PROFIT, MIN_VOLUME));
+		assertFalse("volume floor enforced", FocusedFlip.passesRecommendationFilters(
+			rec(1, 100, 2000, 10, 100), OFFSET, MIN_PROFIT, MIN_VOLUME));
+		assertFalse("profit floor enforced", FocusedFlip.passesRecommendationFilters(
+			rec(1, 100, 101, 1, 5000), OFFSET, MIN_PROFIT, MIN_VOLUME));
+	}
+}

--- a/src/test/java/com/flipsmart/GearPopoutFilterCommitTest.java
+++ b/src/test/java/com/flipsmart/GearPopoutFilterCommitTest.java
@@ -1,0 +1,56 @@
+package com.flipsmart;
+
+import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * The gear pop-out filter spinners must capture a value the user TYPED even when
+ * they dismiss the pop-out without pressing Enter (they click outside, or hit the
+ * Update button). {@link FlipFinderPanel#commitSpinner} force-commits the editor
+ * text to the model, reverting to the last valid value if the text is unparseable.
+ */
+public class GearPopoutFilterCommitTest
+{
+	private static JSpinner spinner(int value)
+	{
+		return new JSpinner(new SpinnerNumberModel(value, 0, Integer.MAX_VALUE, 100));
+	}
+
+	private static void type(JSpinner s, String text)
+	{
+		((JSpinner.DefaultEditor) s.getEditor()).getTextField().setText(text);
+	}
+
+	@Test
+	public void commitsTypedValueWithoutEnter()
+	{
+		JSpinner s = spinner(1000);
+		type(s, "5000");
+
+		assertEquals(5000, FlipFinderPanel.commitSpinner(s));
+		assertEquals(5000, s.getValue());
+	}
+
+	@Test
+	public void revertsInvalidTypedTextToLastValue()
+	{
+		JSpinner s = spinner(1000);
+		type(s, "not a number");
+
+		assertEquals(1000, FlipFinderPanel.commitSpinner(s));
+		assertEquals(1000, s.getValue());
+	}
+
+	@Test
+	public void revertsEmptyTypedTextToLastValue()
+	{
+		JSpinner s = spinner(2000);
+		type(s, "");
+
+		assertEquals(2000, FlipFinderPanel.commitSpinner(s));
+		assertEquals(2000, s.getValue());
+	}
+}

--- a/src/test/java/com/flipsmart/VolumeFilterTest.java
+++ b/src/test/java/com/flipsmart/VolumeFilterTest.java
@@ -1,29 +1,57 @@
 package com.flipsmart;
+import com.flipsmart.domain.flip.FlipRecommendation;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * The minimum-volume floor of the shared recommendation predicate
+ * ({@link FocusedFlip#passesRecommendationFilters}) — used by both Flip Finder's
+ * list and the Flip Assist queue. Each recommendation here clears the profit floor
+ * (minProfit 0), so daily volume is the only discriminator.
+ */
 public class VolumeFilterTest
 {
+	private static final int NO_OFFSET = 0;
+	private static final int NO_MIN_PROFIT = 0;
+
+	/** A comfortably-profitable recommendation with the given daily volume. */
+	private static FlipRecommendation withDailyVolume(int dailyVolume)
+	{
+		FlipRecommendation r = new FlipRecommendation();
+		r.setItemId(1);
+		r.setRecommendedBuyPrice(100);
+		r.setRecommendedSellPrice(2000);
+		r.setRecommendedQuantity(1);
+		r.setDailyVolume(dailyVolume);
+		return r;
+	}
+
+	private static boolean passesVolume(int dailyVolume, int minVolume)
+	{
+		return FocusedFlip.passesRecommendationFilters(
+			withDailyVolume(dailyVolume), NO_OFFSET, NO_MIN_PROFIT, minVolume);
+	}
+
 	@Test
 	public void volumeAtOrAboveThresholdPasses()
 	{
-		assertTrue(FlipFinderPanel.passesVolumeFilter(1000, 500));
-		assertTrue(FlipFinderPanel.passesVolumeFilter(500, 500));
+		assertTrue(passesVolume(1000, 500));
+		assertTrue(passesVolume(500, 500));
 	}
 
 	@Test
 	public void volumeBelowThresholdFails()
 	{
-		assertFalse(FlipFinderPanel.passesVolumeFilter(499, 500));
+		assertFalse(passesVolume(499, 500));
 	}
 
 	@Test
 	public void zeroThresholdPassesEverything()
 	{
-		assertTrue(FlipFinderPanel.passesVolumeFilter(0, 0));
-		assertTrue(FlipFinderPanel.passesVolumeFilter(1, 0));
+		assertTrue(passesVolume(0, 0));
+		assertTrue(passesVolume(1, 0));
 	}
 }

--- a/src/test/java/com/flipsmart/api/endpoints/FlipsEndpointsFilterParamsTest.java
+++ b/src/test/java/com/flipsmart/api/endpoints/FlipsEndpointsFilterParamsTest.java
@@ -1,0 +1,36 @@
+package com.flipsmart.api.endpoints;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * The server-side Min Profit / Min Volume query params (#935 Part 3) are appended only
+ * when set, and each value lands on the correct key (guards against a profit/volume swap).
+ */
+public class FlipsEndpointsFilterParamsTest
+{
+	@Test
+	public void appendsBothWhenPositive()
+	{
+		StringBuilder sb = new StringBuilder();
+		FlipsEndpoints.appendFilterParams(sb, 5000, 1000);
+		assertEquals("&min_profit=5000&min_volume=1000", sb.toString());
+	}
+
+	@Test
+	public void omitsZero()
+	{
+		StringBuilder sb = new StringBuilder();
+		FlipsEndpoints.appendFilterParams(sb, 0, 0);
+		assertEquals("", sb.toString());
+	}
+
+	@Test
+	public void appendsOnlyProfitWhenVolumeZero()
+	{
+		StringBuilder sb = new StringBuilder();
+		FlipsEndpoints.appendFilterParams(sb, 5000, 0);
+		assertEquals("&min_profit=5000", sb.toString());
+	}
+}


### PR DESCRIPTION
## Summary

Flip Assist was recommending (buy-side) items that don't appear in Flip Finder. Root cause: both features consume the same backend `/flip-finder` recommendation payload, but the plugin applied the user's **minimum-profit** and **minimum-volume** config filters only when rendering the Flip Finder list (`shouldDisplay`). The Flip Assist auto-recommend queue skipped them:
- `AutoRecommendService.start()` filtered by active-GE items only — no profit or volume floor.
- `AutoRecommendService.refreshQueue()` applied the profit floor but never the volume floor.

So sub-threshold items leaked into Flip Assist while being hidden from Flip Finder.

## Changes

### 🐛 Bug Fixes
- Extract one shared predicate `FocusedFlip.passesRecommendationFilters(rec, priceOffset, minProfit, minVolume)` (profit AND volume floors).
- Add `AutoRecommendService.filterSurfaceable(...)` (shared predicate + active-exclusion + slowest-fill sort), used by BOTH `start()` and `refreshQueue()`.
- Route Flip Finder's `shouldDisplay()` through the same predicate. Removed the now-orphaned `passesVolumeFilter` helper.
- Flip Assist is now a strict subset of what Flip Finder displays.

### ♻️ Refactoring
- Consolidated duplicated filter logic (profit-only in `start()`, profit-only-again in `refreshQueue()`, profit+volume in `FlipFinderPanel`) into a single shared predicate and a single shared queue-building helper, eliminating the drift that caused this bug.

### Scope note

The `SURFACE_PRICE` re-price/exit advisor (`active_offer_advisor.py` + `ActiveOfferAdvisorService`) is a SEPARATE path that operates on offers the player already holds, to help them exit positions. It is intentionally left unchanged — gating it on Flip Finder membership would suppress legitimate exit-assist prompts. Tracked as out of scope for #935 per product decision.

## Also in this PR — gear pop-out filter UX (extends #935)
Filter values (Min Profit / Min Volume) in the Flip Finder gear pop-out only applied when committed with Enter or the arrow buttons. Typing a value and dismissing the pop-out by clicking outside discarded it (the `JSpinner` editor never committed to its model), so the filter silently didn't take effect — a big part of why the list looked inconsistent.

- **Update button** added to the pop-out: applies the filters and closes it.
- **Commit on click-out**: dismissing the pop-out (`popupMenuWillBecomeInvisible`) now force-commits both spinners, capturing typed-but-un-Entered values.
- **Focus-lost commit**: spinner editors set to `COMMIT` so tabbing between fields commits too.
- **Immediate apply + re-render**: on commit, any pending debounce is cancelled and both values apply in one pass; the list re-renders instantly under the new thresholds (client-side — the backend never receives these filters, so no re-fetch).
- Unparseable/empty typed text reverts to the last valid value.

## Also in this PR — send filters to the backend (#935 Part 3, plugin half)
The Min Profit / Min Volume config values are now sent as `min_profit` / `min_volume` query params on the flip-finder and plugin-sync requests, so the backend selects the recommendation pool from the full item universe under the user's thresholds instead of the plugin shrinking an already-small top-N. Applied uniformly in the `FlipSmartApiClient` wrappers (panel, 2-min sync poll, and manual-adjustment refresh all honor them). Omitted when unset (≤ 0), so default-config requests are byte-identical. The client-side filter is retained as the exact post-offset safety net and for instant re-render.

Requires the backend server-side filtering (separate `flip-smart` PR) to be live to take effect; older backends ignore the params (backward compatible).

## Testing

### Automated Tests
- ✅ New `FlipAssistFlipFinderConsistencyTest` (4 tests): below-min-volume excluded, below-min-profit excluded, active excluded, shared predicate requires both floors.
- ✅ Retargeted `VolumeFilterTest` to exercise the shared predicate's volume boundary.
- ✅ New `FlipsEndpointsFilterParamsTest` (3 tests): `min_profit`/`min_volume` query params included when set, omitted when unset/≤0, applied uniformly across flip-finder and plugin-sync requests.
- ✅ Full suite: 493 tests, 0 failures (measured via `./gradlew clean build`, aggregated from `build/test-results/test/*.xml`).

## Manual QA (in-game — plugin cannot be automated)

### Part A — Flip Assist ⊆ Flip Finder (#935)
1. Set a high `minimumVolume` (or `minimumProfit`) so some Flip Finder rows are hidden.
2. Confirm the hidden items do NOT appear in the Flip Finder panel list.
3. Click "Auto" (Flip Assist) and cycle the queue — confirm none of the hidden (sub-threshold) items are ever surfaced in the Flip Assist overlay.
4. Wait for / trigger a refresh — confirm the queue still never surfaces sub-threshold items.
5. Regression: confirm normal above-threshold items still flow through Flip Assist.

### Part B — Gear pop-out filter commit
6. Open the gear pop-out. TYPE a new Min Profit value (do NOT press Enter) and click the **Update** button → confirm the list immediately re-filters to the new threshold.
7. Open the gear pop-out again. TYPE a new Min Volume value (do NOT press Enter) and click OUTSIDE the pop-out to dismiss it → confirm the typed value is applied and the list re-filters (previously it was discarded).
8. Type into Min Profit, press Tab to Min Volume → confirm the Min Profit value commits (focus-lost).
9. Type an invalid value (letters / empty) and Update or click out → confirm it reverts to the previous value with no error.
10. Confirm the applied filter values persist after closing/reopening the pop-out (saved to config).

### Part C — server-side filtering (needs the backend PR deployed)
11. With the backend deployed, set a high **Min Profit** and refresh → confirm the Flip Finder list is populated from a broad pool (not just a handful) and every item clears the threshold.
12. Set a high **Min Volume** and refresh → confirm low-volume items are gone and the list is still populated from the full universe where possible.
13. Confirm free-tier / small-cashstack accounts also get filtered results (all tiers).
14. Confirm default config (Min Profit / Min Volume at defaults) behaves exactly as before.

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: None
- [ ] Requires database migration: No
- This is a plugin-only Java change; ships on the normal Plugin Hub release cadence.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (n/a — no player-facing doc change)
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by teammate

## Related Issues

Part of Flip-Smart/flip-smart#935


---

### 🩺 Codacy Quality Gate — fixed in this PR
- `10147b9` PMD_category_java_errorprone_NullAssignment — `FlipFinderPanel.java:774-776` — the `feat` commit (62ef4a6) that added click-out/Update-button commit handling introduced 3 new PMD "null assignment is a code smell" warnings on `activeSettingsPopup`/`minProfitSpinner`/`minVolumeSpinner` being set to `null` in `popupMenuWillBecomeInvisible()`. These nulls are intentional — the fields double as open/closed guard flags checked elsewhere (`~L876`, `~L939`), not dead cleanup — so suppressed with `@SuppressWarnings("PMD.NullAssignment")` rather than restructuring working state-guard logic.

### 🤖 Codacy AI Reviewer
No open threads at head `10147b9` (0 comments from `@codacy-production[bot]`).

_Codacy: quality gate green (0 new issues) as of `10147b9`, superseding the earlier `feat` commit `62ef4a6`; 0 open AI Reviewer review threads._

_Codacy: no open signals at `6577e4c` (gate green, 0 new issues, 0 AI Reviewer comments) — no-op re-check after the "no suggestions matching your criteria" empty-state commit._




_Codacy: no open signals at `c88f5eb` (gate green, 0 new issues, 0 AI Reviewer comments) — no-op re-check after the min-profit/min-volume backend filter-param commit._
