### PR TITLE
fix(ge-offer): show the correct item's wiki price & volume on concurrent flips (#972)

### DIFF
--- a/src/main/java/com/flipsmart/GeOfferDescriptionService.java
+++ b/src/main/java/com/flipsmart/GeOfferDescriptionService.java
@@ -221,17 +221,27 @@ public class GeOfferDescriptionService
 	 * @return int[]{itemId, isBuy (1=buy/0=sell), price, qty}, or {@code null} if
 	 *         no actionable context can be determined.
 	 */
-	private int[] resolveOfferContext()
+	int[] resolveOfferContext()
 	{
-		// Source #1: Flip Assist focus. When the player has picked a
-		// recommendation, this is canonical — no slot guessing needed.
+		// Source #1: Flip Assist focus. When the player has picked a recommendation
+		// this carries the richest context (recommended price/qty), but focus tracks
+		// the plugin's *next recommended action* — which is routinely a different item
+		// than the panel currently open. Only trust it when it agrees with the item
+		// actually on screen; otherwise the focused item's wiki price/volume bleeds
+		// onto an unrelated offer panel while 2+ flips are active. When no
+		// on-screen item can be determined yet (e.g. a fresh buy before an item is
+		// picked), focus is still the best available signal.
 		FocusedFlip focus = flipAssistOverlay == null ? null : flipAssistOverlay.getFocusedFlip();
 		if (focus != null)
 		{
-			boolean isBuy = focus.getStep() == FocusedFlip.FlipStep.BUY;
-			int price = isBuy ? focus.getBuyPrice() : focus.getSellPrice();
-			int qty = isBuy ? focus.getBuyQuantity() : focus.getSellQuantity();
-			return new int[]{focus.getItemId(), isBuy ? 1 : 0, price, qty};
+			Integer onScreenItemId = resolveOnScreenItemId();
+			if (onScreenItemId == null || onScreenItemId == focus.getItemId())
+			{
+				boolean isBuy = focus.getStep() == FocusedFlip.FlipStep.BUY;
+				int price = isBuy ? focus.getBuyPrice() : focus.getSellPrice();
+				int qty = isBuy ? focus.getBuyQuantity() : focus.getSellQuantity();
+				return new int[]{focus.getItemId(), isBuy ? 1 : 0, price, qty};
+			}
 		}
 
 		// Source #2: the slot the player clicked. GE_SELECTEDSLOT is
@@ -248,6 +258,33 @@ public class GeOfferDescriptionService
 		// geBuyExamineText / geSellExamineText script callbacks don't fire on
 		// the current Jagex setup window, leaving SETUP_DESC un-replaced.
 		return resolveSetupWindowContext();
+	}
+
+	/**
+	 * The item id the open GE panel is actually showing, independent of Flip Assist
+	 * focus: the committed offer on the active slot (in-flight status panel) if any,
+	 * else the item selected in the "Set up offer" window. Returns {@code null} when
+	 * neither surface exposes an item yet — the caller then treats focus as
+	 * authoritative.
+	 */
+	private Integer resolveOnScreenItemId()
+	{
+		int slot = resolveActiveSlot();
+		if (slot >= 0)
+		{
+			GrandExchangeOffer[] offers = client.getGrandExchangeOffers();
+			if (offers != null && slot < offers.length)
+			{
+				GrandExchangeOffer offer = offers[slot];
+				if (offer != null && offer.getState() != GrandExchangeOfferState.EMPTY)
+				{
+					return offer.getItemId();
+				}
+			}
+		}
+
+		int[] setupCtx = resolveSetupWindowContext();
+		return setupCtx == null ? null : setupCtx[0];
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/GeOfferDescriptionService.java
+++ b/src/main/java/com/flipsmart/GeOfferDescriptionService.java
@@ -223,25 +223,10 @@ public class GeOfferDescriptionService
 	 */
 	int[] resolveOfferContext()
 	{
-		// Source #1: Flip Assist focus. When the player has picked a recommendation
-		// this carries the richest context (recommended price/qty), but focus tracks
-		// the plugin's *next recommended action* — which is routinely a different item
-		// than the panel currently open. Only trust it when it agrees with the item
-		// actually on screen; otherwise the focused item's wiki price/volume bleeds
-		// onto an unrelated offer panel while 2+ flips are active. When no
-		// on-screen item can be determined yet (e.g. a fresh buy before an item is
-		// picked), focus is still the best available signal.
-		FocusedFlip focus = flipAssistOverlay == null ? null : flipAssistOverlay.getFocusedFlip();
-		if (focus != null)
+		int[] focusCtx = resolveFlipAssistFocusContext();
+		if (focusCtx != null)
 		{
-			Integer onScreenItemId = resolveOnScreenItemId();
-			if (onScreenItemId == null || onScreenItemId == focus.getItemId())
-			{
-				boolean isBuy = focus.getStep() == FocusedFlip.FlipStep.BUY;
-				int price = isBuy ? focus.getBuyPrice() : focus.getSellPrice();
-				int qty = isBuy ? focus.getBuyQuantity() : focus.getSellQuantity();
-				return new int[]{focus.getItemId(), isBuy ? 1 : 0, price, qty};
-			}
+			return focusCtx;
 		}
 
 		// Source #2: the slot the player clicked. GE_SELECTEDSLOT is
@@ -258,6 +243,39 @@ public class GeOfferDescriptionService
 		// geBuyExamineText / geSellExamineText script callbacks don't fire on
 		// the current Jagex setup window, leaving SETUP_DESC un-replaced.
 		return resolveSetupWindowContext();
+	}
+
+	/**
+	 * Source #1: Flip Assist focus. When the player has picked a recommendation
+	 * this carries the richest context (recommended price/qty), but focus tracks
+	 * the plugin's *next recommended action* — which is routinely a different item
+	 * than the panel currently open. Only trust it when it agrees with the item
+	 * actually on screen; otherwise the focused item's wiki price/volume bleeds
+	 * onto an unrelated offer panel while 2+ flips are active. When no
+	 * on-screen item can be determined yet (e.g. a fresh buy before an item is
+	 * picked), focus is still the best available signal.
+	 *
+	 * @return int[]{itemId, isBuy (1=buy/0=sell), price, qty}, or {@code null} if
+	 *         Flip Assist focus is absent or disagrees with the on-screen item.
+	 */
+	private int[] resolveFlipAssistFocusContext()
+	{
+		FocusedFlip focus = flipAssistOverlay == null ? null : flipAssistOverlay.getFocusedFlip();
+		if (focus == null)
+		{
+			return null;
+		}
+
+		Integer onScreenItemId = resolveOnScreenItemId();
+		if (onScreenItemId != null && onScreenItemId != focus.getItemId())
+		{
+			return null;
+		}
+
+		boolean isBuy = focus.getStep() == FocusedFlip.FlipStep.BUY;
+		int price = isBuy ? focus.getBuyPrice() : focus.getSellPrice();
+		int qty = isBuy ? focus.getBuyQuantity() : focus.getSellQuantity();
+		return new int[]{focus.getItemId(), isBuy ? 1 : 0, price, qty};
 	}
 
 	/**

--- a/src/test/java/com/flipsmart/GeOfferContextResolutionTest.java
+++ b/src/test/java/com/flipsmart/GeOfferContextResolutionTest.java
@@ -1,0 +1,120 @@
+package com.flipsmart;
+
+import net.runelite.api.Client;
+import net.runelite.api.GrandExchangeOffer;
+import net.runelite.api.GrandExchangeOfferState;
+import net.runelite.api.gameval.VarbitID;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.game.ItemManager;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the item-scoping contract of
+ * {@link GeOfferDescriptionService#resolveOfferContext()} (issue #972).
+ *
+ * <p>Flip Assist focus tracks the plugin's <em>next recommended action</em>, which
+ * is routinely a different item than the GE offer panel the player currently has
+ * open. Focus must therefore only drive the description when it agrees with the
+ * item actually on screen — otherwise the focused item's wiki price/volume bleeds
+ * onto an unrelated offer panel while 2+ flips are active.
+ */
+public class GeOfferContextResolutionTest
+{
+	private static final int ELY_ITEM_ID = 12817;   // focused elsewhere, insta-buy ~515m
+	private static final int KIT_ITEM_ID = 25454;   // item actually on the open offer panel
+
+	private final Client client = mock(Client.class);
+
+	private GeOfferDescriptionService newService()
+	{
+		FlipAssistOverlay overlay = mock(FlipAssistOverlay.class);
+		return new GeOfferDescriptionService(
+			client,
+			mock(ClientThread.class),
+			mock(FlipSmartApiClient.class),
+			mock(FlipSmartPlugin.class),
+			mock(ItemManager.class),
+			overlay);
+	}
+
+	private GeOfferDescriptionService newServiceWithFocus(FocusedFlip focus)
+	{
+		FlipAssistOverlay overlay = mock(FlipAssistOverlay.class);
+		when(overlay.getFocusedFlip()).thenReturn(focus);
+		return new GeOfferDescriptionService(
+			client,
+			mock(ClientThread.class),
+			mock(FlipSmartApiClient.class),
+			mock(FlipSmartPlugin.class),
+			mock(ItemManager.class),
+			overlay);
+	}
+
+	/** Puts an in-flight offer for {@code itemId} on {@code slot} and selects that slot. */
+	private void openOfferPanel(int slot, int itemId, int price)
+	{
+		GrandExchangeOffer offer = mock(GrandExchangeOffer.class);
+		when(offer.getState()).thenReturn(GrandExchangeOfferState.SELLING);
+		when(offer.getItemId()).thenReturn(itemId);
+		when(offer.getPrice()).thenReturn(price);
+		when(offer.getTotalQuantity()).thenReturn(1);
+
+		GrandExchangeOffer[] offers = new GrandExchangeOffer[8];
+		offers[slot] = offer;
+		when(client.getGrandExchangeOffers()).thenReturn(offers);
+		when(client.getVarbitValue(VarbitID.GE_SELECTEDSLOT)).thenReturn(slot);
+	}
+
+	@Test
+	public void focusOnAnotherItemDoesNotBleedOntoOpenOfferPanel()
+	{
+		// Focus is on the Ely (next recommended action) ...
+		GeOfferDescriptionService service =
+			newServiceWithFocus(FocusedFlip.forSell(ELY_ITEM_ID, "Elysian spirit shield", 515_000_000, 1));
+		// ... but the open GE panel is the Dragon Pickaxe Upgrade Kit.
+		openOfferPanel(0, KIT_ITEM_ID, 650_000);
+
+		int[] ctx = service.resolveOfferContext();
+
+		assertNotNull("open offer panel must resolve a context", ctx);
+		assertEquals("resolved item must be the on-screen offer item, not the focus",
+			KIT_ITEM_ID, ctx[0]);
+	}
+
+	@Test
+	public void focusIsUsedWhenItMatchesTheOpenOfferPanel()
+	{
+		// Focus and the open panel are the same item — focus is authoritative and
+		// contributes its recommended price (distinct from the raw offer price).
+		GeOfferDescriptionService service =
+			newServiceWithFocus(FocusedFlip.forSell(KIT_ITEM_ID, "Dragon pickaxe upgrade kit", 700_000, 1));
+		openOfferPanel(0, KIT_ITEM_ID, 650_000);
+
+		int[] ctx = service.resolveOfferContext();
+
+		assertNotNull(ctx);
+		assertEquals(KIT_ITEM_ID, ctx[0]);
+		assertEquals("focus price should drive when focus matches the panel", 700_000, ctx[2]);
+	}
+
+	@Test
+	public void focusIsUsedWhenNoPanelItemCanBeDetermined()
+	{
+		// No offers loaded and no setup window open → nothing on screen to compare
+		// against, so the focus remains the best available context.
+		GeOfferDescriptionService service =
+			newServiceWithFocus(FocusedFlip.forSell(ELY_ITEM_ID, "Elysian spirit shield", 515_000_000, 1));
+		when(client.getGrandExchangeOffers()).thenReturn(null);
+		when(client.getVarbitValue(VarbitID.GE_SELECTEDSLOT)).thenReturn(-1);
+
+		int[] ctx = service.resolveOfferContext();
+
+		assertNotNull(ctx);
+		assertEquals(ELY_ITEM_ID, ctx[0]);
+	}
+}


### PR DESCRIPTION
## Summary

On the GE offer screen the plugin displayed the wrong item's wiki insta-buy price and daily volume when 2+ flips were active. Example from the ticket: selling a Dragon Pickaxe Upgrade Kit (~650k) but the overlay showed an insta-buy of ~515m and volume matching an Elysian Spirit Shield being flipped concurrently.

## Root Cause

`GeOfferDescriptionService.resolveOfferContext()` trusted the Flip Assist **focus** unconditionally as its first context source. Focus tracks the plugin's *next recommended action*, which is routinely a different item than the GE panel the player currently has open. So the focused item's wiki price/volume (looked up correctly by its own itemId) bled onto an unrelated offer panel. The wiki-price / daily-volume caches themselves were never mis-keyed — they were just being fed the wrong itemId.

## Changes

### 🐛 Bug Fixes
- Gate the focus source on the focused item matching the item actually on screen — the active slot's committed offer (in-flight status panel), else the "Set up offer" window selection. When they disagree, fall through to the existing slot/setup context sources, which already read the correct item. Focus still drives when it matches the on-screen item, or when no on-screen item can be determined yet (a fresh buy before an item is picked), preserving the setup-screen recommendation behavior.

## Testing

### Automated Tests
- ✅ New `GeOfferContextResolutionTest` pins the contract:
  - focus on item A + open panel on item B → resolves item B (the bug; fails before the fix)
  - focus matches the open panel → focus drives (carries recommended price)
  - no on-screen item determinable → focus remains authoritative
- ✅ Full suite: 518 tests, 0 failures

### Manual Testing (in-game, plugin — cannot be automated by Playwright)
- [x] Run two concurrent flips (e.g. Elysian Spirit Shield + a cheap item)
- [x] With the plugin actively recommending an action on item A, open the GE offer screen for item B and confirm the insta-buy price and daily volume shown match item B, not item A
- [x] Repeat across buy setup, sell setup, and in-flight status panels

## Deployment Notes

- No env vars, dependencies, or configuration changes required.
- No database migrations (this repo has none).

## Checklist

- [x] Tests added/updated
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by teammate

## Related Issues

Fixes Flip-Smart/flip-smart#972

### 🩺 Codacy Quality Gate — fixed in this PR
- `db0f13f` Lizard_ccn-medium `src/main/java/com/flipsmart/GeOfferDescriptionService.java:224` — extracted the Flip Assist focus branch of `resolveOfferContext()` into `resolveFlipAssistFocusContext()`, dropping cyclomatic complexity from 9 back under the 8 limit

### 🤖 Codacy AI Reviewer
No open AI Reviewer comments on this PR as of `db0f13f`.

