### PR TITLE
fix(auto): hold slot for a collected buy awaiting its sell price

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -95,6 +95,17 @@ public class AutoRecommendService
 	private static final String MSG_SELL_FORMAT = "Auto: Sell %s @ %s";
 	private static final String MSG_BUY_FORMAT = "Auto: Buy %s @ %s";
 
+	/**
+	 * How long after collecting a buy the resolver keeps holding the free slot for the
+	 * item's sell while its sell price resolves (covers a transient wiki-price timeout).
+	 * Sized to comfortably cover realistic resolution latency — an in-field incident took
+	 * ~47s (a wiki-price timeout on a freshly collected item) and the OSRS wiki /latest is
+	 * ~60s CDN-cached, so a too-short window would let the wrong-buy reappear. Past this
+	 * window auto resumes normal buys so a permanently-stuck price can't wedge trading —
+	 * the held item stays sellable and re-surfaces as a LIST the moment its price lands.
+	 */
+	private static final long PENDING_SELL_PRICE_GRACE_MS = 90_000L;
+
 
 	private final FlipSmartConfig config;
 	private final FlipSmartPlugin plugin;
@@ -872,13 +883,36 @@ public class AutoRecommendService
 		// Retire any sticky boxes whose cooldown lapsed or whose offer is gone before we
 		// decide what to surface (cheap no-op when nothing is sticky).
 		reconcileStickyHighlights();
-		ActionDecision decision = actionResolver.resolve(buildResolverInput(excludeItemId));
+		ResolverInput input = buildResolverInput(excludeItemId);
+		ActionDecision decision = actionResolver.resolve(input);
 		log.debug("Auto-recommend: resolver decision {}/{} item={} slot={}",
 			decision.getKind(), decision.getStep(), decision.getItemId(), decision.getSlot());
 		focusedCollectedItemId = decision.getStep() == ActionStep.LIST ? decision.getItemId() : -1;
 		lastAppliedDecision = decision;
 		applyDecision(decision);
+		// When the only thing we could have done was a buy we suppressed for a pending sell,
+		// tell the player we're holding for that item's price rather than showing a vague wait.
+		// Guarded by staleOffers.isEmpty() so we never clobber a re-sell prompt that
+		// applyDecision(IDLE)->promptCollection surfaces for a cooling-down stale offer (which
+		// the resolver excludes from its input but promptCollection still shows).
+		if (decision.getStep() == ActionStep.NONE && input.isBlockBuyForPendingSell()
+			&& staleOffers.isEmpty())
+		{
+			surfacePendingSellStatus(input.getPendingSellItemId());
+		}
 		return decision;
