### PR TITLE
fix(flip-assist): highlight follows current prompt + consistent prompt icon

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -95,6 +95,10 @@ public class AutoRecommendService
 	private static final String MSG_SELL_FORMAT = "Auto: Sell %s @ %s";
 	private static final String MSG_BUY_FORMAT = "Auto: Buy %s @ %s";
 
+	// Coins icon for the sell-side "Collect profit" prompt, so every collect prompt
+	// carries an icon (buy collects show the item; sell collects show coins).
+	private static final int COINS_ITEM_ID = 995;
+
 
 	private final FlipSmartConfig config;
 	private final FlipSmartPlugin plugin;
@@ -135,7 +139,10 @@ public class AutoRecommendService
 	// ObjIntConsumer<message, itemId> — itemId <= 0 means no icon
 	private volatile ObjIntConsumer<String> onOverlayMessageChanged;
 
-	private volatile java.util.function.IntConsumer onStaleOfferPrompted;
+	// Clears all transient slot highlights and lights the live slot for the given
+	// item. Used by both the stale re-sell prompt and the collect prompt so the
+	// bright box always tracks the currently-prompted item.
+	private volatile java.util.function.IntConsumer onHighlightItemSlot;
 
 	// Clears all GE slot adjustment highlights when the stale-offer queue drains,
 	// so a slot highlight never lingers without a matching prompt.
@@ -223,9 +230,9 @@ public class AutoRecommendService
 		this.onOverlayMessageChanged = callback;
 	}
 
-	public void setOnStaleOfferPrompted(java.util.function.IntConsumer callback)
+	public void setOnHighlightItemSlot(java.util.function.IntConsumer callback)
 	{
-		this.onStaleOfferPrompted = callback;
+		this.onHighlightItemSlot = callback;
 	}
 
 	public void setOnClearAllHighlights(Runnable callback)
@@ -1715,11 +1722,35 @@ public class AutoRecommendService
 		updateStatus("Auto: " + overlayMsg);
 		invokeFocusCallback(null);
 		invokeOverlayMessageCallback(overlayMsg, offer.getItemId());
+		highlightItemSlot(offer.getItemId());
+	}
 
-		java.util.function.IntConsumer staleCallback = onStaleOfferPrompted;
-		if (staleCallback != null)
+	/**
+	 * Clear transient slot highlights and light the live GE slot for {@code itemId}
+	 * so the bright box matches the currently-prompted item (the wired callback,
+	 * {@code highlightSlotForItem}, clears then sets). Sticky skip-reminder boxes on
+	 * other slots are preserved (and rendered dimmed) by the overlay.
+	 */
+	private void highlightItemSlot(int itemId)
+	{
+		java.util.function.IntConsumer cb = onHighlightItemSlot;
+		if (cb != null)
 		{
-			staleCallback.accept(offer.getItemId());
+			cb.accept(itemId);
+		}
+	}
+
+	/**
+	 * Drop all transient slot highlights when a no-focus prompt has no slot of its
+	 * own to point at (monitoring / waiting), so a bright box from a prior focus
+	 * doesn't linger under it. Sticky skip-reminder boxes are preserved.
+	 */
+	private void clearTransientHighlights()
+	{
+		Runnable cb = onClearAllHighlights;
+		if (cb != null)
+		{
+			cb.run();
 		}
 	}
 
@@ -2742,8 +2773,10 @@ public class AutoRecommendService
 		else
 		{
 			updateStatus("Auto: Collect profit from GE");
-			invokeOverlayMessageCallback("Collect profit from GE");
+			invokeOverlayMessageCallback("Collect profit from GE", COINS_ITEM_ID);
 		}
+		// Light the collect target's own slot so the highlight matches the prompt.
+		highlightItemSlot(target.getItemId());
 	}
 
 	private void promptCollection()
@@ -2770,17 +2803,23 @@ public class AutoRecommendService
 			else
 			{
 				updateStatus("Auto: Collect profit from GE");
-				invokeOverlayMessageCallback("Collect profit from GE");
+				invokeOverlayMessageCallback("Collect profit from GE", COINS_ITEM_ID);
 			}
