### PR TITLE
fix(ge): scope offer-screen breakeven and wiki prices to the item on screen

### DIFF
--- a/src/main/java/com/flipsmart/GeOfferDescriptionService.java
+++ b/src/main/java/com/flipsmart/GeOfferDescriptionService.java
@@ -178,6 +178,16 @@ public class GeOfferDescriptionService
 		}
 	}
 
+	/**
+	 * Drops the remembered slot when the GE interface is (re)opened. Offers are
+	 * collected and slots reused between visits, so a slot index carried over from
+	 * a previous visit can name an entirely different item.
+	 */
+	public void onGeOffersWidgetLoaded()
+	{
+		lastClickedSlot = -1;
+	}
+
 	// ---------------------------------------------------------------------
 	// Offer status panel — per-frame
 	// ---------------------------------------------------------------------

--- a/src/main/java/com/flipsmart/GeOfferDescriptionService.java
+++ b/src/main/java/com/flipsmart/GeOfferDescriptionService.java
@@ -321,12 +321,19 @@ public class GeOfferDescriptionService
 
 	/**
 	 * Reads the current "Set up offer" screen state directly from varbits/varps.
-	 * Returns {@code null} when the setup window isn't open or no offer is being
-	 * built. Direction encoding: {@code GE_NEWOFFER_TYPE == 1} → sell, anything
-	 * else non-zero → buy.
+	 * Returns {@code null} when the setup window isn't the surface on screen or no
+	 * offer is being built. Direction encoding: {@code GE_NEWOFFER_TYPE == 1} →
+	 * sell, anything else non-zero → buy.
 	 */
 	private int[] resolveSetupWindowContext()
 	{
+		// The in-flight status panel is a different surface with a different
+		// authority (its committed slot), so the setup window never speaks for it.
+		if (isDetailsContainerVisible())
+		{
+			return null;
+		}
+
 		Widget setupDesc = client.getWidget(InterfaceID.GeOffers.SETUP_DESC);
 		if (setupDesc == null || setupDesc.isHidden())
 		{

--- a/src/main/java/com/flipsmart/GeOfferDescriptionService.java
+++ b/src/main/java/com/flipsmart/GeOfferDescriptionService.java
@@ -215,8 +215,9 @@ public class GeOfferDescriptionService
 
 	/**
 	 * Resolves the offer context (itemId, direction, price, quantity) from one of
-	 * three sources, in priority order: Flip Assist focus, the GE slot the player
-	 * clicked, or the live "Set up offer" screen state.
+	 * three sources, ordered by how authoritative each is about the item actually
+	 * on screen: Flip Assist focus (only when it agrees with the screen), the live
+	 * "Set up offer" window, then the committed offer on the active slot.
 	 *
 	 * @return int[]{itemId, isBuy (1=buy/0=sell), price, qty}, or {@code null} if
 	 *         no actionable context can be determined.
@@ -229,20 +230,16 @@ public class GeOfferDescriptionService
 			return focusCtx;
 		}
 
-		// Source #2: the slot the player clicked. GE_SELECTEDSLOT is
-		// only used as a cold-start fallback (haven't seen a click yet).
-		int[] slotCtx = resolveSlotContext();
-		if (slotCtx != null)
+		// The setup window is pre-confirm and belongs to no committed slot, so
+		// while it is open it outranks the active slot: that slot may hold an
+		// unrelated in-flight offer the player merely hovered or clicked earlier.
+		int[] setupCtx = resolveSetupWindowContext();
+		if (setupCtx != null)
 		{
-			return slotCtx;
+			return setupCtx;
 		}
 
-		// Source #3: live "Set up offer" screen state (issue #684). Covers ad-hoc
-		// buy/sell offers being constructed without a Flip Assist focus — the
-		// slot is still EMPTY pre-confirm so #2 returns null, and the
-		// geBuyExamineText / geSellExamineText script callbacks don't fire on
-		// the current Jagex setup window, leaving SETUP_DESC un-replaced.
-		return resolveSetupWindowContext();
+		return resolveSlotContext();
 	}
 
 	/**
@@ -280,13 +277,21 @@ public class GeOfferDescriptionService
 
 	/**
 	 * The item id the open GE panel is actually showing, independent of Flip Assist
-	 * focus: the committed offer on the active slot (in-flight status panel) if any,
-	 * else the item selected in the "Set up offer" window. Returns {@code null} when
-	 * neither surface exposes an item yet — the caller then treats focus as
-	 * authoritative.
+	 * focus: the item selected in the "Set up offer" window if that window is open,
+	 * else the committed offer on the active slot (in-flight status panel). Returns
+	 * {@code null} when neither surface exposes an item yet — the caller then treats
+	 * focus as authoritative.
 	 */
 	private Integer resolveOnScreenItemId()
 	{
+		// The setup window covers the slot tiles, so when it is open the active
+		// slot's committed offer is not what the player is looking at.
+		int[] setupCtx = resolveSetupWindowContext();
+		if (setupCtx != null)
+		{
+			return setupCtx[0];
+		}
+
 		int slot = resolveActiveSlot();
 		if (slot >= 0)
 		{
@@ -301,8 +306,7 @@ public class GeOfferDescriptionService
 			}
 		}
 
-		int[] setupCtx = resolveSetupWindowContext();
-		return setupCtx == null ? null : setupCtx[0];
+		return null;
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/GeOfferDescriptionService.java
+++ b/src/main/java/com/flipsmart/GeOfferDescriptionService.java
@@ -324,6 +324,10 @@ public class GeOfferDescriptionService
 	 * Returns {@code null} when the setup window isn't the surface on screen or no
 	 * offer is being built. Direction encoding: {@code GE_NEWOFFER_TYPE == 1} →
 	 * sell, anything else non-zero → buy.
+	 *
+	 * <p>The per-frame path must read this itself: the geBuyExamineText /
+	 * geSellExamineText callbacks do not fire on the current Jagex setup window, so
+	 * nothing else would replace SETUP_DESC for an offer built without a focus.
 	 */
 	private int[] resolveSetupWindowContext()
 	{

--- a/src/main/java/com/flipsmart/plugin/EventRouter.java
+++ b/src/main/java/com/flipsmart/plugin/EventRouter.java
@@ -227,6 +227,10 @@ public class EventRouter
 		{
 			geHistoryService.onHistoryWidgetLoaded();
 		}
+		if (event.getGroupId() == InterfaceID.GE_OFFERS && geOfferDescriptionService != null)
+		{
+			geOfferDescriptionService.onGeOffersWidgetLoaded();
+		}
 	}
 
 	public void onScriptCallbackEvent(ScriptCallbackEvent event)

--- a/src/test/java/com/flipsmart/GeOfferContextResolutionTest.java
+++ b/src/test/java/com/flipsmart/GeOfferContextResolutionTest.java
@@ -45,6 +45,9 @@ public class GeOfferContextResolutionTest
 	private static final int GE_OFFERS_GROUP = 465;
 	private static final int INDEX_0_CHILD = 7;
 
+	private static final String MSG_SETUP_ITEM = "item must be the one on the setup screen";
+	private static final String MSG_SETUP_PRICE = "price must be the setup screen's";
+
 	private final Client client = mock(Client.class);
 
 	private GeOfferDescriptionService newService()
@@ -179,8 +182,8 @@ public class GeOfferContextResolutionTest
 		int[] ctx = service.resolveOfferContext();
 
 		assertNotNull(ctx);
-		assertEquals("item must be the one on the setup screen", SHARK, ctx[0]);
-		assertEquals("price must be the setup screen's", 960, ctx[2]);
+		assertEquals(MSG_SETUP_ITEM, SHARK, ctx[0]);
+		assertEquals(MSG_SETUP_PRICE, 960, ctx[2]);
 		assertEquals("qty must be the setup screen's", 10_000, ctx[3]);
 	}
 
@@ -197,8 +200,8 @@ public class GeOfferContextResolutionTest
 		int[] ctx = service.resolveOfferContext();
 
 		assertNotNull(ctx);
-		assertEquals("item must be the one on the setup screen", SHARK, ctx[0]);
-		assertEquals("price must be the setup screen's", 960, ctx[2]);
+		assertEquals(MSG_SETUP_ITEM, SHARK, ctx[0]);
+		assertEquals(MSG_SETUP_PRICE, 960, ctx[2]);
 		assertEquals("qty must be the setup screen's", 10_000, ctx[3]);
 	}
 
