### PR TITLE
GE offer slot polish: native widget rendering for border, timer, and item box

### DIFF
--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -97,6 +97,9 @@ public class FlipSmartPlugin extends Plugin
 	private GrandExchangeSlotOverlay geSlotOverlay;
 
 	@Inject
+	private GeSlotWidgetDecorator geSlotDecorator;
+
+	@Inject
 	private FlipAssistOverlay flipAssistOverlay;
 
 	@Inject
@@ -656,6 +659,7 @@ public class FlipSmartPlugin extends Plugin
 		overlayManager.add(geSlotOverlay);
 		overlayManager.add(flipAssistOverlay);
 		overlayManager.add(inventoryHighlightOverlay);
+		clientThread.invoke(geSlotDecorator::reconcile);
 		mouseManager.registerMouseListener(overlayMouseListener);
 
 		// Initialize Flip Assist input listener for hotkey support
@@ -838,6 +842,7 @@ public class FlipSmartPlugin extends Plugin
 		overlayManager.remove(geSlotOverlay);
 		overlayManager.remove(flipAssistOverlay);
 		overlayManager.remove(inventoryHighlightOverlay);
+		clientThread.invoke(geSlotDecorator::shutDownRevert);
 		mouseManager.unregisterMouseListener(overlayMouseListener);
 		
 		// Unregister Flip Assist input listener
@@ -920,6 +925,10 @@ public class FlipSmartPlugin extends Plugin
 	{
 		Player localPlayer = client.getLocalPlayer();
 		atGrandExchange = localPlayer != null && localPlayer.getWorldLocation().getRegionID() == GE_REGION_ID;
+		if (atGrandExchange)
+		{
+			geSlotDecorator.reconcile();
+		}
 
 		// On the first LOGGED_IN tick the local player is sometimes not yet
 		// populated, so syncRSN()'s early-return fires and we'd be stuck with
@@ -964,6 +973,7 @@ public class FlipSmartPlugin extends Plugin
 		offlineSyncService.persistOfferState();
 		geHistoryService.reset();
 		persistAutoRecommendState();
+		geSlotDecorator.revertAll();
 
 		// Stop auto-recommend on logout
 		if (autoRecommendService != null && autoRecommendService.isActive())

--- a/src/main/java/com/flipsmart/GeSlotStateText.java
+++ b/src/main/java/com/flipsmart/GeSlotStateText.java
@@ -1,0 +1,15 @@
+package com.flipsmart;
+
+public final class GeSlotStateText
+{
+    private static final String SPACER = "  ";
+
+    private GeSlotStateText()
+    {
+    }
+
+    public static String build(String label, String timer, String timerColorHex)
+    {
+        return label + SPACER + "<col=" + timerColorHex + ">" + timer + "</col>";
+    }
+}

--- a/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
+++ b/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
@@ -45,7 +45,7 @@ public class GeSlotWidgetDecorator
     private final Map<Long, Integer> registered = new HashMap<>();
     private int nextCustomId = CUSTOM_SPRITE_BASE;
 
-    // slotWidget identityHash -> (borderChildIndex -> vanilla sprite id) captured before first override
+    // slot index -> (borderChildIndex -> vanilla sprite id) captured before first override
     private final Map<Integer, Map<Integer, Integer>> vanillaBorderIds = new HashMap<>();
 
     private final Map<Integer, VanillaText> vanillaText = new HashMap<>();
@@ -100,10 +100,10 @@ public class GeSlotWidgetDecorator
         return id;
     }
 
-    void applyBorder(Widget slotWidget, SlotBorderTint tint)
+    void applyBorder(int slot, Widget slotWidget, SlotBorderTint tint)
     {
         Map<Integer, Integer> captured = vanillaBorderIds
-            .computeIfAbsent(System.identityHashCode(slotWidget), k -> new HashMap<>());
+            .computeIfAbsent(slot, k -> new HashMap<>());
 
         for (int childIndex : BORDER_CHILDREN)
         {
@@ -118,9 +118,9 @@ public class GeSlotWidgetDecorator
         }
     }
 
-    void revertBorder(Widget slotWidget)
+    void revertBorder(int slot, Widget slotWidget)
     {
-        Map<Integer, Integer> captured = vanillaBorderIds.get(System.identityHashCode(slotWidget));
+        Map<Integer, Integer> captured = vanillaBorderIds.get(slot);
         if (captured == null)
         {
             return;
@@ -135,14 +135,14 @@ public class GeSlotWidgetDecorator
         }
     }
 
-    void applyStateText(Widget slotWidget, String label, String timer, String timerColorHex)
+    void applyStateText(int slot, Widget slotWidget, String label, String timer, String timerColorHex)
     {
         Widget text = slotWidget.getChild(STATE_TEXT_CHILD);
         if (text == null)
         {
             return;
         }
-        vanillaText.computeIfAbsent(System.identityHashCode(text),
+        vanillaText.computeIfAbsent(slot,
             k -> new VanillaText(text.getText(), text.getFontId(), text.getXTextAlignment()));
 
         text.setXTextAlignment(WidgetTextAlignment.LEFT);
@@ -150,14 +150,14 @@ public class GeSlotWidgetDecorator
         text.setText(GeSlotStateText.build(label, timer, timerColorHex));
     }
 
-    void revertStateText(Widget slotWidget)
+    void revertStateText(int slot, Widget slotWidget)
     {
         Widget text = slotWidget.getChild(STATE_TEXT_CHILD);
         if (text == null)
         {
             return;
         }
-        VanillaText v = vanillaText.get(System.identityHashCode(text));
+        VanillaText v = vanillaText.get(slot);
         if (v == null)
         {
             return;
@@ -189,43 +189,42 @@ public class GeSlotWidgetDecorator
             GrandExchangeOffer offer = offers[slot];
             if (offer.getState() == GrandExchangeOfferState.EMPTY)
             {
-                revertBorder(slotWidget);
-                revertStateText(slotWidget);
+                revertBorder(slot, slotWidget);
+                revertStateText(slot, slotWidget);
                 continue;
             }
 
-            reconcileBorder(slotWidget, slot, bordersOn);
-            reconcileStateText(slotWidget, slot, offer, timersOn);
+            OfferRecord tracked = plugin.getOfferStore().bySlot(slot);
+            reconcileBorder(slotWidget, slot, tracked, bordersOn);
+            reconcileStateText(slotWidget, slot, tracked, offer, timersOn);
         }
     }
 
-    private void reconcileBorder(Widget slotWidget, int slot, boolean bordersOn)
+    private void reconcileBorder(Widget slotWidget, int slot, OfferRecord tracked, boolean bordersOn)
     {
         if (!bordersOn)
         {
-            revertBorder(slotWidget);
+            revertBorder(slot, slotWidget);
             return;
         }
-        OfferRecord tracked = plugin.getOfferStore().bySlot(slot);
         java.util.Optional<SlotBorderTint> tint =
             SlotBorderTint.forOffer(plugin.calculateCompetitiveness(tracked), config.colorblindMode());
         if (tint.isPresent())
         {
-            applyBorder(slotWidget, tint.get());
+            applyBorder(slot, slotWidget, tint.get());
         }
         else
         {
-            revertBorder(slotWidget);
+            revertBorder(slot, slotWidget);
         }
     }
 
-    private void reconcileStateText(Widget slotWidget, int slot, GrandExchangeOffer offer, boolean timersOn)
+    private void reconcileStateText(Widget slotWidget, int slot, OfferRecord tracked, GrandExchangeOffer offer, boolean timersOn)
     {
-        OfferRecord tracked = plugin.getOfferStore().bySlot(slot);
         long lastActivity = tracked == null ? 0L : tracked.getEffectiveLastActivityAtMillis();
         if (!timersOn || tracked == null || lastActivity <= 0)
         {
-            revertStateText(slotWidget);
+            revertStateText(slot, slotWidget);
             return;
         }
 
@@ -240,7 +239,7 @@ public class GeSlotWidgetDecorator
             ? (config.colorblindMode() ? "0066cc" : "4cbb17")
             : "ffffff";
 
-        applyStateText(slotWidget, label, timer, colorHex);
+        applyStateText(slot, slotWidget, label, timer, colorHex);
     }
 
     public void revertAll()
@@ -250,8 +249,8 @@ public class GeSlotWidgetDecorator
             Widget slotWidget = client.getWidget(GE_INTERFACE_GROUP, SLOT_CONTAINER_START + slot);
             if (slotWidget != null)
             {
-                revertBorder(slotWidget);
-                revertStateText(slotWidget);
+                revertBorder(slot, slotWidget);
+                revertStateText(slot, slotWidget);
             }
         }
     }
@@ -264,5 +263,7 @@ public class GeSlotWidgetDecorator
             client.getSpriteOverrides().remove(id);
         }
         registered.clear();
+        vanillaBorderIds.clear();
+        vanillaText.clear();
     }
 }

--- a/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
+++ b/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
@@ -1,8 +1,6 @@
 package com.flipsmart;
 
 import com.flipsmart.domain.offer.OfferRecord;
-import com.flipsmart.domain.offer.OfferSignal;
-import com.flipsmart.util.TimeUtils;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GrandExchangeOffer;
@@ -25,16 +23,38 @@ public class GeSlotWidgetDecorator
     static final int SLOT_CONTAINER_START = 7;
     static final int GE_MAX_SLOTS = 8;
 