+	}
+
+	/** Overlay message shown while auto holds a slot for a collected item awaiting its sell price. */
+	private void surfacePendingSellStatus(int itemId)
+	{
+		if (itemId <= 0)
+		{
+			return;
+		}
+		String name = resolveItemName(itemId);
+		updateStatus("Auto: Preparing to sell " + name);
+		invokeOverlayMessageCallback("Preparing to sell " + name, itemId);
 	}
 
 	/**
@@ -902,7 +936,8 @@ public class AutoRecommendService
 		{
 			return;
 		}
-		ActionDecision decision = actionResolver.resolve(buildResolverInput(-1, false));
+		ResolverInput input = buildResolverInput(-1, false);
+		ActionDecision decision = actionResolver.resolve(input);
 		if (decision.equals(lastAppliedDecision))
 		{
 			return;
@@ -912,6 +947,14 @@ public class AutoRecommendService
 		focusedCollectedItemId = decision.getStep() == ActionStep.LIST ? decision.getItemId() : -1;
 		lastAppliedDecision = decision;
 		applyDecision(decision);
+		// Mirror resolveAndApply: when a buy was suppressed for a pending sell, hold with a
+		// clear message instead of the generic wait (keeps both resolve paths consistent).
+		// Same staleOffers guard so a cooling-down re-sell prompt is never clobbered.
+		if (decision.getStep() == ActionStep.NONE && input.isBlockBuyForPendingSell()
+			&& staleOffers.isEmpty())
+		{
+			surfacePendingSellStatus(input.getPendingSellItemId());
+		}
 	}
 
 	private void applyDecision(ActionDecision decision)
@@ -2943,6 +2986,8 @@ public class AutoRecommendService
 		PlayerSession session = plugin.getSession();
 
 		List<CollectedItem> collected = new ArrayList<>();
+		boolean blockBuyForPendingSell = false;
+		int pendingSellItemId = -1;
 		if (session != null)
 		{
 			for (Integer itemId : session.getCollectedItemIds())
@@ -2958,6 +3003,19 @@ public class AutoRecommendService
 				Integer resolvedPrice = resolveBestSellPrice(itemId);
 				if (resolvedPrice == null || resolvedPrice <= 0)
 				{
+					// The sell price hasn't resolved yet (e.g. a transient wiki-price timeout).
+					// For a short grace window after collection, flag a pending sell so the
+					// resolver holds the free slot instead of spending it on a new buy that
+					// would strand this just-collected item. Past the window we fall through,
+					// so a permanently-unresolved price can never wedge trading.
+					if (now - session.getCollectedAtMillis(itemId) < PENDING_SELL_PRICE_GRACE_MS)
+					{
+						blockBuyForPendingSell = true;
+						if (pendingSellItemId < 0)
+						{
+							pendingSellItemId = itemId;
+						}
+					}
 					continue;
 				}
 				CollectOrigin origin = session.getCollectOrigin(itemId);
@@ -2991,10 +3049,10 @@ public class AutoRecommendService
 			.collect(java.util.stream.Collectors.toList());
 		if (logInput)
 		{
-			log.debug("Auto-recommend: resolver input filled={}/{} surfaceableBuy={} (item={}, idx={}) queue={} active={} collected={} stale={} completed={}",
+			log.debug("Auto-recommend: resolver input filled={}/{} surfaceableBuy={} (item={}, idx={}) queue={} active={} collected={} stale={} completed={} pendingSell={}",
 				filledSlots, slotLimit, hasSurfaceable, surfaceableItemId, idx,
 				view.size(), plugin.getActiveFlipItemIds().size(), collected.size(),
-				staleSnapshot.size(), completed.size());
+				staleSnapshot.size(), completed.size(), blockBuyForPendingSell ? pendingSellItemId : -1);
 		}
 
 		return ResolverInput.builder()
@@ -3002,6 +3060,7 @@ public class AutoRecommendService
 			.filledSlotCount(filledSlots)
 			.surfaceableBuy(hasSurfaceable, surfaceableItemId)
 			.nowMillis(now)
+			.blockBuyForPendingSell(blockBuyForPendingSell, pendingSellItemId)
 			.completedAwaitingCollection(completed)
 			.staleOffers(staleSnapshot)
 			.collectedAwaitingList(collected)

--- a/src/main/java/com/flipsmart/recommend/ActionResolver.java
+++ b/src/main/java/com/flipsmart/recommend/ActionResolver.java
@@ -50,7 +50,12 @@ public final class ActionResolver {
             }
         }
 
-        if (in.getFilledSlotCount() < in.getSlotLimit() && in.hasSurfaceableBuy()) {
+        // Suppress a new buy while a just-collected item is awaiting its sell price: the free
+        // slot must be held for the pending sell, not spent on a fresh purchase that would
+        // strand the item we already own. Bounded by a grace window upstream so a permanently
+        // unresolved price can't wedge trading.
+        if (in.getFilledSlotCount() < in.getSlotLimit() && in.hasSurfaceableBuy()
+            && !in.isBlockBuyForPendingSell()) {
             candidates.add(new ActionDecision(ActionKind.S2, ActionStep.PLACE_BUY,
                 in.getSurfaceableBuyItemId(), -1, in.getNowMillis()));
         }

--- a/src/main/java/com/flipsmart/recommend/ResolverInput.java
+++ b/src/main/java/com/flipsmart/recommend/ResolverInput.java
@@ -12,6 +12,8 @@ public final class ResolverInput {
     private final boolean hasSurfaceableBuy;
     private final int surfaceableBuyItemId;
     private final long nowMillis;
+    private final boolean blockBuyForPendingSell;
+    private final int pendingSellItemId;
     private final List<OfferRecord> completedAwaitingCollection;
     private final List<OfferRecord> staleOffers;
     private final List<CollectedItem> collectedAwaitingList;
@@ -22,6 +24,8 @@ public final class ResolverInput {
         this.hasSurfaceableBuy = b.hasSurfaceableBuy;
         this.surfaceableBuyItemId = b.surfaceableBuyItemId;
         this.nowMillis = b.nowMillis;
+        this.blockBuyForPendingSell = b.blockBuyForPendingSell;
+        this.pendingSellItemId = b.pendingSellItemId;
         this.completedAwaitingCollection =
             Collections.unmodifiableList(new ArrayList<>(b.completedAwaitingCollection));
         this.staleOffers =
@@ -35,6 +39,14 @@ public final class ResolverInput {
     public boolean hasSurfaceableBuy() { return hasSurfaceableBuy; }
     public int getSurfaceableBuyItemId() { return surfaceableBuyItemId; }
     public long getNowMillis() { return nowMillis; }
+    /**
+     * True when a just-collected item is awaiting a sell price that has not resolved yet
+     * (e.g. a transient wiki-price timeout) and is still within its grace window. While set,
+     * the resolver suppresses a new S2 buy so the free slot is held for the pending sell
+     * rather than spent on a fresh purchase.
+     */
+    public boolean isBlockBuyForPendingSell() { return blockBuyForPendingSell; }
+    public int getPendingSellItemId() { return pendingSellItemId; }
     public List<OfferRecord> getCompletedAwaitingCollection() { return completedAwaitingCollection; }
     public List<OfferRecord> getStaleOffers() { return staleOffers; }
     public List<CollectedItem> getCollectedAwaitingList() { return collectedAwaitingList; }