@@ -220,9 +223,9 @@ public class GeOfferContextResolutionTest
 		int[] ctx = service.resolveOfferContext();
 
 		assertNotNull(ctx);
-		assertEquals("item must be the one on the setup screen", SHARK, ctx[0]);
+		assertEquals(MSG_SETUP_ITEM, SHARK, ctx[0]);
 		assertEquals("direction must be the setup screen's, not the stale slot's", 1, ctx[1]);
-		assertEquals("price must be the setup screen's", 960, ctx[2]);
+		assertEquals(MSG_SETUP_PRICE, 960, ctx[2]);
 	}
 
 	/**
@@ -243,7 +246,7 @@ public class GeOfferContextResolutionTest
 		int[] ctx = service.resolveOfferContext();
 
 		assertNotNull(ctx);
-		assertEquals("item must be the one on the setup screen", SHARK, ctx[0]);
+		assertEquals(MSG_SETUP_ITEM, SHARK, ctx[0]);
 	}
 
 	/** With no setup window open, the clicked slot still owns the in-flight panel. */

--- a/src/test/java/com/flipsmart/GeOfferContextResolutionTest.java
+++ b/src/test/java/com/flipsmart/GeOfferContextResolutionTest.java
@@ -72,6 +72,7 @@ public class GeOfferContextResolutionTest
 		when(client.getVarbitValue(VarbitID.GE_SELECTEDSLOT)).thenReturn(slot);
 	}
 