-    // Border-piece child indices within a GE slot widget (top,bottom,left,right,4 corners,divider,2 intersections,item box).
-    // Values from Flipping Utilities' GeSpriteLoader; confirm vs current client in QA (AC1).
-    static final int[] BORDER_CHILDREN = { 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17 };
-    // "Buy"/"Sell"/"Empty" state-text child index; from FU SlotActivityTimer; confirm in QA (AC6).
+    // Frame pieces (drawn as a thin outer-edge outline) + the item background box (light fill).
+    // The full-width divider (13) is left vanilla so we don't touch the slot interior.
+    static final int[] BORDER_CHILDREN = { 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 17 };
+
+    // Which outer edge(s) each frame piece contributes to the slot's perimeter outline.
+    // Item box (17) is absent -> edges 0 -> rendered as a light fill instead of an outline.
+    private static final Map<Integer, Integer> BORDER_EDGES = new HashMap<>();
+    static
+    {
+        BORDER_EDGES.put(5, SpriteOutline.TOP);
+        BORDER_EDGES.put(6, SpriteOutline.BOTTOM);
+        BORDER_EDGES.put(7, SpriteOutline.LEFT);
+        BORDER_EDGES.put(8, SpriteOutline.RIGHT);
+        BORDER_EDGES.put(9, SpriteOutline.TOP | SpriteOutline.LEFT);
+        BORDER_EDGES.put(10, SpriteOutline.TOP | SpriteOutline.RIGHT);
+        BORDER_EDGES.put(11, SpriteOutline.BOTTOM | SpriteOutline.LEFT);
+        BORDER_EDGES.put(12, SpriteOutline.BOTTOM | SpriteOutline.RIGHT);
+        BORDER_EDGES.put(14, SpriteOutline.LEFT);
+        BORDER_EDGES.put(15, SpriteOutline.RIGHT);
+    }
+
+    private static final int OUTLINE_THICKNESS = 2;
+    // Blend strength for the item-box fill: 0.5 keeps it light so the native texture shows through.
+    private static final double TINT_STRENGTH = 0.5;
+
+    // "Buy"/"Sell"/"Empty" state-text child; we left-align it (clear of the top-right timer) and
+    // nudge it a few px off the border.
     static final int STATE_TEXT_CHILD = 16;
+    private static final int STATE_TEXT_INSET_X = 12;
 
     // Custom sprite-id namespace: high base to avoid colliding with game sprite ids.
     private static final int CUSTOM_SPRITE_BASE = 0x7F00_0000;
-
-    private static final int SLOT_STATE_FONT_ID = 495;
 
     private final Client client;
     private final FlipSmartConfig config;
@@ -45,23 +65,14 @@ public class GeSlotWidgetDecorator
     private final Map<Long, Integer> registered = new HashMap<>();
     private int nextCustomId = CUSTOM_SPRITE_BASE;
 
-    // slot index -> (borderChildIndex -> vanilla sprite id) captured before first override
+    // slot index -> (recolored child index -> vanilla sprite id) captured before first override
     private final Map<Integer, Map<Integer, Integer>> vanillaBorderIds = new HashMap<>();
 
-    private final Map<Integer, VanillaText> vanillaText = new HashMap<>();
+    // slot index -> the state-text widget's original x-alignment, captured before left-aligning it
+    private final Map<Integer, Integer> vanillaTextAlignment = new HashMap<>();
 
-    private static final class VanillaText
-    {
-        final String text;
-        final int fontId;
-        final int xAlignment;
-        VanillaText(String text, int fontId, int xAlignment)
-        {
-            this.text = text;
-            this.fontId = fontId;
-            this.xAlignment = xAlignment;
-        }
-    }
+    // slot index -> the state-text widget's original x position, captured before nudging it right
+    private final Map<Integer, Integer> vanillaTextX = new HashMap<>();
 
     @Inject
     GeSlotWidgetDecorator(Client client, FlipSmartConfig config, FlipSmartPlugin plugin, SpriteManager spriteManager)
@@ -77,7 +88,8 @@ public class GeSlotWidgetDecorator
         return ((long) vanillaSpriteId << 8) | tint.ordinal();
     }
 
-    int customSpriteId(int vanillaSpriteId, SlotBorderTint tint)
+    int customSpriteId(int vanillaSpriteId, SlotBorderTint tint, int edges, int width, int height,
+                       int relX, int relY, int slotWidth, int slotHeight)
     {
         Long k = key(vanillaSpriteId, tint);
         Integer existing = registered.get(k);
@@ -86,16 +98,32 @@ public class GeSlotWidgetDecorator
             return existing;
         }
 
-        BufferedImage vanilla = spriteManager.getSprite(vanillaSpriteId, 0);
-        if (vanilla == null)
+        BufferedImage image;
+        if (edges == 0)
         {
-            // Not loaded yet; keep vanilla this tick, retry next reconcile.
-            return vanillaSpriteId;
+            // Item box: a light fill of the vanilla sprite.
+            BufferedImage vanilla = spriteManager.getSprite(vanillaSpriteId, 0);
+            if (vanilla == null)
+            {
+                // Not loaded yet; keep vanilla this tick, retry next reconcile.
+                return vanillaSpriteId;
+            }
+            image = SpriteRecolor.tint(vanilla, tint.getColor(), TINT_STRENGTH);
+        }
+        else
+        {
+            // Frame piece: a thin edge outline sized to the piece's rendered bounds (so the client
+            // tiles it exactly once), positioned at the slot border via the piece's overhang offset.
+            if (width <= 0 || height <= 0 || slotWidth <= 0 || slotHeight <= 0)
+            {
+                return vanillaSpriteId;
+            }
+            image = SpriteOutline.build(width, height, edges, tint.getColor(), OUTLINE_THICKNESS,
+                relX, relY, slotWidth, slotHeight);
         }
 
-        SpritePixels recolored = ImageUtil.getImageSpritePixels(SpriteRecolor.tint(vanilla, tint.getColor()), client);
         int id = nextCustomId++;
-        client.getSpriteOverrides().put(id, recolored);
+        client.getSpriteOverrides().put(id, ImageUtil.getImageSpritePixels(image, client));
         registered.put(k, id);
         return id;
     }
@@ -104,6 +132,9 @@ public class GeSlotWidgetDecorator
     {
         Map<Integer, Integer> captured = vanillaBorderIds
             .computeIfAbsent(slot, k -> new HashMap<>());
+
+        int slotWidth = slotWidget.getWidth();
+        int slotHeight = slotWidget.getHeight();
 
         for (int childIndex : BORDER_CHILDREN)
         {
@@ -114,7 +145,9 @@ public class GeSlotWidgetDecorator
             }
             captured.putIfAbsent(childIndex, piece.getSpriteId());
             int vanillaId = captured.get(childIndex);
-            piece.setSpriteId(customSpriteId(vanillaId, tint));
+            int edges = BORDER_EDGES.getOrDefault(childIndex, 0);
+            piece.setSpriteId(customSpriteId(vanillaId, tint, edges, piece.getWidth(), piece.getHeight(),
+                piece.getRelativeX(), piece.getRelativeY(), slotWidth, slotHeight));
         }
     }
 
@@ -135,42 +168,10 @@ public class GeSlotWidgetDecorator
         }
     }
 
-    void applyStateText(int slot, Widget slotWidget, String label, String timer, String timerColorHex)
-    {
-        Widget text = slotWidget.getChild(STATE_TEXT_CHILD);
-        if (text == null)
-        {
-            return;
-        }
-        vanillaText.computeIfAbsent(slot,
-            k -> new VanillaText(text.getText(), text.getFontId(), text.getXTextAlignment()));
-
-        text.setXTextAlignment(WidgetTextAlignment.LEFT);
-        text.setFontId(SLOT_STATE_FONT_ID);
-        text.setText(GeSlotStateText.build(label, timer, timerColorHex));
-    }
-
-    void revertStateText(int slot, Widget slotWidget)
-    {
-        Widget text = slotWidget.getChild(STATE_TEXT_CHILD);
-        if (text == null)
-        {
-            return;
-        }
-        VanillaText v = vanillaText.get(slot);
-        if (v == null)
-        {
-            return;
-        }
-        text.setText(v.text);
-        text.setFontId(v.fontId);
-        text.setXTextAlignment(v.xAlignment);
-    }
-
     public void reconcile()
     {
         boolean bordersOn = config.highlightSlotBorders();
-        boolean timersOn = config.showOfferTimers();
+        boolean decorate = bordersOn || config.showOfferTimers();
 
         GrandExchangeOffer[] offers = client.getGrandExchangeOffers();
         if (offers == null)
@@ -196,7 +197,54 @@ public class GeSlotWidgetDecorator
 
             OfferRecord tracked = plugin.getOfferStore().bySlot(slot);
             reconcileBorder(slotWidget, slot, tracked, bordersOn);
-            reconcileStateText(slotWidget, slot, tracked, offer, timersOn);
+            if (decorate)
+            {
+                applyStateText(slot, slotWidget);
+            }
+            else
+            {
+                revertStateText(slot, slotWidget);
+            }
+        }
+    }
+
+    void applyStateText(int slot, Widget slotWidget)
+    {
+        Widget text = slotWidget.getChild(STATE_TEXT_CHILD);
+        if (text == null)
+        {
+            return;
+        }
+        vanillaTextAlignment.putIfAbsent(slot, text.getXTextAlignment());
+        vanillaTextX.putIfAbsent(slot, text.getOriginalX());
+
+        text.setXTextAlignment(WidgetTextAlignment.LEFT);
+        int targetX = vanillaTextX.get(slot) + STATE_TEXT_INSET_X;
+        if (text.getOriginalX() != targetX)
+        {
+            text.setOriginalX(targetX);
+            text.revalidate();
+        }
+    }
+
+    void revertStateText(int slot, Widget slotWidget)
+    {
+        Integer alignment = vanillaTextAlignment.get(slot);
+        if (alignment == null)
+        {
+            return;
+        }
+        Widget text = slotWidget.getChild(STATE_TEXT_CHILD);
+        if (text == null)
+        {
+            return;
+        }
+        text.setXTextAlignment(alignment);
+        Integer originalX = vanillaTextX.get(slot);
+        if (originalX != null && text.getOriginalX() != originalX)
+        {
+            text.setOriginalX(originalX);
+            text.revalidate();
         }
     }
 
