### PR TITLE
feat(active-flips): redesign Active Flips card + manual refresh button

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -16,6 +16,7 @@ import com.flipsmart.api.dto.BlocklistSummary;
 import com.flipsmart.domain.offer.OfferTransition;
 import com.flipsmart.domain.offer.PendingOrder;
 import com.flipsmart.recommend.SmartSellPricer;
+import com.flipsmart.trading.ActiveFlipCardMetrics;
 import com.flipsmart.trading.RealizedFlipProfit;
 import com.flipsmart.ui.panel.CardWidgets;
 import com.flipsmart.ui.panel.LoginPanel;
@@ -3302,9 +3303,10 @@ public class FlipFinderPanel extends PluginPanel
 		JLabel refreshIcon = createRefreshIconLabel(() ->
 		{
 			apiClient.invalidateCache(flip.getItemId());
-			populateActiveFlipCard(flip, panel, headerHolder[0].topPanel, headerHolder[0].namePanel, detailsPanel,
-				pricesLabel, buyLimitLabel, marginLabel, currentProfitLabel, profitPotentialLabel,
-				taxLabel, liquidityLabel, riskLabel);
+			populateActiveFlipCard(flip,
+				new ActiveFlipCardPanels(panel, headerHolder[0].topPanel, headerHolder[0].namePanel, detailsPanel),
+				new ActiveFlipCardLabels(pricesLabel, buyLimitLabel, marginLabel, currentProfitLabel,
+					profitPotentialLabel, taxLabel, liquidityLabel, riskLabel));
 		});
 		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(),
 			ColorScheme.DARKER_GRAY_COLOR, refreshIcon);
@@ -3315,9 +3317,10 @@ public class FlipFinderPanel extends PluginPanel
 		panel.add(topPanel, BorderLayout.NORTH);
 		panel.add(detailsPanel, BorderLayout.CENTER);
 
-		populateActiveFlipCard(flip, panel, topPanel, namePanel, detailsPanel,
-			pricesLabel, buyLimitLabel, marginLabel, currentProfitLabel, profitPotentialLabel,
-			taxLabel, liquidityLabel, riskLabel);
+		populateActiveFlipCard(flip,
+			new ActiveFlipCardPanels(panel, topPanel, namePanel, detailsPanel),
+			new ActiveFlipCardLabels(pricesLabel, buyLimitLabel, marginLabel, currentProfitLabel,
+				profitPotentialLabel, taxLabel, liquidityLabel, riskLabel));
 
 		// Store default background color as client property (will be overwritten if price indicator is applied)
 		panel.putClientProperty("baseBackgroundColor", ColorScheme.DARKER_GRAY_COLOR);
@@ -3398,15 +3401,58 @@ public class FlipFinderPanel extends PluginPanel
 	}
 
 	/**
-	 * Fetch fresh market analysis for an active-flip card and (re)populate its rows.
-	 * Reused by the initial card build and the manual refresh button. The smart-sell
-	 * price is still computed to drive the session write, focus update and price-indicator
-	 * background, even though it is no longer displayed.
+	 * Panels touched when (re)populating an active-flip card.
 	 */
-	private void populateActiveFlipCard(ActiveFlip flip, JPanel panel, JPanel topPanel, JPanel namePanel,
-		JPanel detailsPanel, JLabel pricesLabel, JLabel buyLimitLabel, JLabel marginLabel,
-		JLabel currentProfitLabel, JLabel profitPotentialLabel, JLabel taxLabel,
-		JLabel liquidityLabel, JLabel riskLabel)
+	private static class ActiveFlipCardPanels
+	{
+		final JPanel panel;
+		final JPanel topPanel;
+		final JPanel namePanel;
+		final JPanel detailsPanel;
+
+		ActiveFlipCardPanels(JPanel panel, JPanel topPanel, JPanel namePanel, JPanel detailsPanel)
+		{
+			this.panel = panel;
+			this.topPanel = topPanel;
+			this.namePanel = namePanel;
+			this.detailsPanel = detailsPanel;
+		}
+	}
+
+	/**
+	 * Detail-row labels populated on an active-flip card.
+	 */
+	private static class ActiveFlipCardLabels
+	{
+		final JLabel pricesLabel;
+		final JLabel buyLimitLabel;
+		final JLabel marginLabel;
+		final JLabel currentProfitLabel;
+		final JLabel profitPotentialLabel;
+		final JLabel taxLabel;
+		final JLabel liquidityLabel;
+		final JLabel riskLabel;
+
+		ActiveFlipCardLabels(JLabel pricesLabel, JLabel buyLimitLabel, JLabel marginLabel,
+			JLabel currentProfitLabel, JLabel profitPotentialLabel, JLabel taxLabel,
+			JLabel liquidityLabel, JLabel riskLabel)
+		{
+			this.pricesLabel = pricesLabel;
+			this.buyLimitLabel = buyLimitLabel;
+			this.marginLabel = marginLabel;
+			this.currentProfitLabel = currentProfitLabel;
+			this.profitPotentialLabel = profitPotentialLabel;
+			this.taxLabel = taxLabel;
+			this.liquidityLabel = liquidityLabel;
+			this.riskLabel = riskLabel;
+		}
+	}
+
+	/**
+	 * Fetch fresh market analysis for an active-flip card and (re)populate its rows.
+	 * Reused by the initial card build and the manual refresh button.
+	 */
+	private void populateActiveFlipCard(ActiveFlip flip, ActiveFlipCardPanels panels, ActiveFlipCardLabels labels)
 	{
 		apiClient.getItemAnalysisAsync(flip.getItemId()).thenAccept(analysis ->
 			SwingUtilities.invokeLater(() ->
@@ -3429,94 +3475,129 @@ public class FlipFinderPanel extends PluginPanel
 					}
 				}
 
-				// --- Preserved side effects: smart-sell drives session/focus/background ---
-				PlayerSession session = plugin.getSession();
-				Integer sessionPrice = session != null ? session.getRecommendedPrice(flip.getItemId()) : null;
-				Integer smartSellPrice = (sessionPrice != null && sessionPrice > 0)
-					? sessionPrice
-					: SmartSellPricer.calculateSmartSellPrice(flip, high);
-				if (smartSellPrice != null && smartSellPrice > 0)
+				applySmartSellSideEffects(flip, panels, high);
+
+				if (hasValidMarketPrices(high, low))
 				{
-					if ((sessionPrice == null || sessionPrice <= 0) && session != null)
-					{
-						session.setRecommendedPrice(flip.getItemId(), smartSellPrice);
-					}
-					displayedSellPrices.put(flip.getItemId(), smartSellPrice);
-
-					Integer recommendedPrice = flip.getRecommendedSellPrice();
-					if (recommendedPrice != null && recommendedPrice > 0 && !smartSellPrice.equals(recommendedPrice)
-						&& (currentFocus == null || currentFocus.getItemId() != flip.getItemId()))
-					{
-						Color priceIndicatorBg = smartSellPrice > recommendedPrice
-							? COLOR_PRICE_HIGHER_BG
-							: COLOR_PRICE_LOWER_BG;
-						CardWidgets.applyPriceIndicatorBackground(panel, topPanel, namePanel, detailsPanel, priceIndicatorBg);
-					}
-
-					if (currentFocus != null && currentFocus.getItemId() == flip.getItemId() && currentFocus.isSelling())
-					{
-						FocusedFlip updatedFocus = FocusedFlip.forSell(
-							flip.getItemId(), flip.getItemName(), smartSellPrice,
-							flip.getTotalQuantity(), config.priceOffset());
-						currentFocus = updatedFocus;
-						if (onFocusChanged != null)
-						{
-							onFocusChanged.accept(updatedFocus);
-						}
-					}
-				}
-
-				// --- Redesigned display rows (market-based) ---
-				if (high != null && high > 0 && low != null && low > 0)
-				{
-					long firstBuyMs = flip.getFirstBuyTime() != null
-						? TimeUtils.parseIsoToMillis(flip.getFirstBuyTime())
-						: 0L;
-					RealizedFlipProfit.Result realized = RealizedFlipProfit.compute(
-						plugin.getOfferStore().forItem(flip.getItemId()), flip.getItemId(),
-						flip.getAverageBuyPrice(), firstBuyMs);
-
-					int margin = high - low;
-					double roi = low > 0 ? (margin * 100.0) / low : 0.0;
-					long fullQty = (long) realized.soldQuantity + flip.getTotalQuantity();
-					long profitPotential = (long) margin * fullQty;
-					long cost = (long) low * fullQty;
-					int perItemTax = GeTax.taxFor(flip.getItemId(), high);
-					long totalTax = (long) perItemTax * fullQty;
-
-					int positionNetPerUnit = high - flip.getAverageBuyPrice() - perItemTax;
-					panel.setToolTipText(positionNetPerUnit < 0
-						? "Selling at the current price would be a loss - below your buy price plus tax."
-						: null);
-
-					pricesLabel.setText(PanelFormat.formatMarketBuySellText(low, high));
-					buyLimitLabel.setText(String.format("Buy limit: %s",
-						buyLimit != null ? PanelFormat.formatGPExact(buyLimit) : "?"));
-
-					marginLabel.setText(PanelFormat.formatCurrentMarginText(margin, roi));
-					marginLabel.setForeground(margin < 0 ? COLOR_LOSS_RED : COLOR_PROFIT_GREEN);
-
-					currentProfitLabel.setText(PanelFormat.formatCurrentProfitText(realized.netProfit));
-					currentProfitLabel.setForeground(realized.netProfit < 0 ? COLOR_LOSS_RED : COLOR_PROFIT_GREEN);
-
-					profitPotentialLabel.setText(PanelFormat.formatProfitPotentialText(profitPotential, cost));
-					profitPotentialLabel.setForeground(profitPotential < 0 ? COLOR_LOSS_RED : COLOR_PROFIT_GREEN);
-
-					taxLabel.setText(PanelFormat.formatTaxSplitText(perItemTax, totalTax));
+					populateActiveFlipMarketRows(flip, panels, labels, low, high, buyLimit);
 				}
 				else
 				{
-					pricesLabel.setText("Buy: N/A | Sell: N/A");
-					marginLabel.setText("Current Margin: N/A");
-					currentProfitLabel.setText("Current Profit: N/A");
-					profitPotentialLabel.setText("Profit Potential: N/A");
-					taxLabel.setText("Tax: N/A");
-					panel.setToolTipText(null);
+					labels.pricesLabel.setText("Buy: N/A | Sell: N/A");
+					labels.marginLabel.setText("Current Margin: N/A");
+					labels.currentProfitLabel.setText("Current Profit: N/A");
+					labels.profitPotentialLabel.setText("Profit Potential: N/A");
+					labels.taxLabel.setText("Tax: N/A");
+					panels.panel.setToolTipText(null);
 				}
 
-				updateLiquidityLabel(liquidityLabel, liquidity);
-				updateRiskLabel(riskLabel, risk);
+				updateLiquidityLabel(labels.liquidityLabel, liquidity);
+				updateRiskLabel(labels.riskLabel, risk);
 			}));
+	}
+
+	private static boolean hasValidMarketPrices(Integer high, Integer low)
+	{
+		return high != null && high > 0 && low != null && low > 0;
+	}
+
+	/**
+	 * Smart-sell price still drives the session write, Flip Assist focus update and
+	 * price-indicator background, even though it is no longer displayed on the card.
+	 */
+	private void applySmartSellSideEffects(ActiveFlip flip, ActiveFlipCardPanels panels, Integer high)
+	{
+		PlayerSession session = plugin.getSession();
+		Integer sessionPrice = session != null ? session.getRecommendedPrice(flip.getItemId()) : null;
+		Integer smartSellPrice = (sessionPrice != null && sessionPrice > 0)
+			? sessionPrice
+			: SmartSellPricer.calculateSmartSellPrice(flip, high);
+		if (smartSellPrice == null || smartSellPrice <= 0)
+		{
+			return;
+		}
+
+		if ((sessionPrice == null || sessionPrice <= 0) && session != null)
+		{
+			session.setRecommendedPrice(flip.getItemId(), smartSellPrice);
+		}
+		displayedSellPrices.put(flip.getItemId(), smartSellPrice);
+
+		applyPriceIndicatorIfNeeded(flip, panels, smartSellPrice);
+		updateFocusIfSelected(flip, smartSellPrice);
+	}
+
+	private void applyPriceIndicatorIfNeeded(ActiveFlip flip, ActiveFlipCardPanels panels, int smartSellPrice)
+	{
+		Integer recommendedPrice = flip.getRecommendedSellPrice();
+		boolean focusedOnThisFlip = currentFocus != null && currentFocus.getItemId() == flip.getItemId();
+		if (recommendedPrice == null || recommendedPrice <= 0 || smartSellPrice == recommendedPrice || focusedOnThisFlip)
+		{
+			return;
+		}
+
+		Color priceIndicatorBg = smartSellPrice > recommendedPrice
+			? COLOR_PRICE_HIGHER_BG
+			: COLOR_PRICE_LOWER_BG;
+		CardWidgets.applyPriceIndicatorBackground(panels.panel, panels.topPanel, panels.namePanel, panels.detailsPanel, priceIndicatorBg);
+	}
+
+	private void updateFocusIfSelected(ActiveFlip flip, int smartSellPrice)
+	{
+		if (currentFocus == null || currentFocus.getItemId() != flip.getItemId() || !currentFocus.isSelling())
+		{
+			return;
+		}
+
+		FocusedFlip updatedFocus = FocusedFlip.forSell(
+			flip.getItemId(), flip.getItemName(), smartSellPrice,
+			flip.getTotalQuantity(), config.priceOffset());
+		currentFocus = updatedFocus;
+		if (onFocusChanged != null)
+		{
+			onFocusChanged.accept(updatedFocus);
+		}
+	}
+
+	/**
+	 * Render the market-based detail rows (margin, current profit, profit potential, tax)
+	 * once fresh buy/sell prices are available.
+	 */
+	private void populateActiveFlipMarketRows(ActiveFlip flip, ActiveFlipCardPanels panels,
+		ActiveFlipCardLabels labels, int low, int high, Integer buyLimit)
+	{
+		long firstBuyMs = flip.getFirstBuyTime() != null
+			? TimeUtils.parseIsoToMillis(flip.getFirstBuyTime())
+			: 0L;
+		RealizedFlipProfit.Result realized = RealizedFlipProfit.compute(
+			plugin.getOfferStore().forItem(flip.getItemId()), flip.getItemId(),
+			flip.getAverageBuyPrice(), firstBuyMs);
+		ActiveFlipCardMetrics.Result metrics = ActiveFlipCardMetrics.compute(
+			low, high, flip.getItemId(), flip.getAverageBuyPrice(), realized.soldQuantity, flip.getTotalQuantity());
+
+		if (metrics.positionNetPerUnit < 0)
+		{
+			panels.panel.setToolTipText("Selling at the current price would be a loss - below your buy price plus tax.");
+		}
+		else
+		{
+			panels.panel.setToolTipText(null);
+		}
+
+		labels.pricesLabel.setText(PanelFormat.formatMarketBuySellText(low, high));
+		labels.buyLimitLabel.setText(String.format("Buy limit: %s",
+			buyLimit != null ? PanelFormat.formatGPExact(buyLimit) : "?"));
+
+		labels.marginLabel.setText(PanelFormat.formatCurrentMarginText(metrics.margin, metrics.roi));
+		labels.marginLabel.setForeground(metrics.margin < 0 ? COLOR_LOSS_RED : COLOR_PROFIT_GREEN);
+
+		labels.currentProfitLabel.setText(PanelFormat.formatCurrentProfitText(realized.netProfit));
+		labels.currentProfitLabel.setForeground(realized.netProfit < 0 ? COLOR_LOSS_RED : COLOR_PROFIT_GREEN);
+
+		labels.profitPotentialLabel.setText(PanelFormat.formatProfitPotentialText(metrics.profitPotential, metrics.cost));
+		labels.profitPotentialLabel.setForeground(metrics.profitPotential < 0 ? COLOR_LOSS_RED : COLOR_PROFIT_GREEN);
+
+		labels.taxLabel.setText(PanelFormat.formatTaxSplitText(metrics.perItemTax, metrics.totalTax));
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2474,14 +2474,14 @@ public class FlipFinderPanel extends PluginPanel
 		nameLabel.setForeground(Color.WHITE);
 		nameLabel.setFont(FONT_BOLD_13);
 		// Narrow the name a little more when a third (refresh) icon shares the corner
-		int nameWidth = trailingIcon != null ? 108 : 130;
+		int nameWidth = trailingIcon != null ? 98 : 130;
 		nameLabel.setPreferredSize(new Dimension(nameWidth, nameLabel.getPreferredSize().height));
 		nameLabel.setMaximumSize(new Dimension(nameWidth, Integer.MAX_VALUE));
 
 		namePanel.add(iconLabel, BorderLayout.WEST);
 		namePanel.add(nameLabel, BorderLayout.CENTER);
 
-		JPanel iconsPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 2, 0));
+		JPanel iconsPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 1, 0));
 		iconsPanel.setOpaque(false);
 
 		iconsPanel.add(createBlockIconLabel(itemId, itemName));
@@ -2492,7 +2492,7 @@ public class FlipFinderPanel extends PluginPanel
 			// Visible divider so the refresh action reads as distinct from the two existing icons
 			JLabel divider = new JLabel("|");
 			divider.setForeground(COLOR_TEXT_GRAY);
-			divider.setBorder(BorderFactory.createEmptyBorder(0, 3, 0, 1));
+			divider.setBorder(BorderFactory.createEmptyBorder(0, 2, 0, 0));
 			iconsPanel.add(divider);
 			iconsPanel.add(trailingIcon);
 		}
@@ -2529,7 +2529,7 @@ public class FlipFinderPanel extends PluginPanel
 		JLabel chartLabel = new JLabel(new ImageIcon(chartIcon));
 		chartLabel.setToolTipText("View price history on FlipSmart website");
 		chartLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		chartLabel.setBorder(BorderFactory.createEmptyBorder(0, 4, 0, 0));