+	@SuppressWarnings("PMD.SingularField")
 	private final GrandExchangeOffer[] offers = new GrandExchangeOffer[8];
 
 	/** Puts an in-flight sell offer on {@code slot} without selecting it. */

--- a/src/test/java/com/flipsmart/GeOfferContextResolutionTest.java
+++ b/src/test/java/com/flipsmart/GeOfferContextResolutionTest.java
@@ -239,6 +239,31 @@ public class GeOfferContextResolutionTest
 	}
 
 	/**
+	 * The mirror of the bug: the in-flight status panel is owned by its committed
+	 * slot, so a setup window left visible underneath it must not speak for it.
+	 * onBeforeRender writes one resolved context to both panels, so without this
+	 * the fix would trade one cross-item bleed for another.
+	 */
+	@Test
+	public void inFlightDetailsPanelOutranksACoveredSetupWindow()
+	{
+		GeOfferDescriptionService service = newService();
+
+		putOffer(0, RAW_KARAMBWAN, 274, 4500);
+		clickSlot(service, 0);
+		openSetupWindow(SHARK, 960, 10_000, true);
+
+		Widget details = mock(Widget.class);
+		when(details.isHidden()).thenReturn(false);
+		when(client.getWidget(InterfaceID.GeOffers.DETAILS)).thenReturn(details);
+
+		int[] ctx = service.resolveOfferContext();
+
+		assertNotNull(ctx);
+		assertEquals("the details panel's own slot must win", RAW_KARAMBWAN, ctx[0]);
+	}
+
+	/**
 	 * The clicked-slot latch must not survive a GE visit: slots are reused between
 	 * visits, so a carried-over index can name a different item. After a reopen the
 	 * resolver falls back to the live selected slot until the player clicks again.

--- a/src/test/java/com/flipsmart/GeOfferContextResolutionTest.java
+++ b/src/test/java/com/flipsmart/GeOfferContextResolutionTest.java
@@ -203,6 +203,29 @@ public class GeOfferContextResolutionTest
 	}
 
 	/**
+	 * Buy side: a stale <em>sell</em> slot must not capture a <em>buy</em> setup
+	 * screen. Direction comes from GE_NEWOFFER_TYPE on the setup path but from the
+	 * slot's own state on the slot path, so losing this sends the panel through the
+	 * sell builder and prints a breakeven where the wiki insta-buy belongs.
+	 */
+	@Test
+	public void setupWindowOwnsDirectionAndItemOnTheBuyScreen()
+	{
+		GeOfferDescriptionService service = newService();
+
+		putOffer(0, RAW_KARAMBWAN, 274, 4500); // an in-flight SELL
+		clickSlot(service, 0);
+		openSetupWindow(SHARK, 960, 500, false); // ... while BUYING sharks
+
+		int[] ctx = service.resolveOfferContext();
+
+		assertNotNull(ctx);
+		assertEquals("item must be the one on the setup screen", SHARK, ctx[0]);
+		assertEquals("direction must be the setup screen's, not the stale slot's", 1, ctx[1]);
+		assertEquals("price must be the setup screen's", 960, ctx[2]);
+	}
+
+	/**
 	 * No click ever recorded, so resolveActiveSlot() falls back to GE_SELECTEDSLOT,
 	 * which tracks the *hovered* slot. Hovering an unrelated in-flight offer must
 	 * not poison the setup window either — this is why clearing the clicked-slot

--- a/src/test/java/com/flipsmart/GeOfferContextResolutionTest.java
+++ b/src/test/java/com/flipsmart/GeOfferContextResolutionTest.java
@@ -3,7 +3,11 @@ package com.flipsmart;
 import net.runelite.api.Client;
 import net.runelite.api.GrandExchangeOffer;
 import net.runelite.api.GrandExchangeOfferState;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.api.gameval.VarbitID;
+import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.game.ItemManager;
 import org.junit.Test;
@@ -15,31 +19,37 @@ import static org.mockito.Mockito.when;
 
 /**
  * Pins the item-scoping contract of
- * {@link GeOfferDescriptionService#resolveOfferContext()} (issue #972).
+ * {@link GeOfferDescriptionService#resolveOfferContext()} (issues #972, #992).
  *
- * <p>Flip Assist focus tracks the plugin's <em>next recommended action</em>, which
- * is routinely a different item than the GE offer panel the player currently has
- * open. Focus must therefore only drive the description when it agrees with the
- * item actually on screen — otherwise the focused item's wiki price/volume bleeds
- * onto an unrelated offer panel while 2+ flips are active.
+ * <p>Sources are ranked by how authoritative each is about the item actually on
+ * screen, not by how much context each carries:
+ *
+ * <ol>
+ *   <li>Flip Assist focus tracks the plugin's <em>next recommended action</em>, which
+ *       is routinely a different item than the panel the player has open. It may only
+ *       drive the description when it agrees with the on-screen item (#972).</li>
+ *   <li>The "Set up offer" window is pre-confirm and belongs to no committed slot.
+ *       While it is open it outranks the active slot, which may hold an unrelated
+ *       in-flight offer the player merely hovered or clicked earlier (#992).</li>
+ *   <li>The committed offer on the active slot owns the in-flight status panel.</li>
+ * </ol>
  */
 public class GeOfferContextResolutionTest
 {
 	private static final int ELY_ITEM_ID = 12817;   // focused elsewhere, insta-buy ~515m
 	private static final int KIT_ITEM_ID = 25454;   // item actually on the open offer panel
 
+	private static final int SHARK = 385;           // item on the setup screen
+	private static final int RAW_KARAMBWAN = 3142;  // unrelated in-flight offer on another slot
+
+	private static final int GE_OFFERS_GROUP = 465;
+	private static final int INDEX_0_CHILD = 7;
+
 	private final Client client = mock(Client.class);
 
 	private GeOfferDescriptionService newService()
 	{
-		FlipAssistOverlay overlay = mock(FlipAssistOverlay.class);
-		return new GeOfferDescriptionService(
-			client,
-			mock(ClientThread.class),
-			mock(FlipSmartApiClient.class),
-			mock(FlipSmartPlugin.class),
-			mock(ItemManager.class),
-			overlay);
+		return newServiceWithFocus(null);
 	}
 
 	private GeOfferDescriptionService newServiceWithFocus(FocusedFlip focus)
@@ -58,17 +68,46 @@ public class GeOfferContextResolutionTest
 	/** Puts an in-flight offer for {@code itemId} on {@code slot} and selects that slot. */
 	private void openOfferPanel(int slot, int itemId, int price)
 	{
+		putOffer(slot, itemId, price, 1);
+		when(client.getVarbitValue(VarbitID.GE_SELECTEDSLOT)).thenReturn(slot);
+	}
+
+	/** Puts an in-flight sell offer on {@code slot} without selecting it. */
+	private void putOffer(int slot, int itemId, int price, int qty)
+	{
 		GrandExchangeOffer offer = mock(GrandExchangeOffer.class);
 		when(offer.getState()).thenReturn(GrandExchangeOfferState.SELLING);
 		when(offer.getItemId()).thenReturn(itemId);
 		when(offer.getPrice()).thenReturn(price);
-		when(offer.getTotalQuantity()).thenReturn(1);
+		when(offer.getTotalQuantity()).thenReturn(qty);
 
 		GrandExchangeOffer[] offers = new GrandExchangeOffer[8];
 		offers[slot] = offer;
 		when(client.getGrandExchangeOffers()).thenReturn(offers);
-		when(client.getVarbitValue(VarbitID.GE_SELECTEDSLOT)).thenReturn(slot);
 	}
+
+	/** Opens the "Set up offer" window showing {@code itemId} at price x qty. */
+	private void openSetupWindow(int itemId, int price, int qty, boolean isSell)
+	{
+		Widget setupDesc = mock(Widget.class);
+		when(setupDesc.isHidden()).thenReturn(false);
+		when(client.getWidget(InterfaceID.GeOffers.SETUP_DESC)).thenReturn(setupDesc);
+
+		when(client.getVarbitValue(VarbitID.GE_NEWOFFER_TYPE)).thenReturn(isSell ? 1 : 2);
+		when(client.getVarpValue(VarPlayerID.TRADINGPOST_SEARCH)).thenReturn(itemId);
+		when(client.getVarbitValue(VarbitID.GE_NEWOFFER_PRICE)).thenReturn(price);
+		when(client.getVarbitValue(VarbitID.GE_NEWOFFER_QUANTITY)).thenReturn(qty);
+	}
+
+	/** Player clicks the slot tile for {@code slot} (group 465, child 7+N). */
+	private void clickSlot(GeOfferDescriptionService service, int slot)
+	{
+		MenuOptionClicked event = mock(MenuOptionClicked.class);
+		when(event.getParam1()).thenReturn((GE_OFFERS_GROUP << 16) | (INDEX_0_CHILD + slot));
+		service.onMenuOptionClicked(event);
+	}
+
+	// -- #972: focus must not bleed onto an unrelated panel ---------------------
 
 	@Test
 	public void focusOnAnotherItemDoesNotBleedOntoOpenOfferPanel()
@@ -116,5 +155,85 @@ public class GeOfferContextResolutionTest
 
 		assertNotNull(ctx);
 		assertEquals(ELY_ITEM_ID, ctx[0]);
+	}
+
+	// -- #992: the open setup window outranks an unrelated active slot ----------
+
+	/**
+	 * Reported case: an in-flight Raw Karambwan sell sits on a slot the player
+	 * clicked earlier; the player then sets up a Shark sell. The panel must show
+	 * Shark's numbers, not the Karambwan offer's.
+	 */
+	@Test
+	public void setupWindowOutranksStaleClickedSlot_withFocusOnTheStaleItem()
+	{
+		GeOfferDescriptionService service =
+			newServiceWithFocus(FocusedFlip.forSell(RAW_KARAMBWAN, "Raw karambwan", 274, 4500));
+
+		putOffer(0, RAW_KARAMBWAN, 274, 4500);
+		clickSlot(service, 0);
+		openSetupWindow(SHARK, 960, 10_000, true);
+
+		int[] ctx = service.resolveOfferContext();
+
+		assertNotNull(ctx);
+		assertEquals("item must be the one on the setup screen", SHARK, ctx[0]);
+		assertEquals("price must be the setup screen's", 960, ctx[2]);
+		assertEquals("qty must be the setup screen's", 10_000, ctx[3]);
+	}
+
+	/** Same divergence with no focus at all — isolates the slot path. */
+	@Test
+	public void setupWindowOutranksStaleClickedSlot_withoutFocus()
+	{
+		GeOfferDescriptionService service = newService();
+
+		putOffer(0, RAW_KARAMBWAN, 274, 4500);
+		clickSlot(service, 0);
+		openSetupWindow(SHARK, 960, 10_000, true);
+
+		int[] ctx = service.resolveOfferContext();
+
+		assertNotNull(ctx);
+		assertEquals("item must be the one on the setup screen", SHARK, ctx[0]);
+		assertEquals("price must be the setup screen's", 960, ctx[2]);
+		assertEquals("qty must be the setup screen's", 10_000, ctx[3]);
+	}
+
+	/**
+	 * No click ever recorded, so resolveActiveSlot() falls back to GE_SELECTEDSLOT,
+	 * which tracks the *hovered* slot. Hovering an unrelated in-flight offer must
+	 * not poison the setup window either — this is why clearing the clicked-slot
+	 * latch alone cannot fix the bug.
+	 */
+	@Test
+	public void setupWindowOutranksMerelyHoveredSlot()
+	{
+		GeOfferDescriptionService service = newService();
+
+		putOffer(0, RAW_KARAMBWAN, 274, 4500);
+		when(client.getVarbitValue(VarbitID.GE_SELECTEDSLOT)).thenReturn(0);
+		openSetupWindow(SHARK, 960, 10_000, true);
+
+		int[] ctx = service.resolveOfferContext();
+
+		assertNotNull(ctx);
+		assertEquals("item must be the one on the setup screen", SHARK, ctx[0]);
+	}
+
+	/** With no setup window open, the clicked slot still owns the in-flight panel. */
+	@Test
+	public void clickedSlotStillOwnsInFlightPanelWhenNoSetupWindow()
+	{
+		GeOfferDescriptionService service = newService();
+
+		putOffer(0, RAW_KARAMBWAN, 274, 4500);
+		clickSlot(service, 0);
+		when(client.getWidget(InterfaceID.GeOffers.SETUP_DESC)).thenReturn(null);
+
+		int[] ctx = service.resolveOfferContext();
+
+		assertNotNull(ctx);
+		assertEquals(RAW_KARAMBWAN, ctx[0]);
 	}
 }