@@ -217,29 +265,6 @@ public class GeSlotWidgetDecorator
         {
             revertBorder(slot, slotWidget);
         }
-    }
-
-    private void reconcileStateText(Widget slotWidget, int slot, OfferRecord tracked, GrandExchangeOffer offer, boolean timersOn)
-    {
-        long lastActivity = tracked == null ? 0L : tracked.getEffectiveLastActivityAtMillis();
-        if (!timersOn || tracked == null || lastActivity <= 0)
-        {
-            revertStateText(slot, slotWidget);
-            return;
-        }
-
-        boolean complete = offer.getState() == GrandExchangeOfferState.BOUGHT
-            || offer.getState() == GrandExchangeOfferState.SOLD;
-        String timer = complete && tracked.getCompletedAtMillis() > 0
-            ? TimeUtils.formatFrozenElapsedTime(lastActivity, tracked.getCompletedAtMillis())
-            : TimeUtils.formatElapsedTime(lastActivity);
-
-        String label = OfferSignal.isBuyState(offer.getState()) ? "Buy" : "Sell";
-        String colorHex = complete
-            ? (config.colorblindMode() ? "0066cc" : "4cbb17")
-            : "ffffff";
-
-        applyStateText(slot, slotWidget, label, timer, colorHex);
     }
 
     public void revertAll()
@@ -264,6 +289,7 @@ public class GeSlotWidgetDecorator
         }
         registered.clear();
         vanillaBorderIds.clear();
-        vanillaText.clear();
+        vanillaTextAlignment.clear();
+        vanillaTextX.clear();
     }
 }

--- a/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
+++ b/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
@@ -1,0 +1,75 @@
+package com.flipsmart;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.SpritePixels;
+import net.runelite.client.game.SpriteManager;
+import net.runelite.client.util.ImageUtil;
+
+import javax.inject.Inject;
+import java.awt.image.BufferedImage;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class GeSlotWidgetDecorator
+{
+    static final int GE_INTERFACE_GROUP = 465;
+    static final int SLOT_CONTAINER_START = 7;
+    static final int GE_MAX_SLOTS = 8;
+
+    // Border-piece child indices within a GE slot widget (top,bottom,left,right,4 corners,divider,2 intersections,item box).
+    // Values from Flipping Utilities' GeSpriteLoader; confirm vs current client in QA (AC1).
+    static final int[] BORDER_CHILDREN = { 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17 };
+    // "Buy"/"Sell"/"Empty" state-text child index; from FU SlotActivityTimer; confirm in QA (AC6).
+    static final int STATE_TEXT_CHILD = 16;
+
+    // Custom sprite-id namespace: high base to avoid colliding with game sprite ids.
+    private static final int CUSTOM_SPRITE_BASE = 0x7F00_0000;
+
+    private final Client client;
+    private final FlipSmartConfig config;
+    private final FlipSmartPlugin plugin;
+    private final SpriteManager spriteManager;
+
+    // (vanillaSpriteId, tint) -> custom sprite id already registered in the override map
+    private final Map<Long, Integer> registered = new HashMap<>();
+    private int nextCustomId = CUSTOM_SPRITE_BASE;
+
+    @Inject
+    GeSlotWidgetDecorator(Client client, FlipSmartConfig config, FlipSmartPlugin plugin, SpriteManager spriteManager)
+    {
+        this.client = client;
+        this.config = config;
+        this.plugin = plugin;
+        this.spriteManager = spriteManager;
+    }
+
+    private static long key(int vanillaSpriteId, SlotBorderTint tint)
+    {
+        return ((long) vanillaSpriteId << 8) | tint.ordinal();
+    }
+
+    int customSpriteId(int vanillaSpriteId, SlotBorderTint tint)
+    {
+        Long k = key(vanillaSpriteId, tint);
+        Integer existing = registered.get(k);
+        if (existing != null)
+        {
+            return existing;
+        }
+
+        BufferedImage vanilla = spriteManager.getSprite(vanillaSpriteId, 0);
+        if (vanilla == null)
+        {
+            // Not loaded yet; keep vanilla this tick, retry next reconcile.
+            return vanillaSpriteId;
+        }
+
+        SpritePixels recolored = ImageUtil.getImageSpritePixels(SpriteRecolor.tint(vanilla, tint.getColor()), client);
+        int id = nextCustomId++;
+        client.getSpriteOverrides().put(id, recolored);
+        registered.put(k, id);
+        return id;
+    }
+}

--- a/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
+++ b/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
@@ -3,6 +3,7 @@ package com.flipsmart;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.SpritePixels;
+import net.runelite.api.widgets.Widget;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.util.ImageUtil;
 
@@ -35,6 +36,9 @@ public class GeSlotWidgetDecorator
     // (vanillaSpriteId, tint) -> custom sprite id already registered in the override map
     private final Map<Long, Integer> registered = new HashMap<>();
     private int nextCustomId = CUSTOM_SPRITE_BASE;
+
+    // slotWidget identityHash -> (borderChildIndex -> vanilla sprite id) captured before first override
+    private final Map<Integer, Map<Integer, Integer>> vanillaBorderIds = new HashMap<>();
 
     @Inject
     GeSlotWidgetDecorator(Client client, FlipSmartConfig config, FlipSmartPlugin plugin, SpriteManager spriteManager)
@@ -71,5 +75,40 @@ public class GeSlotWidgetDecorator
         client.getSpriteOverrides().put(id, recolored);
         registered.put(k, id);
         return id;
+    }
+
+    void applyBorder(Widget slotWidget, SlotBorderTint tint)
+    {
+        Map<Integer, Integer> captured = vanillaBorderIds
+            .computeIfAbsent(System.identityHashCode(slotWidget), k -> new HashMap<>());
+
+        for (int childIndex : BORDER_CHILDREN)
+        {
+            Widget piece = slotWidget.getChild(childIndex);
+            if (piece == null)
+            {
+                continue;
+            }
+            captured.putIfAbsent(childIndex, piece.getSpriteId());
+            int vanillaId = captured.get(childIndex);
+            piece.setSpriteId(customSpriteId(vanillaId, tint));
+        }
+    }
+
+    void revertBorder(Widget slotWidget)
+    {
+        Map<Integer, Integer> captured = vanillaBorderIds.get(System.identityHashCode(slotWidget));
+        if (captured == null)
+        {
+            return;
+        }
+        for (Map.Entry<Integer, Integer> e : captured.entrySet())
+        {
+            Widget piece = slotWidget.getChild(e.getKey());
+            if (piece != null)
+            {
+                piece.setSpriteId(e.getValue());
+            }
+        }
     }
 }

--- a/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
+++ b/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
@@ -85,15 +85,17 @@ public class GeSlotWidgetDecorator
         this.spriteManager = spriteManager;
     }
 