+		chartLabel.setBorder(BorderFactory.createEmptyBorder(0, 1, 0, 0));
 		chartLabel.setOpaque(false);
 
 		// Add click listener to open website
@@ -2566,7 +2566,7 @@ public class FlipFinderPanel extends PluginPanel
 		JLabel refreshLabel = new JLabel(new ImageIcon(refreshIcon));
 		refreshLabel.setToolTipText("Refresh latest prices.");
 		refreshLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		refreshLabel.setBorder(BorderFactory.createEmptyBorder(0, 2, 0, 0));
+		refreshLabel.setBorder(BorderFactory.createEmptyBorder(0, 1, 0, 0));
 		refreshLabel.setOpaque(false);
 
 		refreshLabel.addMouseListener(new MouseAdapter()
@@ -3497,7 +3497,7 @@ public class FlipFinderPanel extends PluginPanel
 				applySmartSellSideEffects(flip, panels, high);
 
 				labels.buyLimitLabel.setText(
-					"Buy limit: " + (buyLimit != null ? PanelFormat.formatGPExact(buyLimit) : "?"));
+					"Buy limit: " + (buyLimit != null ? PanelFormat.formatGP(buyLimit) : "?"));
 
 				if (hasValidMarketPrices(high, low))
 				{
@@ -3627,7 +3627,8 @@ public class FlipFinderPanel extends PluginPanel
 		labels.marginLabel.setText(PanelFormat.liveMarginHtml(metrics.margin, metrics.roi));
 		labels.taxLabel.setText("Tax: " + PanelFormat.formatGP((int) Math.min(metrics.totalTax, Integer.MAX_VALUE)));
 		labels.currentProfitLabel.setText(PanelFormat.currentProfitHtml(realized.netProfit));
-		labels.potentialLabel.setText(PanelFormat.potentialHtml(metrics.profitPotential));
+		// Net of tax so Potential is comparable to the (net) Current Profit — gross wildly overstates high-tax items
+		labels.potentialLabel.setText(PanelFormat.potentialHtml(metrics.profitPotential - metrics.totalTax));
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3272,7 +3272,7 @@ public class FlipFinderPanel extends PluginPanel
 
 		// --- Bottom "reference" block: the trade position ---
 		JLabel currentProfitLabel = CardWidgets.createStyledLabel("Current Profit: ...", Color.WHITE);
-		JLabel potentialLabel = CardWidgets.createStyledLabel("Potential: ...", Color.WHITE);
+		JLabel potentialLabel = CardWidgets.createStyledLabel("Max Potential Profit: ...", Color.WHITE);
 		potentialLabel.setFont(FONT_PLAIN_11);
 		JLabel liquidityLabel = CardWidgets.createStyledLabel("Liquidity: ...", Color.CYAN);
 		JLabel riskLabel = CardWidgets.createStyledLabel("Risk: ...", COLOR_YELLOW);
@@ -3496,21 +3496,24 @@ public class FlipFinderPanel extends PluginPanel
 					}
 				}
 
-				applySmartSellSideEffects(flip, panels, high);
+				// The flip's own sell price (session-recommended, else computed) drives both the
+				// side effects and the Max Potential Profit figure.
+				Integer flipSellPrice = resolveSmartSellPrice(flip, high, plugin.getSession());
+				applySmartSellSideEffects(flip, panels, flipSellPrice);
 
 				labels.buyLimitLabel.setText(
 					"Buy limit: " + (buyLimit != null ? PanelFormat.formatGP(buyLimit) : "?"));
 
 				if (hasValidMarketPrices(high, low))
 				{
-					populateActiveFlipMarketRows(flip, panels, labels, low, high);
+					populateActiveFlipMarketRows(flip, panels, labels, low, high, flipSellPrice);
 				}
 				else
 				{
 					labels.pricesLabel.setText("Live Price: N/A");
 					labels.marginLabel.setText("Live Margin: N/A");
 					labels.currentProfitLabel.setText("Current Profit: N/A");
-					labels.potentialLabel.setText("Potential: N/A");
+					labels.potentialLabel.setText("Max Potential Profit: N/A");
 					labels.taxLabel.setText("Tax: N/A");
 					panels.panel.setToolTipText(null);
 				}
@@ -3526,12 +3529,11 @@ public class FlipFinderPanel extends PluginPanel
 	}
 
 	/**
-	 * Smart-sell price still drives the session write, Flip Assist focus update and
-	 * price-indicator background, even though it is no longer displayed on the card.
+	 * The flip's sell price drives the session write, Flip Assist focus update and
+	 * price-indicator background, even though the price itself is not displayed.
 	 */
-	private void applySmartSellSideEffects(ActiveFlip flip, ActiveFlipCardPanels panels, Integer high)
+	private void applySmartSellSideEffects(ActiveFlip flip, ActiveFlipCardPanels panels, Integer smartSellPrice)
 	{
-		Integer smartSellPrice = resolveSmartSellPrice(flip, high, plugin.getSession());
 		if (smartSellPrice == null)
 		{
 			return;
@@ -3600,11 +3602,11 @@ public class FlipFinderPanel extends PluginPanel
 	}
 
 	/**
-	 * Render the market-based detail rows (margin, current profit, profit potential, tax)
-	 * once fresh buy/sell prices are available.
+	 * Render the market-based detail rows (live price, live margin, tax) plus the
+	 * position rows (current profit, max potential profit) once prices are available.
 	 */
 	private void populateActiveFlipMarketRows(ActiveFlip flip, ActiveFlipCardPanels panels,
-		ActiveFlipCardLabels labels, int low, int high)
+		ActiveFlipCardLabels labels, int low, int high, Integer flipSellPrice)
 	{
 		long firstBuyMs = flip.getFirstBuyTime() != null
 			? TimeUtils.parseIsoToMillis(flip.getFirstBuyTime())
@@ -3624,13 +3626,22 @@ public class FlipFinderPanel extends PluginPanel
 			panels.panel.setToolTipText(null);
 		}
 
+		// Max Potential Profit uses the flip's OWN buy/sell prices (not the wiki spread):
+		// (sell - buy - tax) x full flip quantity.
+		long fullQty = (long) realized.soldQuantity + flip.getTotalQuantity();
+		long maxPotentialProfit = 0L;
+		if (flipSellPrice != null && flipSellPrice > 0)
+		{
+			int sellTax = GeTax.taxFor(flip.getItemId(), flipSellPrice);
+			maxPotentialProfit = ((long) flipSellPrice - flip.getAverageBuyPrice() - sellTax) * fullQty;
+		}
+
 		// Colours are baked into the HTML by PanelFormat, so no setForeground needed here.
 		labels.pricesLabel.setText(PanelFormat.livePriceHtml(low, high));
 		labels.marginLabel.setText(PanelFormat.liveMarginHtml(metrics.margin, metrics.roi));
 		labels.taxLabel.setText(PanelFormat.taxHtml(metrics.totalTax));
 		labels.currentProfitLabel.setText(PanelFormat.currentProfitHtml(realized.netProfit));
-		// Net of tax so Potential is comparable to the (net) Current Profit — gross wildly overstates high-tax items
-		labels.potentialLabel.setText(PanelFormat.potentialHtml(metrics.profitPotential - metrics.totalTax));
+		labels.potentialLabel.setText(PanelFormat.maxPotentialProfitHtml(maxPotentialProfit));
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3297,9 +3297,7 @@ public class FlipFinderPanel extends PluginPanel
 			}
 		}
 
-		// Holder defers topPanel/namePanel capture: the refresh closure is built before the
-		// header panels exist (the header needs the finished icon), so it reads through this
-		// array instead of the not-yet-declared locals.
+		// Array indirection: the refresh closure needs the header panels before createItemHeaderPanels produces them.
 		HeaderPanels[] headerHolder = new HeaderPanels[1];
 		JLabel refreshIcon = createRefreshIconLabel(() ->
 		{
@@ -3486,6 +3484,11 @@ public class FlipFinderPanel extends PluginPanel
 					int perItemTax = GeTax.taxFor(flip.getItemId(), high);
 					long totalTax = (long) perItemTax * fullQty;
 
+					int positionNetPerUnit = high - flip.getAverageBuyPrice() - perItemTax;
+					panel.setToolTipText(positionNetPerUnit < 0
+						? "Selling at the current price would be a loss - below your buy price plus tax."
+						: null);
+
 					pricesLabel.setText(PanelFormat.formatMarketBuySellText(low, high));
 					buyLimitLabel.setText(String.format("Buy limit: %s",
 						buyLimit != null ? PanelFormat.formatGPExact(buyLimit) : "?"));
@@ -3508,6 +3511,7 @@ public class FlipFinderPanel extends PluginPanel
 					currentProfitLabel.setText("Current Profit: N/A");
 					profitPotentialLabel.setText("Profit Potential: N/A");
 					taxLabel.setText("Tax: N/A");
+					panel.setToolTipText(null);
 				}
 
 				updateLiquidityLabel(liquidityLabel, liquidity);

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2506,8 +2506,8 @@ public class FlipFinderPanel extends PluginPanel
 			JPanel eastStack = new JPanel();
 			eastStack.setLayout(new BoxLayout(eastStack, BoxLayout.Y_AXIS));
 			eastStack.setOpaque(false);
-			// Small right inset so the icons/buy-limit don't sit flush against the card edge
-			eastStack.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 4));
+			// Right inset so the icons/buy-limit sit well clear of the card edge
+			eastStack.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 11));
 			eastStack.add(iconsPanel);
 			eastStack.add(cornerSubtitle);
 			topPanel.add(eastStack, BorderLayout.EAST);

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3627,7 +3627,7 @@ public class FlipFinderPanel extends PluginPanel
 		// Colours are baked into the HTML by PanelFormat, so no setForeground needed here.
 		labels.pricesLabel.setText(PanelFormat.livePriceHtml(low, high));
 		labels.marginLabel.setText(PanelFormat.liveMarginHtml(metrics.margin, metrics.roi));
-		labels.taxLabel.setText("Tax: " + PanelFormat.formatGP((int) Math.min(metrics.totalTax, Integer.MAX_VALUE)));
+		labels.taxLabel.setText(PanelFormat.taxHtml(metrics.totalTax));
 		labels.currentProfitLabel.setText(PanelFormat.currentProfitHtml(realized.netProfit));
 		// Net of tax so Potential is comparable to the (net) Current Profit — gross wildly overstates high-tax items
 		labels.potentialLabel.setText(PanelFormat.potentialHtml(metrics.profitPotential - metrics.totalTax));

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3259,7 +3259,7 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private JPanel createActiveFlipPanel(ActiveFlip flip)
 	{
-		JPanel panel = CardWidgets.createBaseItemPanel(ColorScheme.DARKER_GRAY_COLOR, 195, true);
+		JPanel panel = CardWidgets.createBaseItemPanel(ColorScheme.DARKER_GRAY_COLOR, 210, true);
 
 		// Details section using BoxLayout for vertical rows
 		JPanel detailsPanel = CardWidgets.createDetailsPanel(ColorScheme.DARKER_GRAY_COLOR);
@@ -3274,6 +3274,8 @@ public class FlipFinderPanel extends PluginPanel
 		JLabel currentProfitLabel = CardWidgets.createStyledLabel("Current Profit: ...", Color.WHITE);
 		JLabel potentialLabel = CardWidgets.createStyledLabel("Max Potential Profit: ...", Color.WHITE);
 		potentialLabel.setFont(FONT_PLAIN_11);
+		JLabel qtyLabel = CardWidgets.createStyledLabel("Qty: ...", COLOR_TEXT_GRAY);
+		qtyLabel.setFont(FONT_PLAIN_11);
 		JLabel liquidityLabel = CardWidgets.createStyledLabel("Liquidity: ...", Color.CYAN);
 		JLabel riskLabel = CardWidgets.createStyledLabel("Risk: ...", COLOR_YELLOW);
 
@@ -3289,7 +3291,7 @@ public class FlipFinderPanel extends PluginPanel
 		rowDivider.setMaximumSize(new Dimension(Integer.MAX_VALUE, 1));
 		detailsPanel.add(rowDivider);
 		detailsPanel.add(Box.createRigidArea(new Dimension(0, 3)));
-		CardWidgets.addLabelsWithSpacing(detailsPanel, currentProfitLabel, potentialLabel,
+		CardWidgets.addLabelsWithSpacing(detailsPanel, currentProfitLabel, potentialLabel, qtyLabel,
 			liquidityLabel, riskLabel);
 
 		if (offerDispositionLookup != null)
@@ -3327,7 +3329,7 @@ public class FlipFinderPanel extends PluginPanel
 			populateActiveFlipCard(flip,
 				new ActiveFlipCardPanels(panel, headerHolder[0].topPanel, headerHolder[0].namePanel, detailsPanel),
 				new ActiveFlipCardLabels(pricesLabel, buyLimitLabel, marginLabel, currentProfitLabel,
-					potentialLabel, taxLabel, liquidityLabel, riskLabel));
+					potentialLabel, qtyLabel, taxLabel, liquidityLabel, riskLabel));
 		});
 		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(),
 			ColorScheme.DARKER_GRAY_COLOR, refreshIcon, buyLimitLabel);
@@ -3341,7 +3343,7 @@ public class FlipFinderPanel extends PluginPanel
 		populateActiveFlipCard(flip,
 			new ActiveFlipCardPanels(panel, topPanel, namePanel, detailsPanel),
 			new ActiveFlipCardLabels(pricesLabel, buyLimitLabel, marginLabel, currentProfitLabel,
-				potentialLabel, taxLabel, liquidityLabel, riskLabel));
+				potentialLabel, qtyLabel, taxLabel, liquidityLabel, riskLabel));
 
 		// Store default background color as client property (will be overwritten if price indicator is applied)
 		panel.putClientProperty("baseBackgroundColor", ColorScheme.DARKER_GRAY_COLOR);
@@ -3450,12 +3452,13 @@ public class FlipFinderPanel extends PluginPanel
 		final JLabel marginLabel;
 		final JLabel currentProfitLabel;
 		final JLabel potentialLabel;
+		final JLabel qtyLabel;
 		final JLabel taxLabel;
 		final JLabel liquidityLabel;
 		final JLabel riskLabel;
 
 		ActiveFlipCardLabels(JLabel pricesLabel, JLabel buyLimitLabel, JLabel marginLabel,
-			JLabel currentProfitLabel, JLabel potentialLabel, JLabel taxLabel,
+			JLabel currentProfitLabel, JLabel potentialLabel, JLabel qtyLabel, JLabel taxLabel,
 			JLabel liquidityLabel, JLabel riskLabel)
 		{
 			this.pricesLabel = pricesLabel;
@@ -3463,6 +3466,7 @@ public class FlipFinderPanel extends PluginPanel
 			this.marginLabel = marginLabel;
 			this.currentProfitLabel = currentProfitLabel;
 			this.potentialLabel = potentialLabel;
+			this.qtyLabel = qtyLabel;
 			this.taxLabel = taxLabel;
 			this.liquidityLabel = liquidityLabel;
 			this.riskLabel = riskLabel;
@@ -3496,6 +3500,13 @@ public class FlipFinderPanel extends PluginPanel
 					}
 				}
 
+				// Realized fills (sold-so-far) drive both Qty and Current Profit; compute once.
+				RealizedFlipProfit.Result realized = RealizedFlipProfit.compute(
+					plugin.getOfferStore().forItem(flip.getItemId()), flip.getItemId(), flip.getAverageBuyPrice(),
+					flip.getFirstBuyTime() != null ? TimeUtils.parseIsoToMillis(flip.getFirstBuyTime()) : 0L);
+				long fullQty = (long) realized.soldQuantity + flip.getTotalQuantity();
+				labels.qtyLabel.setText(PanelFormat.qtyHtml(realized.soldQuantity, fullQty));
+
 				// The flip's own sell price (session-recommended, else computed) drives both the
 				// side effects and the Max Potential Profit figure.
 				Integer flipSellPrice = resolveSmartSellPrice(flip, high, plugin.getSession());