--- a/src/test/java/com/flipsmart/GeOfferContextResolutionTest.java
+++ b/src/test/java/com/flipsmart/GeOfferContextResolutionTest.java
@@ -72,6 +72,8 @@ public class GeOfferContextResolutionTest
 		when(client.getVarbitValue(VarbitID.GE_SELECTEDSLOT)).thenReturn(slot);
 	}
 
+	private final GrandExchangeOffer[] offers = new GrandExchangeOffer[8];
+
 	/** Puts an in-flight sell offer on {@code slot} without selecting it. */
 	private void putOffer(int slot, int itemId, int price, int qty)
 	{
@@ -81,7 +83,6 @@ public class GeOfferContextResolutionTest
 		when(offer.getPrice()).thenReturn(price);
 		when(offer.getTotalQuantity()).thenReturn(qty);
 
-		GrandExchangeOffer[] offers = new GrandExchangeOffer[8];
 		offers[slot] = offer;
 		when(client.getGrandExchangeOffers()).thenReturn(offers);
 	}
@@ -235,5 +236,30 @@ public class GeOfferContextResolutionTest
 
 		assertNotNull(ctx);
 		assertEquals(RAW_KARAMBWAN, ctx[0]);
+	}
+
+	/**
+	 * The clicked-slot latch must not survive a GE visit: slots are reused between
+	 * visits, so a carried-over index can name a different item. After a reopen the
+	 * resolver falls back to the live selected slot until the player clicks again.
+	 */
+	@Test
+	public void reopeningGeClearsTheClickedSlotLatch()
+	{
+		GeOfferDescriptionService service = newService();
+
+		putOffer(0, RAW_KARAMBWAN, 274, 4500);
+		putOffer(3, SHARK, 960, 10_000);
+		when(client.getWidget(InterfaceID.GeOffers.SETUP_DESC)).thenReturn(null);
+
+		clickSlot(service, 0);
+		assertEquals("clicked slot owns the panel while the GE stays open",
+			RAW_KARAMBWAN, service.resolveOfferContext()[0]);
+
+		service.onGeOffersWidgetLoaded();
+		when(client.getVarbitValue(VarbitID.GE_SELECTEDSLOT)).thenReturn(3);
+
+		assertEquals("a reopened GE must not carry the previous visit's slot",
+			SHARK, service.resolveOfferContext()[0]);
 	}
 }