-    private static long key(int vanillaSpriteId, SlotBorderTint tint)
+    // Different border children can share a vanilla sprite id while needing different outline
+    // shapes (e.g. a straight-edge piece vs. a corner piece), so edges must be part of the key.
+    private static long key(int vanillaSpriteId, SlotBorderTint tint, int edges)
     {
-        return ((long) vanillaSpriteId << 8) | tint.ordinal();
+        return ((long) vanillaSpriteId << 12) | ((long) (edges & 0xF) << 8) | tint.ordinal();
     }
 
     int customSpriteId(int vanillaSpriteId, SlotBorderTint tint, int edges, int width, int height,
                        int relX, int relY, int slotWidth, int slotHeight)
     {
-        Long k = key(vanillaSpriteId, tint);
+        Long k = key(vanillaSpriteId, tint, edges);
         Integer existing = registered.get(k);
         if (existing != null)
         {

--- a/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
+++ b/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
@@ -1,6 +1,8 @@
 package com.flipsmart;
 
 import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.domain.offer.OfferSignal;
+import com.flipsmart.util.TimeUtils;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GrandExchangeOffer;
@@ -48,8 +50,8 @@ public class GeSlotWidgetDecorator
     // Blend strength for the item-box fill: 0.5 keeps it light so the native texture shows through.
     private static final double TINT_STRENGTH = 0.5;
 
-    // "Buy"/"Sell"/"Empty" state-text child; we left-align it (clear of the top-right timer) and
-    // nudge it a few px off the border.
+    // "Buy"/"Sell"/"Empty" state-text child. We left-align it, nudge it a few px off the border,
+    // and append the color-tagged timer after the label.
     static final int STATE_TEXT_CHILD = 16;
     private static final int STATE_TEXT_INSET_X = 12;
 
@@ -171,7 +173,8 @@ public class GeSlotWidgetDecorator
     public void reconcile()
     {
         boolean bordersOn = config.highlightSlotBorders();
-        boolean decorate = bordersOn || config.showOfferTimers();
+        boolean timersOn = config.showOfferTimers();
+        boolean decorate = bordersOn || timersOn;
 
         GrandExchangeOffer[] offers = client.getGrandExchangeOffers();
         if (offers == null)
@@ -199,7 +202,7 @@ public class GeSlotWidgetDecorator
             reconcileBorder(slotWidget, slot, tracked, bordersOn);
             if (decorate)
             {
-                applyStateText(slot, slotWidget);
+                applyStateText(slot, slotWidget, offer, tracked, timersOn);
             }
             else
             {
@@ -208,7 +211,7 @@ public class GeSlotWidgetDecorator
         }
     }
 
-    void applyStateText(int slot, Widget slotWidget)
+    void applyStateText(int slot, Widget slotWidget, GrandExchangeOffer offer, OfferRecord tracked, boolean timersOn)
     {
         Widget text = slotWidget.getChild(STATE_TEXT_CHILD);
         if (text == null)
@@ -218,13 +221,49 @@ public class GeSlotWidgetDecorator
         vanillaTextAlignment.putIfAbsent(slot, text.getXTextAlignment());
         vanillaTextX.putIfAbsent(slot, text.getOriginalX());
 
-        text.setXTextAlignment(WidgetTextAlignment.LEFT);
+        boolean changed = false;
+        if (text.getXTextAlignment() != WidgetTextAlignment.LEFT)
+        {
+            text.setXTextAlignment(WidgetTextAlignment.LEFT);
+            changed = true;
+        }
         int targetX = vanillaTextX.get(slot) + STATE_TEXT_INSET_X;
         if (text.getOriginalX() != targetX)
         {
             text.setOriginalX(targetX);
+            changed = true;
+        }
+
+        String desired = stateTextFor(offer, tracked, timersOn);
+        if (!desired.equals(text.getText()))
+        {
+            text.setText(desired);
+            changed = true;
+        }
+        if (changed)
+        {
             text.revalidate();
         }
+    }
+
+    private String stateTextFor(GrandExchangeOffer offer, OfferRecord tracked, boolean timersOn)
+    {
+        String label = OfferSignal.isBuyState(offer.getState()) ? "Buy" : "Sell";
+        long lastActivity = tracked == null ? 0L : tracked.getEffectiveLastActivityAtMillis();
+        if (!timersOn || tracked == null || lastActivity <= 0)
+        {
+            return label;
+        }
+
+        boolean complete = offer.getState() == GrandExchangeOfferState.BOUGHT
+            || offer.getState() == GrandExchangeOfferState.SOLD;
+        String timer = complete && tracked.getCompletedAtMillis() > 0
+            ? TimeUtils.formatFrozenElapsedTime(lastActivity, tracked.getCompletedAtMillis())
+            : TimeUtils.formatElapsedTime(lastActivity);
+        String colorHex = complete
+            ? (config.colorblindMode() ? "0066cc" : "4cbb17")
+            : "ffffff";
+        return GeSlotStateText.build(label, timer, colorHex);
     }
 
     void revertStateText(int slot, Widget slotWidget)

--- a/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
+++ b/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.SpritePixels;
 import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetTextAlignment;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.util.ImageUtil;
 
@@ -28,6 +29,8 @@ public class GeSlotWidgetDecorator
     // Custom sprite-id namespace: high base to avoid colliding with game sprite ids.
     private static final int CUSTOM_SPRITE_BASE = 0x7F00_0000;
 
+    private static final int SLOT_STATE_FONT_ID = 495;
+
     private final Client client;
     private final FlipSmartConfig config;
     private final FlipSmartPlugin plugin;
@@ -39,6 +42,21 @@ public class GeSlotWidgetDecorator
 
     // slotWidget identityHash -> (borderChildIndex -> vanilla sprite id) captured before first override
     private final Map<Integer, Map<Integer, Integer>> vanillaBorderIds = new HashMap<>();
+
+    private final Map<Integer, VanillaText> vanillaText = new HashMap<>();
+
+    private static final class VanillaText
+    {
+        final String text;
+        final int fontId;
+        final int xAlignment;
+        VanillaText(String text, int fontId, int xAlignment)
+        {
+            this.text = text;
+            this.fontId = fontId;
+            this.xAlignment = xAlignment;
+        }
+    }
 
     @Inject
     GeSlotWidgetDecorator(Client client, FlipSmartConfig config, FlipSmartPlugin plugin, SpriteManager spriteManager)
@@ -110,5 +128,37 @@ public class GeSlotWidgetDecorator
                 piece.setSpriteId(e.getValue());
             }
         }
+    }
+
+    void applyStateText(Widget slotWidget, String label, String timer, String timerColorHex)
+    {
+        Widget text = slotWidget.getChild(STATE_TEXT_CHILD);
+        if (text == null)
+        {
+            return;
+        }
+        vanillaText.computeIfAbsent(System.identityHashCode(text),
+            k -> new VanillaText(text.getText(), text.getFontId(), text.getXTextAlignment()));
+
+        text.setXTextAlignment(WidgetTextAlignment.LEFT);
+        text.setFontId(SLOT_STATE_FONT_ID);
+        text.setText(GeSlotStateText.build(label, timer, timerColorHex));
+    }
+
+    void revertStateText(Widget slotWidget)
+    {
+        Widget text = slotWidget.getChild(STATE_TEXT_CHILD);
+        if (text == null)
+        {
+            return;
+        }
+        VanillaText v = vanillaText.get(System.identityHashCode(text));
+        if (v == null)
+        {
+            return;
+        }
+        text.setText(v.text);
+        text.setFontId(v.fontId);
+        text.setXTextAlignment(v.xAlignment);
     }
 }

--- a/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
+++ b/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
@@ -1,7 +1,12 @@
 package com.flipsmart;
 
+import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.domain.offer.OfferSignal;
+import com.flipsmart.util.TimeUtils;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.GrandExchangeOffer;
+import net.runelite.api.GrandExchangeOfferState;
 import net.runelite.api.SpritePixels;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetTextAlignment;
@@ -160,5 +165,104 @@ public class GeSlotWidgetDecorator
         text.setText(v.text);
         text.setFontId(v.fontId);
         text.setXTextAlignment(v.xAlignment);
+    }
+
+    public void reconcile()
+    {
+        boolean bordersOn = config.highlightSlotBorders();
+        boolean timersOn = config.showOfferTimers();
+
+        GrandExchangeOffer[] offers = client.getGrandExchangeOffers();
+        if (offers == null)
+        {
+            return;
+        }
+
+        for (int slot = 0; slot < Math.min(offers.length, GE_MAX_SLOTS); slot++)
+        {
+            Widget slotWidget = client.getWidget(GE_INTERFACE_GROUP, SLOT_CONTAINER_START + slot);
+            if (slotWidget == null || slotWidget.isHidden())
+            {
+                continue;
+            }
+
+            GrandExchangeOffer offer = offers[slot];
+            if (offer.getState() == GrandExchangeOfferState.EMPTY)
+            {
+                revertBorder(slotWidget);
+                revertStateText(slotWidget);
+                continue;
+            }
+
+            reconcileBorder(slotWidget, slot, bordersOn);
+            reconcileStateText(slotWidget, slot, offer, timersOn);
+        }
+    }
+
+    private void reconcileBorder(Widget slotWidget, int slot, boolean bordersOn)
+    {
+        if (!bordersOn)
+        {
+            revertBorder(slotWidget);
+            return;
+        }
+        OfferRecord tracked = plugin.getOfferStore().bySlot(slot);
+        java.util.Optional<SlotBorderTint> tint =
+            SlotBorderTint.forOffer(plugin.calculateCompetitiveness(tracked), config.colorblindMode());
+        if (tint.isPresent())
+        {
+            applyBorder(slotWidget, tint.get());
+        }
+        else
+        {
+            revertBorder(slotWidget);
+        }
+    }
+
+    private void reconcileStateText(Widget slotWidget, int slot, GrandExchangeOffer offer, boolean timersOn)
+    {
+        OfferRecord tracked = plugin.getOfferStore().bySlot(slot);
+        long lastActivity = tracked == null ? 0L : tracked.getEffectiveLastActivityAtMillis();
+        if (!timersOn || tracked == null || lastActivity <= 0)
+        {
+            revertStateText(slotWidget);
+            return;
+        }
+
+        boolean complete = offer.getState() == GrandExchangeOfferState.BOUGHT
+            || offer.getState() == GrandExchangeOfferState.SOLD;
+        String timer = complete && tracked.getCompletedAtMillis() > 0
+            ? TimeUtils.formatFrozenElapsedTime(lastActivity, tracked.getCompletedAtMillis())
+            : TimeUtils.formatElapsedTime(lastActivity);
+
+        String label = OfferSignal.isBuyState(offer.getState()) ? "Buy" : "Sell";
+        String colorHex = complete
+            ? (config.colorblindMode() ? "0066cc" : "4cbb17")
+            : "ffffff";
+
+        applyStateText(slotWidget, label, timer, colorHex);
+    }
+
+    public void revertAll()
+    {
+        for (int slot = 0; slot < GE_MAX_SLOTS; slot++)
+        {
+            Widget slotWidget = client.getWidget(GE_INTERFACE_GROUP, SLOT_CONTAINER_START + slot);
+            if (slotWidget != null)
+            {
+                revertBorder(slotWidget);
+                revertStateText(slotWidget);
+            }
+        }
+    }
+
+    public void shutDownRevert()
+    {
+        revertAll();
+        for (Integer id : registered.values())
+        {
+            client.getSpriteOverrides().remove(id);
+        }
+        registered.clear();
     }
 }

--- a/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
@@ -4,7 +4,6 @@ import com.flipsmart.domain.offer.OfferRecord;
 import com.flipsmart.domain.offer.OfferSignal;
 import com.flipsmart.util.BuyPriceLookup;
 import com.flipsmart.util.GeTax;
-import com.flipsmart.util.TimeUtils;
 import com.flipsmart.util.GpUtils;
 
 import lombok.extern.slf4j.Slf4j;
@@ -53,8 +52,6 @@ public class GrandExchangeSlotOverlay extends Overlay
 	// Colors - designed to blend with GE's brown/tan color scheme
 	private static final Color COLOR_COMPETITIVE = new Color(76, 187, 23);        // OSRS green
 	private static final Color COLOR_UNCOMPETITIVE = new Color(215, 75, 75);      // Soft red