@@ -3506,7 +3517,7 @@ public class FlipFinderPanel extends PluginPanel
 
 				if (hasValidMarketPrices(high, low))
 				{
-					populateActiveFlipMarketRows(flip, panels, labels, low, high, flipSellPrice);
+					populateActiveFlipMarketRows(flip, panels, labels, low, high, flipSellPrice, realized, fullQty);
 				}
 				else
 				{
@@ -3606,14 +3617,9 @@ public class FlipFinderPanel extends PluginPanel
 	 * position rows (current profit, max potential profit) once prices are available.
 	 */
 	private void populateActiveFlipMarketRows(ActiveFlip flip, ActiveFlipCardPanels panels,
-		ActiveFlipCardLabels labels, int low, int high, Integer flipSellPrice)
+		ActiveFlipCardLabels labels, int low, int high, Integer flipSellPrice,
+		RealizedFlipProfit.Result realized, long fullQty)
 	{
-		long firstBuyMs = flip.getFirstBuyTime() != null
-			? TimeUtils.parseIsoToMillis(flip.getFirstBuyTime())
-			: 0L;
-		RealizedFlipProfit.Result realized = RealizedFlipProfit.compute(
-			plugin.getOfferStore().forItem(flip.getItemId()), flip.getItemId(),
-			flip.getAverageBuyPrice(), firstBuyMs);
 		ActiveFlipCardMetrics.Result metrics = ActiveFlipCardMetrics.compute(
 			low, high, flip.getItemId(), flip.getAverageBuyPrice(), realized.soldQuantity, flip.getTotalQuantity());
 
@@ -3628,7 +3634,6 @@ public class FlipFinderPanel extends PluginPanel
 
 		// Max Potential Profit uses the flip's OWN buy/sell prices (not the wiki spread):
 		// (sell - buy - tax) x full flip quantity.
-		long fullQty = (long) realized.soldQuantity + flip.getTotalQuantity();
 		long maxPotentialProfit = 0L;
 		if (flipSellPrice != null && flipSellPrice > 0)
 		{
@@ -3651,116 +3656,52 @@ public class FlipFinderPanel extends PluginPanel
 	private JPanel createPendingOrderPanel(PendingOrder pending)
 	{
 		Color bgColor = new Color(55, 55, 65); // Slightly different color for pending
-		JPanel panel = CardWidgets.createBaseItemPanel(bgColor, 180, false);
+		JPanel panel = CardWidgets.createBaseItemPanel(bgColor, 210, false);
 
-		// Top section: Item icon and name
-		HeaderPanels header = createItemHeaderPanels(pending.itemId, pending.itemName, bgColor);
-		JPanel topPanel = header.topPanel;
-		JPanel namePanel = header.namePanel;
-
-		// Details section using BoxLayout for vertical rows
 		JPanel detailsPanel = CardWidgets.createDetailsPanel(bgColor);
 
-		// Row 1: Buy: X | Sell: Y (with placeholders until data loads)
-		String sellText = pending.recommendedSellPrice != null && pending.recommendedSellPrice > 0
-			? PanelFormat.formatGPExact(pending.recommendedSellPrice) : "...";
-		JLabel pricesLabel = CardWidgets.createStyledLabel(
-			String.format(FORMAT_BUY_SELL, PanelFormat.formatGPExact(pending.pricePerItem), sellText), Color.WHITE);
+		// --- Top "live" block ---
+		JLabel pricesLabel = CardWidgets.createStyledLabel("Live Price: ...", Color.WHITE);
+		JLabel marginLabel = CardWidgets.createStyledLabel("Live Margin: ...", Color.WHITE);
+		JLabel taxLabel = CardWidgets.createStyledLabel("Tax: ...", COLOR_TEXT_GRAY);
+		taxLabel.setFont(FONT_PLAIN_11);
 
-		// Row 2: Qty: X/Y (Limit: Z)
-		JLabel qtyLabel = CardWidgets.createStyledLabel(
-			String.format("Qty: %d/%d (Limit: ...)", pending.quantityFilled, pending.quantity), COLOR_TEXT_GRAY);
-
-		// Row 3: Tax = W
-		JLabel taxLabel = CardWidgets.createStyledLabel("Tax = ...", Color.CYAN);
-
-		// Row 4: Margin: X (Y% ROI)
-		JLabel marginLabel = CardWidgets.createStyledLabel("Margin: ...", COLOR_YELLOW);
-
-		// Row 5: Profit: X | Cost: Y
-		int potentialInvestment = pending.quantity * pending.pricePerItem;
-		JLabel profitCostLabel = CardWidgets.createStyledLabel(
-			String.format("Profit: ... | Cost: %s", PanelFormat.formatGP(potentialInvestment)), COLOR_PROFIT_GREEN);
-
-		// Row 6: Liquidity: X (Rating) | Y/hr
+		// --- Bottom "reference" block (no Current Profit — nothing sold on a buy) ---
+		JLabel potentialLabel = CardWidgets.createStyledLabel("Max Potential Profit: ...", Color.WHITE);
+		potentialLabel.setFont(FONT_PLAIN_11);
+		JLabel qtyLabel = CardWidgets.createStyledLabel("Qty: ...", COLOR_TEXT_GRAY);
+		qtyLabel.setFont(FONT_PLAIN_11);
 		JLabel liquidityLabel = CardWidgets.createStyledLabel("Liquidity: ...", Color.CYAN);
-
-		// Row 7: Risk: X (Rating)
 		JLabel riskLabel = CardWidgets.createStyledLabel("Risk: ...", COLOR_YELLOW);
 
-		// Add all rows with small spacing
-		CardWidgets.addLabelsWithSpacing(detailsPanel, pricesLabel, qtyLabel, taxLabel, marginLabel, 
-			profitCostLabel, liquidityLabel, riskLabel);
+		JLabel buyLimitLabel = CardWidgets.createStyledLabel("Buy limit: ...", COLOR_TEXT_GRAY);
+		buyLimitLabel.setFont(FONT_PLAIN_11);
+
+		CardWidgets.addLabelsWithSpacing(detailsPanel, pricesLabel, marginLabel, taxLabel);
+		detailsPanel.add(Box.createRigidArea(new Dimension(0, 3)));
+		JSeparator rowDivider = new JSeparator();
+		rowDivider.setForeground(new Color(70, 70, 70));
+		rowDivider.setMaximumSize(new Dimension(Integer.MAX_VALUE, 1));
+		detailsPanel.add(rowDivider);
+		detailsPanel.add(Box.createRigidArea(new Dimension(0, 3)));
+		CardWidgets.addLabelsWithSpacing(detailsPanel, potentialLabel, qtyLabel, liquidityLabel, riskLabel);
+
+		// Header with refresh + corner buy-limit, matching the active-flip cards
+		JLabel refreshIcon = createRefreshIconLabel(() ->
+		{
+			apiClient.invalidateCache(pending.itemId);
+			populatePendingCardRows(pending, pricesLabel, marginLabel, taxLabel, qtyLabel,
+				potentialLabel, liquidityLabel, riskLabel, buyLimitLabel);
+		});
+		HeaderPanels header = createItemHeaderPanels(pending.itemId, pending.itemName, bgColor, refreshIcon, buyLimitLabel);
+		JPanel topPanel = header.topPanel;
+		JPanel namePanel = header.namePanel;
 
 		panel.add(topPanel, BorderLayout.NORTH);
 		panel.add(detailsPanel, BorderLayout.CENTER);
 
-		// Fetch market data to populate all fields
-		apiClient.getItemAnalysisAsync(pending.itemId).thenAccept(analysis ->
-		{
-			SwingUtilities.invokeLater(() ->
-			{
-				Integer buyLimit = null;
-				FlipAnalysis.Liquidity liquidity = null;
-				FlipAnalysis.Risk risk = null;
-				Integer currentSellPrice = null;
-				
-				if (analysis != null)
-				{
-					buyLimit = analysis.getBuyLimit();
-					liquidity = analysis.getLiquidity();
-					risk = analysis.getRisk();
-					
-					if (analysis.getCurrentPrices() != null)
-					{
-						currentSellPrice = analysis.getCurrentPrices().getHigh();
-					}
-				}
-				
-				// Use recommended sell price or current market price
-				Integer sellPrice = pending.recommendedSellPrice != null && pending.recommendedSellPrice > 0
-					? pending.recommendedSellPrice : currentSellPrice;
-				
-				if (sellPrice != null && sellPrice > 0)
-				{
-					// Row 1: Update prices
-					pricesLabel.setText(PanelFormat.formatBuySellText(pending.pricePerItem, sellPrice));
-
-					int geTax = GeTax.taxFor(pending.itemId, sellPrice);
-
-					// Calculate margin and profit
-					int marginPerItem = sellPrice - pending.pricePerItem - geTax;
-					int totalProfit = marginPerItem * pending.quantity;
-					double roi = (marginPerItem * 100.0) / pending.pricePerItem;
-					
-					// Row 2: Update Qty (Limit) | Tax
-					String limitText = buyLimit != null ? String.valueOf(buyLimit) : "?";
-					qtyLabel.setText(String.format("Qty: %d/%d (Limit: %s)", 
-						pending.quantityFilled, pending.quantity, limitText));
-					taxLabel.setText(String.format("Tax = %s", PanelFormat.formatGP(geTax * pending.quantity)));
-					
-					// Row 3: Update Margin
-					marginLabel.setText(PanelFormat.formatMarginText(marginPerItem, roi, totalProfit <= 0));
-					marginLabel.setForeground(totalProfit <= 0 ? COLOR_LOSS_RED : COLOR_YELLOW);
-					
-					// Row 4: Update Profit | Cost
-					profitCostLabel.setText(PanelFormat.formatProfitCostText(totalProfit, potentialInvestment));
-					profitCostLabel.setForeground(totalProfit > 0 ? COLOR_PROFIT_GREEN : COLOR_LOSS_RED);
-				}
-				else
-				{
-					pricesLabel.setText(PanelFormat.formatBuySellText(pending.pricePerItem, null));
-					marginLabel.setText("Margin: N/A");
-					profitCostLabel.setText(String.format("Profit: N/A | Cost: %s", PanelFormat.formatGP(potentialInvestment)));
-				}
-				
-				// Row 5: Update Liquidity
-				updateLiquidityLabel(liquidityLabel, liquidity);
-				
-				// Row 6: Update Risk
-				updateRiskLabel(riskLabel, risk);
-			});
-		});
+		populatePendingCardRows(pending, pricesLabel, marginLabel, taxLabel, qtyLabel,
+			potentialLabel, liquidityLabel, riskLabel, buyLimitLabel);
 
 		// Add click listener for focus selection
 		panel.addMouseListener(new MouseAdapter()
@@ -3801,6 +3742,73 @@ public class FlipFinderPanel extends PluginPanel
 		}
 
 		return panel;
+	}
+
+	/**
+	 * Fetch market analysis and (re)populate a pending buy card's rows. Reused by the
+	 * initial build and the refresh button. Mirrors the active-flip card layout minus
+	 * Current Profit (nothing is sold on a pending buy).
+	 */
+	private void populatePendingCardRows(PendingOrder pending, JLabel pricesLabel, JLabel marginLabel,
+		JLabel taxLabel, JLabel qtyLabel, JLabel potentialLabel, JLabel liquidityLabel,
+		JLabel riskLabel, JLabel buyLimitLabel)
+	{
+		qtyLabel.setText(PanelFormat.qtyHtml(pending.quantityFilled, pending.quantity));
+
+		apiClient.getItemAnalysisAsync(pending.itemId).thenAccept(analysis ->
+			SwingUtilities.invokeLater(() ->
+			{
+				Integer high = null;
+				Integer low = null;
+				Integer buyLimit = null;
+				FlipAnalysis.Liquidity liquidity = null;
+				FlipAnalysis.Risk risk = null;
+
+				if (analysis != null)
+				{
+					buyLimit = analysis.getBuyLimit();
+					liquidity = analysis.getLiquidity();
+					risk = analysis.getRisk();
+					if (analysis.getCurrentPrices() != null)
+					{
+						high = analysis.getCurrentPrices().getHigh();
+						low = analysis.getCurrentPrices().getLow();
+					}
+				}
+
+				buyLimitLabel.setText("Buy limit: " + (buyLimit != null ? PanelFormat.formatGP(buyLimit) : "?"));
+
+				if (high != null && high > 0 && low != null && low > 0)
+				{
+					int margin = high - low;
+					double roi = (margin * 100.0) / low;
+					long totalTax = (long) GeTax.taxFor(pending.itemId, high) * pending.quantity;
+					pricesLabel.setText(PanelFormat.livePriceHtml(low, high));
+					marginLabel.setText(PanelFormat.liveMarginHtml(margin, roi));
+					taxLabel.setText(PanelFormat.taxHtml(totalTax));
+				}
+				else
+				{
+					pricesLabel.setText("Live Price: N/A");
+					marginLabel.setText("Live Margin: N/A");
+					taxLabel.setText("Tax: N/A");
+				}
+
+				// Max Potential Profit for the pending buy: (sell - buy - tax) x ordered qty,
+				// where sell is the flip's recommended sell price (else the current market high).
+				Integer sellPrice = pending.recommendedSellPrice != null && pending.recommendedSellPrice > 0
+					? pending.recommendedSellPrice : high;
+				long maxPotentialProfit = 0L;
+				if (sellPrice != null && sellPrice > 0)
+				{
+					int sellTax = GeTax.taxFor(pending.itemId, sellPrice);
+					maxPotentialProfit = ((long) sellPrice - pending.pricePerItem - sellTax) * pending.quantity;
+				}
+				potentialLabel.setText(PanelFormat.maxPotentialProfitHtml(maxPotentialProfit));
+
+				updateLiquidityLabel(liquidityLabel, liquidity);
+				updateRiskLabel(riskLabel, risk);
+			}));
 	}
 	
 	/**

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3236,7 +3236,7 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private JPanel createActiveFlipPanel(ActiveFlip flip)
 	{
-		JPanel panel = CardWidgets.createBaseItemPanel(ColorScheme.DARKER_GRAY_COLOR, 210, true);
+		JPanel panel = CardWidgets.createBaseItemPanel(ColorScheme.DARKER_GRAY_COLOR, 195, true);
 
 		// Details section using BoxLayout for vertical rows
 		JPanel detailsPanel = CardWidgets.createDetailsPanel(ColorScheme.DARKER_GRAY_COLOR);
@@ -3250,11 +3250,8 @@ public class FlipFinderPanel extends PluginPanel
 		// Row: Current Margin (market spread) with ROI
 		JLabel marginLabel = CardWidgets.createStyledLabel("Current Margin: ...", COLOR_YELLOW);
 
-		// Row: Current Profit (realized on units sold so far)
+		// Row: Current Profit (realized) | Potential (projected) on one line
 		JLabel currentProfitLabel = CardWidgets.createStyledLabel("Current Profit: ...", COLOR_PROFIT_GREEN);
-
-		// Row: Profit Potential | Cost
-		JLabel profitPotentialLabel = CardWidgets.createStyledLabel("Profit Potential: ...", COLOR_PROFIT_GREEN);
 
 		// Row: Tax (per-item | total)
 		JLabel taxLabel = CardWidgets.createStyledLabel("Tax: ...", Color.CYAN);
@@ -3266,7 +3263,7 @@ public class FlipFinderPanel extends PluginPanel
 		JLabel riskLabel = CardWidgets.createStyledLabel("Risk: ...", COLOR_YELLOW);
 
 		CardWidgets.addLabelsWithSpacing(detailsPanel, pricesLabel, buyLimitLabel, marginLabel,
-			currentProfitLabel, profitPotentialLabel);
+			currentProfitLabel);
 		// Deliberate blank spacer separating the pricing/profit block from tax/risk
 		detailsPanel.add(Box.createRigidArea(new Dimension(0, 8)));
 		CardWidgets.addLabelsWithSpacing(detailsPanel, taxLabel, liquidityLabel, riskLabel);
@@ -3306,7 +3303,7 @@ public class FlipFinderPanel extends PluginPanel
 			populateActiveFlipCard(flip,
 				new ActiveFlipCardPanels(panel, headerHolder[0].topPanel, headerHolder[0].namePanel, detailsPanel),
 				new ActiveFlipCardLabels(pricesLabel, buyLimitLabel, marginLabel, currentProfitLabel,
-					profitPotentialLabel, taxLabel, liquidityLabel, riskLabel));
+					taxLabel, liquidityLabel, riskLabel));
 		});
 		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(),
 			ColorScheme.DARKER_GRAY_COLOR, refreshIcon);
@@ -3320,7 +3317,7 @@ public class FlipFinderPanel extends PluginPanel
 		populateActiveFlipCard(flip,
 			new ActiveFlipCardPanels(panel, topPanel, namePanel, detailsPanel),
 			new ActiveFlipCardLabels(pricesLabel, buyLimitLabel, marginLabel, currentProfitLabel,
-				profitPotentialLabel, taxLabel, liquidityLabel, riskLabel));
+				taxLabel, liquidityLabel, riskLabel));
 
 		// Store default background color as client property (will be overwritten if price indicator is applied)
 		panel.putClientProperty("baseBackgroundColor", ColorScheme.DARKER_GRAY_COLOR);
@@ -3428,20 +3425,18 @@ public class FlipFinderPanel extends PluginPanel
 		final JLabel buyLimitLabel;
 		final JLabel marginLabel;
 		final JLabel currentProfitLabel;
-		final JLabel profitPotentialLabel;
 		final JLabel taxLabel;
 		final JLabel liquidityLabel;
 		final JLabel riskLabel;
 
 		ActiveFlipCardLabels(JLabel pricesLabel, JLabel buyLimitLabel, JLabel marginLabel,
-			JLabel currentProfitLabel, JLabel profitPotentialLabel, JLabel taxLabel,
+			JLabel currentProfitLabel, JLabel taxLabel,
 			JLabel liquidityLabel, JLabel riskLabel)
 		{
 			this.pricesLabel = pricesLabel;
 			this.buyLimitLabel = buyLimitLabel;
 			this.marginLabel = marginLabel;
 			this.currentProfitLabel = currentProfitLabel;
-			this.profitPotentialLabel = profitPotentialLabel;
 			this.taxLabel = taxLabel;
 			this.liquidityLabel = liquidityLabel;
 			this.riskLabel = riskLabel;
@@ -3485,8 +3480,7 @@ public class FlipFinderPanel extends PluginPanel
 				{
 					labels.pricesLabel.setText("Buy: N/A | Sell: N/A");
 					labels.marginLabel.setText("Current Margin: N/A");
-					labels.currentProfitLabel.setText("Current Profit: N/A");
-					labels.profitPotentialLabel.setText("Profit Potential: N/A");
+					labels.currentProfitLabel.setText("Current Profit: N/A | Potential: N/A");
 					labels.taxLabel.setText("Tax: N/A");
 					panels.panel.setToolTipText(null);
 				}
@@ -3607,11 +3601,9 @@ public class FlipFinderPanel extends PluginPanel
 		labels.marginLabel.setText(PanelFormat.formatCurrentMarginText(metrics.margin, metrics.roi));
 		labels.marginLabel.setForeground(metrics.margin < 0 ? COLOR_LOSS_RED : COLOR_PROFIT_GREEN);
 
-		labels.currentProfitLabel.setText(PanelFormat.formatCurrentProfitText(realized.netProfit));
+		labels.currentProfitLabel.setText(
+			PanelFormat.formatProfitCombinedText(realized.netProfit, metrics.profitPotential));
 		labels.currentProfitLabel.setForeground(realized.netProfit < 0 ? COLOR_LOSS_RED : COLOR_PROFIT_GREEN);
-
-		labels.profitPotentialLabel.setText(PanelFormat.formatProfitPotentialText(metrics.profitPotential, metrics.cost));
-		labels.profitPotentialLabel.setForeground(metrics.profitPotential < 0 ? COLOR_LOSS_RED : COLOR_PROFIT_GREEN);
 
 		labels.taxLabel.setText(PanelFormat.formatTaxSplitText(metrics.perItemTax, metrics.totalTax));
 	}

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2506,6 +2506,8 @@ public class FlipFinderPanel extends PluginPanel
 			JPanel eastStack = new JPanel();
 			eastStack.setLayout(new BoxLayout(eastStack, BoxLayout.Y_AXIS));
 			eastStack.setOpaque(false);
+			// Small right inset so the icons/buy-limit don't sit flush against the card edge
+			eastStack.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 4));
 			eastStack.add(iconsPanel);
 			eastStack.add(cornerSubtitle);
 			topPanel.add(eastStack, BorderLayout.EAST);

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3507,24 +3507,40 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private void applySmartSellSideEffects(ActiveFlip flip, ActiveFlipCardPanels panels, Integer high)
 	{
-		PlayerSession session = plugin.getSession();
-		Integer sessionPrice = session != null ? session.getRecommendedPrice(flip.getItemId()) : null;
-		Integer smartSellPrice = (sessionPrice != null && sessionPrice > 0)
-			? sessionPrice
-			: SmartSellPricer.calculateSmartSellPrice(flip, high);
-		if (smartSellPrice == null || smartSellPrice <= 0)
+		Integer smartSellPrice = resolveSmartSellPrice(flip, high, plugin.getSession());
+		if (smartSellPrice == null)
 		{
 			return;
 		}
 
-		if ((sessionPrice == null || sessionPrice <= 0) && session != null)
-		{
-			session.setRecommendedPrice(flip.getItemId(), smartSellPrice);
-		}
 		displayedSellPrices.put(flip.getItemId(), smartSellPrice);
-
 		applyPriceIndicatorIfNeeded(flip, panels, smartSellPrice);
 		updateFocusIfSelected(flip, smartSellPrice);
+	}
+
+	/**
+	 * Prefer the session's already-recommended price; otherwise compute one and persist
+	 * it to the session so later cards/refreshes stay pinned to the same price.
+	 */
+	private static Integer resolveSmartSellPrice(ActiveFlip flip, Integer high, PlayerSession session)
+	{
+		Integer sessionPrice = session != null ? session.getRecommendedPrice(flip.getItemId()) : null;
+		if (isValidPrice(sessionPrice))
+		{
+			return sessionPrice;
+		}
+
+		Integer computedPrice = SmartSellPricer.calculateSmartSellPrice(flip, high);
+		if (isValidPrice(computedPrice) && session != null)
+		{
+			session.setRecommendedPrice(flip.getItemId(), computedPrice);
+		}
+		return isValidPrice(computedPrice) ? computedPrice : null;
+	}
+
+	private static boolean isValidPrice(Integer price)
+	{
+		return price != null && price > 0;
 	}
 
 	private void applyPriceIndicatorIfNeeded(ActiveFlip flip, ActiveFlipCardPanels panels, int smartSellPrice)

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2448,10 +2448,16 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private HeaderPanels createItemHeaderPanels(int itemId, String itemName, Color bgColor)
 	{
-		return createItemHeaderPanels(itemId, itemName, bgColor, null);
+		return createItemHeaderPanels(itemId, itemName, bgColor, null, null);
 	}
 
 	private HeaderPanels createItemHeaderPanels(int itemId, String itemName, Color bgColor, JLabel trailingIcon)
+	{
+		return createItemHeaderPanels(itemId, itemName, bgColor, trailingIcon, null);
+	}
+
+	private HeaderPanels createItemHeaderPanels(int itemId, String itemName, Color bgColor,
+		JLabel trailingIcon, JLabel cornerSubtitle)
 	{
 		JPanel topPanel = new JPanel(new BorderLayout(4, 0));
 		topPanel.setBackground(bgColor);
@@ -2492,7 +2498,22 @@ public class FlipFinderPanel extends PluginPanel
 		}
 
 		topPanel.add(namePanel, BorderLayout.CENTER);
-		topPanel.add(iconsPanel, BorderLayout.EAST);
+		if (cornerSubtitle != null)
+		{
+			// Stack the corner subtitle (e.g. buy limit) beneath the icon row, right-aligned
+			iconsPanel.setAlignmentX(Component.RIGHT_ALIGNMENT);
+			cornerSubtitle.setAlignmentX(Component.RIGHT_ALIGNMENT);
+			JPanel eastStack = new JPanel();
+			eastStack.setLayout(new BoxLayout(eastStack, BoxLayout.Y_AXIS));
+			eastStack.setOpaque(false);
+			eastStack.add(iconsPanel);
+			eastStack.add(cornerSubtitle);
+			topPanel.add(eastStack, BorderLayout.EAST);
+		}
+		else
+		{
+			topPanel.add(iconsPanel, BorderLayout.EAST);
+		}
 
 		return new HeaderPanels(topPanel, namePanel);
 	}
@@ -3241,32 +3262,33 @@ public class FlipFinderPanel extends PluginPanel
 		// Details section using BoxLayout for vertical rows
 		JPanel detailsPanel = CardWidgets.createDetailsPanel(ColorScheme.DARKER_GRAY_COLOR);
 
-		// Row: Buy (market low) | Sell (market high)
-		JLabel pricesLabel = CardWidgets.createStyledLabel("Buy: ... | Sell: ...", Color.WHITE);
+		// --- Top "live" block: instant market info (HTML rows carry their own colours) ---
+		JLabel pricesLabel = CardWidgets.createStyledLabel("Live Price: ...", Color.WHITE);
+		JLabel marginLabel = CardWidgets.createStyledLabel("Live Margin: ...", Color.WHITE);
+		JLabel taxLabel = CardWidgets.createStyledLabel("Tax: ...", COLOR_TEXT_GRAY);
+		taxLabel.setFont(FONT_PLAIN_11);
 
-		// Row: Buy limit
-		JLabel buyLimitLabel = CardWidgets.createStyledLabel("Buy limit: ...", COLOR_TEXT_GRAY);
-
-		// Row: Current Margin (market spread) with ROI
-		JLabel marginLabel = CardWidgets.createStyledLabel("Current Margin: ...", COLOR_YELLOW);
-
-		// Row: Current Profit (realized) | Potential (projected) on one line
-		JLabel currentProfitLabel = CardWidgets.createStyledLabel("Current Profit: ...", COLOR_PROFIT_GREEN);
-
-		// Row: Tax (per-item | total)
-		JLabel taxLabel = CardWidgets.createStyledLabel("Tax: ...", Color.CYAN);
-
-		// Row: Liquidity
+		// --- Bottom "reference" block: the trade position ---
+		JLabel currentProfitLabel = CardWidgets.createStyledLabel("Current Profit: ...", Color.WHITE);
+		JLabel potentialLabel = CardWidgets.createStyledLabel("Potential: ...", Color.WHITE);
+		potentialLabel.setFont(FONT_PLAIN_11);
 		JLabel liquidityLabel = CardWidgets.createStyledLabel("Liquidity: ...", Color.CYAN);
-
-		// Row: Risk
 		JLabel riskLabel = CardWidgets.createStyledLabel("Risk: ...", COLOR_YELLOW);
 
-		CardWidgets.addLabelsWithSpacing(detailsPanel, pricesLabel, buyLimitLabel, marginLabel,
-			currentProfitLabel);
-		// Deliberate blank spacer separating the pricing/profit block from tax/risk
-		detailsPanel.add(Box.createRigidArea(new Dimension(0, 8)));
-		CardWidgets.addLabelsWithSpacing(detailsPanel, taxLabel, liquidityLabel, riskLabel);
+		// Buy limit lives in the header corner, not the body
+		JLabel buyLimitLabel = CardWidgets.createStyledLabel("Buy limit: ...", COLOR_TEXT_GRAY);
+		buyLimitLabel.setFont(FONT_PLAIN_11);
+
+		CardWidgets.addLabelsWithSpacing(detailsPanel, pricesLabel, marginLabel, taxLabel);
+		// Divider separates the "live" block from the position-reference block
+		detailsPanel.add(Box.createRigidArea(new Dimension(0, 3)));
+		JSeparator rowDivider = new JSeparator();
+		rowDivider.setForeground(new Color(70, 70, 70));
+		rowDivider.setMaximumSize(new Dimension(Integer.MAX_VALUE, 1));
+		detailsPanel.add(rowDivider);
+		detailsPanel.add(Box.createRigidArea(new Dimension(0, 3)));
+		CardWidgets.addLabelsWithSpacing(detailsPanel, currentProfitLabel, potentialLabel,
+			liquidityLabel, riskLabel);
 
 		if (offerDispositionLookup != null)
 		{
@@ -3303,10 +3325,10 @@ public class FlipFinderPanel extends PluginPanel
 			populateActiveFlipCard(flip,
 				new ActiveFlipCardPanels(panel, headerHolder[0].topPanel, headerHolder[0].namePanel, detailsPanel),
 				new ActiveFlipCardLabels(pricesLabel, buyLimitLabel, marginLabel, currentProfitLabel,
-					taxLabel, liquidityLabel, riskLabel));
+					potentialLabel, taxLabel, liquidityLabel, riskLabel));
 		});
 		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(),