### PR DESCRIPTION
## Summary

On the GE "Set up offer" screen, the plugin-injected lines (Breakeven / Tax applied / Your profit) showed data for a *different* item than the one on screen. Reported case: a Shark sell listed at 960 gp x 10,000 qty displayed a breakeven of 260gp. The screenshot's other lines confirm the whole block came from another trade — "Tax applied: 22.5k (5 per item)" implies 5gp tax (2% of ~250gp) x 4,500 qty, and "Your profit: +40,500 (+9 per item)" is 9 x 4,500. The player's concurrent Raw Karambwan trade was 274gp x 4,500 qty. Only the item name "Shark" was correct on screen, and that's the game's own text, not the plugin's.

## Changes

### Root Cause

`resolveOfferContext()` ranked its three context sources by how much context each carried rather than by authority over what is actually on screen:
1. Flip Assist focus (a prediction of the *next* recommended action)
2. the active slot (`lastClickedSlot`, else the `GE_SELECTEDSLOT` varbit)
3. the live "Set up offer" window — consulted last

The setup window is the only surface that actually knows what the player is looking at during setup, but any non-empty active slot outranked it — via both the focus-agreement check in `resolveOnScreenItemId()` and directly in `resolveSlotContext()`. The active slot is whatever the player clicked, or is merely hovering, which during setup is routinely an unrelated in-flight offer.