@@ -47,6 +59,8 @@ public final class ResolverInput {
         private boolean hasSurfaceableBuy;
         private int surfaceableBuyItemId = -1;
         private long nowMillis;
+        private boolean blockBuyForPendingSell;
+        private int pendingSellItemId = -1;
         private List<OfferRecord> completedAwaitingCollection = new ArrayList<>();
         private List<OfferRecord> staleOffers = new ArrayList<>();
         private List<CollectedItem> collectedAwaitingList = new ArrayList<>();
@@ -57,6 +71,9 @@ public final class ResolverInput {
             this.hasSurfaceableBuy = has; this.surfaceableBuyItemId = itemId; return this;
         }
         public Builder nowMillis(long v) { this.nowMillis = v; return this; }
+        public Builder blockBuyForPendingSell(boolean block, int itemId) {
+            this.blockBuyForPendingSell = block; this.pendingSellItemId = itemId; return this;
+        }
         public Builder completedAwaitingCollection(List<OfferRecord> v) {
             this.completedAwaitingCollection = v; return this;
         }

--- a/src/main/java/com/flipsmart/recommend/ResolverInput.java
+++ b/src/main/java/com/flipsmart/recommend/ResolverInput.java
@@ -24,7 +24,7 @@ public final class ResolverInput {
         this.hasSurfaceableBuy = b.hasSurfaceableBuy;
         this.surfaceableBuyItemId = b.surfaceableBuyItemId;
         this.nowMillis = b.nowMillis;
-        this.blockBuyForPendingSell = b.blockBuyForPendingSell;
+        this.blockBuyForPendingSell = b.blockBuy;
         this.pendingSellItemId = b.pendingSellItemId;
         this.completedAwaitingCollection =
             Collections.unmodifiableList(new ArrayList<>(b.completedAwaitingCollection));
@@ -59,7 +59,7 @@ public final class ResolverInput {
         private boolean hasSurfaceableBuy;
         private int surfaceableBuyItemId = -1;
         private long nowMillis;
-        private boolean blockBuyForPendingSell;
+        private boolean blockBuy;
         private int pendingSellItemId = -1;
         private List<OfferRecord> completedAwaitingCollection = new ArrayList<>();
         private List<OfferRecord> staleOffers = new ArrayList<>();
@@ -72,7 +72,7 @@ public final class ResolverInput {
         }
         public Builder nowMillis(long v) { this.nowMillis = v; return this; }
         public Builder blockBuyForPendingSell(boolean block, int itemId) {
-            this.blockBuyForPendingSell = block; this.pendingSellItemId = itemId; return this;
+            this.blockBuy = block; this.pendingSellItemId = itemId; return this;
         }
         public Builder completedAwaitingCollection(List<OfferRecord> v) {
             this.completedAwaitingCollection = v; return this;

--- a/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
@@ -89,6 +89,36 @@ public class AutoRecommendDispatchTest {
     }
 
     @Test
+    public void collectedBuyAwaitingSellPriceHoldsSlotInsteadOfNewBuy() {
+        // Repro of the in-game bug: a just-collected buy (item 2550) is in inventory but its
+        // sell price hasn't resolved yet (e.g. a wiki-price timeout). Auto must NOT jump to a
+        // new buy (surfaceable item 21 from setUp) — it holds the free slot for the pending sell.
+        when(plugin.getFilledGESlotCount()).thenReturn(7);
+        when(plugin.getInventoryCountForItem(2550)).thenReturn(15000);
+        session.addCollectedItem(2550, 15000, CollectOrigin.COMPLETED_BUY, System.currentTimeMillis());
+        // no recommended price for 2550 → resolveBestSellPrice null → pending sell
+
+        ActionDecision d = service.resolveAndApply(-1);
+
+        assertNotEquals(ActionStep.PLACE_BUY, d.getStep());
+        assertEquals(ActionKind.IDLE, d.getKind());
+    }
+
+    @Test
+    public void collectedBuySurfacesSellOncePriceResolves() {
+        // Once the sell price lands, the held item lists (SELL_WAITING) ahead of a new buy.
+        when(plugin.getFilledGESlotCount()).thenReturn(7);
+        when(plugin.getInventoryCountForItem(2550)).thenReturn(15000);
+        session.addCollectedItem(2550, 15000, CollectOrigin.COMPLETED_BUY, System.currentTimeMillis());
+        session.setRecommendedPrice(2550, 839);
+
+        ActionDecision d = service.resolveAndApply(-1);
+
+        assertEquals(ActionStep.LIST, d.getStep());
+        assertEquals(2550, d.getItemId());
+    }
+
+    @Test
     public void identicalStateTwiceReturnsSameDecision() {
         when(plugin.getFilledGESlotCount()).thenReturn(7); // a free slot so the held sell can surface
         when(plugin.getInventoryCountForItem(11)).thenReturn(3);

--- a/src/test/java/com/flipsmart/AutoRecommendResolverInputTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendResolverInputTest.java
@@ -7,6 +7,8 @@ import com.flipsmart.trading.OfferStore;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -46,6 +48,38 @@ public class AutoRecommendResolverInputTest {
         assertEquals(100, in.getCompletedAwaitingCollection().get(0).getItemId());
         assertEquals(8, in.getSlotLimit());
         assertEquals(1, in.getFilledSlotCount());
+    }
+
+    @Test
+    public void unpricedCollectedItemWithinGraceBlocksNewBuy() {
+        // Just-collected, in inventory, but no sell price yet (e.g. a wiki-price timeout).
+        // It must NOT appear as a listable item, but it MUST flag a pending-sell block so
+        // the resolver holds the free slot instead of surfacing a new buy.
+        when(plugin.getInventoryCountForItem(777)).thenReturn(3);
+        session.addCollectedItem(777, 3,
+            com.flipsmart.recommend.CollectOrigin.COMPLETED_BUY, System.currentTimeMillis());
+        // no recommended price set → resolveBestSellPrice returns null
+
+        ResolverInput in = service.buildResolverInput(-1);
+
+        assertEquals(0, in.getCollectedAwaitingList().size());
+        assertTrue(in.isBlockBuyForPendingSell());
+        assertEquals(777, in.getPendingSellItemId());
+    }
+
+    @Test
+    public void unpricedCollectedItemPastGraceDoesNotBlockNewBuy() {
+        // If the price never resolves, the block must lift after the grace window so a
+        // stuck price can't wedge trading — auto resumes normal buys.
+        when(plugin.getInventoryCountForItem(777)).thenReturn(3);
+        session.addCollectedItem(777, 3,
+            com.flipsmart.recommend.CollectOrigin.COMPLETED_BUY,
+            System.currentTimeMillis() - 180_000L); // collected 3 min ago, past the grace window
+
+        ResolverInput in = service.buildResolverInput(-1);
+
+        assertEquals(0, in.getCollectedAwaitingList().size());
+        assertFalse(in.isBlockBuyForPendingSell());
     }
 
     @Test

--- a/src/test/java/com/flipsmart/recommend/ActionResolverTest.java
+++ b/src/test/java/com/flipsmart/recommend/ActionResolverTest.java
@@ -183,6 +183,20 @@ public class ActionResolverTest {
         ResolverInput in = base().filledSlotCount(5).surfaceableBuy(false, -1).build();
         assertEquals(ActionDecision.IDLE, resolver.resolve(in));
     }
+    @Test public void noS2WhenBlockedForPendingSell() {
+        // A just-collected item is awaiting its sell price: hold the free slot instead of
+        // spending it on a new buy that would strand the item we already own.
+        ResolverInput in = base().filledSlotCount(7).surfaceableBuy(true, 21)
+            .blockBuyForPendingSell(true, 777).build();
+        assertEquals(ActionDecision.IDLE, resolver.resolve(in));
+    }
+    @Test public void pendingSellBlockDoesNotSuppressHigherPriority() {
+        // The block only gates the S2 buy — a more urgent S1 cancel must still fire.
+        ResolverInput in = base().filledSlotCount(7).surfaceableBuy(true, 21)
+            .blockBuyForPendingSell(true, 777)
+            .staleOffers(Arrays.asList(staleBuyPartial(0, 11, 5L))).build();
+        assertEquals(ActionKind.S1, resolver.resolve(in).getKind());
+    }
 
     // ---- list-step requires a sell price (no empty label) ----
     @Test public void collectedItemWithoutSellPriceIsNotSurfaced() {


### PR DESCRIPTION
## What & why

In auto-mode, collecting a completed **buy** whose sell price hadn't resolved yet prompted a **new buy of a different item** instead of prompting to **sell the item just collected** — spending capital on a fresh purchase while the held item sat unsold. Found during in-game QA.

**Root cause** (traced from client.log): `buildResolverInput` silently dropped (`continue`) an in-inventory collected item when `resolveBestSellPrice` returned null, so the resolver never saw it (`collected=0`), generated no list candidate, and fell through to an S2 empty-slot buy:

```
23:21:19  Buy collected check - itemId=2550 (Ring of recoil), isCollected=true, sellPrice=null
...every resolver line: collected=0
23:22:10  resolver decision S2/PLACE_BUY item=29013 (Blue moon chestplate)   ← wrong buy
```

The ~47s wrong-buy window was driven by transient `Failed to fetch wiki prices: timeout`.

## Changes
- `buildResolverInput` flags a grace-windowed **`blockBuyForPendingSell`** instead of silently dropping the unpriced in-inventory item.
- `ActionResolver` **suppresses the S2 buy** while the flag is set — holds the free slot for the pending sell. The block gates **only** S2; S1/S3/S4/S5/SELL_WAITING are unaffected.
- Grace window **90s** (covers the observed ~47s resolution + the OSRS wiki `/latest` ~60s CDN cache). Past it, auto resumes normal buys so a permanently-stuck price can't wedge trading, and the held item lists the moment its price lands.
- Overlay shows **"Preparing to sell X"** while holding, guarded by `staleOffers.isEmpty()` so it never clobbers a cooling-down re-sell prompt. Applied identically in both resolve paths.

Plugin-only; no API/contract change.

## Tests
- `ActionResolverTest`: S2 suppressed when blocked; block does not suppress a higher-priority S1 cancel.
- `AutoRecommendResolverInputTest`: unpriced collected item within grace → block flag set (and not surfaced as list); past grace → no block.
- `AutoRecommendDispatchTest`: end-to-end — collected buy awaiting price **holds** (IDLE, not PLACE_BUY); surfaces the **sell** once the price resolves.
- Full `./gradlew build` green (checkstyle + all tests).

## Manual QA (in-game, auto-mode)
1. Fill ~7/8 slots with a surfaceable buy queued.
2. Let a buy complete and **collect** it while wiki prices are momentarily unavailable (or right after a price timeout).
3. Confirm the overlay shows **"Preparing to sell <item>"** and does **NOT** jump to a new buy; the freed slot stays held.
4. When the price resolves, confirm it surfaces **Sell <item>**, not a buy.
5. Edge: leave an unpriced held item ~90s with no price — confirm auto then resumes a normal buy (no permanent stall) and the item stays sellable.

**Watch item:** a freed slot may sit on "Preparing to sell X" for up to 90s during a wiki outage (benign — all other slots keep trading).

<details>
<summary>🔎 plugin-reviewer probe — verdict: ship-with-watch</summary>

Resolver-zone change; reviewed against the S1–S6 priority anchors (#757). Two issues were found and **fixed within this diff**: (1) an unconditional "Preparing to sell" override could clobber a cooling-down re-sell prompt that `promptCollection` surfaces from the unfiltered `staleOffers` — guarded with `staleOffers.isEmpty()`; (2) the grace window was initially 30s but the in-field incident took ~47s to resolve, so it was raised to 90s to actually cover realistic price latency. Invariants preserved: the block gates only S2 (higher tiers unaffected, pinned by test), `collectedItemWithoutSellPriceIsNotSurfaced` (#757) still holds, and the grace fallthrough bounds the hold so a stuck price can't wedge trading. No top risk ≥63% post-fix. New anchor classes recorded: `unpriced-collected-item-dropped-from-resolver-input`, `status-override-after-applyDecision-clobbers-prompt`. Watch: the up-to-90s idle-slot hold (no automated coverage — covered by QA step 5).

</details>

Closes Flip-Smart/flip-smart#969

### 🩺 Codacy Quality Gate — fixed in this PR
- `b738d9a` PMD_AvoidFieldNameMatchingMethodName `ResolverInput.java:62` — renamed the `Builder`'s internal field to `blockBuy` so it no longer shadows the fluent setter `blockBuyForPendingSell(...)`; public getter/setter names unchanged.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `b738d9a` `ResolverInput.java:62` — same finding as the quality-gate issue above (dual-channel report); resolved by the same commit.