-			ColorScheme.DARKER_GRAY_COLOR, refreshIcon);
+			ColorScheme.DARKER_GRAY_COLOR, refreshIcon, buyLimitLabel);
 		headerHolder[0] = header;
 		JPanel topPanel = header.topPanel;
 		JPanel namePanel = header.namePanel;
@@ -3317,7 +3339,7 @@ public class FlipFinderPanel extends PluginPanel
 		populateActiveFlipCard(flip,
 			new ActiveFlipCardPanels(panel, topPanel, namePanel, detailsPanel),
 			new ActiveFlipCardLabels(pricesLabel, buyLimitLabel, marginLabel, currentProfitLabel,
-				taxLabel, liquidityLabel, riskLabel));
+				potentialLabel, taxLabel, liquidityLabel, riskLabel));
 
 		// Store default background color as client property (will be overwritten if price indicator is applied)
 		panel.putClientProperty("baseBackgroundColor", ColorScheme.DARKER_GRAY_COLOR);
@@ -3425,18 +3447,20 @@ public class FlipFinderPanel extends PluginPanel
 		final JLabel buyLimitLabel;
 		final JLabel marginLabel;
 		final JLabel currentProfitLabel;
+		final JLabel potentialLabel;
 		final JLabel taxLabel;
 		final JLabel liquidityLabel;
 		final JLabel riskLabel;
 
 		ActiveFlipCardLabels(JLabel pricesLabel, JLabel buyLimitLabel, JLabel marginLabel,
-			JLabel currentProfitLabel, JLabel taxLabel,
+			JLabel currentProfitLabel, JLabel potentialLabel, JLabel taxLabel,
 			JLabel liquidityLabel, JLabel riskLabel)
 		{
 			this.pricesLabel = pricesLabel;
 			this.buyLimitLabel = buyLimitLabel;
 			this.marginLabel = marginLabel;
 			this.currentProfitLabel = currentProfitLabel;
+			this.potentialLabel = potentialLabel;
 			this.taxLabel = taxLabel;
 			this.liquidityLabel = liquidityLabel;
 			this.riskLabel = riskLabel;
@@ -3472,15 +3496,19 @@ public class FlipFinderPanel extends PluginPanel
 
 				applySmartSellSideEffects(flip, panels, high);
 
+				labels.buyLimitLabel.setText(
+					"Buy limit: " + (buyLimit != null ? PanelFormat.formatGPExact(buyLimit) : "?"));
+
 				if (hasValidMarketPrices(high, low))
 				{
-					populateActiveFlipMarketRows(flip, panels, labels, low, high, buyLimit);
+					populateActiveFlipMarketRows(flip, panels, labels, low, high);
 				}
 				else
 				{
-					labels.pricesLabel.setText("Buy: N/A | Sell: N/A");
-					labels.marginLabel.setText("Current Margin: N/A");
-					labels.currentProfitLabel.setText("Current Profit: N/A | Potential: N/A");
+					labels.pricesLabel.setText("Live Price: N/A");
+					labels.marginLabel.setText("Live Margin: N/A");
+					labels.currentProfitLabel.setText("Current Profit: N/A");
+					labels.potentialLabel.setText("Potential: N/A");
 					labels.taxLabel.setText("Tax: N/A");
 					panels.panel.setToolTipText(null);
 				}
@@ -3574,7 +3602,7 @@ public class FlipFinderPanel extends PluginPanel
 	 * once fresh buy/sell prices are available.
 	 */
 	private void populateActiveFlipMarketRows(ActiveFlip flip, ActiveFlipCardPanels panels,
-		ActiveFlipCardLabels labels, int low, int high, Integer buyLimit)
+		ActiveFlipCardLabels labels, int low, int high)
 	{
 		long firstBuyMs = flip.getFirstBuyTime() != null
 			? TimeUtils.parseIsoToMillis(flip.getFirstBuyTime())
@@ -3594,18 +3622,12 @@ public class FlipFinderPanel extends PluginPanel
 			panels.panel.setToolTipText(null);
 		}
 
-		labels.pricesLabel.setText(PanelFormat.formatMarketBuySellText(low, high));
-		labels.buyLimitLabel.setText(String.format("Buy limit: %s",
-			buyLimit != null ? PanelFormat.formatGPExact(buyLimit) : "?"));
-
-		labels.marginLabel.setText(PanelFormat.formatCurrentMarginText(metrics.margin, metrics.roi));
-		labels.marginLabel.setForeground(metrics.margin < 0 ? COLOR_LOSS_RED : COLOR_PROFIT_GREEN);
-
-		labels.currentProfitLabel.setText(
-			PanelFormat.formatProfitCombinedText(realized.netProfit, metrics.profitPotential));
-		labels.currentProfitLabel.setForeground(realized.netProfit < 0 ? COLOR_LOSS_RED : COLOR_PROFIT_GREEN);
-
-		labels.taxLabel.setText(PanelFormat.formatTaxSplitText(metrics.perItemTax, metrics.totalTax));
+		// Colours are baked into the HTML by PanelFormat, so no setForeground needed here.
+		labels.pricesLabel.setText(PanelFormat.livePriceHtml(low, high));
+		labels.marginLabel.setText(PanelFormat.liveMarginHtml(metrics.margin, metrics.roi));
+		labels.taxLabel.setText("Tax: " + PanelFormat.formatGP((int) Math.min(metrics.totalTax, Integer.MAX_VALUE)));
+		labels.currentProfitLabel.setText(PanelFormat.currentProfitHtml(realized.netProfit));
+		labels.potentialLabel.setText(PanelFormat.potentialHtml(metrics.profitPotential));
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2447,41 +2447,48 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private HeaderPanels createItemHeaderPanels(int itemId, String itemName, Color bgColor)
 	{
+		return createItemHeaderPanels(itemId, itemName, bgColor, null);
+	}
+
+	private HeaderPanels createItemHeaderPanels(int itemId, String itemName, Color bgColor, JLabel trailingIcon)
+	{
 		JPanel topPanel = new JPanel(new BorderLayout(4, 0));
 		topPanel.setBackground(bgColor);
 
 		JPanel namePanel = new JPanel(new BorderLayout(5, 0));
 		namePanel.setBackground(bgColor);
 
-		// Get item image
 		AsyncBufferedImage itemImage = itemManager.getImage(itemId);
 		JLabel iconLabel = new JLabel();
 		CardWidgets.setupIconLabel(iconLabel, itemImage);
 
-		// Use HTML to allow text wrapping for long item names
 		String escapedName = PanelFormat.escapeHtml(itemName);
 		JLabel nameLabel = new JLabel("<html>" + escapedName + "</html>");
 		nameLabel.setForeground(Color.WHITE);
 		nameLabel.setFont(FONT_BOLD_13);
-		// Limit the name label width to ensure icons always fit
-		// Panel is ~220px wide, minus item icon (36px), block+chart icons (40px), padding (14px) = ~130px for name
-		nameLabel.setPreferredSize(new Dimension(130, nameLabel.getPreferredSize().height));
-		nameLabel.setMaximumSize(new Dimension(130, Integer.MAX_VALUE));
+		// Narrow the name a little more when a third (refresh) icon shares the corner
+		int nameWidth = trailingIcon != null ? 108 : 130;
+		nameLabel.setPreferredSize(new Dimension(nameWidth, nameLabel.getPreferredSize().height));
+		nameLabel.setMaximumSize(new Dimension(nameWidth, Integer.MAX_VALUE));
 
 		namePanel.add(iconLabel, BorderLayout.WEST);
 		namePanel.add(nameLabel, BorderLayout.CENTER);
 
-		// Create icons panel with chart icon and block icon
 		JPanel iconsPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 2, 0));
 		iconsPanel.setOpaque(false);
 
-		// Create block icon
-		JLabel blockIconLabel = createBlockIconLabel(itemId, itemName);
-		iconsPanel.add(blockIconLabel);
+		iconsPanel.add(createBlockIconLabel(itemId, itemName));
+		iconsPanel.add(createChartIconLabel(itemId));
 
-		// Create chart icon
-		JLabel chartIconLabel = createChartIconLabel(itemId);
-		iconsPanel.add(chartIconLabel);
+		if (trailingIcon != null)
+		{
+			// Visible divider so the refresh action reads as distinct from the two existing icons
+			JLabel divider = new JLabel("|");
+			divider.setForeground(COLOR_TEXT_GRAY);
+			divider.setBorder(BorderFactory.createEmptyBorder(0, 3, 0, 1));
+			iconsPanel.add(divider);
+			iconsPanel.add(trailingIcon);
+		}
 
 		topPanel.add(namePanel, BorderLayout.CENTER);
 		topPanel.add(iconsPanel, BorderLayout.EAST);
@@ -2528,6 +2535,58 @@ public class FlipFinderPanel extends PluginPanel
 		});
 
 		return chartLabel;