-	private static final Color COLOR_TIMER_TEXT = new Color(255, 255, 255);       // White
-	private static final Color COLOR_TIMER_SHADOW = new Color(0, 0, 0, 160);      // Subtle shadow
 	private static final Color COLOR_FLIP_ASSIST_GLOW = new Color(255, 185, 50);  // Orange glow for flip assist
 
 	// Colorblind-safe alternative colors (blue/orange instead of green/red)
@@ -290,24 +287,20 @@ public class GrandExchangeSlotOverlay extends Overlay
 		OfferRecord trackedOffer = plugin.getOfferStore().bySlot(slot);
 		FlipSmartPlugin.OfferCompetitiveness competitiveness = plugin.calculateCompetitiveness(trackedOffer);
 
-		// Render the indicator bar with colored background and timer
 		renderIndicatorBar(graphics, bounds, trackedOffer, offer, competitiveness, slot);
-		renderCompletionCheckbox(graphics, bounds, offer);
 
 		return checkForTooltip(bounds, offer);
 	}
 
 	/**
-	 * Render the slot overlay with colored border around the entire slot
-	 * and timer in the top-right corner (like Flipping Utilities).
+	 * Render the amber Flip Assist glow for the slot, if any.
 	 */
 	private void renderIndicatorBar(Graphics2D graphics, Rectangle bounds, OfferRecord trackedOffer,
 									GrandExchangeOffer offer, FlipSmartPlugin.OfferCompetitiveness competitiveness, int slot)
 	{
-		// Draw colored border around the entire slot. A current-action highlight
-		// (bright amber pulse) always wins over a skipped-item reminder on the same
-		// slot; a sticky-only slot renders dimmed so it reads as secondary and never
-		// competes with the slot the Flip Assist panel is currently prompting.
+		// A current-action highlight (bright amber pulse) always wins over a skipped-item
+		// reminder on the same slot; a sticky-only slot renders dimmed so it reads as
+		// secondary and never competes with the slot the Flip Assist panel is prompting.
 		if (adjustmentHighlights.containsKey(slot))
 		{
 			drawOrangeGlow(graphics, bounds);
@@ -315,96 +308,6 @@ public class GrandExchangeSlotOverlay extends Overlay
 		else if (stickyAdjustmentSlots.contains(slot))
 		{
 			drawDimReminderGlow(graphics, bounds);
-		}
-		else if (config.highlightSlotBorders() && competitiveness != FlipSmartPlugin.OfferCompetitiveness.UNKNOWN)
-		{
-			Color borderColor = (competitiveness == FlipSmartPlugin.OfferCompetitiveness.COMPETITIVE)
-				? getBorderCompetitiveColor()
-				: getBorderUncompetitiveColor();
-
-			Stroke originalStroke = graphics.getStroke();
-			graphics.setColor(borderColor);
-			graphics.setStroke(new BasicStroke(3));
-			graphics.drawRoundRect(bounds.x + 1, bounds.y + 1, bounds.width - 2, bounds.height - 2, 4, 4);
-			graphics.setStroke(originalStroke);
-		}
-
-		// Draw timer in top-right corner — uses locally persisted timestamps
-		// that survive plugin restarts via OfflineSyncService
-		long effectiveLastActivity = trackedOffer == null ? 0L : trackedOffer.getEffectiveLastActivityAtMillis();
-		if (config.showOfferTimers() && trackedOffer != null && effectiveLastActivity > 0)
-		{
-			boolean isComplete = offer.getState() == GrandExchangeOfferState.BOUGHT ||
-								 offer.getState() == GrandExchangeOfferState.SOLD;
-
-			long realStartTime = effectiveLastActivity;
-
-			String timerText;
-			if (isComplete && trackedOffer.getCompletedAtMillis() > 0)
-			{
-				timerText = TimeUtils.formatFrozenElapsedTime(realStartTime, trackedOffer.getCompletedAtMillis());
-			}
-			else
-			{
-				timerText = TimeUtils.formatElapsedTime(realStartTime);
-			}
-
-			Font originalFont = graphics.getFont();
-			graphics.setFont(new Font("Arial", Font.BOLD, 11));
-			FontMetrics fm = graphics.getFontMetrics();
-
-			// Position timer in top-right corner with padding
-			int timerWidth = fm.stringWidth(timerText);
-			int textX = bounds.x + bounds.width - timerWidth - 6;
-			int textY = bounds.y + 14;
-
-			// Draw timer shadow and text
-			graphics.setColor(COLOR_TIMER_SHADOW);
-			graphics.drawString(timerText, textX + 1, textY + 1);
-			graphics.setColor(isComplete ? getCompetitiveColor() : COLOR_TIMER_TEXT);
-			graphics.drawString(timerText, textX, textY);
-
-			graphics.setFont(originalFont);
-		}
-	}
-
-	/**
-	 * Get competitive border color (more opaque than background)
-	 */
-	private Color getBorderCompetitiveColor()
-	{
-		if (config.colorblindMode())
-		{
-			return new Color(0, 102, 204, 200);  // Semi-opaque blue
-		}
-		return new Color(76, 187, 23, 200);  // Semi-opaque green
-	}
-
-	/**
-	 * Get uncompetitive border color (more opaque than background)
-	 */
-	private Color getBorderUncompetitiveColor()
-	{
-		if (config.colorblindMode())
-		{
-			return new Color(255, 140, 0, 200);  // Semi-opaque orange
-		}
-		return new Color(215, 75, 75, 200);  // Semi-opaque red (similar to yellow in screenshot)
-	}
-
-	/**
-	 * Render completion checkbox if order is complete
-	 */
-	private void renderCompletionCheckbox(Graphics2D graphics, Rectangle bounds, GrandExchangeOffer offer)
-	{
-		boolean isComplete = offer.getState() == GrandExchangeOfferState.BOUGHT ||
-							 offer.getState() == GrandExchangeOfferState.SOLD;
-
-		if (config.showCompetitivenessIndicators() && isComplete)
-		{
-			// Position checkbox at top-right of slot
-			int topY = bounds.y + 18;
-			drawCompletionCheckbox(graphics, bounds.x + bounds.width - 12, topY - 4);
 		}
 	}
 
@@ -459,40 +362,6 @@ public class GrandExchangeSlotOverlay extends Overlay
 		}
 
 		return null;
