### PR TITLE
Fix premature sell prompt for collected buy-partial while buy offer still live

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -2627,9 +2627,7 @@ public class AutoRecommendService
 			{
 				continue;
 			}
-			// Mirror buildResolverInput: hold the sell for a collected partial while its buy is
-			// still live so auto-mode doesn't prompt selling before the buy finishes filling.
-			if (offerStore.hasLiveBuyOfferForItem(itemId))
+			if (isItemBeingAcquired(itemId))
 			{
 				continue;
 			}
@@ -2686,6 +2684,12 @@ public class AutoRecommendService
 		{
 			return null; // off-thread — cannot determine; caller must NOT treat as absent
 		}
+	}
+
+	/** True if a live buy offer is still filling for this item — don't surface it for sale yet. */
+	private boolean isItemBeingAcquired(int itemId)
+	{
+		return offerStore.hasLiveBuyOfferForItem(itemId);
 	}
 
 	private boolean isItemInInventory(int itemId)
@@ -3041,10 +3045,7 @@ public class AutoRecommendService
 				{
 					continue;
 				}
-				// Still acquiring this item — a live buy is filling (e.g. a partial fill collected
-				// while the buy runs on). Don't surface a sell for the collected partial until the
-				// buy completes or is cancelled, so we never split one flip into a premature sell.
-				if (offerStore.hasLiveBuyOfferForItem(itemId))
+				if (isItemBeingAcquired(itemId))
 				{
 					continue;
 				}

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -2627,6 +2627,12 @@ public class AutoRecommendService
 			{
 				continue;
 			}
+			// Mirror buildResolverInput: hold the sell for a collected partial while its buy is
+			// still live so auto-mode doesn't prompt selling before the buy finishes filling.
+			if (offerStore.hasLiveBuyOfferForItem(itemId))
+			{
+				continue;
+			}
 
 			int result = evaluateCollectedItem(itemId, staleItems);
 			if (result >= 0)
@@ -3032,6 +3038,13 @@ public class AutoRecommendService
 			for (Integer itemId : session.getCollectedItemIds())
 			{
 				if (offerStore.hasActiveSellOfferForItem(itemId))
+				{
+					continue;
+				}
+				// Still acquiring this item — a live buy is filling (e.g. a partial fill collected
+				// while the buy runs on). Don't surface a sell for the collected partial until the
+				// buy completes or is cancelled, so we never split one flip into a premature sell.
+				if (offerStore.hasLiveBuyOfferForItem(itemId))
 				{
 					continue;
 				}

--- a/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
@@ -167,6 +167,28 @@ public class AutoRecommendDispatchTest {
     }
 
     @Test
+    public void collectedPartialWithLiveBuyOfferIsNotSurfacedAsList() {
+        // A partial fill collected while the buy is still filling must NOT prompt a sell — the flip
+        // shouldn't be split into a premature sell before the buy completes. Mirrors the
+        // active-sell-offer guard for a still-live buy.
+        when(plugin.getFilledGESlotCount()).thenReturn(7); // free slot: isolate the live-buy filter, not the slot gate
+
+        OfferRecord liveBuy = OfferRecord
+            .newOffer(2, 0, 43, "item-43", true, 5, 100, 0L)
+            .withFill(1, 100L, OfferState.PARTIAL_FILL, 1L); // 1/5 bought, buy still live
+        offerStore.importRecords(Arrays.asList(liveBuy));
+
+        session.addCollectedItem(43, 1, CollectOrigin.COMPLETED_BUY, 1L); // collected the 1 partial
+        session.setRecommendedPrice(43, 300);
+        when(plugin.getInventoryCountForItem(43)).thenReturn(1);
+
+        ActionDecision d = service.resolveAndApply(-1);
+
+        assertNotEquals("must not surface a sell for a partial while its buy is still filling",
+            ActionStep.LIST, d.getStep());
+    }
+
+    @Test
     public void onSellOrderPlacedRemovesItemFromCollectedSoAutoModeDoesNotReList() {
         when(plugin.getFilledGESlotCount()).thenReturn(7); // free slot so the held sell can list
         when(plugin.getInventoryCountForItem(55)).thenReturn(5);


### PR DESCRIPTION
## Summary

During #918 in-game QA we found a pre-existing Active-mode auto-recommend bug: when a buy partially fills and the player collects the bought-so-far units while the buy offer is **still live**, auto-mode immediately prompted a sell for that collected partial — splitting one flip into a premature sell plus a still-running buy.

The fix adds an `OfferStore.hasLiveBuyOfferForItem(itemId)` guard to both `buildResolverInput` and `findNextSellableCollectedItem` in `AutoRecommendService.java`, mirroring the existing active-sell-offer guard. A collected partial is now held out of sell candidates until its buy offer is terminal (fully filled or cancelled).

Cancelled-partial buys are unaffected — the existing `PARTIAL_CANCEL` flow is untouched, so collected units from a cancelled buy still surface for sell as before.

## Changes

### 🐛 Bug Fixes
- Added `OfferStore.hasLiveBuyOfferForItem(itemId)` guard to `buildResolverInput` and `findNextSellableCollectedItem` in `AutoRecommendService.java`, so a collected buy-partial is never surfaced as a sell candidate while its originating buy offer is still live.

### ✅ Tests
- Added regression test `collectedPartialWithLiveBuyOfferIsNotSurfacedAsList` in `AutoRecommendDispatchTest.java`, verified locally to fail without the guard and pass with it.

## Testing

### Automated Tests
- ✅ `./gradlew build` passing (compile + tests + checkstyle green)
- ✅ New regression test `collectedPartialWithLiveBuyOfferIsNotSurfacedAsList` added and passing

### Manual Testing
- [ ] Collect a partial from a still-live buy → no sell prompt surfaces.
- [ ] Let the buy fully fill + collect → units surface for sell as normal.
- [ ] Cancel a partial buy → collected units still surface for sell (PARTIAL_CANCEL flow unchanged).

## API Changes

N/A (plugin-only change, no API changes).

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: None
- [ ] Requires database migration: No

Rides the existing plugin release / Plugin Hub cadence.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (N/A — no player-facing doc changes)
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by teammate

## Related Issues

Closes Flip-Smart/flip-smart#976


### 🩺 Codacy — no open signals at `098e453`
- AI Reviewer: 0 comments open.
- Quality Gate: passing, 0 new issues.