+	}
+
+	private JLabel createRefreshIconLabel(Runnable onRefresh)
+	{
+		java.awt.image.BufferedImage refreshIcon = PanelFormat.drawRefreshIcon(new Color(120, 200, 255));
+
+		JLabel refreshLabel = new JLabel(new ImageIcon(refreshIcon));
+		refreshLabel.setToolTipText("Refresh latest prices.");
+		refreshLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+		refreshLabel.setBorder(BorderFactory.createEmptyBorder(0, 2, 0, 0));
+		refreshLabel.setOpaque(false);
+
+		refreshLabel.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(MouseEvent e)
+			{
+				e.consume();
+				if (!refreshLabel.isEnabled())
+				{
+					return;
+				}
+				refreshLabel.setEnabled(false);
+				refreshLabel.setCursor(Cursor.getDefaultCursor());
+				onRefresh.run();
+				// Re-enable shortly after; the async re-populate updates the rows independently
+				javax.swing.Timer timer = new javax.swing.Timer(1200, ev ->
+				{
+					refreshLabel.setEnabled(true);
+					refreshLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+				});
+				timer.setRepeats(false);
+				timer.start();
+			}
+
+			@Override
+			public void mouseEntered(MouseEvent e)
+			{
+				if (refreshLabel.isEnabled())
+				{
+					refreshLabel.setIcon(new ImageIcon(PanelFormat.drawRefreshIcon(new Color(170, 225, 255))));
+				}
+			}
+
+			@Override
+			public void mouseExited(MouseEvent e)
+			{
+				refreshLabel.setIcon(new ImageIcon(refreshIcon));
+			}
+		});
+
+		return refreshLabel;
 	}
 
 	/**
@@ -3176,12 +3235,7 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private JPanel createActiveFlipPanel(ActiveFlip flip)
 	{
-		JPanel panel = CardWidgets.createBaseItemPanel(ColorScheme.DARKER_GRAY_COLOR, 180, true);
-
-		// Top section: Item icon and name
-		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(), ColorScheme.DARKER_GRAY_COLOR);
-		JPanel topPanel = header.topPanel;
-		JPanel namePanel = header.namePanel;
+		JPanel panel = CardWidgets.createBaseItemPanel(ColorScheme.DARKER_GRAY_COLOR, 210, true);
 
 		// Details section using BoxLayout for vertical rows
 		JPanel detailsPanel = CardWidgets.createDetailsPanel(ColorScheme.DARKER_GRAY_COLOR);
@@ -3242,6 +3296,23 @@ public class FlipFinderPanel extends PluginPanel
 				}
 			}
 		}
+
+		// Holder defers topPanel/namePanel capture: the refresh closure is built before the
+		// header panels exist (the header needs the finished icon), so it reads through this
+		// array instead of the not-yet-declared locals.
+		HeaderPanels[] headerHolder = new HeaderPanels[1];
+		JLabel refreshIcon = createRefreshIconLabel(() ->
+		{
+			apiClient.invalidateCache(flip.getItemId());
+			populateActiveFlipCard(flip, panel, headerHolder[0].topPanel, headerHolder[0].namePanel, detailsPanel,
+				pricesLabel, buyLimitLabel, marginLabel, currentProfitLabel, profitPotentialLabel,
+				taxLabel, liquidityLabel, riskLabel);
+		});
+		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(),
+			ColorScheme.DARKER_GRAY_COLOR, refreshIcon);
+		headerHolder[0] = header;
+		JPanel topPanel = header.topPanel;
+		JPanel namePanel = header.namePanel;
 
 		panel.add(topPanel, BorderLayout.NORTH);
 		panel.add(detailsPanel, BorderLayout.CENTER);

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -16,6 +16,7 @@ import com.flipsmart.api.dto.BlocklistSummary;
 import com.flipsmart.domain.offer.OfferTransition;
 import com.flipsmart.domain.offer.PendingOrder;
 import com.flipsmart.recommend.SmartSellPricer;
+import com.flipsmart.trading.RealizedFlipProfit;
 import com.flipsmart.ui.panel.CardWidgets;
 import com.flipsmart.ui.panel.LoginPanel;
 import com.flipsmart.ui.panel.PanelFormat;
@@ -3185,33 +3186,35 @@ public class FlipFinderPanel extends PluginPanel
 		// Details section using BoxLayout for vertical rows
 		JPanel detailsPanel = CardWidgets.createDetailsPanel(ColorScheme.DARKER_GRAY_COLOR);
 
-		// Row 1: Buy: X | Sell: Y (placeholders until data loads)
-		JLabel pricesLabel = CardWidgets.createStyledLabel(
-			String.format("Buy: %s | Sell: ...", PanelFormat.formatGPExact(flip.getAverageBuyPrice())), Color.WHITE);
+		// Row: Buy (market low) | Sell (market high)
+		JLabel pricesLabel = CardWidgets.createStyledLabel("Buy: ... | Sell: ...", Color.WHITE);
 
-		// Row 2: Qty: X (Limit: Y)
-		JLabel qtyLabel = CardWidgets.createStyledLabel(
-			String.format("Qty: %d (Limit: ...)", flip.getTotalQuantity()), COLOR_TEXT_GRAY);
+		// Row: Buy limit
+		JLabel buyLimitLabel = CardWidgets.createStyledLabel("Buy limit: ...", COLOR_TEXT_GRAY);
 
-		// Row 3: Tax = Z
-		JLabel taxLabel = CardWidgets.createStyledLabel("Tax = ...", Color.CYAN);
+		// Row: Current Margin (market spread) with ROI
+		JLabel marginLabel = CardWidgets.createStyledLabel("Current Margin: ...", COLOR_YELLOW);
 
-		// Row 4: Margin: X (Y% ROI)
-		JLabel marginLabel = CardWidgets.createStyledLabel("Margin: ...", COLOR_YELLOW);
+		// Row: Current Profit (realized on units sold so far)
+		JLabel currentProfitLabel = CardWidgets.createStyledLabel("Current Profit: ...", COLOR_PROFIT_GREEN);
 
-		// Row 5: Profit: X | Cost: Y
-		JLabel profitCostLabel = CardWidgets.createStyledLabel(
-			String.format("Profit: ... | Cost: %s", PanelFormat.formatGP(flip.getTotalInvested())), COLOR_PROFIT_GREEN);
+		// Row: Profit Potential | Cost
+		JLabel profitPotentialLabel = CardWidgets.createStyledLabel("Profit Potential: ...", COLOR_PROFIT_GREEN);
 
-		// Row 6: Liquidity: X (Rating) | Y/hr
+		// Row: Tax (per-item | total)
+		JLabel taxLabel = CardWidgets.createStyledLabel("Tax: ...", Color.CYAN);
+
+		// Row: Liquidity
 		JLabel liquidityLabel = CardWidgets.createStyledLabel("Liquidity: ...", Color.CYAN);
 
-		// Row 7: Risk: X (Rating)
+		// Row: Risk
 		JLabel riskLabel = CardWidgets.createStyledLabel("Risk: ...", COLOR_YELLOW);
 
-		// Add all rows with small spacing
-		CardWidgets.addLabelsWithSpacing(detailsPanel, pricesLabel, qtyLabel, taxLabel, marginLabel,
-			profitCostLabel, liquidityLabel, riskLabel);
+		CardWidgets.addLabelsWithSpacing(detailsPanel, pricesLabel, buyLimitLabel, marginLabel,
+			currentProfitLabel, profitPotentialLabel);
+		// Deliberate blank spacer separating the pricing/profit block from tax/risk
+		detailsPanel.add(Box.createRigidArea(new Dimension(0, 8)));
+		CardWidgets.addLabelsWithSpacing(detailsPanel, taxLabel, liquidityLabel, riskLabel);
 
 		if (offerDispositionLookup != null)
 		{
@@ -3243,146 +3246,9 @@ public class FlipFinderPanel extends PluginPanel
 		panel.add(topPanel, BorderLayout.NORTH);
 		panel.add(detailsPanel, BorderLayout.CENTER);
 
-		// Fetch current market data to populate all fields
-		apiClient.getItemAnalysisAsync(flip.getItemId()).thenAccept(analysis ->
-		{
-			SwingUtilities.invokeLater(() ->
-			{
-				Integer currentMarketPrice = null;
-				Integer dailyVolume = null;
-				Integer buyLimit = null;
-				FlipAnalysis.Liquidity liquidity = null;
-				FlipAnalysis.Risk risk = null;
-				
-				if (analysis != null)
-				{
-					buyLimit = analysis.getBuyLimit();
-					liquidity = analysis.getLiquidity();
-					risk = analysis.getRisk();
-					
-					if (analysis.getCurrentPrices() != null)
-					{
-						FlipAnalysis.CurrentPrices prices = analysis.getCurrentPrices();
-						currentMarketPrice = prices.getHigh();
-					}
-					
-					// Get daily volume from liquidity info
-					if (liquidity != null && liquidity.getTotalVolumePerHour() != null)
-					{
-						dailyVolume = (int)(liquidity.getTotalVolumePerHour() * 24);
-					}
-				}
-				
-				// Session is the source of truth for sell price (initial smart-sell or
-				// any subsequent adjustment writes there). Only fall through to the
-				// freshly-computed smart-sell when the session has nothing yet.
-				PlayerSession session = plugin.getSession();
-				Integer sessionPrice = session != null ? session.getRecommendedPrice(flip.getItemId()) : null;
-				Integer smartSellPrice = (sessionPrice != null && sessionPrice > 0)
-					? sessionPrice
-					: SmartSellPricer.calculateSmartSellPrice(flip, currentMarketPrice);
-				boolean pastThreshold = SmartSellPricer.shouldUseLossMinimizingPrice(flip, dailyVolume);
-
-				if (smartSellPrice != null && smartSellPrice > 0)
-				{
-					if ((sessionPrice == null || sessionPrice <= 0) && session != null)
-					{
-						session.setRecommendedPrice(flip.getItemId(), smartSellPrice);
-					}
-					displayedSellPrices.put(flip.getItemId(), smartSellPrice);
-					
-					// Apply background color based on price comparison with original recommendation
-					// Green if selling higher than recommended, red if selling lower
-					Integer recommendedPrice = flip.getRecommendedSellPrice();
-					if (recommendedPrice != null && recommendedPrice > 0 && !smartSellPrice.equals(recommendedPrice))
-					{
-						Color priceIndicatorBg = smartSellPrice > recommendedPrice 
-							? COLOR_PRICE_HIGHER_BG  // Green - selling higher than estimate
-							: COLOR_PRICE_LOWER_BG;  // Red - selling lower than estimate
-						
-						// Apply to panel and all child panels (not focused panel - that has its own style)
-						if (currentFocus == null || currentFocus.getItemId() != flip.getItemId())
-						{
-							CardWidgets.applyPriceIndicatorBackground(panel, topPanel, namePanel, detailsPanel, priceIndicatorBg);
-						}
-					}
-					
-					// Update Flip Assist if this item is currently focused
-					if (currentFocus != null && currentFocus.getItemId() == flip.getItemId() && currentFocus.isSelling())
-					{
-						int priceOffset = config.priceOffset();
-						FocusedFlip updatedFocus = FocusedFlip.forSell(
-							flip.getItemId(),
-							flip.getItemName(),
-							smartSellPrice,
-							flip.getTotalQuantity(),
-							priceOffset
-						);
-						currentFocus = updatedFocus;
-						if (onFocusChanged != null)
-						{
-							onFocusChanged.accept(updatedFocus);
-						}
-					}
-					
-					// Row 1: Update Buy | Sell prices
-					String priceSuffix = pastThreshold ? "*" : "";
-					pricesLabel.setText(String.format("Buy: %s | Sell: %s%s", 
-						PanelFormat.formatGPExact(flip.getAverageBuyPrice()),
-						PanelFormat.formatGPExact(smartSellPrice),
-						priceSuffix));
-
-					int geTax = GeTax.taxFor(flip.getItemId(), smartSellPrice);
-
-					// Calculate margin and profit
-					int marginPerItem = smartSellPrice - flip.getAverageBuyPrice() - geTax;
-					int totalProfit = marginPerItem * flip.getTotalQuantity();
-					double roi = (marginPerItem * 100.0) / flip.getAverageBuyPrice();
-					
-					// Row 2: Update Qty (Limit) | Tax
-					String limitText = buyLimit != null ? String.valueOf(buyLimit) : "?";
-					qtyLabel.setText(String.format("Qty: %d (Limit: %s)", flip.getTotalQuantity(), limitText));
-					taxLabel.setText(String.format("Tax = %s", PanelFormat.formatGP(geTax * flip.getTotalQuantity())));
-					
-					// Row 3: Update Margin with ROI (show warning color if not profitable)
-					marginLabel.setText(PanelFormat.formatMarginText(marginPerItem, roi, totalProfit <= 0));
-					marginLabel.setForeground(totalProfit <= 0 ? COLOR_LOSS_RED : COLOR_YELLOW);
-					
-					// Row 4: Update Profit | Cost - use cyan for higher sell, orange for lower
-					profitCostLabel.setText(PanelFormat.formatProfitCostText(totalProfit, flip.getTotalInvested()));
-					if (totalProfit <= 0)
-					{
-						profitCostLabel.setForeground(COLOR_LOSS_RED);
-					}
-					else if (recommendedPrice != null && recommendedPrice > 0 && smartSellPrice > recommendedPrice)
-					{
-						profitCostLabel.setForeground(Color.CYAN);  // Cyan for higher-than-expected profit
-					}
-					else
-					{
-						profitCostLabel.setForeground(COLOR_PROFIT_GREEN);
-					}
-					
-					// Show warning tooltip if past threshold and losing money
-					if (pastThreshold && totalProfit < 0)
-					{
-						panel.setToolTipText("Price adjusted to minimize loss. Original recommended price was not achievable.");
-					}
-				}
-				else
-				{
-					pricesLabel.setText(PanelFormat.formatBuySellText(flip.getAverageBuyPrice(), null));
-					marginLabel.setText("Margin: N/A");
-					profitCostLabel.setText(String.format("Profit: N/A | Cost: %s", PanelFormat.formatGP(flip.getTotalInvested())));
-				}
-				
-				// Row 5: Update Liquidity
-				updateLiquidityLabel(liquidityLabel, liquidity);
-				
-				// Row 6: Update Risk
-				updateRiskLabel(riskLabel, risk);
-			});
-		});
+		populateActiveFlipCard(flip, panel, topPanel, namePanel, detailsPanel,
+			pricesLabel, buyLimitLabel, marginLabel, currentProfitLabel, profitPotentialLabel,
+			taxLabel, liquidityLabel, riskLabel);
 
 		// Store default background color as client property (will be overwritten if price indicator is applied)
 		panel.putClientProperty("baseBackgroundColor", ColorScheme.DARKER_GRAY_COLOR);
@@ -3460,6 +3326,122 @@ public class FlipFinderPanel extends PluginPanel
 		});
 
 		return panel;
+	}
+
+	/**
+	 * Fetch fresh market analysis for an active-flip card and (re)populate its rows.
+	 * Reused by the initial card build and the manual refresh button. The smart-sell
+	 * price is still computed to drive the session write, focus update and price-indicator
+	 * background, even though it is no longer displayed.
+	 */
+	private void populateActiveFlipCard(ActiveFlip flip, JPanel panel, JPanel topPanel, JPanel namePanel,
+		JPanel detailsPanel, JLabel pricesLabel, JLabel buyLimitLabel, JLabel marginLabel,
+		JLabel currentProfitLabel, JLabel profitPotentialLabel, JLabel taxLabel,
+		JLabel liquidityLabel, JLabel riskLabel)
+	{
+		apiClient.getItemAnalysisAsync(flip.getItemId()).thenAccept(analysis ->
+			SwingUtilities.invokeLater(() ->
+			{
+				Integer high = null;
+				Integer low = null;
+				Integer buyLimit = null;
+				FlipAnalysis.Liquidity liquidity = null;
+				FlipAnalysis.Risk risk = null;
+
+				if (analysis != null)
+				{
+					buyLimit = analysis.getBuyLimit();
+					liquidity = analysis.getLiquidity();
+					risk = analysis.getRisk();
+					if (analysis.getCurrentPrices() != null)
+					{
+						high = analysis.getCurrentPrices().getHigh();
+						low = analysis.getCurrentPrices().getLow();
+					}
+				}
+
+				// --- Preserved side effects: smart-sell drives session/focus/background ---
+				PlayerSession session = plugin.getSession();
+				Integer sessionPrice = session != null ? session.getRecommendedPrice(flip.getItemId()) : null;
+				Integer smartSellPrice = (sessionPrice != null && sessionPrice > 0)
+					? sessionPrice
+					: SmartSellPricer.calculateSmartSellPrice(flip, high);
+				if (smartSellPrice != null && smartSellPrice > 0)
+				{
+					if ((sessionPrice == null || sessionPrice <= 0) && session != null)
+					{
+						session.setRecommendedPrice(flip.getItemId(), smartSellPrice);
+					}
+					displayedSellPrices.put(flip.getItemId(), smartSellPrice);
+
+					Integer recommendedPrice = flip.getRecommendedSellPrice();
+					if (recommendedPrice != null && recommendedPrice > 0 && !smartSellPrice.equals(recommendedPrice)
+						&& (currentFocus == null || currentFocus.getItemId() != flip.getItemId()))
+					{
+						Color priceIndicatorBg = smartSellPrice > recommendedPrice
+							? COLOR_PRICE_HIGHER_BG
+							: COLOR_PRICE_LOWER_BG;
+						CardWidgets.applyPriceIndicatorBackground(panel, topPanel, namePanel, detailsPanel, priceIndicatorBg);
+					}
+
+					if (currentFocus != null && currentFocus.getItemId() == flip.getItemId() && currentFocus.isSelling())
+					{
+						FocusedFlip updatedFocus = FocusedFlip.forSell(
+							flip.getItemId(), flip.getItemName(), smartSellPrice,
+							flip.getTotalQuantity(), config.priceOffset());
+						currentFocus = updatedFocus;
+						if (onFocusChanged != null)
+						{
+							onFocusChanged.accept(updatedFocus);
+						}
+					}
+				}
+
+				// --- Redesigned display rows (market-based) ---
+				if (high != null && high > 0 && low != null && low > 0)
+				{
+					long firstBuyMs = flip.getFirstBuyTime() != null
+						? TimeUtils.parseIsoToMillis(flip.getFirstBuyTime())
+						: 0L;
+					RealizedFlipProfit.Result realized = RealizedFlipProfit.compute(
+						plugin.getOfferStore().forItem(flip.getItemId()), flip.getItemId(),
+						flip.getAverageBuyPrice(), firstBuyMs);
+
+					int margin = high - low;
+					double roi = low > 0 ? (margin * 100.0) / low : 0.0;
+					long fullQty = (long) realized.soldQuantity + flip.getTotalQuantity();
+					long profitPotential = (long) margin * fullQty;
+					long cost = (long) low * fullQty;
+					int perItemTax = GeTax.taxFor(flip.getItemId(), high);
+					long totalTax = (long) perItemTax * fullQty;
+
+					pricesLabel.setText(PanelFormat.formatMarketBuySellText(low, high));
+					buyLimitLabel.setText(String.format("Buy limit: %s",
+						buyLimit != null ? PanelFormat.formatGPExact(buyLimit) : "?"));
+
+					marginLabel.setText(PanelFormat.formatCurrentMarginText(margin, roi));
+					marginLabel.setForeground(margin < 0 ? COLOR_LOSS_RED : COLOR_PROFIT_GREEN);
+
+					currentProfitLabel.setText(PanelFormat.formatCurrentProfitText(realized.netProfit));
+					currentProfitLabel.setForeground(realized.netProfit < 0 ? COLOR_LOSS_RED : COLOR_PROFIT_GREEN);
+
+					profitPotentialLabel.setText(PanelFormat.formatProfitPotentialText(profitPotential, cost));
+					profitPotentialLabel.setForeground(profitPotential < 0 ? COLOR_LOSS_RED : COLOR_PROFIT_GREEN);
+
+					taxLabel.setText(PanelFormat.formatTaxSplitText(perItemTax, totalTax));
+				}
+				else
+				{
+					pricesLabel.setText("Buy: N/A | Sell: N/A");
+					marginLabel.setText("Current Margin: N/A");
+					currentProfitLabel.setText("Current Profit: N/A");
+					profitPotentialLabel.setText("Profit Potential: N/A");
+					taxLabel.setText("Tax: N/A");
+				}
+
+				updateLiquidityLabel(liquidityLabel, liquidity);
+				updateRiskLabel(riskLabel, risk);
+			}));
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipSmartConfig.java
+++ b/src/main/java/com/flipsmart/FlipSmartConfig.java
@@ -611,7 +611,16 @@ public interface FlipSmartConfig extends Config
 		return true;
 	}
 