-	}
-
-	/**
-	 * Draw completion checkbox indicator (green/blue checkmark for orders ready to collect)
-	 */
-	private void drawCompletionCheckbox(Graphics2D graphics, int x, int y)
-	{
-		int size = 10;
-		int centerX = x - size / 2;
-		int centerY = y - size / 2;
-
-		// Draw outer shadow for depth
-		graphics.setColor(new Color(0, 0, 0, 80));
-		graphics.fillOval(centerX + 1, centerY + 1, size, size);
-
-		// Draw filled circle (green or blue for colorblind mode)
-		graphics.setColor(getCompetitiveColor());
-		graphics.fillOval(centerX, centerY, size, size);
-
-		// Draw checkmark
-		graphics.setColor(Color.WHITE);
-		graphics.setStroke(new BasicStroke(1.5f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
-
-		int padding = 3;
-		int left = centerX + padding;
-		int right = centerX + size - padding;
-		int bottom = centerY + size - padding;
-		int midY = centerY + size / 2;
-		int checkMidX = centerX + size / 3;
-
-		graphics.drawLine(left, midY, checkMidX, bottom - 1);
-		graphics.drawLine(checkMidX, bottom - 1, right, centerY + padding);
-
-		graphics.setStroke(new BasicStroke(1));
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
@@ -5,6 +5,7 @@ import com.flipsmart.domain.offer.OfferSignal;
 import com.flipsmart.util.BuyPriceLookup;
 import com.flipsmart.util.GeTax;
 import com.flipsmart.util.GpUtils;
+import com.flipsmart.util.TimeUtils;
 
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -52,6 +53,8 @@ public class GrandExchangeSlotOverlay extends Overlay
 	// Colors - designed to blend with GE's brown/tan color scheme
 	private static final Color COLOR_COMPETITIVE = new Color(76, 187, 23);        // OSRS green
 	private static final Color COLOR_UNCOMPETITIVE = new Color(215, 75, 75);      // Soft red
+	private static final Color COLOR_TIMER_TEXT = new Color(255, 255, 255);       // White
+	private static final Color COLOR_TIMER_SHADOW = new Color(0, 0, 0, 160);      // Subtle shadow
 	private static final Color COLOR_FLIP_ASSIST_GLOW = new Color(255, 185, 50);  // Orange glow for flip assist
 
 	// Colorblind-safe alternative colors (blue/orange instead of green/red)
@@ -285,9 +288,8 @@ public class GrandExchangeSlotOverlay extends Overlay
 		}
 
 		OfferRecord trackedOffer = plugin.getOfferStore().bySlot(slot);
-		FlipSmartPlugin.OfferCompetitiveness competitiveness = plugin.calculateCompetitiveness(trackedOffer);
 
-		renderIndicatorBar(graphics, bounds, trackedOffer, offer, competitiveness, slot);
+		renderIndicatorBar(graphics, bounds, trackedOffer, offer, slot);
 
 		return checkForTooltip(bounds, offer);
 	}
@@ -296,11 +298,13 @@ public class GrandExchangeSlotOverlay extends Overlay
 	 * Render the amber Flip Assist glow for the slot, if any.
 	 */
 	private void renderIndicatorBar(Graphics2D graphics, Rectangle bounds, OfferRecord trackedOffer,
-									GrandExchangeOffer offer, FlipSmartPlugin.OfferCompetitiveness competitiveness, int slot)
+									GrandExchangeOffer offer, int slot)
 	{
 		// A current-action highlight (bright amber pulse) always wins over a skipped-item
 		// reminder on the same slot; a sticky-only slot renders dimmed so it reads as
 		// secondary and never competes with the slot the Flip Assist panel is prompting.
+		// The competitiveness border itself is a native sprite recolor (GeSlotWidgetDecorator),
+		// not drawn here, so it always sits under the game's hover text.
 		if (adjustmentHighlights.containsKey(slot))
 		{
 			drawOrangeGlow(graphics, bounds);
@@ -308,6 +312,34 @@ public class GrandExchangeSlotOverlay extends Overlay
 		else if (stickyAdjustmentSlots.contains(slot))
 		{
 			drawDimReminderGlow(graphics, bounds);
+		}
+
+		// Timer in the top-right corner, clear of the "Buy"/"Sell" label (nudged in from the
+		// left border by GeSlotWidgetDecorator).
+		long effectiveLastActivity = trackedOffer == null ? 0L : trackedOffer.getEffectiveLastActivityAtMillis();
+		if (config.showOfferTimers() && trackedOffer != null && effectiveLastActivity > 0)
+		{
+			boolean isComplete = offer.getState() == GrandExchangeOfferState.BOUGHT ||
+								 offer.getState() == GrandExchangeOfferState.SOLD;
+
+			String timerText = isComplete && trackedOffer.getCompletedAtMillis() > 0
+				? TimeUtils.formatFrozenElapsedTime(effectiveLastActivity, trackedOffer.getCompletedAtMillis())
+				: TimeUtils.formatElapsedTime(effectiveLastActivity);
+
+			Font originalFont = graphics.getFont();
+			graphics.setFont(new Font("Arial", Font.BOLD, 11));
+			FontMetrics fm = graphics.getFontMetrics();
+
+			int timerWidth = fm.stringWidth(timerText);
+			int textX = bounds.x + bounds.width - timerWidth - 6;
+			int textY = bounds.y + 14;
+
+			graphics.setColor(COLOR_TIMER_SHADOW);
+			graphics.drawString(timerText, textX + 1, textY + 1);
+			graphics.setColor(isComplete ? getCompetitiveColor() : COLOR_TIMER_TEXT);
+			graphics.drawString(timerText, textX, textY);
+
+			graphics.setFont(originalFont);
 		}
 	}
 

--- a/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
@@ -1,11 +1,9 @@
 package com.flipsmart;
 import com.flipsmart.api.dto.WikiPrice;
-import com.flipsmart.domain.offer.OfferRecord;
 import com.flipsmart.domain.offer.OfferSignal;
 import com.flipsmart.util.BuyPriceLookup;
 import com.flipsmart.util.GeTax;
 import com.flipsmart.util.GpUtils;
-import com.flipsmart.util.TimeUtils;
 
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -53,8 +51,6 @@ public class GrandExchangeSlotOverlay extends Overlay
 	// Colors - designed to blend with GE's brown/tan color scheme
 	private static final Color COLOR_COMPETITIVE = new Color(76, 187, 23);        // OSRS green
 	private static final Color COLOR_UNCOMPETITIVE = new Color(215, 75, 75);      // Soft red
-	private static final Color COLOR_TIMER_TEXT = new Color(255, 255, 255);       // White
-	private static final Color COLOR_TIMER_SHADOW = new Color(0, 0, 0, 160);      // Subtle shadow
 	private static final Color COLOR_FLIP_ASSIST_GLOW = new Color(255, 185, 50);  // Orange glow for flip assist
 
 	// Colorblind-safe alternative colors (blue/orange instead of green/red)
@@ -287,24 +283,21 @@ public class GrandExchangeSlotOverlay extends Overlay
 			return null;
 		}
 
-		OfferRecord trackedOffer = plugin.getOfferStore().bySlot(slot);
-
-		renderIndicatorBar(graphics, bounds, trackedOffer, offer, slot);
+		renderAmberGlow(graphics, bounds, slot);
 
 		return checkForTooltip(bounds, offer);
 	}
 
 	/**
-	 * Render the amber Flip Assist glow for the slot, if any.
+	 * Render the amber Flip Assist glow for the slot, if any. The competitiveness border and the
+	 * timer are native widget manipulations (GeSlotWidgetDecorator), not drawn here, so they always
+	 * sit under the game's hover text.
 	 */