+			// Light the collect target's own slot so the highlight matches the prompt.
+			highlightItemSlot(first.getItemId());
 		}
 		else if (adjustments.hasBuyDeadlines() || adjustments.hasSellStates())
 		{
+			// Monitoring/waiting prompts point at no slot of their own, so drop any
+			// bright box left over from a prior focus rather than let it linger.
+			clearTransientHighlights();
 			// Offers are being monitored for staleness — don't say "Waiting for flips"
 			updateStatus("Auto: Monitoring active offers");
 			invokeOverlayMessageCallback("Monitoring active offers");
 		}
 		else
 		{
+			clearTransientHighlights();
 			if (!plugin.isPremium() && !hasAvailableGESlots())
 			{
 				updateStatus("Auto: Waiting for flips");

--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -314,7 +314,12 @@ public class FlipAssistOverlay extends Overlay
 			{
 				return null;
 			}
-			return renderHintBox(graphics, message);
+			// The icon must track the message actually shown: only the item-carrying
+			// auto-status prompt ("Collect X") gets an icon. History/monitoring/login/
+			// hint prompts outrank it in selectNoFocusMessage but carry no item, so a
+			// leftover autoStatusItemId must not paint an icon onto them.
+			int hintIconItemId = iconForNoFocusMessage(message, autoStatusMessage, autoStatusItemId);
+			return renderHintBox(graphics, message, hintIconItemId);
 		}
 		
 		// Only show when GE is open or when we have an active flip
@@ -380,9 +385,8 @@ public class FlipAssistOverlay extends Overlay
 	 *   "Collect items from GE" subtitle
 	 *   [icon] item name
 	 */
-	private Dimension renderHintBox(Graphics2D graphics, String message)
+	private Dimension renderHintBox(Graphics2D graphics, String message, int itemId)
 	{
-		int itemId = autoStatusItemId;
 		boolean hasIcon = itemId > 0;
 		int hintIconSize = 20;
 
@@ -1037,7 +1041,23 @@ public class FlipAssistOverlay extends Overlay
 		}
 		return hintMessage;
 	}
-	
+
+	/**
+	 * The item icon to draw beside a no-focus hint message. Only the auto-status
+	 * prompt carries an item ("Collect X"); every other message source (history,
+	 * monitoring, login, hint, fallback) is text-only. Returning the item id only
+	 * when the displayed message is exactly the auto-status message keeps the icon
+	 * from bleeding onto a higher-priority text-only prompt.
+	 */
+	static int iconForNoFocusMessage(String displayedMessage, String autoStatusMessage, int autoStatusItemId)
+	{
+		if (autoStatusItemId > 0 && displayedMessage != null && displayedMessage.equals(autoStatusMessage))
+		{
+			return autoStatusItemId;
+		}
+		return 0;
+	}
+
 	private Widget[] getOfferPanelChildren()
 	{
 		Widget offerPanel = client.getWidget(GE_INTERFACE_GROUP, GE_OFFER_PANEL_CHILD);

--- a/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
@@ -304,11 +304,17 @@ public class GrandExchangeSlotOverlay extends Overlay
 	private void renderIndicatorBar(Graphics2D graphics, Rectangle bounds, OfferRecord trackedOffer,
 									GrandExchangeOffer offer, FlipSmartPlugin.OfferCompetitiveness competitiveness, int slot)
 	{
-		// Draw colored border around the entire slot
-		boolean hasAdjustment = adjustmentHighlights.containsKey(slot) || stickyAdjustmentSlots.contains(slot);
-		if (hasAdjustment)
+		// Draw colored border around the entire slot. A current-action highlight
+		// (bright amber pulse) always wins over a skipped-item reminder on the same
+		// slot; a sticky-only slot renders dimmed so it reads as secondary and never
+		// competes with the slot the Flip Assist panel is currently prompting.
+		if (adjustmentHighlights.containsKey(slot))
 		{
 			drawOrangeGlow(graphics, bounds);
+		}
+		else if (stickyAdjustmentSlots.contains(slot))
+		{
+			drawDimReminderGlow(graphics, bounds);
 		}
 		else if (config.highlightSlotBorders() && competitiveness != FlipSmartPlugin.OfferCompetitiveness.UNKNOWN)
 		{
@@ -847,5 +853,25 @@ public class GrandExchangeSlotOverlay extends Overlay
 		graphics.setColor(borderColor);
 		graphics.setStroke(new BasicStroke(2));
 		graphics.drawRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, 4, 4);
+	}
+
+	/**
+	 * Dimmed, non-pulsing amber border for a skipped-item reminder. Kept visually
+	 * subordinate to the bright current-action glow so it reminds without competing
+	 * with the slot the Flip Assist panel is actively prompting.
+	 */
+	private void drawDimReminderGlow(Graphics2D graphics, Rectangle bounds)
+	{
+		Stroke originalStroke = graphics.getStroke();
+		Color reminderColor = new Color(
+			COLOR_FLIP_ASSIST_GLOW.getRed(),
+			COLOR_FLIP_ASSIST_GLOW.getGreen(),
+			COLOR_FLIP_ASSIST_GLOW.getBlue(),
+			90
+		);
+		graphics.setColor(reminderColor);
+		graphics.setStroke(new BasicStroke(2));
+		graphics.drawRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, 4, 4);
+		graphics.setStroke(originalStroke);
 	}
 }