-	// Hidden — coming soon, not exposed in UI
+	// Hidden — coming soon, not exposed in UI. Needs @ConfigItem so RuneLite's config
+	// proxy resolves the default (false) instead of returning null and NPE-ing on unbox.
+	@ConfigItem(
+		keyName = "notifyFlipSuggestion",
+		name = "Flip Suggestion",
+		description = "Notify when a new flip suggestion is available",
+		section = NOTIFICATIONS_SECTION,
+		position = 2,
+		hidden = true
+	)
 	default boolean notifyFlipSuggestion()
 	{
 		return false;

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -705,11 +705,16 @@ public class FlipSmartPlugin extends Plugin
 
 	public void updateInventoryHighlightForFocus(FocusedFlip focus)
 	{
-		inventoryHighlightOverlay.clearAll();
-		if (focus != null && focus.isSelling())
+		// The overlay canonicalizes item ids, which RuneLite requires on the client thread.
+		// Clear + add run together so a rapid focus change can't leave a stale highlight.
+		clientThread.invoke(() ->
 		{
-			inventoryHighlightOverlay.addHighlight(focus.getItemId());
-		}
+			inventoryHighlightOverlay.clearAll();
+			if (focus != null && focus.isSelling())
+			{
+				inventoryHighlightOverlay.addHighlight(focus.getItemId());
+			}
+		});
 	}
 
 	public void handleAutoRecommendFocusChanged(FocusedFlip focus)

--- a/src/main/java/com/flipsmart/trading/ActiveFlipCardMetrics.java
+++ b/src/main/java/com/flipsmart/trading/ActiveFlipCardMetrics.java
@@ -4,7 +4,7 @@ import com.flipsmart.util.GeTax;
 
 /**
  * Market-based metrics for an active-flip card row (margin, ROI, profit potential,
- * tax split, break-even position). Pure: a function of the supplied prices and
+ * total tax, break-even position). Pure: a function of the supplied prices and
  * quantities, independent of Swing state.
  */
 public final class ActiveFlipCardMetrics
@@ -14,17 +14,14 @@ public final class ActiveFlipCardMetrics
 		public final int margin;
 		public final double roi;
 		public final long profitPotential;
-		public final int perItemTax;
 		public final long totalTax;
 		public final int positionNetPerUnit;
 
-		Result(int margin, double roi, long profitPotential, int perItemTax,
-			long totalTax, int positionNetPerUnit)
+		Result(int margin, double roi, long profitPotential, long totalTax, int positionNetPerUnit)
 		{
 			this.margin = margin;
 			this.roi = roi;
 			this.profitPotential = profitPotential;
-			this.perItemTax = perItemTax;
 			this.totalTax = totalTax;
 			this.positionNetPerUnit = positionNetPerUnit;
 		}
@@ -53,6 +50,6 @@ public final class ActiveFlipCardMetrics
 		long totalTax = (long) perItemTax * fullQuantity;
 		int positionNetPerUnit = high - averageBuyPrice - perItemTax;
 
-		return new Result(margin, roi, profitPotential, perItemTax, totalTax, positionNetPerUnit);
+		return new Result(margin, roi, profitPotential, totalTax, positionNetPerUnit);
 	}
 }

--- a/src/main/java/com/flipsmart/trading/ActiveFlipCardMetrics.java
+++ b/src/main/java/com/flipsmart/trading/ActiveFlipCardMetrics.java
@@ -14,18 +14,16 @@ public final class ActiveFlipCardMetrics
 		public final int margin;
 		public final double roi;
 		public final long profitPotential;
-		public final long cost;
 		public final int perItemTax;
 		public final long totalTax;
 		public final int positionNetPerUnit;
 
-		Result(int margin, double roi, long profitPotential, long cost, int perItemTax,
+		Result(int margin, double roi, long profitPotential, int perItemTax,
 			long totalTax, int positionNetPerUnit)
 		{
 			this.margin = margin;
 			this.roi = roi;
 			this.profitPotential = profitPotential;
-			this.cost = cost;
 			this.perItemTax = perItemTax;
 			this.totalTax = totalTax;
 			this.positionNetPerUnit = positionNetPerUnit;
@@ -51,11 +49,10 @@ public final class ActiveFlipCardMetrics
 		double roi = low > 0 ? (margin * 100.0) / low : 0.0;
 		long fullQuantity = (long) realizedSoldQuantity + remainingQuantity;
 		long profitPotential = (long) margin * fullQuantity;
-		long cost = (long) low * fullQuantity;
 		int perItemTax = GeTax.taxFor(itemId, high);
 		long totalTax = (long) perItemTax * fullQuantity;
 		int positionNetPerUnit = high - averageBuyPrice - perItemTax;
 
-		return new Result(margin, roi, profitPotential, cost, perItemTax, totalTax, positionNetPerUnit);
+		return new Result(margin, roi, profitPotential, perItemTax, totalTax, positionNetPerUnit);
 	}
 }

--- a/src/main/java/com/flipsmart/trading/ActiveFlipCardMetrics.java
+++ b/src/main/java/com/flipsmart/trading/ActiveFlipCardMetrics.java
@@ -1,0 +1,61 @@
+package com.flipsmart.trading;
+
+import com.flipsmart.util.GeTax;
+
+/**
+ * Market-based metrics for an active-flip card row (margin, ROI, profit potential,
+ * tax split, break-even position). Pure: a function of the supplied prices and
+ * quantities, independent of Swing state.
+ */
+public final class ActiveFlipCardMetrics
+{
+	public static final class Result
+	{
+		public final int margin;
+		public final double roi;
+		public final long profitPotential;
+		public final long cost;
+		public final int perItemTax;
+		public final long totalTax;
+		public final int positionNetPerUnit;
+
+		Result(int margin, double roi, long profitPotential, long cost, int perItemTax,
+			long totalTax, int positionNetPerUnit)
+		{
+			this.margin = margin;
+			this.roi = roi;
+			this.profitPotential = profitPotential;
+			this.cost = cost;
+			this.perItemTax = perItemTax;
+			this.totalTax = totalTax;
+			this.positionNetPerUnit = positionNetPerUnit;
+		}
+	}
+
+	private ActiveFlipCardMetrics()
+	{
+	}
+
+	/**
+	 * @param low             current market low (instant-buy target)
+	 * @param high            current market high (instant-sell target)
+	 * @param itemId          item id, for the GE tax-exempt list
+	 * @param averageBuyPrice player's average buy price for the flip
+	 * @param realizedSoldQuantity units already sold and realized this flip
+	 * @param remainingQuantity    units still held (flip.getTotalQuantity())
+	 */
+	public static Result compute(int low, int high, int itemId, int averageBuyPrice,
+		int realizedSoldQuantity, int remainingQuantity)
+	{
+		int margin = high - low;
+		double roi = low > 0 ? (margin * 100.0) / low : 0.0;
+		long fullQuantity = (long) realizedSoldQuantity + remainingQuantity;
+		long profitPotential = (long) margin * fullQuantity;
+		long cost = (long) low * fullQuantity;
+		int perItemTax = GeTax.taxFor(itemId, high);
+		long totalTax = (long) perItemTax * fullQuantity;
+		int positionNetPerUnit = high - averageBuyPrice - perItemTax;
+
+		return new Result(margin, roi, profitPotential, cost, perItemTax, totalTax, positionNetPerUnit);
+	}
+}

--- a/src/main/java/com/flipsmart/trading/ActiveFlipCardMetrics.java
+++ b/src/main/java/com/flipsmart/trading/ActiveFlipCardMetrics.java
@@ -13,15 +13,13 @@ public final class ActiveFlipCardMetrics
 	{
 		public final int margin;
 		public final double roi;
-		public final long profitPotential;
 		public final long totalTax;
 		public final int positionNetPerUnit;
 
-		Result(int margin, double roi, long profitPotential, long totalTax, int positionNetPerUnit)
+		Result(int margin, double roi, long totalTax, int positionNetPerUnit)
 		{
 			this.margin = margin;
 			this.roi = roi;
-			this.profitPotential = profitPotential;
 			this.totalTax = totalTax;
 			this.positionNetPerUnit = positionNetPerUnit;
 		}
@@ -45,11 +43,10 @@ public final class ActiveFlipCardMetrics
 		int margin = high - low;
 		double roi = low > 0 ? (margin * 100.0) / low : 0.0;
 		long fullQuantity = (long) realizedSoldQuantity + remainingQuantity;
-		long profitPotential = (long) margin * fullQuantity;
 		int perItemTax = GeTax.taxFor(itemId, high);
 		long totalTax = (long) perItemTax * fullQuantity;
 		int positionNetPerUnit = high - averageBuyPrice - perItemTax;
 
-		return new Result(margin, roi, profitPotential, totalTax, positionNetPerUnit);
+		return new Result(margin, roi, totalTax, positionNetPerUnit);
 	}
 }

--- a/src/main/java/com/flipsmart/trading/RealizedFlipProfit.java
+++ b/src/main/java/com/flipsmart/trading/RealizedFlipProfit.java
@@ -1,0 +1,68 @@
+package com.flipsmart.trading;
+
+import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.util.GeTax;
+import java.util.List;
+
+/**
+ * Realized profit on the units of an active flip that have actually sold, computed
+ * from locally-tracked GE sell fills. Pure: a function of the supplied records.
+ */
+public final class RealizedFlipProfit
+{
+	public static final class Result
+	{
+		public final int soldQuantity;
+		public final long grossProceeds;
+		public final long taxTotal;
+		public final long netProfit;
+
+		Result(int soldQuantity, long grossProceeds, long taxTotal, long netProfit)
+		{
+			this.soldQuantity = soldQuantity;
+			this.grossProceeds = grossProceeds;
+			this.taxTotal = taxTotal;
+			this.netProfit = netProfit;
+		}
+	}
+
+	private RealizedFlipProfit()
+	{
+	}
+
+	/**
+	 * @param itemRecords     all offer records for the item (e.g. OfferStore.forItem)
+	 * @param itemId          item id, for the GE tax-exempt list
+	 * @param averageBuyPrice player's average buy price for the flip
+	 * @param sinceMillis     include only sells last active at/after this epoch-ms
+	 *                        (the current flip's first-buy time); 0 includes all
+	 */
+	public static Result compute(List<OfferRecord> itemRecords, int itemId, int averageBuyPrice, long sinceMillis)
+	{
+		int soldQuantity = 0;
+		long grossProceeds = 0L;
+		long taxTotal = 0L;
+
+		if (itemRecords != null)
+		{
+			for (OfferRecord r : itemRecords)
+			{
+				if (r == null || r.isBuy() || r.getFilledQuantity() <= 0)
+				{
+					continue;
+				}
+				if (r.getEffectiveLastActivityAtMillis() < sinceMillis)
+				{
+					continue;
+				}
+				soldQuantity += r.getFilledQuantity();
+				grossProceeds += r.getSpent();
+				taxTotal += (long) GeTax.taxFor(itemId, r.getPrice()) * r.getFilledQuantity();
+			}
+		}
+
+		long buyCost = (long) soldQuantity * averageBuyPrice;
+		long netProfit = grossProceeds - buyCost - taxTotal;
+		return new Result(soldQuantity, grossProceeds, taxTotal, netProfit);
+	}
+}

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -28,8 +28,7 @@ public final class PanelFormat
 	private static final String FORMAT_VOLUME = "Volume: %s/day";
 	private static final String FORMAT_RISK = "Risk: %.0f (%s)";
 	private static final String FORMAT_CURRENT_MARGIN = "Current Margin: %s gp (%.1f%% ROI)";
-	private static final String FORMAT_CURRENT_PROFIT = "Current Profit: %s";
-	private static final String FORMAT_PROFIT_POTENTIAL = "Profit Potential: %s | Cost: %s";
+	private static final String FORMAT_PROFIT_COMBINED = "Current Profit: %s | Potential: %s";
 	private static final String FORMAT_TAX_SPLIT = "Tax: %s | %s";
 	private static final String UNKNOWN_RATING = "Unknown";
 	private static final String LIQUIDITY_NA = "Liquidity: N/A";
@@ -197,16 +196,14 @@ public final class PanelFormat
 		return String.format(FORMAT_CURRENT_MARGIN, signedShort(marginGp), roiPercent);
 	}
 