-	private void renderIndicatorBar(Graphics2D graphics, Rectangle bounds, OfferRecord trackedOffer,
-									GrandExchangeOffer offer, int slot)
+	private void renderAmberGlow(Graphics2D graphics, Rectangle bounds, int slot)
 	{
 		// A current-action highlight (bright amber pulse) always wins over a skipped-item
 		// reminder on the same slot; a sticky-only slot renders dimmed so it reads as
 		// secondary and never competes with the slot the Flip Assist panel is prompting.
-		// The competitiveness border itself is a native sprite recolor (GeSlotWidgetDecorator),
-		// not drawn here, so it always sits under the game's hover text.
 		if (adjustmentHighlights.containsKey(slot))
 		{
 			drawOrangeGlow(graphics, bounds);
@@ -312,34 +305,6 @@ public class GrandExchangeSlotOverlay extends Overlay
 		else if (stickyAdjustmentSlots.contains(slot))
 		{
 			drawDimReminderGlow(graphics, bounds);
-		}
-
-		// Timer in the top-right corner, clear of the "Buy"/"Sell" label (nudged in from the
-		// left border by GeSlotWidgetDecorator).
-		long effectiveLastActivity = trackedOffer == null ? 0L : trackedOffer.getEffectiveLastActivityAtMillis();
-		if (config.showOfferTimers() && trackedOffer != null && effectiveLastActivity > 0)
-		{
-			boolean isComplete = offer.getState() == GrandExchangeOfferState.BOUGHT ||
-								 offer.getState() == GrandExchangeOfferState.SOLD;
-
-			String timerText = isComplete && trackedOffer.getCompletedAtMillis() > 0
-				? TimeUtils.formatFrozenElapsedTime(effectiveLastActivity, trackedOffer.getCompletedAtMillis())
-				: TimeUtils.formatElapsedTime(effectiveLastActivity);
-
-			Font originalFont = graphics.getFont();
-			graphics.setFont(new Font("Arial", Font.BOLD, 11));
-			FontMetrics fm = graphics.getFontMetrics();
-
-			int timerWidth = fm.stringWidth(timerText);
-			int textX = bounds.x + bounds.width - timerWidth - 6;
-			int textY = bounds.y + 14;
-
-			graphics.setColor(COLOR_TIMER_SHADOW);
-			graphics.drawString(timerText, textX + 1, textY + 1);
-			graphics.setColor(isComplete ? getCompetitiveColor() : COLOR_TIMER_TEXT);
-			graphics.drawString(timerText, textX, textY);
-
-			graphics.setFont(originalFont);
 		}
 	}
 

--- a/src/main/java/com/flipsmart/SlotBorderTint.java
+++ b/src/main/java/com/flipsmart/SlotBorderTint.java
@@ -1,0 +1,37 @@
+package com.flipsmart;
+
+import java.awt.Color;
+import java.util.Optional;
+
+public enum SlotBorderTint
+{
+    GREEN(new Color(76, 187, 23)),
+    RED(new Color(215, 75, 75)),
+    BLUE(new Color(0, 102, 204)),
+    ORANGE(new Color(255, 140, 0));
+
+    private final Color color;
+
+    SlotBorderTint(Color color)
+    {
+        this.color = color;
+    }
+
+    public Color getColor()
+    {
+        return color;
+    }
+
+    public static Optional<SlotBorderTint> forOffer(FlipSmartPlugin.OfferCompetitiveness competitiveness, boolean colorblind)
+    {
+        switch (competitiveness)
+        {
+            case COMPETITIVE:
+                return Optional.of(colorblind ? BLUE : GREEN);
+            case UNCOMPETITIVE:
+                return Optional.of(colorblind ? ORANGE : RED);
+            default:
+                return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/flipsmart/SpriteOutline.java
+++ b/src/main/java/com/flipsmart/SpriteOutline.java
@@ -1,0 +1,54 @@
+package com.flipsmart;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+/**
+ * Builds a thin edge-outline sprite for one GE slot border piece.
+ *
+ * <p>The frame pieces overhang the visible slot by a few px (their outer edge sticks out past the
+ * slot bounds), so the slot's actual border does not sit at the sprite's own edge. Each line is
+ * therefore positioned at the slot border expressed in the piece's local coordinates —
+ * {@code -relX}/{@code -relY} for the top/left, {@code slot - rel - thickness} for the bottom/right —
+ * and the {@link Graphics2D} clip drops any part that falls outside the piece. Corners (which are
+ * aligned to the slot) resolve to their own edges under the same formula.
+ */
+public final class SpriteOutline
+{
+    public static final int TOP = 1;
+    public static final int BOTTOM = 2;
+    public static final int LEFT = 4;
+    public static final int RIGHT = 8;
+
+    private SpriteOutline()
+    {
+    }
+
+    public static BufferedImage build(int width, int height, int edges, Color color, int thickness,
+                                      int relX, int relY, int slotWidth, int slotHeight)
+    {
+        BufferedImage out = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        int t = Math.max(1, thickness);
+        Graphics2D g = out.createGraphics();
+        g.setColor(color);
+        if ((edges & TOP) != 0)
+        {
+            g.fillRect(0, -relY, width, t);
+        }
+        if ((edges & BOTTOM) != 0)
+        {
+            g.fillRect(0, slotHeight - relY - t, width, t);
+        }
+        if ((edges & LEFT) != 0)
+        {
+            g.fillRect(-relX, 0, t, height);
+        }
+        if ((edges & RIGHT) != 0)
+        {
+            g.fillRect(slotWidth - relX - t, 0, t, height);
+        }
+        g.dispose();
+        return out;
+    }
+}

--- a/src/main/java/com/flipsmart/SpriteRecolor.java
+++ b/src/main/java/com/flipsmart/SpriteRecolor.java
@@ -1,0 +1,40 @@
+package com.flipsmart;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+
+public final class SpriteRecolor
+{
+    private SpriteRecolor()
+    {
+    }
+
+    public static BufferedImage tint(BufferedImage src, Color color)
+    {
+        int w = src.getWidth();
+        int h = src.getHeight();
+        BufferedImage out = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+
+        for (int y = 0; y < h; y++)
+        {
+            for (int x = 0; x < w; x++)
+            {
+                int argb = src.getRGB(x, y);
+                int a = argb >>> 24;
+                if (a == 0)
+                {
+                    out.setRGB(x, y, 0);
+                    continue;
+                }
+                int r = (argb >> 16) & 0xff;
+                int g = (argb >> 8) & 0xff;
+                int b = argb & 0xff;
+                int nr = r * color.getRed() / 255;
+                int ng = g * color.getGreen() / 255;
+                int nb = b * color.getBlue() / 255;
+                out.setRGB(x, y, (a << 24) | (nr << 16) | (ng << 8) | nb);
+            }
+        }
+        return out;
+    }
+}

--- a/src/main/java/com/flipsmart/SpriteRecolor.java
+++ b/src/main/java/com/flipsmart/SpriteRecolor.java
@@ -9,11 +9,6 @@ public final class SpriteRecolor
     {
     }
 
-    public static BufferedImage tint(BufferedImage src, Color color)
-    {
-        return tint(src, color, 1.0);
-    }
-
     /**
      * Multiply-tints each pixel toward {@code color}, then blends that result back toward the
      * original by {@code strength} (1.0 = full tint, 0.0 = untouched). Lower strengths keep the

--- a/src/main/java/com/flipsmart/SpriteRecolor.java
+++ b/src/main/java/com/flipsmart/SpriteRecolor.java
@@ -11,6 +11,17 @@ public final class SpriteRecolor
 
     public static BufferedImage tint(BufferedImage src, Color color)
     {
+        return tint(src, color, 1.0);
+    }
+
+    /**
+     * Multiply-tints each pixel toward {@code color}, then blends that result back toward the
+     * original by {@code strength} (1.0 = full tint, 0.0 = untouched). Lower strengths keep the
+     * native texture visible for a lighter accent. Alpha is preserved; transparent pixels stay
+     * transparent.
+     */
+    public static BufferedImage tint(BufferedImage src, Color color, double strength)
+    {
         int w = src.getWidth();
         int h = src.getHeight();
         BufferedImage out = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
@@ -29,9 +40,9 @@ public final class SpriteRecolor
                 int r = (argb >> 16) & 0xff;
                 int g = (argb >> 8) & 0xff;
                 int b = argb & 0xff;
-                int nr = r * color.getRed() / 255;
-                int ng = g * color.getGreen() / 255;
-                int nb = b * color.getBlue() / 255;
+                int nr = (int) Math.round(r + (r * color.getRed() / 255 - r) * strength);
+                int ng = (int) Math.round(g + (g * color.getGreen() / 255 - g) * strength);
+                int nb = (int) Math.round(b + (b * color.getBlue() / 255 - b) * strength);
                 out.setRGB(x, y, (a << 24) | (nr << 16) | (ng << 8) | nb);
             }
         }

--- a/src/test/java/com/flipsmart/GeSlotStateTextTest.java
+++ b/src/test/java/com/flipsmart/GeSlotStateTextTest.java
@@ -1,0 +1,27 @@
+package com.flipsmart;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class GeSlotStateTextTest
+{
+    @Test
+    public void buyWithShortTimer()
+    {
+        assertEquals("Buy  <col=ffffff>5:32</col>", GeSlotStateText.build("Buy", "5:32", "ffffff"));
+    }
+
+    @Test
+    public void sellWithHourLengthTimerDoesNotTruncateOrReorder()
+    {
+        // AC9: even at hour lengths the label + timer are one clean string
+        assertEquals("Sell  <col=4cbb17>1:23:45</col>", GeSlotStateText.build("Sell", "1:23:45", "4cbb17"));
+    }
+
+    @Test
+    public void labelStaysUntaggedSoItKeepsNativeColor()
+    {
+        String out = GeSlotStateText.build("Buy", "0:05", "ffffff");
+        assertEquals("Buy", out.substring(0, out.indexOf("<col=")).trim());
+    }
+}

--- a/src/test/java/com/flipsmart/SlotBorderTintTest.java
+++ b/src/test/java/com/flipsmart/SlotBorderTintTest.java
@@ -1,0 +1,40 @@
+package com.flipsmart;
+
+import org.junit.Test;
+import java.awt.Color;
+import java.util.Optional;
+import static org.junit.Assert.assertEquals;
+import static com.flipsmart.FlipSmartPlugin.OfferCompetitiveness.*;
+
+public class SlotBorderTintTest
+{
+    @Test
+    public void competitiveNormalIsGreen()
+    {
+        assertEquals(Optional.of(SlotBorderTint.GREEN), SlotBorderTint.forOffer(COMPETITIVE, false));
+        assertEquals(new Color(76, 187, 23), SlotBorderTint.GREEN.getColor());
+    }
+
+    @Test
+    public void uncompetitiveNormalIsRed()
+    {
+        assertEquals(Optional.of(SlotBorderTint.RED), SlotBorderTint.forOffer(UNCOMPETITIVE, false));
+        assertEquals(new Color(215, 75, 75), SlotBorderTint.RED.getColor());
+    }
+
+    @Test
+    public void colorblindSwapsToBlueAndOrange()
+    {
+        assertEquals(Optional.of(SlotBorderTint.BLUE), SlotBorderTint.forOffer(COMPETITIVE, true));
+        assertEquals(Optional.of(SlotBorderTint.ORANGE), SlotBorderTint.forOffer(UNCOMPETITIVE, true));
+        assertEquals(new Color(0, 102, 204), SlotBorderTint.BLUE.getColor());
+        assertEquals(new Color(255, 140, 0), SlotBorderTint.ORANGE.getColor());
+    }
+
+    @Test
+    public void unknownYieldsEmpty()
+    {
+        assertEquals(Optional.empty(), SlotBorderTint.forOffer(UNKNOWN, false));
+        assertEquals(Optional.empty(), SlotBorderTint.forOffer(UNKNOWN, true));
+    }
+}

--- a/src/test/java/com/flipsmart/SpriteOutlineTest.java
+++ b/src/test/java/com/flipsmart/SpriteOutlineTest.java
@@ -1,0 +1,46 @@
+package com.flipsmart;
+
+import org.junit.Test;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import static org.junit.Assert.assertEquals;
+
+public class SpriteOutlineTest
+{
+    private static final Color GREEN = new Color(0, 255, 0);
+    private static final int OPAQUE = GREEN.getRGB();
+
+    @Test
+    public void topEdgePieceDrawsLineAtSlotBorderNotSpriteEdge()
+    {
+        // Mirrors the vanilla top edge piece: 83x32 overhanging 13px above the slot (relY=-13).
+        BufferedImage out = SpriteOutline.build(83, 32, SpriteOutline.TOP, GREEN, 2, 16, -13, 115, 110);
+
+        // The slot's top border sits at piece-local y = -relY = 13, not at the sprite's own top (y=0).
+        assertEquals(OPAQUE, out.getRGB(40, 13));
+        assertEquals("sprite top (above the slot) stays transparent", 0, out.getRGB(40, 0));
+        assertEquals("below the border line stays transparent", 0, out.getRGB(40, 20));
+    }
+
+    @Test
+    public void rightEdgePieceDrawsLineAtSlotRightBorder()
+    {
+        // Vanilla right edge piece: 32x78 at relX=95; slot right border = slotWidth - relX - t = 18.
+        BufferedImage out = SpriteOutline.build(32, 78, SpriteOutline.RIGHT, GREEN, 2, 95, 16, 115, 110);
+
+        assertEquals(OPAQUE, out.getRGB(18, 40));
+        assertEquals("sprite right edge (past the slot) stays transparent", 0, out.getRGB(31, 40));
+        assertEquals("sprite left stays transparent", 0, out.getRGB(0, 40));
+    }
+
+    @Test
+    public void alignedCornerDrawsTwoEdgesAtItsOwnCorner()
+    {
+        // Top-left corner is aligned to the slot (relX=relY=0), so the formula resolves to its own edges.
+        BufferedImage out = SpriteOutline.build(32, 32, SpriteOutline.TOP | SpriteOutline.LEFT, GREEN, 2, 0, 0, 115, 110);
+
+        assertEquals("top line", OPAQUE, out.getRGB(15, 0));
+        assertEquals("left line", OPAQUE, out.getRGB(0, 15));
+        assertEquals("interior transparent", 0, out.getRGB(16, 16));
+    }
+}

--- a/src/test/java/com/flipsmart/SpriteRecolorTest.java
+++ b/src/test/java/com/flipsmart/SpriteRecolorTest.java
@@ -8,14 +8,26 @@ import static org.junit.Assert.assertEquals;
 public class SpriteRecolorTest
 {
     @Test
-    public void midGrayTintedGreenKeepsLuminanceOnGreenChannelOnly()
+    public void fullStrengthMidGrayTintedGreenKeepsLuminanceOnGreenChannelOnly()
     {
         BufferedImage src = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
         src.setRGB(0, 0, new Color(128, 128, 128, 255).getRGB());
 
-        BufferedImage out = SpriteRecolor.tint(src, new Color(0, 255, 0));
+        BufferedImage out = SpriteRecolor.tint(src, new Color(0, 255, 0), 1.0);
 
         assertEquals(new Color(0, 128, 0, 255).getRGB(), out.getRGB(0, 0));
+    }
+
+    @Test
+    public void halfStrengthBlendsBackTowardOriginal()
+    {
+        BufferedImage src = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+        src.setRGB(0, 0, new Color(128, 128, 128, 255).getRGB());
+
+        // Full tint = (0,128,0); half strength halves the delta from the original 128 → (64,128,64).
+        BufferedImage out = SpriteRecolor.tint(src, new Color(0, 255, 0), 0.5);
+
+        assertEquals(new Color(64, 128, 64, 255).getRGB(), out.getRGB(0, 0));
     }
 
     @Test
@@ -24,7 +36,7 @@ public class SpriteRecolorTest
         BufferedImage src = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
         src.setRGB(0, 0, 0x00000000);
 
-        BufferedImage out = SpriteRecolor.tint(src, new Color(255, 0, 0));
+        BufferedImage out = SpriteRecolor.tint(src, new Color(255, 0, 0), 1.0);
 
         assertEquals(0, (out.getRGB(0, 0) >>> 24));
     }
@@ -35,7 +47,7 @@ public class SpriteRecolorTest
         BufferedImage src = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
         src.setRGB(0, 0, new Color(200, 200, 200, 120).getRGB());
 
-        BufferedImage out = SpriteRecolor.tint(src, new Color(255, 255, 255));
+        BufferedImage out = SpriteRecolor.tint(src, new Color(255, 255, 255), 1.0);
 
         assertEquals(120, (out.getRGB(0, 0) >>> 24));
     }

--- a/src/test/java/com/flipsmart/SpriteRecolorTest.java
+++ b/src/test/java/com/flipsmart/SpriteRecolorTest.java
@@ -1,0 +1,42 @@
+package com.flipsmart;
+
+import org.junit.Test;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import static org.junit.Assert.assertEquals;
+
+public class SpriteRecolorTest
+{
+    @Test
+    public void midGrayTintedGreenKeepsLuminanceOnGreenChannelOnly()
+    {
+        BufferedImage src = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+        src.setRGB(0, 0, new Color(128, 128, 128, 255).getRGB());
+
+        BufferedImage out = SpriteRecolor.tint(src, new Color(0, 255, 0));
+
+        assertEquals(new Color(0, 128, 0, 255).getRGB(), out.getRGB(0, 0));
+    }
+
+    @Test
+    public void transparentPixelStaysTransparent()
+    {
+        BufferedImage src = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+        src.setRGB(0, 0, 0x00000000);
+
+        BufferedImage out = SpriteRecolor.tint(src, new Color(255, 0, 0));
+
+        assertEquals(0, (out.getRGB(0, 0) >>> 24));
+    }
+
+    @Test
+    public void preservesAlpha()
+    {
+        BufferedImage src = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+        src.setRGB(0, 0, new Color(200, 200, 200, 120).getRGB());
+
+        BufferedImage out = SpriteRecolor.tint(src, new Color(255, 255, 255));
+
+        assertEquals(120, (out.getRGB(0, 0) >>> 24));
+    }
+}


### PR DESCRIPTION
## Summary

Reworks the Grand Exchange 8-slot "home" screen decorations to render natively on the game's own widgets instead of as a painted overlay, so FlipSmart's slot indicators sit *under* the client's native hover tooltips rather than drawing over them. Competitiveness border, item-box tint, and the Buy/Sell timer all move to native widget manipulation; the completion checkmark is removed entirely.

## Changes

### ♻️ Refactoring / 🎨 UI-UX Polish

- **Native slot border outline**: new `SpriteOutline` class generates a thin 2px colored edge line per GE frame widget piece, sized to that piece's rendered bounds so the client tiles it once, and positioned at the true slot border via each piece's overhang offset. This replaces the previous overlay-painted border rectangle.
- **Border color selection**: new `SlotBorderTint` class maps slot competitiveness state to the outline color.
- **Item background light fill**: the item background box now gets a subtle fill via `SpriteRecolor.tint(..., 0.5)`, which blends the tint back toward the original texture (native GE frame art still shows through) rather than a flat painted color.
- **Native offer timer**: new `GeSlotStateText` class renders the offer timer directly on the existing "Buy"/"Sell" state-text widget, color-tagged and left-aligned with a 12px inset, replacing the old painted-overlay timer text.
- **Completion checkmark removed**: the checkmark that previously indicated a completed offer has been removed entirely.
- **`GrandExchangeSlotOverlay` trimmed**: now only draws the amber Flip-Assist glow and the hover price tooltip. All competitiveness-border, timer, and checkmark drawing was removed (superseded by the native widget path below).
- **New collaborator: `GeSlotWidgetDecorator`**: owns all native widget manipulation described above (sprite recoloring/registration, border-child sprite swap, state-text rewrite). Wired into the plugin lifecycle in `FlipSmartPlugin`:
  - registers recolored sprites at startup
  - reconciles slot decorations every game tick while at the GE
  - reverts all widgets to their original vanilla state on logout/shutdown
- Internal robustness fix folded into this branch: vanilla-capture maps are now keyed by GE slot index rather than widget identity, since RuneLite widget instances aren't stable identity keys across ticks.

## Testing

### Automated Tests

- ✅ New unit tests, all passing:
  - `SpriteOutlineTest` (3 tests) — edge-piece line placement at the true slot border, not the sprite's own edge; correct two-edge draw at aligned corners
  - `SpriteRecolorTest` (4 tests) — multiply-tint blending behavior
  - `SlotBorderTintTest` (4 tests) — competitiveness-state → color mapping
  - `GeSlotStateTextTest` (3 tests) — native Buy/Sell text + appended timer construction
- ✅ Full existing suite: **555 tests, 0 failures, 0 errors, 0 skipped** across 78 test suites, via `./gradlew build`
- N/A — no Playwright/browser QA is possible for this repo. RuneLite is a desktop Java game client, not a browser application, so there is no automated way to drive the actual client UI.

### Manually Verified

This was manually tested live by the author in a real RuneLite client against a live GE session. The following were confirmed working end-to-end:

- [x] Viewed all 8 GE slots with a mix of buying, selling, and completed offers
- [x] A clean thin colored outline appears at the slot border and sits *under* hover tooltips (no more overlay-over-tooltip clipping)
- [x] The item background box shows a light fill with the native GE frame texture still visible through it
- [x] The offer timer renders natively on the Buy/Sell text and no longer draws over hover tooltips
- [x] No completion checkmark appears on completed offers
- [x] "Buy"/"Sell" text stays positioned clear of the border at all 8 slot positions

## API Changes

N/A — plugin-only change, no backend API surface touched.

## Database Migrations

N/A — no backend/database component in this repo.

## Deployment Notes

- No environment variables added or changed.
- No new dependencies added.
- No configuration changes required.
- Ships via the normal RuneLite Plugin Hub release cadence once merged (no runtime migration or rollout coordination needed).

## Checklist

- [x] Tests added/updated
- [x] Manually verified live in a real RuneLite client
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] LOC-budget comment scan clean (no issue-ref or narrative comments added to plugin source)
- [ ] Reviewed by teammate

## Related Issues

Part of Flip-Smart/flip-smart#981

## Screenshots

None attached to this PR — see "Manually Verified" above for the confirmed behaviors.

### 🩺 Codacy Quality Gate — dismissed via API (noise)
- `PMD_category_java_multithreading_UseConcurrentHashMap` `GeSlotWidgetDecorator.java:34,67,71,74,77,135` (6 findings) — single-threaded RuneLite client-thread access only; no concurrent mutation of these fields ever occurs.
- `Lizard_parameter-count-medium` `GeSlotWidgetDecorator.java:93` (`customSpriteId`, 9 params) — pixel-geometry code where each parameter independently drives outline placement math; inherently complex native-widget manipulation code.
- `Lizard_ccn-medium` `GeSlotWidgetDecorator.java:249` (`stateTextFor`, complexity 11) — same class of rendering-orchestration complexity.
- `Lizard_parameter-count-medium` `SpriteOutline.java:28` (`build`, 9 params) — pixel-geometry outline-drawing code.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `5436add` `GeSlotWidgetDecorator.java:88-97` — folded `edges` into the custom-sprite cache key so border pieces sharing a vanilla sprite id but needing different outline shapes no longer collide on the same cached sprite.

### 🤖 Codacy AI Reviewer — deferred (in-thread rationale)
- `GeSlotWidgetDecorator.java:251` — static "Buy"/"Sell" labels vs. native "Bought"/"Sold" wording on completed offers is a product/UX decision, not a mechanical fix; timer + color already signal completion. Needs author/reviewer sign-off before changing display text in this rendering-sensitive class.
- `GeSlotWidgetDecorator.java:22` — no unit coverage yet for the reconciliation logic itself (sibling pure-function classes do have tests); needs RuneLite Widget/Client mocking infrastructure this suite doesn't have — out of scope for this PR, candidate for a tech-debt follow-up.
- `GeSlotWidgetDecorator.java:211`, `GeSlotStateText.java:3`, `GrandExchangeSlotOverlay.java:343` — three comments anchored to earlier revisions of the diff (before timer support landed in `ca227b9` / before overlay cleanup landed in `ed5bdf8`); all moot against the current code.

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `GeSlotWidgetDecorator.java:34,67` (ConcurrentHashMap suggestions, 3 comments) — single-threaded client-thread access only.
- `SpriteOutline.java:28` (param-count suggestions, 2 comments) — pixel-geometry signature; reshaping it is out of scope for a mechanical Codacy pass.
