### PR TITLE
Active Flips: fix name truncation, bold live prices, 60s auto-refresh, remove redundant profit rows

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -138,7 +138,10 @@ public class FlipFinderPanel extends PluginPanel
 	private static final Font FONT_PLAIN_12 = new Font(FONT_ARIAL, Font.PLAIN, 12);
 	private static final Font FONT_BOLD_12 = new Font(FONT_ARIAL, Font.BOLD, 12);
 	private static final Font FONT_BOLD_16 = new Font(FONT_ARIAL, Font.BOLD, 16);
-	
+
+	private static final int ACTIVE_FLIPS_PRICE_REFRESH_MS = 60_000;
+	private static final int TAB_ACTIVE_FLIPS = 1;
+
 
 	private final transient FlipSmartConfig config;
 	private final transient FlipSmartApiClient apiClient;
@@ -181,6 +184,10 @@ public class FlipFinderPanel extends PluginPanel
 	private transient JPanel currentFocusedPanel = null;
 	private transient int currentFocusedItemId = -1;
 	private transient java.util.function.Consumer<FocusedFlip> onFocusChanged;
+
+	/** Refresh closures for the cards currently on the Active Flips tab; rebuilt with the list. */
+	private final transient java.util.List<Runnable> activeFlipCardRefreshers = new java.util.ArrayList<>();
+	private transient javax.swing.Timer activeFlipsPriceTimer;
 
 	// Cache displayed sell prices to ensure focus uses same price as shown in UI
 	// Key: itemId, Value: calculated sell price shown in the active flip panel