-	/** Current Profit: realized net on units sold so far (signed short form, no suffix). */
-	public static String formatCurrentProfitText(long netProfit)
+	/**
+	 * One-line profit row: realized net on units sold so far (signed, explicit +) and
+	 * projected full-flip potential (signed). Cost dropped to keep the card compact.
+	 */
+	public static String formatProfitCombinedText(long realizedNet, long potential)
 	{
-		return String.format(FORMAT_CURRENT_PROFIT, signedShort(clampInt(netProfit)));
-	}
-
-	/** Profit Potential | Cost: profit is signed short; cost is unsigned short. */
-	public static String formatProfitPotentialText(long profit, long cost)
-	{
-		return String.format(FORMAT_PROFIT_POTENTIAL, GpUtils.formatGPSigned(clampInt(profit)), formatGP(clampInt(cost)));
+		return String.format(FORMAT_PROFIT_COMBINED, signedShort(clampInt(realizedNet)),
+			GpUtils.formatGPSigned(clampInt(potential)));
 	}
 
 	/** Tax: per-item (exact) | total (short). */

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -236,17 +236,27 @@ public final class PanelFormat
 	}
 
 	/**
+	 * Shared setup for a transparent icon canvas: antialiasing on, cleared to fully
+	 * transparent so the icon draws over a blank background instead of opaque black.
+	 */
+	private static Graphics2D createTransparentIconGraphics(BufferedImage icon)
+	{
+		Graphics2D g = icon.createGraphics();
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+		g.setComposite(AlphaComposite.Clear);
+		g.fillRect(0, 0, icon.getWidth(), icon.getHeight());
+		g.setComposite(AlphaComposite.SrcOver);
+		return g;
+	}
+
+	/**
 	 * Draw a bar chart icon onto a 14x14 image with the given colors.
 	 */
 	public static BufferedImage drawChartIcon(Color barColor, Color baselineColor)
 	{
 		BufferedImage icon = new BufferedImage(14, 14, BufferedImage.TYPE_INT_ARGB);
-		Graphics2D g = icon.createGraphics();
-		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-
-		g.setComposite(AlphaComposite.Clear);
-		g.fillRect(0, 0, 14, 14);
-		g.setComposite(AlphaComposite.SrcOver);
+		Graphics2D g = createTransparentIconGraphics(icon);
 
 		g.setColor(barColor);
 		g.fillRect(1, 9, 3, 4);   // Short bar
@@ -266,12 +276,7 @@ public final class PanelFormat
 	public static BufferedImage drawClockIcon(Color color)
 	{
 		BufferedImage icon = new BufferedImage(12, 12, BufferedImage.TYPE_INT_ARGB);
-		Graphics2D g = icon.createGraphics();
-		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-
-		g.setComposite(AlphaComposite.Clear);
-		g.fillRect(0, 0, 12, 12);
-		g.setComposite(AlphaComposite.SrcOver);
+		Graphics2D g = createTransparentIconGraphics(icon);
 
 		g.setColor(color);
 		g.setStroke(new BasicStroke(1.2f));
@@ -329,12 +334,7 @@ public final class PanelFormat
 	public static BufferedImage drawBlockIcon(Color color)
 	{
 		BufferedImage icon = new BufferedImage(14, 14, BufferedImage.TYPE_INT_ARGB);
-		Graphics2D g = icon.createGraphics();
-		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-
-		g.setComposite(AlphaComposite.Clear);
-		g.fillRect(0, 0, 14, 14);
-		g.setComposite(AlphaComposite.SrcOver);
+		Graphics2D g = createTransparentIconGraphics(icon);
 
 		g.setColor(color);
 		g.setStroke(new BasicStroke(1.5f));
@@ -351,12 +351,7 @@ public final class PanelFormat
 	public static BufferedImage drawRefreshIcon(Color color)
 	{
 		BufferedImage icon = new BufferedImage(14, 14, BufferedImage.TYPE_INT_ARGB);
-		Graphics2D g = icon.createGraphics();
-		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-
-		g.setComposite(AlphaComposite.Clear);
-		g.fillRect(0, 0, 14, 14);
-		g.setComposite(AlphaComposite.SrcOver);
+		Graphics2D g = createTransparentIconGraphics(icon);
 
 		g.setColor(color);
 		g.setStroke(new BasicStroke(1.5f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -27,6 +27,11 @@ public final class PanelFormat
 	private static final String FORMAT_LIQUIDITY = "Liquidity: %.0f (%s) | %s";
 	private static final String FORMAT_VOLUME = "Volume: %s/day";
 	private static final String FORMAT_RISK = "Risk: %.0f (%s)";
+	private static final String FORMAT_BUY_INSTASELL = "Buy: %s | insta-sell: %s";
+	private static final String FORMAT_CURRENT_MARGIN = "Current Margin: %s gp (%.1f%% ROI)";
+	private static final String FORMAT_CURRENT_PROFIT = "Current Profit: %s";
+	private static final String FORMAT_PROFIT_POTENTIAL = "Profit Potential: %s | Cost: %s";
+	private static final String FORMAT_TAX_SPLIT = "Tax: %s | %s";
 	private static final String UNKNOWN_RATING = "Unknown";
 	private static final String LIQUIDITY_NA = "Liquidity: N/A";
 	private static final String VOLUME_NA = "Volume: N/A";
@@ -179,6 +184,56 @@ public final class PanelFormat
 			? formatGPExact(sellPrice)
 			: "N/A";
 		return String.format(FORMAT_BUY_SELL, formatGPExact(buyPrice), sellText);
+	}
+
+	/** Row 1: market low labeled "Buy", market high labeled "insta-sell" (labels intentionally inverted per design). */
+	public static String formatBuyInstaSellText(int low, int high)
+	{
+		return String.format(FORMAT_BUY_INSTASELL, formatGPExact(low), formatGPExact(high));
+	}
+
+	/** Current Margin: gross market spread (signed, " gp") with ROI percentage. */
+	public static String formatCurrentMarginText(int marginGp, double roiPercent)
+	{
+		return String.format(FORMAT_CURRENT_MARGIN, signedShort(marginGp), roiPercent);
+	}
+
+	/** Current Profit: realized net on units sold so far (signed short form, no suffix). */
+	public static String formatCurrentProfitText(long netProfit)
+	{
+		return String.format(FORMAT_CURRENT_PROFIT, signedShort(clampInt(netProfit)));
+	}
+
+	/** Profit Potential | Cost: profit is signed short; cost is unsigned short. */
+	public static String formatProfitPotentialText(long profit, long cost)
+	{
+		return String.format(FORMAT_PROFIT_POTENTIAL, GpUtils.formatGPSigned(clampInt(profit)), formatGP(clampInt(cost)));
+	}
+
+	/** Tax: per-item (exact) | total (short). */
+	public static String formatTaxSplitText(int perItem, long total)
+	{
+		return String.format(FORMAT_TAX_SPLIT, formatGPExact(perItem), formatGP(clampInt(total)));
+	}
+
+	/** Short-form gp with an explicit '+' on positive values ("+6", "-6", "0"). */
+	private static String signedShort(int v)
+	{
+		return (v > 0 ? "+" : "") + GpUtils.formatGPSigned(v);
+	}
+
+	/** Saturating cast of a long into the int range for the gp formatters. */
+	private static int clampInt(long v)
+	{
+		if (v > Integer.MAX_VALUE)
+		{
+			return Integer.MAX_VALUE;
+		}
+		if (v < Integer.MIN_VALUE)
+		{
+			return Integer.MIN_VALUE;
+		}
+		return (int) v;
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -225,6 +225,12 @@ public final class PanelFormat
 		return htmlRow(coloured(HEX_MUTED, "Tax: " + formatGP(clampInt(total))));
 	}
 
+	/** Qty: progress/total in the muted secondary colour (e.g. "Qty: 3/5"). */
+	public static String qtyHtml(int done, long total)
+	{
+		return htmlRow(coloured(HEX_MUTED, "Qty: " + done + "/" + total));
+	}
+
 	/** Wrap card-row content as a Swing HTML label body. */
 	private static String htmlRow(String inner)
 	{

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -219,6 +219,12 @@ public final class PanelFormat
 			+ coloured(colour, GpUtils.formatGPSigned(clampInt(potential))));
 	}
 
+	/** Tax: whole row in the muted secondary colour, matching the Potential label. */
+	public static String taxHtml(long total)
+	{
+		return htmlRow(coloured(HEX_MUTED, "Tax: " + formatGP(clampInt(total))));
+	}
+
 	/** Wrap card-row content as a Swing HTML label body. */
 	private static String htmlRow(String inner)
 	{

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -27,9 +27,13 @@ public final class PanelFormat
 	private static final String FORMAT_LIQUIDITY = "Liquidity: %.0f (%s) | %s";
 	private static final String FORMAT_VOLUME = "Volume: %s/day";
 	private static final String FORMAT_RISK = "Risk: %.0f (%s)";
-	private static final String FORMAT_CURRENT_MARGIN = "Current Margin: %s gp (%.1f%% ROI)";
-	private static final String FORMAT_PROFIT_COMBINED = "Current Profit: %s | Potential: %s";
-	private static final String FORMAT_TAX_SPLIT = "Tax: %s | %s";
+	// Value colours for the active-flip card HTML rows (hex, no leading #).
+	private static final String HEX_PRICE_LOW = "6fb1ff";    // market low (buy side)
+	private static final String HEX_PRICE_HIGH = "ffab54";   // market high (sell side)
+	private static final String HEX_PROFIT = "5ee66e";       // green: profit
+	private static final String HEX_LOSS = "ff6b6b";         // red: loss
+	private static final String HEX_PROFIT_LABEL = "ffce54"; // gold: "Current Profit" label
+	private static final String HEX_MUTED = "9aa0a8";        // gray: secondary label
 	private static final String UNKNOWN_RATING = "Unknown";
 	private static final String LIQUIDITY_NA = "Liquidity: N/A";
 	private static final String VOLUME_NA = "Volume: N/A";
@@ -184,38 +188,35 @@ public final class PanelFormat
 		return String.format(FORMAT_BUY_SELL, formatGPExact(buyPrice), sellText);
 	}
 
-	/** Row 1: market low labeled "Buy", market high labeled "Sell". */
-	public static String formatMarketBuySellText(int low, int high)
+	/** Top "live" price row: market low (blue) | market high (orange); label keeps the label colour. */
+	public static String livePriceHtml(int low, int high)
 	{
-		return String.format(FORMAT_BUY_SELL, formatGPExact(low), formatGPExact(high));
+		return "<html>Live Price: <font color='#" + HEX_PRICE_LOW + "'>" + formatGPExact(low)
+			+ "</font> | <font color='#" + HEX_PRICE_HIGH + "'>" + formatGPExact(high) + "</font></html>";
 	}
 
-	/** Current Margin: gross market spread (signed, " gp") with ROI percentage. */
-	public static String formatCurrentMarginText(int marginGp, double roiPercent)
+	/** Live Margin: gross market spread coloured green (profit) / red (loss), with ROI. No "+" prefix. */
+	public static String liveMarginHtml(int margin, double roiPercent)
 	{
-		return String.format(FORMAT_CURRENT_MARGIN, signedShort(marginGp), roiPercent);
+		String colour = margin < 0 ? HEX_LOSS : HEX_PROFIT;
+		return "<html>Live Margin: <font color='#" + colour + "'>" + GpUtils.formatGPSigned(margin)
+			+ String.format(" (%.1f%% ROI)", roiPercent) + "</font></html>";
 	}
 
-	/**
-	 * One-line profit row: realized net on units sold so far (signed, explicit +) and
-	 * projected full-flip potential (signed). Cost dropped to keep the card compact.
-	 */
-	public static String formatProfitCombinedText(long realizedNet, long potential)
+	/** Current Profit: gold label + realized value coloured green (profit) / red (loss). */
+	public static String currentProfitHtml(long realizedNet)
 	{
-		return String.format(FORMAT_PROFIT_COMBINED, signedShort(clampInt(realizedNet)),
-			GpUtils.formatGPSigned(clampInt(potential)));
+		String colour = realizedNet < 0 ? HEX_LOSS : HEX_PROFIT;
+		return "<html><font color='#" + HEX_PROFIT_LABEL + "'>Current Profit: </font><font color='#"
+			+ colour + "'>" + GpUtils.formatGPSigned(clampInt(realizedNet)) + "</font></html>";
 	}
 
-	/** Tax: per-item (exact) | total (short). */
-	public static String formatTaxSplitText(int perItem, long total)
+	/** Potential: muted label + projected value coloured green (profit) / red (loss). */
+	public static String potentialHtml(long potential)
 	{
-		return String.format(FORMAT_TAX_SPLIT, formatGPExact(perItem), formatGP(clampInt(total)));
-	}
-
-	/** Short-form gp with an explicit '+' on positive values ("+6", "-6", "0"). */
-	private static String signedShort(int v)
-	{
-		return (v > 0 ? "+" : "") + GpUtils.formatGPSigned(v);
+		String colour = potential < 0 ? HEX_LOSS : HEX_PROFIT;
+		return "<html><font color='#" + HEX_MUTED + "'>Potential: </font><font color='#"
+			+ colour + "'>" + GpUtils.formatGPSigned(clampInt(potential)) + "</font></html>";
 	}
 
 	/** Saturating cast of a long into the int range for the gp formatters. */

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -211,12 +211,12 @@ public final class PanelFormat
 			+ coloured(colour, GpUtils.formatGPSigned(clampInt(realizedNet))));
 	}
 
-	/** Potential: muted label + projected value coloured green (profit) / red (loss). */
-	public static String potentialHtml(long potential)
+	/** Max Potential Profit: muted label + value coloured green (profit) / red (loss). */
+	public static String maxPotentialProfitHtml(long maxProfit)
 	{
-		String colour = potential < 0 ? HEX_LOSS : HEX_PROFIT;
-		return htmlRow(coloured(HEX_MUTED, "Potential: ")
-			+ coloured(colour, GpUtils.formatGPSigned(clampInt(potential))));
+		String colour = maxProfit < 0 ? HEX_LOSS : HEX_PROFIT;
+		return htmlRow(coloured(HEX_MUTED, "Max Potential Profit: ")
+			+ coloured(colour, GpUtils.formatGPSigned(clampInt(maxProfit))));
 	}
 
 	/** Tax: whole row in the muted secondary colour, matching the Potential label. */

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -27,7 +27,6 @@ public final class PanelFormat
 	private static final String FORMAT_LIQUIDITY = "Liquidity: %.0f (%s) | %s";
 	private static final String FORMAT_VOLUME = "Volume: %s/day";
 	private static final String FORMAT_RISK = "Risk: %.0f (%s)";
-	private static final String FORMAT_MARKET_BUY_SELL = "Buy: %s | Sell: %s";
 	private static final String FORMAT_CURRENT_MARGIN = "Current Margin: %s gp (%.1f%% ROI)";
 	private static final String FORMAT_CURRENT_PROFIT = "Current Profit: %s";
 	private static final String FORMAT_PROFIT_POTENTIAL = "Profit Potential: %s | Cost: %s";
@@ -189,7 +188,7 @@ public final class PanelFormat
 	/** Row 1: market low labeled "Buy", market high labeled "Sell". */
 	public static String formatMarketBuySellText(int low, int high)
 	{
-		return String.format(FORMAT_MARKET_BUY_SELL, formatGPExact(low), formatGPExact(high));
+		return String.format(FORMAT_BUY_SELL, formatGPExact(low), formatGPExact(high));
 	}
 
 	/** Current Margin: gross market spread (signed, " gp") with ROI percentage. */

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -27,7 +27,7 @@ public final class PanelFormat
 	private static final String FORMAT_LIQUIDITY = "Liquidity: %.0f (%s) | %s";
 	private static final String FORMAT_VOLUME = "Volume: %s/day";
 	private static final String FORMAT_RISK = "Risk: %.0f (%s)";
-	private static final String FORMAT_BUY_INSTASELL = "Buy: %s | insta-sell: %s";
+	private static final String FORMAT_MARKET_BUY_SELL = "Buy: %s | Sell: %s";
 	private static final String FORMAT_CURRENT_MARGIN = "Current Margin: %s gp (%.1f%% ROI)";
 	private static final String FORMAT_CURRENT_PROFIT = "Current Profit: %s";
 	private static final String FORMAT_PROFIT_POTENTIAL = "Profit Potential: %s | Cost: %s";
@@ -186,10 +186,10 @@ public final class PanelFormat
 		return String.format(FORMAT_BUY_SELL, formatGPExact(buyPrice), sellText);
 	}
 
-	/** Row 1: market low labeled "Buy", market high labeled "insta-sell" (labels intentionally inverted per design). */
-	public static String formatBuyInstaSellText(int low, int high)
+	/** Row 1: market low labeled "Buy", market high labeled "Sell". */
+	public static String formatMarketBuySellText(int low, int high)
 	{
-		return String.format(FORMAT_BUY_INSTASELL, formatGPExact(low), formatGPExact(high));
+		return String.format(FORMAT_MARKET_BUY_SELL, formatGPExact(low), formatGPExact(high));
 	}
 
 	/** Current Margin: gross market spread (signed, " gp") with ROI percentage. */

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -191,32 +191,44 @@ public final class PanelFormat
 	/** Top "live" price row: market low (blue) | market high (orange); label keeps the label colour. */
 	public static String livePriceHtml(int low, int high)
 	{
-		return "<html>Live Price: <font color='#" + HEX_PRICE_LOW + "'>" + formatGPExact(low)
-			+ "</font> | <font color='#" + HEX_PRICE_HIGH + "'>" + formatGPExact(high) + "</font></html>";
+		return htmlRow("Live Price: " + coloured(HEX_PRICE_LOW, formatGPExact(low))
+			+ " | " + coloured(HEX_PRICE_HIGH, formatGPExact(high)));
 	}
 
 	/** Live Margin: gross market spread coloured green (profit) / red (loss), with ROI. No "+" prefix. */
 	public static String liveMarginHtml(int margin, double roiPercent)
 	{
 		String colour = margin < 0 ? HEX_LOSS : HEX_PROFIT;
-		return "<html>Live Margin: <font color='#" + colour + "'>" + GpUtils.formatGPSigned(margin)
-			+ String.format(" (%.1f%% ROI)", roiPercent) + "</font></html>";
+		return htmlRow("Live Margin: "
+			+ coloured(colour, GpUtils.formatGPSigned(margin) + String.format(" (%.1f%% ROI)", roiPercent)));
 	}
 
 	/** Current Profit: gold label + realized value coloured green (profit) / red (loss). */
 	public static String currentProfitHtml(long realizedNet)
 	{
 		String colour = realizedNet < 0 ? HEX_LOSS : HEX_PROFIT;
-		return "<html><font color='#" + HEX_PROFIT_LABEL + "'>Current Profit: </font><font color='#"
-			+ colour + "'>" + GpUtils.formatGPSigned(clampInt(realizedNet)) + "</font></html>";
+		return htmlRow(coloured(HEX_PROFIT_LABEL, "Current Profit: ")
+			+ coloured(colour, GpUtils.formatGPSigned(clampInt(realizedNet))));
 	}
 
 	/** Potential: muted label + projected value coloured green (profit) / red (loss). */
 	public static String potentialHtml(long potential)
 	{
 		String colour = potential < 0 ? HEX_LOSS : HEX_PROFIT;
-		return "<html><font color='#" + HEX_MUTED + "'>Potential: </font><font color='#"
-			+ colour + "'>" + GpUtils.formatGPSigned(clampInt(potential)) + "</font></html>";
+		return htmlRow(coloured(HEX_MUTED, "Potential: ")
+			+ coloured(colour, GpUtils.formatGPSigned(clampInt(potential))));
+	}
+
+	/** Wrap card-row content as a Swing HTML label body. */
+	private static String htmlRow(String inner)
+	{
+		return "<html>" + inner + "</html>";
+	}
+
+	/** Colour a span of text with the given hex (no leading #). */
+	private static String coloured(String hex, String text)
+	{
+		return "<font color='#" + hex + "'>" + text + "</font>";
 	}
 
 	/** Saturating cast of a long into the int range for the gp formatters. */

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -347,6 +347,31 @@ public final class PanelFormat
 	}
 
 	/**
+	 * Draw a circular-arrow refresh icon onto a 14x14 image with the given color.
+	 */
+	public static BufferedImage drawRefreshIcon(Color color)
+	{
+		BufferedImage icon = new BufferedImage(14, 14, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = icon.createGraphics();
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+		g.setComposite(AlphaComposite.Clear);
+		g.fillRect(0, 0, 14, 14);
+		g.setComposite(AlphaComposite.SrcOver);
+
+		g.setColor(color);
+		g.setStroke(new BasicStroke(1.5f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+		// ~300-degree arc leaves a gap at the top-right for the arrowhead
+		g.drawArc(2, 2, 9, 9, 60, 300);
+		// arrowhead at the arc's open end
+		g.drawLine(11, 3, 11, 6);
+		g.drawLine(11, 3, 8, 3);
+
+		g.dispose();
+		return icon;
+	}
+
+	/**
 	 * Get the base background color for a panel (either price indicator color or default).
 	 * Checks for stored client property first, falls back to default color.
 	 */

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -376,12 +376,11 @@ public final class PanelFormat
 		Graphics2D g = createTransparentIconGraphics(icon);
 
 		g.setColor(color);
-		g.setStroke(new BasicStroke(1.5f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
-		// ~300-degree arc leaves a gap at the top-right for the arrowhead
-		g.drawArc(2, 2, 9, 9, 60, 300);
-		// arrowhead at the arc's open end
-		g.drawLine(11, 3, 11, 6);
-		g.drawLine(11, 3, 8, 3);
+		g.setStroke(new BasicStroke(1.8f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_ROUND));
+		// Open ring (~250 deg) with a clear gap at the top-right where the arrowhead sits
+		g.drawArc(3, 4, 8, 8, 30, 250);
+		// Solid arrowhead at the ring's open (top-right) end, tip pointing right = clockwise reload
+		g.fillPolygon(new int[] {8, 13, 9}, new int[] {1, 4, 7}, 3);
 
 		g.dispose();
 		return icon;

--- a/src/test/java/com/flipsmart/trading/RealizedFlipProfitTest.java
+++ b/src/test/java/com/flipsmart/trading/RealizedFlipProfitTest.java
@@ -1,0 +1,68 @@
+package com.flipsmart.trading;
+
+import static org.junit.Assert.assertEquals;
+import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.domain.offer.OfferState;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+public class RealizedFlipProfitTest
+{
+	private static final int ITEM_ID = 12934; // Zulrah's scales (not tax-exempt)
+
+	private static OfferRecord sell(int qty, int price, long spent, long activityMs)
+	{
+		// newOffer(offerId, slot, itemId, itemName, buy=false, totalQuantity, price, now)
+		return OfferRecord.newOffer(1L, 0, ITEM_ID, "Zulrah's scales", false, qty, price, activityMs)
+			.withFill(qty, spent, OfferState.FILLED, activityMs);
+	}
+
+	private static OfferRecord buy(int qty, int price, long spent, long activityMs)
+	{
+		return OfferRecord.newOffer(2L, 1, ITEM_ID, "Zulrah's scales", true, qty, price, activityMs)
+			.withFill(qty, spent, OfferState.FILLED, activityMs);
+	}
+
+	@Test
+	public void noSellsYieldsZero()
+	{
+		RealizedFlipProfit.Result r = RealizedFlipProfit.compute(Collections.emptyList(), ITEM_ID, 173, 0L);
+		assertEquals(0, r.soldQuantity);
+		assertEquals(0L, r.grossProceeds);
+		assertEquals(0L, r.netProfit);
+	}
+
+	@Test
+	public void buyRecordsAreIgnored()
+	{
+		List<OfferRecord> recs = Collections.singletonList(buy(100, 173, 17_300L, 1000L));
+		RealizedFlipProfit.Result r = RealizedFlipProfit.compute(recs, ITEM_ID, 173, 0L);
+		assertEquals(0, r.soldQuantity);
+		assertEquals(0L, r.netProfit);
+	}
+
+	@Test
+	public void realizedNetIsProceedsMinusBuyCostMinusTax()
+	{
+		// sell 1000 @ 179 => proceeds 179,000; tax = taxFor(179)*1000; buyCost = 1000*173
+		OfferRecord s = sell(1000, 179, 179_000L, 5000L);
+		RealizedFlipProfit.Result r = RealizedFlipProfit.compute(Collections.singletonList(s), ITEM_ID, 173, 0L);
+		long expectedTax = (long) com.flipsmart.util.GeTax.taxFor(ITEM_ID, 179) * 1000;
+		assertEquals(1000, r.soldQuantity);
+		assertEquals(179_000L, r.grossProceeds);
+		assertEquals(expectedTax, r.taxTotal);
+		assertEquals(179_000L - (1000L * 173) - expectedTax, r.netProfit);
+	}
+
+	@Test
+	public void sellsBeforeCutoffAreExcluded()
+	{
+		OfferRecord older = sell(500, 179, 89_500L, 1000L);
+		OfferRecord newer = sell(500, 179, 89_500L, 9000L);
+		RealizedFlipProfit.Result r = RealizedFlipProfit.compute(Arrays.asList(older, newer), ITEM_ID, 173, 5000L);
+		assertEquals(500, r.soldQuantity); // only the newer sell counts
+		assertEquals(89_500L, r.grossProceeds);
+	}
+}

--- a/src/test/java/com/flipsmart/ui/panel/PanelFormatActiveFlipsTest.java
+++ b/src/test/java/com/flipsmart/ui/panel/PanelFormatActiveFlipsTest.java
@@ -21,18 +21,16 @@ public class PanelFormatActiveFlipsTest
 	}
 
 	@Test
-	public void currentProfitIsSignedShortForm()
+	public void profitCombinedShowsRealizedSignedAndPotential()
 	{
-		assertEquals("Current Profit: +1.2M", PanelFormat.formatCurrentProfitText(1_200_000L));
-		assertEquals("Current Profit: -500.0K", PanelFormat.formatCurrentProfitText(-500_000L));
-		assertEquals("Current Profit: 0", PanelFormat.formatCurrentProfitText(0L));
-	}
-
-	@Test
-	public void profitPotentialProfitSignedCostUnsigned()
-	{
-		assertEquals("Profit Potential: 180.0K | Cost: 3.6M", PanelFormat.formatProfitPotentialText(180_000L, 3_600_000L));
-		assertEquals("Profit Potential: -12.0K | Cost: 1.0M", PanelFormat.formatProfitPotentialText(-12_000L, 1_000_000L));
+		assertEquals("Current Profit: +35.0K | Potential: 539.0K",
+			PanelFormat.formatProfitCombinedText(35_000L, 539_000L));
+		assertEquals("Current Profit: +1.2M | Potential: 180.0K",
+			PanelFormat.formatProfitCombinedText(1_200_000L, 180_000L));
+		assertEquals("Current Profit: -12.0K | Potential: -5.0K",
+			PanelFormat.formatProfitCombinedText(-12_000L, -5_000L));
+		assertEquals("Current Profit: 0 | Potential: 0",
+			PanelFormat.formatProfitCombinedText(0L, 0L));
 	}
 
 	@Test

--- a/src/test/java/com/flipsmart/ui/panel/PanelFormatActiveFlipsTest.java
+++ b/src/test/java/com/flipsmart/ui/panel/PanelFormatActiveFlipsTest.java
@@ -1,0 +1,44 @@
+package com.flipsmart.ui.panel;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class PanelFormatActiveFlipsTest
+{
+	@Test
+	public void buyInstaSellShowsLowThenHighWithCommas()
+	{
+		assertEquals("Buy: 173 | insta-sell: 179", PanelFormat.formatBuyInstaSellText(173, 179));
+		assertEquals("Buy: 1,234 | insta-sell: 5,678", PanelFormat.formatBuyInstaSellText(1234, 5678));
+	}
+
+	@Test
+	public void currentMarginIsSignedGpWithRoi()
+	{
+		assertEquals("Current Margin: +6 gp (3.5% ROI)", PanelFormat.formatCurrentMarginText(6, 3.468));
+		assertEquals("Current Margin: -4 gp (-2.3% ROI)", PanelFormat.formatCurrentMarginText(-4, -2.31));
+		assertEquals("Current Margin: 0 gp (0.0% ROI)", PanelFormat.formatCurrentMarginText(0, 0.0));
+	}
+
+	@Test
+	public void currentProfitIsSignedShortForm()
+	{
+		assertEquals("Current Profit: +1.2M", PanelFormat.formatCurrentProfitText(1_200_000L));
+		assertEquals("Current Profit: -500.0K", PanelFormat.formatCurrentProfitText(-500_000L));
+		assertEquals("Current Profit: 0", PanelFormat.formatCurrentProfitText(0L));
+	}
+
+	@Test
+	public void profitPotentialProfitSignedCostUnsigned()
+	{
+		assertEquals("Profit Potential: 180.0K | Cost: 3.6M", PanelFormat.formatProfitPotentialText(180_000L, 3_600_000L));
+		assertEquals("Profit Potential: -12.0K | Cost: 1.0M", PanelFormat.formatProfitPotentialText(-12_000L, 1_000_000L));
+	}
+
+	@Test
+	public void taxSplitPerItemExactTotalShort()
+	{
+		assertEquals("Tax: 2 | 60.0K", PanelFormat.formatTaxSplitText(2, 60_000L));
+		assertEquals("Tax: 1,000 | 5.0M", PanelFormat.formatTaxSplitText(1000, 5_000_000L));
+	}
+}

--- a/src/test/java/com/flipsmart/ui/panel/PanelFormatActiveFlipsTest.java
+++ b/src/test/java/com/flipsmart/ui/panel/PanelFormatActiveFlipsTest.java
@@ -6,10 +6,10 @@ import org.junit.Test;
 public class PanelFormatActiveFlipsTest
 {
 	@Test
-	public void buyInstaSellShowsLowThenHighWithCommas()
+	public void marketBuySellShowsLowThenHighWithCommas()
 	{
-		assertEquals("Buy: 173 | insta-sell: 179", PanelFormat.formatBuyInstaSellText(173, 179));
-		assertEquals("Buy: 1,234 | insta-sell: 5,678", PanelFormat.formatBuyInstaSellText(1234, 5678));
+		assertEquals("Buy: 173 | Sell: 179", PanelFormat.formatMarketBuySellText(173, 179));
+		assertEquals("Buy: 1,234 | Sell: 5,678", PanelFormat.formatMarketBuySellText(1234, 5678));
 	}
 
 	@Test

--- a/src/test/java/com/flipsmart/ui/panel/PanelFormatActiveFlipsTest.java
+++ b/src/test/java/com/flipsmart/ui/panel/PanelFormatActiveFlipsTest.java
@@ -36,10 +36,13 @@ public class PanelFormatActiveFlipsTest
 	}
 
 	@Test
-	public void potentialMutedLabelValueColouredBySign()
+	public void maxPotentialProfitMutedLabelValueColouredBySign()
 	{
 		assertEquals(
-			"<html><font color='#9aa0a8'>Potential: </font><font color='#5ee66e'>539.0K</font></html>",
-			PanelFormat.potentialHtml(539_000L));
+			"<html><font color='#9aa0a8'>Max Potential Profit: </font><font color='#5ee66e'>178.5K</font></html>",
+			PanelFormat.maxPotentialProfitHtml(178_500L));
+		assertEquals(
+			"<html><font color='#9aa0a8'>Max Potential Profit: </font><font color='#ff6b6b'>-49.6K</font></html>",
+			PanelFormat.maxPotentialProfitHtml(-49_600L));
 	}
 }

--- a/src/test/java/com/flipsmart/ui/panel/PanelFormatActiveFlipsTest.java
+++ b/src/test/java/com/flipsmart/ui/panel/PanelFormatActiveFlipsTest.java
@@ -6,37 +6,40 @@ import org.junit.Test;
 public class PanelFormatActiveFlipsTest
 {
 	@Test
-	public void marketBuySellShowsLowThenHighWithCommas()
+	public void livePriceColoursLowBlueHighOrangeWithCommas()
 	{
-		assertEquals("Buy: 173 | Sell: 179", PanelFormat.formatMarketBuySellText(173, 179));
-		assertEquals("Buy: 1,234 | Sell: 5,678", PanelFormat.formatMarketBuySellText(1234, 5678));
+		assertEquals(
+			"<html>Live Price: <font color='#6fb1ff'>1,500,000</font> | <font color='#ffab54'>2,000,000</font></html>",
+			PanelFormat.livePriceHtml(1_500_000, 2_000_000));
 	}
 
 	@Test
-	public void currentMarginIsSignedGpWithRoi()
+	public void liveMarginGreenOnProfitRedOnLossNoPlusSign()
 	{
-		assertEquals("Current Margin: +6 gp (3.5% ROI)", PanelFormat.formatCurrentMarginText(6, 3.468));
-		assertEquals("Current Margin: -4 gp (-2.3% ROI)", PanelFormat.formatCurrentMarginText(-4, -2.31));
-		assertEquals("Current Margin: 0 gp (0.0% ROI)", PanelFormat.formatCurrentMarginText(0, 0.0));
+		assertEquals(
+			"<html>Live Margin: <font color='#5ee66e'>60.0K (1.5% ROI)</font></html>",
+			PanelFormat.liveMarginHtml(60_000, 1.5));
+		assertEquals(
+			"<html>Live Margin: <font color='#ff6b6b'>-4.0K (-2.3% ROI)</font></html>",
+			PanelFormat.liveMarginHtml(-4_000, -2.31));
 	}
 
 	@Test
-	public void profitCombinedShowsRealizedSignedAndPotential()
+	public void currentProfitGoldLabelValueColouredBySign()
 	{
-		assertEquals("Current Profit: +35.0K | Potential: 539.0K",
-			PanelFormat.formatProfitCombinedText(35_000L, 539_000L));
-		assertEquals("Current Profit: +1.2M | Potential: 180.0K",
-			PanelFormat.formatProfitCombinedText(1_200_000L, 180_000L));
-		assertEquals("Current Profit: -12.0K | Potential: -5.0K",
-			PanelFormat.formatProfitCombinedText(-12_000L, -5_000L));
-		assertEquals("Current Profit: 0 | Potential: 0",
-			PanelFormat.formatProfitCombinedText(0L, 0L));
+		assertEquals(
+			"<html><font color='#ffce54'>Current Profit: </font><font color='#5ee66e'>35.0K</font></html>",
+			PanelFormat.currentProfitHtml(35_000L));
+		assertEquals(
+			"<html><font color='#ffce54'>Current Profit: </font><font color='#ff6b6b'>-12.0K</font></html>",
+			PanelFormat.currentProfitHtml(-12_000L));
 	}
 
 	@Test
-	public void taxSplitPerItemExactTotalShort()
+	public void potentialMutedLabelValueColouredBySign()
 	{
-		assertEquals("Tax: 2 | 60.0K", PanelFormat.formatTaxSplitText(2, 60_000L));
-		assertEquals("Tax: 1,000 | 5.0M", PanelFormat.formatTaxSplitText(1000, 5_000_000L));
+		assertEquals(
+			"<html><font color='#9aa0a8'>Potential: </font><font color='#5ee66e'>539.0K</font></html>",
+			PanelFormat.potentialHtml(539_000L));
 	}
 }

--- a/src/test/java/com/flipsmart/ui/panel/RefreshIconTest.java
+++ b/src/test/java/com/flipsmart/ui/panel/RefreshIconTest.java
@@ -1,0 +1,39 @@
+package com.flipsmart.ui.panel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import org.junit.Test;
+
+public class RefreshIconTest
+{
+	@Test
+	public void drawsFourteenBySfourteenIcon()
+	{
+		BufferedImage icon = PanelFormat.drawRefreshIcon(new Color(120, 200, 255));
+		assertNotNull(icon);
+		assertEquals(14, icon.getWidth());
+		assertEquals(14, icon.getHeight());
+	}
+
+	@Test
+	public void drawsAtLeastOneVisiblePixel()
+	{
+		BufferedImage icon = PanelFormat.drawRefreshIcon(new Color(120, 200, 255));
+		boolean anyOpaque = false;
+		for (int x = 0; x < 14 && !anyOpaque; x++)
+		{
+			for (int y = 0; y < 14; y++)
+			{
+				if (((icon.getRGB(x, y) >>> 24) & 0xFF) > 0)
+				{
+					anyOpaque = true;
+					break;
+				}
+			}
+		}
+		assertTrue("expected the refresh glyph to draw visible pixels", anyOpaque);
+	}
+}


### PR DESCRIPTION
## Summary
Redesigns the plugin's Active Flips side-panel card into a two-block layout — a top "live" block for at-a-glance market info and a bottom block for the trade position — and adds a per-card manual refresh button.

## Card layout

Top "live" block (instant market info):
- `Live Price: <low> | <high>` — current market low (blue) and high (orange)
- `Live Margin: <high−low> (<roi>% ROI)` — gross market spread; green on profit, red on loss
- `Tax: <total>` — total GE tax for the flip (small, muted)

— divider —

Reference block (the trade position):
- `Current Profit: <realized net>` — realized profit on units sold so far; gold label, green/red value
- `Potential: <market margin × full flip qty>` — projected whole-flip profit (small)
- `Liquidity` / `Risk` — unchanged, repositioned

Header: item name, block/chart icons, and a refresh icon; `Buy limit` shown in the header corner.

## Behavior
- Realized "Current Profit" is computed client-side from locally-tracked GE fills (`RealizedFlipProfit`). Accepted limitation: counts fills seen this session or restored on this device only.
- Per-value colors are rendered via HTML; no `+`/`-` glyphs — color signals profit/loss (a real loss still shows a natural `-`).
- Break-even loss tooltip on the card when selling at the current price would be below your buy price + tax.
- Refresh button (Active-Flips cards only): invalidates the cached analysis and re-fetches current prices, updating the live rows; briefly disabled while in flight.

## Design deviations from the original ticket ACs (agreed during design)
- Profit Potential and total Tax scale by the flip's full quantity, not the buy limit.
- The redesign went through the "Buy | Sell" → "Live Price" naming and merged/split profit rows per author feedback; the smart-sell price and its `*` flag were removed from the card (still computed internally to drive focus/background).

## Fixes discovered during QA
- Off-thread `itemManager.canonicalize` crash on the auto-recommend focus path — fixed by wrapping the inventory-highlight clear+add in a single `clientThread.invoke(...)` at `updateInventoryHighlightForFocus` (canonicalize on the client thread; clear+add atomic).

## Testing
- Unit tests: `PanelFormat` HTML row formatters, `RealizedFlipProfit`, refresh icon.
- `./gradlew build` green (compile + checkstyle + full suite); Codacy quality gate green.
- Manual in-game QA of card layout/colors and refresh behavior: final pass pending by the author.

## Follow-up / out of scope
- #961 — `clampInt` long-overflow edge (deferred, tracked separately).

Part of Flip-Smart/flip-smart#956