--- a/src/main/java/com/flipsmart/plugin/ServiceWiring.java
+++ b/src/main/java/com/flipsmart/plugin/ServiceWiring.java
@@ -56,7 +56,7 @@ public class ServiceWiring
 		autoRecommendService.setOnFocusChanged(plugin::handleAutoRecommendFocusChanged);
 		autoRecommendService.setOnOverlayMessageChanged(flipAssistOverlay::setAutoStatusMessage);
 		autoRecommendService.setDisplayedSellPriceProvider(itemId -> plugin.getFlipFinderPanel() != null ? plugin.getFlipFinderPanel().getDisplayedSellPrice(itemId) : null);
-		autoRecommendService.setOnStaleOfferPrompted(plugin::highlightSlotForItem);
+		autoRecommendService.setOnHighlightItemSlot(plugin::highlightSlotForItem);
 		autoRecommendService.setOnClearAllHighlights(geSlotOverlay::clearAllAdjustmentHighlights);
 		autoRecommendService.setOnStickyHighlight(geSlotOverlay::setStickyAdjustmentHighlight);
 		autoRecommendService.setOnClearStickyHighlight(geSlotOverlay::clearStickyAdjustmentHighlight);

--- a/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
@@ -173,7 +173,7 @@ public class AutoRecommendDispatchTest {
         service.addToStaleQueue(partialBuy);
 
         AtomicInteger capturedId = new AtomicInteger(-1);
-        service.setOnStaleOfferPrompted(capturedId::set);
+        service.setOnHighlightItemSlot(capturedId::set);
 
         ActionDecision d = service.resolveAndApply(-1);
 
@@ -195,7 +195,7 @@ public class AutoRecommendDispatchTest {
 
         AtomicInteger highlightCalls = new AtomicInteger();
         AtomicInteger lastHighlightItem = new AtomicInteger(-1);
-        service.setOnStaleOfferPrompted(id -> {
+        service.setOnHighlightItemSlot(id -> {
             highlightCalls.incrementAndGet();
             lastHighlightItem.set(id);
         });
@@ -538,6 +538,30 @@ public class AutoRecommendDispatchTest {
         String overlay = service.getLastOverlayMessage();
         assertTrue("overlay must mention item-200, not profit; got: " + overlay,
             overlay != null && overlay.contains("item-200"));
+    }
+
+    @Test
+    public void collectPromptLightsResolverChosenItemSlot() {
+        // The slot highlight must follow the collect prompt: when the resolver picks the
+        // completed BUY (item-200), the highlight callback must fire for 200 — not linger
+        // on the completed SELL (item-100) or any prior focus.
+        when(plugin.getFilledGESlotCount()).thenReturn(8);
+        when(plugin.hasCollectableGEOffers()).thenReturn(true);
+
+        OfferRecord completedSell = OfferRecord
+            .newOffer(1, 0, 100, "item-100", false, 5, 300, 0L)
+            .withFill(5, 1500L, OfferState.FILLED, 1L);
+        OfferRecord completedBuy = OfferRecord
+            .newOffer(2, 5, 200, "item-200", true, 10, 100, 0L)
+            .withFill(10, 1000L, OfferState.FILLED, 2L);
+        offerStore.importRecords(Arrays.asList(completedSell, completedBuy));
+
+        AtomicInteger highlightedItem = new AtomicInteger(-1);
+        service.setOnHighlightItemSlot(highlightedItem::set);
+
+        service.resolveAndApply(-1);
+
+        assertEquals("highlight must follow the collect prompt's item", 200, highlightedItem.get());
     }
 
     // AC1/AC2 (#919): a skipped buy is snoozed for its cooldown, so the next resolve

--- a/src/test/java/com/flipsmart/FlipAssistNoFocusMessageTest.java
+++ b/src/test/java/com/flipsmart/FlipAssistNoFocusMessageTest.java
@@ -118,4 +118,50 @@ public class FlipAssistNoFocusMessageTest
 	{
 		assertEquals(LOGIN, select(false, false, null, null, false, true));
 	}
+
+	// --- iconForNoFocusMessage: the icon must track the DISPLAYED message ---
+
+	private static final String COLLECT_ITEM = "Collect Obsidian platebody";
+	private static final int OBSIDIAN_ID = 21301;
+
+	// The item-carrying auto-status prompt shows its icon.
+	@Test
+	public void iconShownForAutoStatusItemPrompt()
+	{
+		assertEquals(OBSIDIAN_ID,
+			FlipAssistOverlay.iconForNoFocusMessage(COLLECT_ITEM, COLLECT_ITEM, OBSIDIAN_ID));
+	}
+
+	// Bug: a higher-priority text-only prompt (e.g. "Open GE History") must NOT
+	// inherit the leftover item icon from a prior "Collect X" auto-status message.
+	@Test
+	public void noIconWhenHistoryPromptOutranksAutoStatus()
+	{
+		assertEquals(0,
+			FlipAssistOverlay.iconForNoFocusMessage(HIST, COLLECT_ITEM, OBSIDIAN_ID));
+	}
+
+	// A text-only auto-status message (itemId 0, e.g. "Waiting for flips") shows no icon.
+	@Test
+	public void noIconForTextOnlyAutoStatus()
+	{
+		assertEquals(0,
+			FlipAssistOverlay.iconForNoFocusMessage(HINT, HINT, 0));
+	}
+
+	// Null displayed message → no icon.
+	@Test
+	public void noIconForNullMessage()
+	{
+		assertEquals(0,
+			FlipAssistOverlay.iconForNoFocusMessage(null, COLLECT_ITEM, OBSIDIAN_ID));
+	}
+
+	// No auto-status message at all → no icon regardless of leftover id.
+	@Test
+	public void noIconWhenNoAutoStatusMessage()
+	{
+		assertEquals(0,
+			FlipAssistOverlay.iconForNoFocusMessage(MONITOR, null, OBSIDIAN_ID));
+	}
 }


### PR DESCRIPTION
## What & why

Two related Flip Assist auto-mode overlay inconsistencies, both rooted in the prompt being assembled from three independently-set fields — prompt text, prompt icon (`autoStatusItemId`), and GE slot highlight (`adjustmentHighlights`/`stickyAdjustmentSlots`) — that drifted out of sync.

**Bug 1 — wrong slot highlighted.** The panel would say "Collect Obsidian platebody" while the orange box was lit on the Mage's book slot (a skipped re-sell). The collect/monitor prompt path never cleared transient highlights, collect prompts lit no slot of their own, and skipped-item sticky reminders rendered at full brightness.

**Bug 2 — wrong/missing icon.** A "Check GE history" prompt showed a leftover item icon (it outranks the collect message, but the icon still tracked the old item); a sell-side "Collect profit" prompt showed no icon at all.

## Changes
- **Icon binds to the displayed message** (`iconForNoFocusMessage`) — only the item-carrying "Collect X" prompt draws an icon; history/monitoring/login/hint prompts draw none.
- **Sell/profit collects show a coins icon** (995) so every collect prompt is consistent.
- **Highlight follows the current prompt** — collect/re-sell prompts light their own slot in bright amber (`highlightItemSlot`); monitor/waiting prompts clear the transient box (`clearTransientHighlights`). Both synchronous — no deferred clear, avoiding the clear-vs-set EDT race.
- **Skipped-item reminders render dimmed / non-pulsing** (`drawDimReminderGlow`) so the bright box always matches the panel while the skip-cooldown reminder (from the skip-cooldown feature) is preserved.
- Renames `onStaleOfferPrompted` → `onHighlightItemSlot` (now shared by the stale re-sell and collect paths).

Plugin-only; no API/contract change.

## Tests
- `FlipAssistNoFocusMessageTest`: 5 new cases pin `iconForNoFocusMessage` (icon shown for "Collect X"; suppressed for history/text-only/null/no-auto-status prompts).
- `AutoRecommendDispatchTest`: new `collectPromptLightsResolverChosenItemSlot` — the highlight callback fires for the resolver-chosen collect item, not slot-0.
- Full `./gradlew build` green (checkstyle + all tests).

## Manual QA (in-game, auto-mode) — plugin QA is manual
1. Fill two buys of different items.
2. Trigger a re-sell prompt on item A and **skip** it → A's box should go **dim**.
3. Let the resolver surface "Collect B" → **B's slot bright, A's slot dim**, panel shows Collect B with B's icon.
4. Complete offers and collect a **sell** → prompt shows a **coins** icon, not blank.
5. Open the GE **History** tab → history prompt shows **no** item icon.
6. Repeat in colorblind mode → confirm the dim box is still perceptible.

**Watch item:** the dimmed skip-reminder alpha is tuned by eye (no automated coverage). Confirm in-game it's clearly less prominent than the current-action box but still visible.

<details>
<summary>🔎 plugin-reviewer probe — verdict: ship-with-watch</summary>

Root cause named as a new anchor class `decoupled-overlay-triplet-drift`. No top risk ≥63%. EDT clear-vs-set race (anchor `deferred-focus-update-races-refresh`, #757) was applied as a design constraint — the highlight set is kept synchronous and a would-be deferred clear was removed rather than raced. Invariants preserved: the skip-cooldown sticky lifecycle is untouched (only its render style changed); `clearAllAdjustmentHighlights` still preserves sticky. Secondary surface (inline-comment tier): dimmed-reminder perceptibility (60% — the one change with no automated coverage; covered by manual QA step 6). Verdict: **ship-with-watch** — watch the dim rendering during QA.

</details>

### 🩺 Codacy Quality Gate — dismissed via API (noise)
- `Lizard_nloc-medium` `src/main/java/com/flipsmart/FlipAssistOverlay.java:388` — `renderHintBox` (100 lines, limit 50) is pre-existing overlay-rendering complexity (layout math + graphics drawing interleaved); this PR only added the `itemId` param, it didn't grow the method. Dismissed as accepted noise per the Lizard-complexity-on-UI-rendering policy.

### 🤖 Codacy AI Reviewer — deferred (in-thread rationale)
- `src/main/java/com/flipsmart/FlipAssistOverlay.java:388` — suggested extracting a `calculateHintLayout` helper out of `renderHintBox`. Same underlying complexity concern as the dismissed quality-gate finding above; reasonable idea but a standalone refactor out of scope for this icon-consistency fix.

---

Closes Flip-Smart/flip-smart#968