### The Fix

Reorder sources by authority: while the setup window is on screen, it now outranks the active slot in both resolution paths. Focus may still refine price/qty, but only when it agrees on the item (preserving the existing #972 contract). A third commit gates the setup window on the details container being hidden, so the fix can't bleed in the opposite direction — `onBeforeRender` writes one resolved context to both the setup panel and the in-flight status panel, and those two panels have different authorities.

**Note: this is a recurrence.** `GeOfferContextResolutionTest` already existed for issue #972 with the same symptom ("the focused item's price/volume bleeds onto an unrelated offer panel while 2+ flips are active"). It passed throughout, because every existing test set the offer and the selected slot *together* — modeling only consistent state — and none opened the setup window. The tests encoded the same assumption as the code. The new tests specifically construct the divergent states that were previously untested.

**On AC4 (why closing/reopening the GE seemed to cure it).** `lastClickedSlot` was written on every slot click and never cleared, so it outlived the visit that set it — this is why the symptom was sticky for a whole GE session and appeared cured by a reopen. But it is NOT the root cause. One of the new tests records no click at all and still reproduces the bug, because `resolveActiveSlot()` falls back to `GE_SELECTEDSLOT`, which tracks the *hovered* slot, not just clicks. Clearing the latch alone would have been a non-fix. It is fixed anyway (commit `f849cca`, reset when the offers interface loads) as a real latent bug in its own right, so a GE reopen now genuinely clears the state it only used to seem to clear.

### Commits

- `b7a54c6` fix(ge): scope offer description to the item on the setup window — root cause fix
- `f849cca` fix(ge): drop the remembered offer slot when the GE reopens — AC4 latch fix
- `1f4dea7` fix(ge): keep the setup window from speaking for the in-flight panel — opposite-direction guard
- `2c303db` docs(ge): keep the note on why the per-frame path reads the setup window

## Testing

### Automated

6 new tests added to `GeOfferContextResolutionTest` (9 total in that file now, up from 3 as of #972). Each new test was verified to FAIL without its corresponding fix before the fix landed:

- `setupWindowOutranksStaleClickedSlot_withFocusOnTheStaleItem` — the exact reported scenario
- `setupWindowOutranksStaleClickedSlot_withoutFocus` — isolates the slot path
- `setupWindowOutranksMerelyHoveredSlot` — no click ever recorded; proves the latch alone is not the cause
- `inFlightDetailsPanelOutranksACoveredSetupWindow` — the opposite-direction guard
- `reopeningGeClearsTheClickedSlotLatch` — AC4
- `clickedSlotStillOwnsInFlightPanelWhenNoSetupWindow` — control; pins that the existing #972 contract still holds

Full suite is 570 tests / 0 failures (was 564 tests on master pre-branch; +6 new).

### Manual Testing

- [x] Open the GE and immediately set up a sell for an item you hold. Breakeven/tax/profit match that item and that listed price x qty.
- [x] With an in-flight offer for item A on one slot, set up an offer for item B on another slot. B's setup panel shows B's numbers.
- [x] Repeat the above while hovering the mouse over item A's slot tile during setup — this is the specific trigger the unit tests pin (GE_SELECTEDSLOT tracks hover, not just clicks).
- [x] Click item A's slot to view its details, back out, then set up an offer for item B. B's panel shows B's numbers.
- [x] Rapidly switch items within a single setup slot; each shows its own numbers.
- [x] Use the GE continuously for an extended session (AC6) without closing it; confirm no cross-item bleed appears over time.
- [x] Confirm in-flight offer status panels still show their own slot's item (guards against the opposite-direction regression from the third commit).
- [x] Buy side: wiki insta-buy price / daily volume / buy limit correspond to the item actually being bought (AC2).

### AC Mapping

AC1 done. AC2 done (same resolver feeds the buy-side description). AC3 done (root cause identified as an unscoped source-priority order, not a stale cache). AC4 answered and fixed (the click latch was a contributing/aggravating factor, not the root cause — see note above). AC5/AC6/AC7 pending the user's in-game QA, tracked via the manual checklist above.

## Related Issues

Part of Flip-Smart/flip-smart#992

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated and passing
- [x] No new source comments referencing issue numbers (Plugin Hub LOC budget)
- [ ] Manual in-game QA (pending — see Manual Testing checklist above)

## Codacy Resolution

### 🩺 Codacy Quality Gate — fixed in this PR
- `78b70f6` PMD_SingularField `src/test/java/com/flipsmart/GeOfferContextResolutionTest.java:75` — suppressed via `@SuppressWarnings("PMD.SingularField")`; the `offers` field is intentionally shared mutable fixture state across multiple `putOffer()` calls within a single test (e.g. `reopeningGeClearsTheClickedSlotLatch`), so converting it to a local variable would drop earlier offers on each subsequent call.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `78b70f6` `src/test/java/com/flipsmart/GeOfferContextResolutionTest.java:75` — same fix as the quality-gate item above (two AI Reviewer comments flagged the same line).

### 🤖 Codacy AI Reviewer — deferred (in-thread rationale)
- `src/main/java/com/flipsmart/GeOfferDescriptionService.java:246` (2 comments) — suggested resolving `resolveSetupWindowContext()` once and threading it through `resolveFlipAssistFocusContext`/`resolveOnScreenItemId`. Deferred: this would restructure the exact priority-order call graph that implements the setup-window-outranks-active-slot fix in this PR; not comfortable making that structural change without a fuller pass to verify the ordering invariant is preserved.
- `src/test/java/com/flipsmart/GeOfferContextResolutionTest.java:186,209` (2 comments) — suggested consolidating the new pinning tests' setup into a shared parameterized helper. Deferred: keeping each new regression scenario's setup inline keeps it independently readable and avoids a helper abstraction masking a divergence between scenarios.

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `src/main/java/com/flipsmart/GeOfferDescriptionService.java:332` — flagged `isDetailsContainerVisible()` as undefined/build-breaking. It is defined at line 140 (pre-existing helper, also used at line 120) and the build compiles clean; this was a diff-hunk visibility artifact, not a real missing method.