@@ -630,6 +637,14 @@ public class FlipFinderPanel extends PluginPanel
 		tabbedPane.addChangeListener(e ->
 		{
 			int selectedIndex = tabbedPane.getSelectedIndex();
+			if (selectedIndex == TAB_ACTIVE_FLIPS)
+			{
+				startActiveFlipsPriceTimer();
+			}
+			else
+			{
+				stopActiveFlipsPriceTimer();
+			}
 			if (selectedIndex == 1 && !currentActiveFlips.isEmpty())
 			{
 				// Switched to Active Flips tab, update status
@@ -1232,6 +1247,55 @@ public class FlipFinderPanel extends PluginPanel
 		updateRefreshCountdownLabel();
 	}
 
+	/**
+	 * Live prices are only worth polling while someone is looking at them. The wiki feed
+	 * the backend reads is itself ~60s CDN-cached, so a faster cadence would buy nothing.
+	 */
+	private void startActiveFlipsPriceTimer()
+	{
+		if (activeFlipsPriceTimer == null)
+		{
+			activeFlipsPriceTimer = new javax.swing.Timer(ACTIVE_FLIPS_PRICE_REFRESH_MS,
+				e -> runActiveFlipsPriceRefresh());
+			activeFlipsPriceTimer.setRepeats(true);
+		}
+		if (!activeFlipsPriceTimer.isRunning())
+		{
+			activeFlipsPriceTimer.start();
+		}
+	}
+
+	private void stopActiveFlipsPriceTimer()
+	{
+		if (activeFlipsPriceTimer != null && activeFlipsPriceTimer.isRunning())
+		{
+			activeFlipsPriceTimer.stop();
+		}
+	}
+
+	/** A manual refresh is a full interval's worth of freshness, so restart the cadence. */
+	private void restartActiveFlipsPriceTimer()
+	{
+		if (activeFlipsPriceTimer != null && activeFlipsPriceTimer.isRunning())
+		{
+			activeFlipsPriceTimer.restart();
+		}
+	}
+
+	private void runActiveFlipsPriceRefresh()
+	{
+		if (!isShowing() || tabbedPane.getSelectedIndex() != TAB_ACTIVE_FLIPS)
+		{
+			stopActiveFlipsPriceTimer();
+			return;
+		}
+		// Copy: a refresh repopulates cards, which can rebuild the list underneath us.
+		for (Runnable refresher : new java.util.ArrayList<>(activeFlipCardRefreshers))
+		{
+			refresher.run();
+		}
+	}
+
 	private void updateRefreshCountdownLabel()
 	{
 		if (refreshCountdownLabel == null)
@@ -1793,7 +1857,8 @@ public class FlipFinderPanel extends PluginPanel
 	private void displayActiveFlipsAndPending(java.util.List<ActiveFlip> activeFlips, java.util.List<PendingOrder> pendingOrders)
 	{
 		activeFlipsListContainer.removeAll();
-		
+		activeFlipCardRefreshers.clear();
+
 		// Build a map of pending orders by itemId for smart deduplication
 		java.util.Map<Integer, java.util.List<PendingOrder>> pendingByItemId = buildPendingOrdersMap(pendingOrders);
 		
@@ -2604,6 +2669,7 @@ public class FlipFinderPanel extends PluginPanel
 				refreshLabel.setEnabled(false);
 				refreshLabel.setCursor(Cursor.getDefaultCursor());
 				onRefresh.run();
+				restartActiveFlipsPriceTimer();
 				// Re-enable shortly after; the async re-populate updates the rows independently
 				javax.swing.Timer timer = new javax.swing.Timer(1200, ev ->
 				{
@@ -3296,14 +3362,16 @@ public class FlipFinderPanel extends PluginPanel
 
 		// Array indirection: the refresh closure needs the header panels before createItemHeaderPanels produces them.
 		HeaderPanels[] headerHolder = new HeaderPanels[1];
-		JLabel refreshIcon = createRefreshIconLabel(() ->
+		Runnable refreshCard = () ->
 		{
 			apiClient.invalidateCache(flip.getItemId());
 			populateActiveFlipCard(flip,
 				new ActiveFlipCardPanels(panel, headerHolder[0].topPanel, headerHolder[0].namePanel, detailsPanel),
 				new ActiveFlipCardLabels(pricesLabel, buyLimitLabel, marginLabel, currentProfitLabel,
 					potentialLabel, qtyLabel, taxLabel, liquidityLabel, riskLabel));
-		});
+		};
+		activeFlipCardRefreshers.add(refreshCard);
+		JLabel refreshIcon = createRefreshIconLabel(refreshCard);
 		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(),
 			ColorScheme.DARKER_GRAY_COLOR, refreshIcon, buyLimitLabel);
 		headerHolder[0] = header;
@@ -3661,12 +3729,14 @@ public class FlipFinderPanel extends PluginPanel
 		CardWidgets.addLabelsWithSpacing(detailsPanel, potentialLabel, qtyLabel, liquidityLabel, riskLabel);
 
 		// Header with refresh + corner buy-limit, matching the active-flip cards
-		JLabel refreshIcon = createRefreshIconLabel(() ->
+		Runnable refreshCard = () ->
 		{
 			apiClient.invalidateCache(pending.itemId);
 			populatePendingCardRows(pending, pricesLabel, marginLabel, taxLabel, qtyLabel,
 				potentialLabel, liquidityLabel, riskLabel, buyLimitLabel);
-		});
+		};
+		activeFlipCardRefreshers.add(refreshCard);
+		JLabel refreshIcon = createRefreshIconLabel(refreshCard);
 		HeaderPanels header = createItemHeaderPanels(pending.itemId, pending.itemName, bgColor, refreshIcon, buyLimitLabel);
 		allowForWrappedName(panel, header.extraNameHeight);
 		JPanel topPanel = header.topPanel;

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -19,6 +19,7 @@ import com.flipsmart.recommend.SmartSellPricer;
 import com.flipsmart.trading.ActiveFlipCardMetrics;
 import com.flipsmart.trading.RealizedFlipProfit;
 import com.flipsmart.ui.panel.CardWidgets;
+import com.flipsmart.ui.panel.ItemNameFit;
 import com.flipsmart.ui.panel.LoginPanel;
 import com.flipsmart.ui.panel.PanelFormat;
 import com.flipsmart.util.BuyPriceLookup;
@@ -138,7 +139,6 @@ public class FlipFinderPanel extends PluginPanel
 	private static final Font FONT_PLAIN_11 = new Font(FONT_ARIAL, Font.PLAIN, 11);
 	private static final Font FONT_PLAIN_12 = new Font(FONT_ARIAL, Font.PLAIN, 12);
 	private static final Font FONT_BOLD_12 = new Font(FONT_ARIAL, Font.BOLD, 12);
-	private static final Font FONT_BOLD_13 = new Font(FONT_ARIAL, Font.BOLD, 13);
 	private static final Font FONT_BOLD_16 = new Font(FONT_ARIAL, Font.BOLD, 16);
 	
 
@@ -2435,12 +2435,26 @@ public class FlipFinderPanel extends PluginPanel
 	{
 		final JPanel topPanel;
 		final JPanel namePanel;
+		/** Pixels a wrapped name adds beyond one line; 0 when the name fits on one. */
+		final int extraNameHeight;
 
-		HeaderPanels(JPanel topPanel, JPanel namePanel)
+		HeaderPanels(JPanel topPanel, JPanel namePanel, int extraNameHeight)
 		{
 			this.topPanel = topPanel;
 			this.namePanel = namePanel;
+			this.extraNameHeight = extraNameHeight;
 		}
+	}
+
+	/** Give the card back the pixels a wrapped name took, so the cap cannot clip the last row. */
+	private static void allowForWrappedName(JPanel card, int extraNameHeight)
+	{
+		if (extraNameHeight <= 0)
+		{
+			return;
+		}
+		Dimension max = card.getMaximumSize();
+		card.setMaximumSize(new Dimension(max.width, max.height + extraNameHeight));
 	}
 
 	/**
@@ -2469,14 +2483,23 @@ public class FlipFinderPanel extends PluginPanel
 		JLabel iconLabel = new JLabel();
 		CardWidgets.setupIconLabel(iconLabel, itemImage);
 
-		String escapedName = PanelFormat.escapeHtml(itemName);
-		JLabel nameLabel = new JLabel("<html>" + escapedName + "</html>");
+		JLabel nameLabel = new JLabel();
 		nameLabel.setForeground(Color.WHITE);
-		nameLabel.setFont(FONT_BOLD_13);
+		nameLabel.setVerticalAlignment(SwingConstants.TOP);
 		// Narrow the name a little more when a third (refresh) icon shares the corner
 		int nameWidth = trailingIcon != null ? 98 : 130;
-		nameLabel.setPreferredSize(new Dimension(nameWidth, nameLabel.getPreferredSize().height));
-		nameLabel.setMaximumSize(new Dimension(nameWidth, Integer.MAX_VALUE));
+		ItemNameFit.Fit nameFit = ItemNameFit.fit(itemName, nameWidth,
+			(text, size) -> nameLabel.getFontMetrics(new Font(FONT_ARIAL, Font.BOLD, size)).stringWidth(text));
+		Font nameFont = new Font(FONT_ARIAL, Font.BOLD, nameFit.getFontSize());
+		nameLabel.setFont(nameFont);
+		nameLabel.setText(nameFit.getHtml());
+		// Size the height from the line count we chose. Measuring the label before the
+		// width constraint applies reports a single line, which is what clipped names.
+		int nameLineHeight = nameLabel.getFontMetrics(nameFont).getHeight();
+		int nameHeight = nameFit.getLineCount() * nameLineHeight;
+		nameLabel.setPreferredSize(new Dimension(nameWidth, nameHeight));
+		nameLabel.setMaximumSize(new Dimension(nameWidth, nameHeight));
+		int extraNameHeight = (nameFit.getLineCount() - 1) * nameLineHeight;
 
 		namePanel.add(iconLabel, BorderLayout.WEST);
 		namePanel.add(nameLabel, BorderLayout.CENTER);
@@ -2517,7 +2540,7 @@ public class FlipFinderPanel extends PluginPanel
 			topPanel.add(iconsPanel, BorderLayout.EAST);
 		}
 
-		return new HeaderPanels(topPanel, namePanel);
+		return new HeaderPanels(topPanel, namePanel, extraNameHeight);
 	}
 	
 	/**
@@ -3346,6 +3369,7 @@ public class FlipFinderPanel extends PluginPanel
 		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(),
 			ColorScheme.DARKER_GRAY_COLOR, refreshIcon, buyLimitLabel);
 		headerHolder[0] = header;
+		allowForWrappedName(panel, header.extraNameHeight);
 		JPanel topPanel = header.topPanel;
 		JPanel namePanel = header.namePanel;
 
@@ -3706,6 +3730,7 @@ public class FlipFinderPanel extends PluginPanel
 				potentialLabel, liquidityLabel, riskLabel, buyLimitLabel);
 		});
 		HeaderPanels header = createItemHeaderPanels(pending.itemId, pending.itemName, bgColor, refreshIcon, buyLimitLabel);
+		allowForWrappedName(panel, header.extraNameHeight);
 		JPanel topPanel = header.topPanel;
 		JPanel namePanel = header.namePanel;
 

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -142,7 +142,6 @@ public class FlipFinderPanel extends PluginPanel
 	private static final int ACTIVE_FLIPS_PRICE_REFRESH_MS = 60_000;
 	private static final int TAB_ACTIVE_FLIPS = 1;
 
-
 	private final transient FlipSmartConfig config;
 	private final transient FlipSmartApiClient apiClient;
 	private final transient ItemManager itemManager;
@@ -645,7 +644,7 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				stopActiveFlipsPriceTimer();
 			}
-			if (selectedIndex == 1 && !currentActiveFlips.isEmpty())
+			if (selectedIndex == TAB_ACTIVE_FLIPS && !currentActiveFlips.isEmpty())
 			{
 				// Switched to Active Flips tab, update status
 				int itemCount = currentActiveFlips.size();
@@ -1002,6 +1001,11 @@ public class FlipFinderPanel extends PluginPanel
 			refreshCountdownTimer.stop();
 			refreshCountdownTimer = null;
 		}
+		if (activeFlipsPriceTimer != null)
+		{
+			activeFlipsPriceTimer.stop();
+			activeFlipsPriceTimer = null;
+		}
 	}
 
 	/**
@@ -1257,7 +1261,6 @@ public class FlipFinderPanel extends PluginPanel
 		{
 			activeFlipsPriceTimer = new javax.swing.Timer(ACTIVE_FLIPS_PRICE_REFRESH_MS,
 				e -> runActiveFlipsPriceRefresh());
-			activeFlipsPriceTimer.setRepeats(true);
 		}
 		if (!activeFlipsPriceTimer.isRunning())
 		{
@@ -1276,10 +1279,25 @@ public class FlipFinderPanel extends PluginPanel
 	/** A manual refresh is a full interval's worth of freshness, so restart the cadence. */
 	private void restartActiveFlipsPriceTimer()
 	{
-		if (activeFlipsPriceTimer != null && activeFlipsPriceTimer.isRunning())
+		startActiveFlipsPriceTimer();
+		activeFlipsPriceTimer.restart();
+	}
+
+	@Override
+	public void onActivate()
+	{
+		// The sidebar reopening fires no tab-change event, so this is the only signal
+		// that re-arms the price timer after a collapse.
+		if (tabbedPane.getSelectedIndex() == TAB_ACTIVE_FLIPS)
 		{
-			activeFlipsPriceTimer.restart();
+			startActiveFlipsPriceTimer();
 		}
+	}
+
+	@Override
+	public void onDeactivate()
+	{
+		stopActiveFlipsPriceTimer();
 	}
 
 	private void runActiveFlipsPriceRefresh()
@@ -1292,7 +1310,15 @@ public class FlipFinderPanel extends PluginPanel
 		// Copy: a refresh repopulates cards, which can rebuild the list underneath us.
 		for (Runnable refresher : new java.util.ArrayList<>(activeFlipCardRefreshers))
 		{
-			refresher.run();
+			try
+			{
+				refresher.run();
+			}
+			catch (RuntimeException ex)
+			{
+				// One bad card must not starve the rest of the sweep.
+				log.debug("Active flip price refresh failed for a card: {}", ex.getMessage());
+			}
 		}
 	}
 
@@ -3370,11 +3396,11 @@ public class FlipFinderPanel extends PluginPanel
 				new ActiveFlipCardLabels(pricesLabel, buyLimitLabel, marginLabel, currentProfitLabel,
 					potentialLabel, qtyLabel, taxLabel, liquidityLabel, riskLabel));
 		};
-		activeFlipCardRefreshers.add(refreshCard);
 		JLabel refreshIcon = createRefreshIconLabel(refreshCard);
 		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(),
 			ColorScheme.DARKER_GRAY_COLOR, refreshIcon, buyLimitLabel);
 		headerHolder[0] = header;
+		activeFlipCardRefreshers.add(refreshCard);
 		allowForWrappedName(panel, header.extraNameHeight);
 		JPanel topPanel = header.topPanel;
 		JPanel namePanel = header.namePanel;

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1316,7 +1316,10 @@ public class FlipFinderPanel extends PluginPanel
 			catch (RuntimeException ex)
 			{
 				// One bad card must not starve the rest of the sweep.
-				log.debug("Active flip price refresh failed for a card: {}", ex.getMessage());
+				if (log.isDebugEnabled())
+				{
+					log.debug("Active flip price refresh failed for a card: {}", ex.getMessage());
+				}
 			}
 		}
 	}

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1610,7 +1610,7 @@ public class FlipFinderPanel extends PluginPanel
 			int invested = currentActiveFlips.stream()
 				.mapToInt(ActiveFlip::getTotalInvested)
 				.sum();
-			if (tabbedPane.getSelectedIndex() == 1)
+			if (tabbedPane.getSelectedIndex() == TAB_ACTIVE_FLIPS)
 			{
 				statusLabel.setText(String.format("%d active %s | %s invested",
 					itemCount,
@@ -2542,7 +2542,10 @@ public class FlipFinderPanel extends PluginPanel
 			return;
 		}
 		Dimension max = card.getMaximumSize();
-		card.setMaximumSize(new Dimension(max.width, max.height + extraNameHeight));
+		int raised = max.height > Integer.MAX_VALUE - extraNameHeight
+			? Integer.MAX_VALUE
+			: max.height + extraNameHeight;
+		card.setMaximumSize(new Dimension(max.width, raised));
 	}
 
 	/**
@@ -3673,6 +3676,12 @@ public class FlipFinderPanel extends PluginPanel
 		FocusedFlip updatedFocus = FocusedFlip.forSell(
 			flip.getItemId(), flip.getItemName(), smartSellPrice,
 			sellQuantityFor(flip), config.priceOffset());
+		// Re-pushing an unchanged focus clears the overlay's active prompt and re-writes
+		// the GE search varp, so a periodic refresh must not do it.
+		if (updatedFocus.equals(currentFocus))
+		{
+			return;
+		}
 		currentFocus = updatedFocus;
 		if (onFocusChanged != null)
 		{
@@ -3895,6 +3904,7 @@ public class FlipFinderPanel extends PluginPanel
 
 		// Top section: Item icon and name
 		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(), backgroundColor);
+		allowForWrappedName(panel, header.extraNameHeight);
 		JPanel topPanel = header.topPanel;
 
 		// Details section with profit/loss info - use GridBagLayout for tighter column spacing

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1,6 +1,4 @@
 package com.flipsmart;
-import com.flipsmart.domain.offer.OfferAction;
-import com.flipsmart.api.dto.OfferAdviceResponse;
 import com.flipsmart.domain.flip.CompletedFlip;
 import com.flipsmart.domain.flip.FlipRecommendation;
 import com.flipsmart.api.dto.ActiveFlipsResponse;
@@ -183,7 +181,6 @@ public class FlipFinderPanel extends PluginPanel
 	private transient JPanel currentFocusedPanel = null;
 	private transient int currentFocusedItemId = -1;
 	private transient java.util.function.Consumer<FocusedFlip> onFocusChanged;
-	private transient java.util.function.IntFunction<OfferAdviceResponse> offerDispositionLookup;
 
 	// Cache displayed sell prices to ensure focus uses same price as shown in UI
 	// Key: itemId, Value: calculated sell price shown in the active flip panel
@@ -2936,38 +2933,6 @@ public class FlipFinderPanel extends PluginPanel
 		this.onFocusChanged = callback;
 	}
 
-	public void setOfferDispositionLookup(java.util.function.IntFunction<OfferAdviceResponse> lookup)
-	{
-		this.offerDispositionLookup = lookup;
-	}
-
-	private static String activeOfferVerb(OfferAction action, Integer netProfitEstimate)
-	{
-		boolean isLoss = netProfitEstimate != null && netProfitEstimate < 0;
-		boolean isProfit = netProfitEstimate != null && netProfitEstimate > 0;
-		switch (action)
-		{
-			case MOVE_PRICE_DOWN:
-				return "Move price down";
-			case EXIT_AT_BREAKEVEN:
-				if (isLoss)
-				{
-					return "Exit at a loss";
-				}
-				return isProfit ? "Take profit" : "Exit at breakeven";
-			case EXIT_AT_LOSS:
-				return "Exit at a loss";
-			default:
-				return "";
-		}
-	}
-
-	private static String formatSignedGp(int amount)
-	{
-		return (amount >= 0 ? "+" : "-") + GpUtils.formatGP(Math.abs(amount));
-	}
-
-
 	/**
 	 * Set the callback for when authentication succeeds.
 	 * This allows the plugin to sync RSN after Discord login.
@@ -3328,33 +3293,6 @@ public class FlipFinderPanel extends PluginPanel
 		detailsPanel.add(Box.createRigidArea(new Dimension(0, 3)));
 		CardWidgets.addLabelsWithSpacing(detailsPanel, currentProfitLabel, potentialLabel, qtyLabel,
 			liquidityLabel, riskLabel);
-
-		if (offerDispositionLookup != null)
-		{
-			OfferAdviceResponse advice = offerDispositionLookup.apply(flip.getItemId());
-			String verb = advice != null && advice.getActionEnum() != null
-				? activeOfferVerb(advice.getActionEnum(), advice.getNetProfitEstimate())
-				: "";
-			if (!verb.isEmpty())
-			{
-				detailsPanel.add(Box.createRigidArea(new Dimension(0, 2)));
-
-				String verbLine = advice.getNewPrice() != null
-					? verb + ": " + String.format("%,d", advice.getNewPrice()) + "gp"
-					: verb;
-				JLabel verbLabel = CardWidgets.createStyledLabel(verbLine, Color.ORANGE);
-				verbLabel.setToolTipText(advice.getReason());
-				detailsPanel.add(verbLabel);
-
-				if (advice.getNetProfitEstimate() != null)
-				{
-					int net = advice.getNetProfitEstimate();
-					String keyword = net < 0 ? "Loss" : (net > 0 ? "Profit" : "Breakeven");
-					Color netColor = net < 0 ? new Color(255, 100, 100) : new Color(80, 255, 120);
-					detailsPanel.add(CardWidgets.createStyledLabel(keyword + ": " + formatSignedGp(net), netColor));
-				}
-			}
-		}
 
 		// Array indirection: the refresh closure needs the header panels before createItemHeaderPanels produces them.
 		HeaderPanels[] headerHolder = new HeaderPanels[1];

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1004,7 +1004,6 @@ public class FlipFinderPanel extends PluginPanel
 		if (activeFlipsPriceTimer != null)
 		{
 			activeFlipsPriceTimer.stop();
-			activeFlipsPriceTimer = null;
 		}
 	}
 

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1514,8 +1514,6 @@ public class FlipSmartPlugin extends Plugin
 			}
 		});
 
-		flipFinderPanel.setOfferDispositionLookup(id -> activeOfferAdvisorService.getDisposition(id));
-
 		// Connect auth success callback to sync RSN after Discord login
 		flipFinderPanel.setOnAuthSuccess(() -> {
 			// Sync RSN to API if we have one (player is logged in)

--- a/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
@@ -21,9 +21,9 @@ import static com.flipsmart.api.ApiHttpTransport.urlEncode;
 
 /**
  * Item analysis, flip recommendations and flip-adjustment endpoints.
- * Owns the per-item analysis cache. Analysis feeds slow-moving card display
- * fields (buy limit, liquidity, risk), so a long TTL is acceptable; live
- * prices on cards come from the active-flips payload, not from here.
+ * Analysis responses are cached for CACHE_DURATION_MS. The Active Flips cards read their
+ * live prices from here, so they invalidate per item before refetching rather than wait
+ * out this TTL.
  */
 public class FlipsEndpoints
 {

--- a/src/main/java/com/flipsmart/ui/panel/ItemNameFit.java
+++ b/src/main/java/com/flipsmart/ui/panel/ItemNameFit.java
@@ -101,18 +101,7 @@ public final class ItemNameFit
 
 		for (String word : text.split(" +"))
 		{
-			String rest = word;
-			while (measurer.widthOf(rest, size) > boxWidth)
-			{
-				int cut = longestPrefixThatFits(rest, boxWidth, size, measurer);
-				if (current.length() > 0)
-				{
-					lines.add(current.toString());
-					current.setLength(0);
-				}
-				lines.add(rest.substring(0, cut));
-				rest = rest.substring(cut);
-			}
+			String rest = flushOverlongWord(word, lines, current, boxWidth, size, measurer);
 			if (rest.isEmpty())
 			{
 				continue;
@@ -143,6 +132,24 @@ public final class ItemNameFit
 			lines.add("");
 		}
 		return lines;
+	}
+
+	/** Splits {@code word} across {@code lines} while it's wider than the box; returns the remainder. */
+	private static String flushOverlongWord(String word, List<String> lines, StringBuilder current, int boxWidth, int size, WidthMeasurer measurer)
+	{
+		String rest = word;
+		while (measurer.widthOf(rest, size) > boxWidth)
+		{
+			int cut = longestPrefixThatFits(rest, boxWidth, size, measurer);
+			if (current.length() > 0)
+			{
+				lines.add(current.toString());
+				current.setLength(0);
+			}
+			lines.add(rest.substring(0, cut));
+			rest = rest.substring(cut);
+		}
+		return rest;
 	}
 
 	/** At least 1, so a box too narrow for any glyph still terminates the split loop. */

--- a/src/main/java/com/flipsmart/ui/panel/ItemNameFit.java
+++ b/src/main/java/com/flipsmart/ui/panel/ItemNameFit.java
@@ -63,7 +63,6 @@ public final class ItemNameFit
 
 	private ItemNameFit()
 	{
-		// Utility class - prevent instantiation
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/ui/panel/ItemNameFit.java
+++ b/src/main/java/com/flipsmart/ui/panel/ItemNameFit.java
@@ -1,0 +1,188 @@
+package com.flipsmart.ui.panel;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Chooses a font size and line breaks so an item name fits the fixed-width name box
+ * in a flip card header.
+ *
+ * Measurement is injected rather than taken from a Font so the algorithm is testable
+ * without a display: headless CI has no Arial and silently substitutes a font with
+ * different metrics.
+ */
+public final class ItemNameFit
+{
+	public static final int MAX_FONT_SIZE = 13;
+	public static final int MIN_FONT_SIZE = 10;
+	public static final int MAX_LINES = 2;
+
+	private static final String ELLIPSIS = "…";
+
+	/** Rendered width of {@code text} at {@code fontSize}, in pixels. */
+	@FunctionalInterface
+	public interface WidthMeasurer
+	{
+		int widthOf(String text, int fontSize);
+	}
+
+	/** A chosen layout: the raw lines, the font size they assume, and their HTML render. */
+	public static final class Fit
+	{
+		private final List<String> lines;
+		private final int fontSize;
+
+		Fit(List<String> lines, int fontSize)
+		{
+			this.lines = Collections.unmodifiableList(new ArrayList<>(lines));
+			this.fontSize = fontSize;
+		}
+
+		/** The raw, unescaped lines this fit chose. */
+		public List<String> getLines()
+		{
+			return lines;
+		}
+
+		public String getHtml()
+		{
+			return toHtml(lines);
+		}
+
+		public int getFontSize()
+		{
+			return fontSize;
+		}
+
+		public int getLineCount()
+		{
+			return lines.size();
+		}
+	}
+
+	private ItemNameFit()
+	{
+		// Utility class - prevent instantiation
+	}
+
+	/**
+	 * Largest size in [MIN_FONT_SIZE, MAX_FONT_SIZE] whose greedy wrap fits in
+	 * MAX_LINES lines of {@code boxWidth}, else the floor size with the last line
+	 * ellipsized.
+	 */
+	public static Fit fit(String name, int boxWidth, WidthMeasurer measurer)
+	{
+		String safe = name == null ? "" : name.trim();
+		if (safe.isEmpty())
+		{
+			return new Fit(Collections.singletonList(""), MAX_FONT_SIZE);
+		}
+
+		for (int size = MAX_FONT_SIZE; size >= MIN_FONT_SIZE; size--)
+		{
+			List<String> lines = wrap(safe, boxWidth, size, measurer);
+			if (lines.size() <= MAX_LINES)
+			{
+				return new Fit(lines, size);
+			}
+		}
+
+		List<String> lines = wrap(safe, boxWidth, MIN_FONT_SIZE, measurer);
+		List<String> kept = new ArrayList<>(lines.subList(0, MAX_LINES));
+		kept.set(MAX_LINES - 1, ellipsize(kept.get(MAX_LINES - 1), boxWidth, MIN_FONT_SIZE, measurer));
+		return new Fit(kept, MIN_FONT_SIZE);
+	}
+
+	/** Greedy word wrap; a word wider than the box on its own is split at characters. */
+	private static List<String> wrap(String text, int boxWidth, int size, WidthMeasurer measurer)
+	{
+		List<String> lines = new ArrayList<>();
+		StringBuilder current = new StringBuilder();
+
+		for (String word : text.split(" +"))
+		{
+			String rest = word;
+			while (measurer.widthOf(rest, size) > boxWidth)
+			{
+				int cut = longestPrefixThatFits(rest, boxWidth, size, measurer);
+				if (current.length() > 0)
+				{
+					lines.add(current.toString());
+					current.setLength(0);
+				}
+				lines.add(rest.substring(0, cut));
+				rest = rest.substring(cut);
+			}
+			if (rest.isEmpty())
+			{
+				continue;
+			}
+			String candidate = current.length() == 0 ? rest : current + " " + rest;
+			if (measurer.widthOf(candidate, size) <= boxWidth)
+			{
+				current.setLength(0);
+				current.append(candidate);
+			}
+			else
+			{
+				if (current.length() > 0)
+				{
+					lines.add(current.toString());
+				}
+				current.setLength(0);
+				current.append(rest);
+			}
+		}
+
+		if (current.length() > 0)
+		{
+			lines.add(current.toString());
+		}
+		if (lines.isEmpty())
+		{
+			lines.add("");
+		}
+		return lines;
+	}
+
+	/** At least 1, so a box too narrow for any glyph still terminates the split loop. */
+	private static int longestPrefixThatFits(String word, int boxWidth, int size, WidthMeasurer measurer)
+	{
+		int cut = 0;
+		for (int i = 1; i <= word.length(); i++)
+		{
+			if (measurer.widthOf(word.substring(0, i), size) > boxWidth)
+			{
+				break;
+			}
+			cut = i;
+		}
+		return Math.max(1, cut);
+	}
+
+	private static String ellipsize(String line, int boxWidth, int size, WidthMeasurer measurer)
+	{
+		String trimmed = line;
+		while (!trimmed.isEmpty() && measurer.widthOf(trimmed + ELLIPSIS, size) > boxWidth)
+		{
+			trimmed = trimmed.substring(0, trimmed.length() - 1);
+		}
+		return trimmed + ELLIPSIS;
+	}
+
+	/** Escape last: wrapping measured the raw text, so "&" sized as 1 char, not 5. */
+	private static String toHtml(List<String> lines)
+	{
+		StringBuilder sb = new StringBuilder("<html>");
+		for (int i = 0; i < lines.size(); i++)
+		{
+			if (i > 0)
+			{
+				sb.append("<br>");
+			}
+			sb.append(PanelFormat.escapeHtml(lines.get(i)));
+		}
+		return sb.append("</html>").toString();
+	}
+}

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -243,7 +243,7 @@ public final class PanelFormat
 		return "<font color='#" + hex + "'>" + text + "</font>";
 	}
 
-	/** Emphasise a span. The live prices are the number players actually read. */
+	/** Emphasise a span. The live prices are the numbers players actually read. */
 	private static String bold(String text)
 	{
 		return "<b>" + text + "</b>";

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -188,11 +188,11 @@ public final class PanelFormat
 		return String.format(FORMAT_BUY_SELL, formatGPExact(buyPrice), sellText);
 	}
 
-	/** Top "live" price row: market low (blue) | market high (orange); label keeps the label colour. */
+	/** Top "live" price row: market low (blue) | market high (orange), both bold; label stays plain. */
 	public static String livePriceHtml(int low, int high)
 	{
-		return htmlRow("Live Price: " + coloured(HEX_PRICE_LOW, formatGPExact(low))
-			+ " | " + coloured(HEX_PRICE_HIGH, formatGPExact(high)));
+		return htmlRow("Live Price: " + bold(coloured(HEX_PRICE_LOW, formatGPExact(low)))
+			+ " | " + bold(coloured(HEX_PRICE_HIGH, formatGPExact(high))));
 	}
 
 	/** Live Margin: gross market spread coloured green (profit) / red (loss), with ROI. No "+" prefix. */
@@ -241,6 +241,12 @@ public final class PanelFormat
 	private static String coloured(String hex, String text)
 	{
 		return "<font color='#" + hex + "'>" + text + "</font>";
+	}
+
+	/** Emphasise a span. The live prices are the number players actually read. */
+	private static String bold(String text)
+	{
+		return "<b>" + text + "</b>";
 	}
 
 	/** Saturating cast of a long into the int range for the gp formatters. */

--- a/src/test/java/com/flipsmart/ui/panel/ItemNameFitTest.java
+++ b/src/test/java/com/flipsmart/ui/panel/ItemNameFitTest.java
@@ -1,0 +1,125 @@
+package com.flipsmart.ui.panel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class ItemNameFitTest
+{
+	/**
+	 * Deterministic stand-in for FontMetrics: every glyph is fontSize/2 px wide.
+	 * Real Arial metrics are unavailable on headless CI, so asserting against them
+	 * would be meaningless there; the algorithm is what these tests cover.
+	 */
+	private static final ItemNameFit.WidthMeasurer FIXED = (text, size) -> text.length() * (size / 2);
+
+	@Test
+	public void shortNameStaysOneLineAtMaxSize()
+	{
+		ItemNameFit.Fit fit = ItemNameFit.fit("Twisted bow", 98, FIXED);
+		assertEquals(13, fit.getFontSize());
+		assertEquals(1, fit.getLineCount());
+		assertEquals("<html>Twisted bow</html>", fit.getHtml());
+	}
+
+	@Test
+	public void longNameWrapsToTwoLinesWithoutShrinking()
+	{
+		ItemNameFit.Fit fit = ItemNameFit.fit("Dragon pickaxe upgrade kit", 98, FIXED);
+		assertEquals(13, fit.getFontSize());
+		assertEquals(2, fit.getLineCount());
+		assertEquals("<html>Dragon pickaxe<br>upgrade kit</html>", fit.getHtml());
+	}
+
+	@Test
+	public void shrinksOnlyWhenTwoLinesAtMaxSizeWouldNotFit()
+	{
+		ItemNameFit.Fit fit = ItemNameFit.fit("Alpha bravo charlie delta echo foxtrot", 98, FIXED);
+		assertEquals(11, fit.getFontSize());
+		assertEquals(2, fit.getLineCount());
+		assertEquals("<html>Alpha bravo charlie<br>delta echo foxtrot</html>", fit.getHtml());
+	}
+
+	@Test
+	public void ellipsizesAtFloorWhenEvenTwoLinesCannotHoldIt()
+	{
+		ItemNameFit.Fit fit = ItemNameFit.fit("Alpha bravo charlie delta echo foxtrot golf hotel", 98, FIXED);
+		assertEquals(10, fit.getFontSize());
+		assertEquals(2, fit.getLineCount());
+		assertTrue("expected the truncated line to end in an ellipsis: " + fit.getHtml(),
+			fit.getHtml().endsWith("…</html>"));
+	}
+
+	@Test
+	public void neverGoesBelowTheReadabilityFloor()
+	{
+		ItemNameFit.Fit fit = ItemNameFit.fit(
+			"Alpha bravo charlie delta echo foxtrot golf hotel india juliet", 98, FIXED);
+		assertEquals(ItemNameFit.MIN_FONT_SIZE, fit.getFontSize());
+		assertTrue(fit.getLineCount() <= ItemNameFit.MAX_LINES);
+	}
+
+	@Test
+	public void hardSplitsASingleWordWiderThanTheBox()
+	{
+		ItemNameFit.Fit fit = ItemNameFit.fit("Supercalifragilisticexpialidocious", 98, FIXED);
+		assertTrue(fit.getLineCount() <= ItemNameFit.MAX_LINES);
+		assertTrue(fit.getFontSize() >= ItemNameFit.MIN_FONT_SIZE);
+	}
+
+	@Test
+	public void escapesHtmlAfterMeasuringSoAmpersandsDoNotOvershrink()
+	{
+		ItemNameFit.Fit fit = ItemNameFit.fit("Salt & pepper", 98, FIXED);
+		assertEquals(13, fit.getFontSize());
+		// Measured as 13 raw chars, not 17 escaped ones; escaping happens on render only.
+		assertEquals(java.util.Collections.singletonList("Salt & pepper"), fit.getLines());
+		assertEquals("<html>Salt &amp; pepper</html>", fit.getHtml());
+	}
+
+	@Test
+	public void nullOrBlankNameIsHarmless()
+	{
+		assertEquals("<html></html>", ItemNameFit.fit(null, 98, FIXED).getHtml());
+		assertEquals(1, ItemNameFit.fit("   ", 98, FIXED).getLineCount());
+	}
+
+	/**
+	 * Invariants, not sizes: these must hold for whatever font the JVM actually resolves.
+	 * Headless CI has no Arial and substitutes something else, so "this name is 13pt" is
+	 * not assertable here — but "no line overflows its box" always is.
+	 */
+	@Test
+	public void everyChosenLineFitsTheBoxUnderRealFontMetrics()
+	{
+		java.awt.Graphics2D g = new java.awt.image.BufferedImage(1, 1,
+			java.awt.image.BufferedImage.TYPE_INT_ARGB).createGraphics();
+		ItemNameFit.WidthMeasurer real =
+			(text, size) -> g.getFontMetrics(new java.awt.Font("Arial", java.awt.Font.BOLD, size))
+				.stringWidth(text);
+
+		String[] names = {
+			"Twisted bow",
+			"Rune platebody",
+			"Elysian spirit shield",
+			"Torva platelegs (damaged)",
+			"Dragon pickaxe upgrade kit",
+			"Armadyl godsword ornament kit",
+		};
+
+		for (String name : names)
+		{
+			ItemNameFit.Fit fit = ItemNameFit.fit(name, 98, real);
+			assertTrue(name + " used " + fit.getLineCount() + " lines",
+				fit.getLineCount() <= ItemNameFit.MAX_LINES);
+			assertTrue(name + " shrank to " + fit.getFontSize() + "pt",
+				fit.getFontSize() >= ItemNameFit.MIN_FONT_SIZE
+					&& fit.getFontSize() <= ItemNameFit.MAX_FONT_SIZE);
+			for (String line : fit.getLines())
+			{
+				assertTrue(name + " line '" + line + "' overflows the 98px box",
+					real.widthOf(line, fit.getFontSize()) <= 98);
+			}
+		}
+	}
+}

--- a/src/test/java/com/flipsmart/ui/panel/PanelFormatActiveFlipsTest.java
+++ b/src/test/java/com/flipsmart/ui/panel/PanelFormatActiveFlipsTest.java
@@ -6,10 +6,11 @@ import org.junit.Test;
 public class PanelFormatActiveFlipsTest
 {
 	@Test
-	public void livePriceColoursLowBlueHighOrangeWithCommas()
+	public void livePriceColoursLowBlueHighOrangeWithCommasAndBoldsBothValues()
 	{
 		assertEquals(
-			"<html>Live Price: <font color='#6fb1ff'>1,500,000</font> | <font color='#ffab54'>2,000,000</font></html>",
+			"<html>Live Price: <b><font color='#6fb1ff'>1,500,000</font></b>"
+				+ " | <b><font color='#ffab54'>2,000,000</font></b></html>",
 			PanelFormat.livePriceHtml(1_500_000, 2_000_000));
 	}
 


### PR DESCRIPTION
## Summary

Fixes item name truncation on Active Flips cards, bolds live insta-buy/insta-sell prices, adds a 60s auto-refresh of live prices while the tab is visible, and removes the redundant bottom profit/take-profit rows now that "Current Profit" and "Max Potential Profit" already sit at the top of each card. Two additional regressions surfaced and fixed during implementation: the card timer could permanently die on sidebar collapse+reopen, and the new price-refresh timer could silently wipe an active in-game competitive re-prompt.

## Changes

### 🐛 Bug Fixes

- **AC1 — item name truncation.** Root cause: the name label's height was measured *before* its width constraint applied, so it was sized for one line; the `<html>` wrapper then wrapped the view to three lines inside a one-line-tall label, clipping lines 2-3 mid-glyph. The bug was vertical, not a width/ellipsis issue.
  - Deliberate, user-approved deviation from the ticket: the ticket prescribed shrinking the font until the name fits one line. Measured against the real 98px box, that yields 7pt for "Dragon pickaxe upgrade kit" and 6pt for "Armadyl godsword ornament kit" — unreadable, defeating AC1's own goal. Instead: wrap to at most 2 lines, shrink only if still overflowing, floor at 10pt, ellipsize below that. Result: 16 of 18 sampled item names stay at full 13pt with no shrinking at all; worst case is 10pt and still readable. "Dragon pickaxe upgrade kit" renders at full 13pt over two lines.
  - New pure class `ui/panel/ItemNameFit` does the wrap/fit. Width measurement is injected via a `WidthMeasurer` functional interface rather than taken from a `Font`, because headless CI has no Arial and silently substitutes a different font, so an exact-size assertion would be meaningless there. Tests cover the algorithm with a deterministic fake measurer, plus invariants ("no line overflows its box") against real font metrics.
- **Timer would have died permanently on the first sidebar collapse+reopen** (found in review, fixed on this branch). Collapsing fires no tab-change event, so the timer stopped on its own visibility check, and reopening (tab index unchanged) never restarted it. Fixed by driving it from the panel's `onActivate`/`onDeactivate` lifecycle (`ClientUI.toggleSidebar` → `SwingUtil.activate/deactivate` → `Activatable`), and by making the per-card icon's restart self-healing.
- **The 60s refresh would have silently wiped the in-game competitive re-prompt** (found in review, fixed on this branch), re-writing the `GE_LAST_SEARCHED` varp every minute. Re-pushing an identical focus clears the overlay's `autoStatusMessage`; harmless when only user actions triggered it, but the timer made it periodic. Fixed with an equality guard so an unchanged focus is a true no-op.

### ✨ New Features

- **AC2 — bold live prices.** Both insta-buy (blue `6fb1ff`) and insta-sell (orange `ffab54`) values are now bolded; the "Live Price:" label stays plain. One formatter change in `PanelFormat.livePriceHtml`, so both card types pick it up.
- **AC3 — 60s auto-refresh of live prices.** Was not previously implemented (the ticket asked to verify/add it). Prices come from `/analysis/{itemId}`, cached 15 minutes client-side — which is why the manual per-card refresh icon exists (it calls `invalidateCache` first). 60s is the real floor: the backend's upstream OSRS Wiki `/latest` feed is itself ~60s CDN-cached, so polling faster buys nothing. Tab-gated: a shared 60s Swing timer runs only while the Active Flips tab is selected AND the panel is showing — one call per card per minute while visible, zero otherwise. The per-card refresh icon restarts the cadence. Each card registers the same closure the manual button already runs, reusing the proven fetch path. `CACHE_DURATION_MS` deliberately left at 15 min (lowering it would affect every other analysis consumer; cards invalidate per-item before fetching anyway); a stale doc comment there claiming card prices don't come from that endpoint is corrected since it stopped being true when the manual refresh button was added.

### ♻️ Refactoring

- **AC4 — remove redundant bottom profit/take-profit rows.** "Current Profit" and "Max Potential Profit" already sit at the top of the card; the second pair at the bottom was noise. Removing them orphaned the whole `offerDispositionLookup` chain, so that goes too (64 lines deleted, 0 added). `ActiveOfferAdvisorService` is untouched and still drives the in-game GE prompts via `GrandExchangeTracker` — only the panel's display of its disposition was removed.

## Testing

### Automated Tests
- ✅ Full suite: 564 tests, 0 failures, 0 errors (`./gradlew clean test --console=plain`), up from a 555-test baseline — this branch adds 9 tests in `ItemNameFitTest`
- ✅ Build: `./gradlew build --console=plain` — jar builds successfully
- ✅ Confirmed again with a quick `./gradlew test --console=plain` re-run immediately before opening this PR

### Manual Testing
- [x] Long name, Active Flips card (e.g. Dragon pickaxe upgrade kit) — renders on 2 lines at full size, nothing clipped
- [x] Long name, Pending order card — same, and the card's bottom row (Risk) is not clipped
- [x] Long name, Completed flip card — not clipped (110px cap); expand the card and confirm the Duration/GE Tax rows are fine
- [x] Short name (e.g. Twisted bow) — unchanged from today: one line, full size, no vertical shift
- [x] Worst case (e.g. Armadyl godsword ornament kit) — 2 lines, visibly smaller but readable
- [x] Live Price row, both card types — both numbers bold, blue/orange unchanged, "Live Price:" plain
- [x] Bottom of an active card — no "Take profit: …" row and no second "Profit: …" row
- [x] In-game GE prompts still work — the advisor is unaffected
- [x] Prompt is not wiped: focus an active sell card with a competitive/adjustment prompt showing, sit on the tab for 90s — the prompt must still be there (this is the regression fixed above)
- [x] Prices refresh: idle on the Active Flips tab through two 60s ticks with a volatile item — the Live Price row moves; client.log shows two /analysis/{itemId} calls 60s apart per card
- [x] Tab gating both directions: switch to another tab → calls stop; switch back → they resume
- [x] Sidebar collapse/reopen: collapse the sidebar → calls stop; reopen (same tab) → they resume within one interval
- [x] Manual icon resets cadence: click a card's refresh icon at ~t=45s → next auto-tick lands ~60s after the click, not ~15s later
- [x] Focus still changes: clicking a different card still updates the in-game focus (the equality guard must not suppress genuine changes)

## API Changes

N/A — plugin-only change, no backend API surface.

## Database Migrations

N/A

## Deployment Notes

- [ ] Environment variables added/changed: none
- [ ] Dependencies added: none
- [ ] Configuration changes: none
- [ ] Requires database migration: No

Regular plugin release cadence (Plugin Hub) applies once merged.

## Checklist

- [x] Tests added/updated (`ItemNameFitTest` new, `PanelFormatActiveFlipsTest` updated)
- [x] Documentation updated (stale doc comment on `CACHE_DURATION_MS` corrected)
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by teammate

## Related Issues

Part of Flip-Smart/flip-smart#980

### 🩺 Codacy Quality Gate — fixed in this PR
- `d375401` Lizard_ccn-medium `src/main/java/com/flipsmart/ui/panel/ItemNameFit.java:97` — extracted the overlong-word split loop into `flushOverlongWord()`, dropping `wrap()`'s cyclomatic complexity back under the threshold (pure extraction, no behavior change)
- `a50323b` PMD_NullAssignment `src/main/java/com/flipsmart/FlipFinderPanel.java:1007` — dropped the redundant null-assignment after `Timer.stop()` in `shutdown()` (terminal cleanup path, unrelated to the `onActivate`/`onDeactivate` timer lifecycle)
- `8716125` PMD_GuardLogStatement `src/main/java/com/flipsmart/FlipFinderPanel.java:1320` — guarded the price-refresh sweep's debug log with `isDebugEnabled()`

### 🤖 Codacy AI Reviewer — fixed in this PR
- `d375401` `src/main/java/com/flipsmart/ui/panel/ItemNameFit.java:97` — same complexity fix as above, matching the reviewer's suggested extraction
- `8716125` `src/main/java/com/flipsmart/FlipFinderPanel.java:1320` — same guard-log fix as above

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `src/main/java/com/flipsmart/FlipFinderPanel.java:2549` — claimed `allowForWrappedName` needed to also raise `preferredSize`, not just `maximumSize`. The card's `preferredSize` is never fixed anywhere in this class; it's computed dynamically via nested `BorderLayout`s from `nameLabel`'s own explicit size, which already reflects the wrapped line count. Only the `maximumSize` cap needed raising, which is what the code does.

