### PR TITLE
Add sound + desktop alert when a GE offer needs action

### DIFF
--- a/src/main/java/com/flipsmart/ActionAlertNotifier.java
+++ b/src/main/java/com/flipsmart/ActionAlertNotifier.java
@@ -1,0 +1,143 @@
+package com.flipsmart;
+
+import com.flipsmart.recommend.ActionDecision;
+import com.flipsmart.recommend.ActionStep;
+import net.runelite.client.Notifier;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.IntFunction;
+import java.util.function.LongSupplier;
+
+/**
+ * Fires a RuneLite notification when a Grand Exchange offer needs the player's action,
+ * so a player who is not watching the client does not miss it.
+ *
+ * Alert identity is deliberately coarser than {@link ActionDecision} equality. An
+ * empty-slot buy carries the Flip Finder queue's current suggestion, which rotates on
+ * every refresh — but what the player must do, "a slot is free", does not change when
+ * the suggested item does, so PLACE_BUY is keyed item-agnostically.
+ *
+ * Enable/sound/desktop gating belongs to RuneLite: {@link Notifier#notify} no-ops when
+ * the notification is disabled, and honours the player's global notification settings
+ * unless they opt into overriding them.
+ */
+public class ActionAlertNotifier
+{
+	/** Minimum gap before the same alert key may fire again. */
+	static final long COOLDOWN_MS = 60_000L;
+
+	/** Housekeeping cap; expired entries are pruned lazily well before this. */
+	private static final int MAX_ENTRIES = 64;
+
+	private final Notifier notifier;
+	private final FlipSmartConfig config;
+	private final IntFunction<String> itemNames;
+	private final LongSupplier clock;
+
+	/** alert key -> wall-clock instant at which it may fire again. */
+	private final Map<String, Long> cooldownUntilMillis = new ConcurrentHashMap<>();
+
+	private volatile String lastAlertKey;
+
+	public ActionAlertNotifier(Notifier notifier, FlipSmartConfig config, IntFunction<String> itemNames)
+	{
+		this(notifier, config, itemNames, System::currentTimeMillis);
+	}
+
+	/** Test seam: inject a deterministic clock. */
+	ActionAlertNotifier(Notifier notifier, FlipSmartConfig config, IntFunction<String> itemNames, LongSupplier clock)
+	{
+		this.notifier = notifier;
+		this.config = config;
+		this.itemNames = itemNames;
+		this.clock = clock;
+	}
+
+	/**
+	 * Offer a decision for alerting. Safe to call on every resolve — repeats of an
+	 * unchanged action are silent.
+	 */
+	public void onDecision(ActionDecision decision)
+	{
+		String key = alertKey(decision);
+		if (key == null)
+		{
+			lastAlertKey = null;
+			return;
+		}
+		if (key.equals(lastAlertKey))
+		{
+			return;
+		}
+		lastAlertKey = key;
+		if (isCoolingDown(key))
+		{
+			return;
+		}
+		mark(key);
+		notifier.notify(config.actionAlert(), message(decision, itemNames));
+	}
+
+	/** The player-facing identity of an action, or null when there is nothing to do. */
+	static String alertKey(ActionDecision decision)
+	{
+		if (decision == null || decision.getStep() == ActionStep.NONE)
+		{
+			return null;
+		}
+		switch (decision.getStep())
+		{
+			case PLACE_BUY:
+				return "PLACE_BUY";
+			case LIST:
+				return "LIST:" + decision.getItemId();
+			default:
+				return decision.getStep() + ":" + decision.getItemId() + ":" + decision.getSlot();
+		}
+	}
+
+	static String message(ActionDecision decision, IntFunction<String> itemNames)
+	{
+		switch (decision.getStep())
+		{
+			case PLACE_BUY:
+				return "A Grand Exchange slot is free";
+			case LIST:
+				return "List " + itemNames.apply(decision.getItemId()) + " to sell";
+			case CANCEL:
+				return "Cancel your " + itemNames.apply(decision.getItemId()) + " offer";
+			case REPRICE:
+				return "Adjust the price of your " + itemNames.apply(decision.getItemId()) + " offer";
+			case COLLECT:
+				return "Collect your " + itemNames.apply(decision.getItemId());
+			default:
+				return "A Grand Exchange offer needs attention";
+		}
+	}
+
+	private boolean isCoolingDown(String key)
+	{
+		Long until = cooldownUntilMillis.get(key);
+		if (until == null)
+		{
+			return false;
+		}
+		if (clock.getAsLong() >= until)
+		{
+			cooldownUntilMillis.remove(key);
+			return false;
+		}
+		return true;
+	}
+
+	private void mark(String key)
+	{
+		long now = clock.getAsLong();
+		cooldownUntilMillis.put(key, now + COOLDOWN_MS);
+		if (cooldownUntilMillis.size() > MAX_ENTRIES)
+		{
+			cooldownUntilMillis.entrySet().removeIf(entry -> now >= entry.getValue());
+		}
+	}
+}

--- a/src/main/java/com/flipsmart/ActionAlertNotifier.java
+++ b/src/main/java/com/flipsmart/ActionAlertNotifier.java
@@ -6,6 +6,7 @@ import net.runelite.client.Notifier;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BooleanSupplier;
 import java.util.function.IntFunction;
 import java.util.function.LongSupplier;
 
@@ -33,6 +34,7 @@ public class ActionAlertNotifier
 	private final Notifier notifier;
 	private final FlipSmartConfig config;
 	private final IntFunction<String> itemNames;
+	private final BooleanSupplier clientFocused;
 	private final LongSupplier clock;
 
 	/** alert key -> wall-clock instant at which it may fire again. */
@@ -40,23 +42,26 @@ public class ActionAlertNotifier
 
 	private volatile String lastAlertKey;
 
-	public ActionAlertNotifier(Notifier notifier, FlipSmartConfig config, IntFunction<String> itemNames)
+	public ActionAlertNotifier(Notifier notifier, FlipSmartConfig config, IntFunction<String> itemNames,
+		BooleanSupplier clientFocused)
 	{
-		this(notifier, config, itemNames, System::currentTimeMillis);
+		this(notifier, config, itemNames, clientFocused, System::currentTimeMillis);
 	}
 
 	/** Test seam: inject a deterministic clock. */
-	ActionAlertNotifier(Notifier notifier, FlipSmartConfig config, IntFunction<String> itemNames, LongSupplier clock)
+	ActionAlertNotifier(Notifier notifier, FlipSmartConfig config, IntFunction<String> itemNames,
+		BooleanSupplier clientFocused, LongSupplier clock)
 	{
 		this.notifier = notifier;
 		this.config = config;
 		this.itemNames = itemNames;
+		this.clientFocused = clientFocused;
 		this.clock = clock;
 	}
 
 	/**
-	 * Offer a decision for alerting. Safe to call on every resolve — repeats of an
-	 * unchanged action are silent.
+	 * Offer a decision for alerting. Safe to call on every resolve and every tick —
+	 * repeats of an unchanged action are silent.
 	 */
 	public void onDecision(ActionDecision decision)
 	{
@@ -67,6 +72,13 @@ public class ActionAlertNotifier
 			return;
 		}
 		if (key.equals(lastAlertKey))
+		{
+			return;
+		}
+		// While the client is focused RuneLite discards the notification, so treating it
+		// as delivered would strand the action: the player walks away and is never told.
+		// Leave it unconsumed instead — the next tick re-offers it once they look away.
+		if (clientFocused.getAsBoolean())
 		{
 			return;
 		}

--- a/src/main/java/com/flipsmart/ActionAlertNotifier.java
+++ b/src/main/java/com/flipsmart/ActionAlertNotifier.java
@@ -63,6 +63,7 @@ public class ActionAlertNotifier
 	 * Offer a decision for alerting. Safe to call on every resolve and every tick —
 	 * repeats of an unchanged action are silent.
 	 */
+	@SuppressWarnings("PMD.NullAssignment")
 	public void onDecision(ActionDecision decision)
 	{
 		String key = alertKey(decision);

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -973,6 +973,10 @@ public class AutoRecommendService
 		}
 		ResolverInput input = buildResolverInput(-1, false);
 		ActionDecision decision = actionResolver.resolve(input);
+		// Re-offer every tick, before the change guard: an alert suppressed while the client
+		// was focused is still pending, and this is what delivers it once the player looks
+		// away. The notifier dedupes, so an unchanged action stays silent.
+		notifyActionAlert(decision);
 		if (decision.equals(lastAppliedDecision))
 		{
 			return;
@@ -981,7 +985,6 @@ public class AutoRecommendService
 			decision.getKind(), decision.getStep(), decision.getItemId(), decision.getSlot());
 		focusedCollectedItemId = decision.getStep() == ActionStep.LIST ? decision.getItemId() : -1;
 		lastAppliedDecision = decision;
-		notifyActionAlert(decision);
 		applyDecision(decision);
 		// Mirror resolveAndApply: when a buy was suppressed for a pending sell, hold with a
 		// clear message instead of the generic wait (keeps both resolve paths consistent).

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -198,6 +198,11 @@ public class AutoRecommendService
 	// detection so the per-tick re-resolve only repaints (and logs) when the action changes.
 	private ActionDecision lastAppliedDecision;
 
+	// Fires on each applied decision so action alerts can notify. The notifier owns its own
+	// change detection: resolveAndApply re-applies unchanged decisions on every offer event,
+	// while the tick re-resolve only calls on change.
+	private Consumer<ActionDecision> onActionAlert;
+
 	// Whether a FocusedFlip (buy/sell setup overlay) is currently shown. The game-tick
 	// re-resolve heals BLANK overlays only — it must never override an action already shown,
 	// so it stays out of the way of a direct focus (e.g. collect -> sell) that the resolver's
@@ -235,6 +240,11 @@ public class AutoRecommendService
 	public void setOnStatusChanged(Consumer<String> callback)
 	{
 		this.onStatusChanged = callback;
+	}
+
+	public void setOnActionAlert(Consumer<ActionDecision> callback)
+	{
+		this.onActionAlert = callback;
 	}
 
 	public void setOnQueueAdvanced(Runnable callback)
@@ -913,6 +923,7 @@ public class AutoRecommendService
 			decision.getKind(), decision.getStep(), decision.getItemId(), decision.getSlot());
 		focusedCollectedItemId = decision.getStep() == ActionStep.LIST ? decision.getItemId() : -1;
 		lastAppliedDecision = decision;
+		notifyActionAlert(decision);
 		applyDecision(decision);
 		// When the only thing we could have done was a buy we suppressed for a pending sell,
 		// tell the player we're holding for that item's price rather than showing a vague wait.
@@ -970,6 +981,7 @@ public class AutoRecommendService
 			decision.getKind(), decision.getStep(), decision.getItemId(), decision.getSlot());
 		focusedCollectedItemId = decision.getStep() == ActionStep.LIST ? decision.getItemId() : -1;
 		lastAppliedDecision = decision;
+		notifyActionAlert(decision);
 		applyDecision(decision);
 		// Mirror resolveAndApply: when a buy was suppressed for a pending sell, hold with a
 		// clear message instead of the generic wait (keeps both resolve paths consistent).
@@ -1037,6 +1049,14 @@ public class AutoRecommendService
 		String name = resolveItemName(itemId);
 		int qty = session.getCollectedQuantity(itemId);
 		focusSellForItem(itemId, name, qty);
+	}
+
+	private void notifyActionAlert(ActionDecision decision)
+	{
+		if (onActionAlert != null)
+		{
+			onActionAlert.accept(decision);
+		}
 	}
 
 	private String resolveItemName(int itemId)

--- a/src/main/java/com/flipsmart/FlipSmartConfig.java
+++ b/src/main/java/com/flipsmart/FlipSmartConfig.java
@@ -5,6 +5,7 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Keybind;
+import net.runelite.client.config.Notification;
 
 import java.awt.event.KeyEvent;
 
@@ -580,7 +581,7 @@ public interface FlipSmartConfig extends Config
 	// ============================================
 	@ConfigSection(
 		name = "Notifications",
-		description = "Discord webhook notifications for trade events",
+		description = "In-game action alerts and Discord webhook notifications for trade events",
 		position = 6,
 		closedByDefault = false
 	)
@@ -624,6 +625,18 @@ public interface FlipSmartConfig extends Config
 	default boolean notifyFlipSuggestion()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "actionAlert",
+		name = "Action Alert",
+		description = "Notify when a Grand Exchange offer needs action. Sound and desktop popup follow your RuneLite notification settings unless you override them here.",
+		section = NOTIFICATIONS_SECTION,
+		position = 3
+	)
+	default Notification actionAlert()
+	{
+		return Notification.ON;
 	}
 
 	@ConfigSection(

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -48,6 +48,7 @@ import net.runelite.api.gameval.VarbitID;
 import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.client.Notifier;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.ui.ClientUI;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.input.MouseListener;
 import net.runelite.client.input.MouseManager;
@@ -114,6 +115,9 @@ public class FlipSmartPlugin extends Plugin
 
 	@Inject
 	private Notifier notifier;
+
+	@Inject
+	private ClientUI clientUI;
 
 	@Inject
 	private KeyManager keyManager;
@@ -689,7 +693,7 @@ public class FlipSmartPlugin extends Plugin
 			() -> { if (flipFinderPanel != null) flipFinderPanel.refresh(); },
 			() -> { if (flipFinderPanel != null) flipFinderPanel.refreshActiveFlips(); });
 		serviceWiring.wireServiceCallbacks(this, offlineSyncService, activeFlipTracker, refreshCoalescer);
-		autoRecommendService = serviceWiring.initializeAutoRecommendService(this, config, flipAssistOverlay, geSlotOverlay, offerStore, notifier);
+		autoRecommendService = serviceWiring.initializeAutoRecommendService(this, config, flipAssistOverlay, geSlotOverlay, offerStore, notifier, clientUI);
 		activeOfferAdvisorService = serviceWiring.initializeActiveOfferAdvisor(this);
 		scheduler.startActiveOfferAdvisorTimer(session::isLoggedIntoRunescape, this::pollActiveOfferAdvisor);
 		manualAdjustmentTracker = serviceWiring.initializeManualAdjustmentTracker(this, config, flipAssistOverlay,

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -46,6 +46,7 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.api.gameval.VarPlayerID;
+import net.runelite.client.Notifier;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.input.MouseListener;
@@ -110,6 +111,9 @@ public class FlipSmartPlugin extends Plugin
 
 	@Inject
 	private ChatMessageManager chatMessageManager;
+
+	@Inject
+	private Notifier notifier;
 
 	@Inject
 	private KeyManager keyManager;
@@ -685,7 +689,7 @@ public class FlipSmartPlugin extends Plugin
 			() -> { if (flipFinderPanel != null) flipFinderPanel.refresh(); },
 			() -> { if (flipFinderPanel != null) flipFinderPanel.refreshActiveFlips(); });
 		serviceWiring.wireServiceCallbacks(this, offlineSyncService, activeFlipTracker, refreshCoalescer);
-		autoRecommendService = serviceWiring.initializeAutoRecommendService(this, config, flipAssistOverlay, geSlotOverlay, offerStore);
+		autoRecommendService = serviceWiring.initializeAutoRecommendService(this, config, flipAssistOverlay, geSlotOverlay, offerStore, notifier);
 		activeOfferAdvisorService = serviceWiring.initializeActiveOfferAdvisor(this);
 		scheduler.startActiveOfferAdvisorTimer(session::isLoggedIntoRunescape, this::pollActiveOfferAdvisor);
 		manualAdjustmentTracker = serviceWiring.initializeManualAdjustmentTracker(this, config, flipAssistOverlay,

--- a/src/main/java/com/flipsmart/plugin/ServiceWiring.java
+++ b/src/main/java/com/flipsmart/plugin/ServiceWiring.java
@@ -19,6 +19,7 @@ import com.flipsmart.trading.OfferStore;
 import com.flipsmart.trading.RoundTripLedger;
 import com.flipsmart.trading.TransactionLogger;
 import net.runelite.client.Notifier;
+import net.runelite.client.ui.ClientUI;
 
 import javax.swing.SwingUtilities;
 
@@ -53,10 +54,11 @@ public class ServiceWiring
 	 */
 	public AutoRecommendService initializeAutoRecommendService(FlipSmartPlugin plugin, FlipSmartConfig config,
 		FlipAssistOverlay flipAssistOverlay, GrandExchangeSlotOverlay geSlotOverlay, OfferStore offerStore,
-		Notifier notifier)
+		Notifier notifier, ClientUI clientUI)
 	{
 		AutoRecommendService autoRecommendService = new AutoRecommendService(config, plugin, offerStore);
-		ActionAlertNotifier actionAlerts = new ActionAlertNotifier(notifier, config, plugin::getItemName);
+		ActionAlertNotifier actionAlerts = new ActionAlertNotifier(notifier, config, plugin::getItemName,
+			clientUI::isFocused);
 		autoRecommendService.setOnActionAlert(actionAlerts::onDecision);
 		autoRecommendService.setOnFocusChanged(plugin::handleAutoRecommendFocusChanged);
 		autoRecommendService.setOnOverlayMessageChanged(flipAssistOverlay::setAutoStatusMessage);

--- a/src/main/java/com/flipsmart/plugin/ServiceWiring.java
+++ b/src/main/java/com/flipsmart/plugin/ServiceWiring.java
@@ -1,5 +1,6 @@
 package com.flipsmart.plugin;
 
+import com.flipsmart.ActionAlertNotifier;
 import com.flipsmart.ActiveFlipTracker;
 import com.flipsmart.ActiveOfferAdvisorService;
 import com.flipsmart.AutoRecommendService;
@@ -17,6 +18,7 @@ import com.flipsmart.GrandExchangeTracker;
 import com.flipsmart.trading.OfferStore;
 import com.flipsmart.trading.RoundTripLedger;
 import com.flipsmart.trading.TransactionLogger;
+import net.runelite.client.Notifier;
 
 import javax.swing.SwingUtilities;
 
@@ -50,9 +52,12 @@ public class ServiceWiring
 	 * @return the constructed AutoRecommendService
 	 */
 	public AutoRecommendService initializeAutoRecommendService(FlipSmartPlugin plugin, FlipSmartConfig config,
-		FlipAssistOverlay flipAssistOverlay, GrandExchangeSlotOverlay geSlotOverlay, OfferStore offerStore)
+		FlipAssistOverlay flipAssistOverlay, GrandExchangeSlotOverlay geSlotOverlay, OfferStore offerStore,
+		Notifier notifier)
 	{
 		AutoRecommendService autoRecommendService = new AutoRecommendService(config, plugin, offerStore);
+		ActionAlertNotifier actionAlerts = new ActionAlertNotifier(notifier, config, plugin::getItemName);
+		autoRecommendService.setOnActionAlert(actionAlerts::onDecision);
 		autoRecommendService.setOnFocusChanged(plugin::handleAutoRecommendFocusChanged);
 		autoRecommendService.setOnOverlayMessageChanged(flipAssistOverlay::setAutoStatusMessage);
 		autoRecommendService.setDisplayedSellPriceProvider(itemId -> plugin.getFlipFinderPanel() != null ? plugin.getFlipFinderPanel().getDisplayedSellPrice(itemId) : null);

--- a/src/test/java/com/flipsmart/ActionAlertNotifierTest.java
+++ b/src/test/java/com/flipsmart/ActionAlertNotifierTest.java
@@ -194,6 +194,59 @@ public class ActionAlertNotifierTest
 			ActionAlertNotifier.message(decision(ActionKind.S4, ActionStep.REPRICE, ITEM, 3), this::name));
 	}
 
+	/**
+	 * S2 exists only while the queue has a surfaceable buy, so a refresh that briefly
+	 * empties it flaps PLACE_BUY -> COLLECT -> PLACE_BUY. Those are different keys, so
+	 * only the cooldown stops the third from re-alerting.
+	 */
+	@Test
+	public void flapWithinCooldownDoesNotReAlert()
+	{
+		alerts.onDecision(placeBuy(ITEM));
+		now += 1_000L;
+		alerts.onDecision(collect(OTHER_ITEM, 2));
+		now += 1_000L;
+		alerts.onDecision(placeBuy(ITEM));
+
+		verify(notifier, times(2)).notify(any(Notification.class), anyString());
+	}
+
+	/** Once the window lapses, a genuinely recurring action alerts again. */
+	@Test
+	public void flapAfterCooldownReAlerts()
+	{
+		alerts.onDecision(placeBuy(ITEM));
+		now += 1_000L;
+		alerts.onDecision(collect(OTHER_ITEM, 2));
+		now += ActionAlertNotifier.COOLDOWN_MS;
+		alerts.onDecision(placeBuy(ITEM));
+
+		verify(notifier, times(3)).notify(any(Notification.class), anyString());
+	}
+
+	/** The window holds right up to its boundary. */
+	@Test
+	public void stillCoolingJustBeforeExpiry()
+	{
+		alerts.onDecision(placeBuy(ITEM));
+		now += 1_000L;
+		alerts.onDecision(collect(OTHER_ITEM, 2));
+		now += ActionAlertNotifier.COOLDOWN_MS - 1_001L;
+		alerts.onDecision(placeBuy(ITEM));
+
+		verify(notifier, times(2)).notify(any(Notification.class), anyString());
+	}
+
+	/** Cooldowns are per key — one key cooling must not silence another. */
+	@Test
+	public void cooldownsAreIndependentPerKey()
+	{
+		alerts.onDecision(cancel(ITEM, 3));
+		alerts.onDecision(cancel(OTHER_ITEM, 4));
+
+		verify(notifier, times(2)).notify(any(Notification.class), anyString());
+	}
+
 	/** The alert-key table: PLACE_BUY is item-agnostic, LIST is per-item, the rest are per-offer. */
 	@Test
 	public void alertKeyTable()

--- a/src/test/java/com/flipsmart/ActionAlertNotifierTest.java
+++ b/src/test/java/com/flipsmart/ActionAlertNotifierTest.java
@@ -1,0 +1,210 @@
+package com.flipsmart;
+
+import com.flipsmart.recommend.ActionDecision;
+import com.flipsmart.recommend.ActionKind;
+import com.flipsmart.recommend.ActionStep;
+import net.runelite.client.Notifier;
+import net.runelite.client.config.Notification;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the action-alert trigger: which decisions alert, how repeats and flaps are
+ * suppressed, and the message text. The empty-slot buy carries a queue-sourced itemId
+ * that rotates on every Flip Finder refresh, so the alert key is deliberately coarser
+ * than ActionDecision equality — {@link #rotatingBuySuggestionAlertsOnce()} pins that.
+ */
+public class ActionAlertNotifierTest
+{
+	private static final int ITEM = 4151;
+	private static final int OTHER_ITEM = 561;
+	private static final String ITEM_NAME = "Abyssal whip";
+	private static final String OTHER_NAME = "Nature rune";
+
+	private Notifier notifier;
+	private FlipSmartConfig config;
+	private long now;
+	private ActionAlertNotifier alerts;
+
+	@Before
+	public void setUp()
+	{
+		notifier = mock(Notifier.class);
+		config = mock(FlipSmartConfig.class);
+		when(config.actionAlert()).thenReturn(Notification.ON);
+		now = 1_000_000L;
+		alerts = new ActionAlertNotifier(notifier, config, this::name, () -> now);
+	}
+
+	private String name(int itemId)
+	{
+		return itemId == ITEM ? ITEM_NAME : OTHER_NAME;
+	}
+
+	private static ActionDecision decision(ActionKind kind, ActionStep step, int itemId, int slot)
+	{
+		return new ActionDecision(kind, step, itemId, slot, 0L);
+	}
+
+	private static ActionDecision cancel(int itemId, int slot)
+	{
+		return decision(ActionKind.S6, ActionStep.CANCEL, itemId, slot);
+	}
+
+	private static ActionDecision collect(int itemId, int slot)
+	{
+		return decision(ActionKind.S5, ActionStep.COLLECT, itemId, slot);
+	}
+
+	private static ActionDecision placeBuy(int itemId)
+	{
+		return decision(ActionKind.S2, ActionStep.PLACE_BUY, itemId, -1);
+	}
+
+	/** A fresh cancel recommendation alerts, naming the item. */
+	@Test
+	public void newCancelDecisionAlertsOnce()
+	{
+		alerts.onDecision(cancel(ITEM, 3));
+
+		verify(notifier, times(1)).notify(eq(Notification.ON), anyString());
+	}
+
+	/** The configured Notification is handed to RuneLite, which owns enable-gating. */
+	@Test
+	public void notifyReceivesTheConfiguredNotification()
+	{
+		Notification configured = Notification.OFF;
+		when(config.actionAlert()).thenReturn(configured);
+
+		alerts.onDecision(cancel(ITEM, 3));
+
+		verify(notifier).notify(eq(configured), anyString());
+	}
+
+	/** resolveAndApply re-applies an unchanged decision on every offer event. */
+	@Test
+	public void repeatedDecisionIsSilent()
+	{
+		alerts.onDecision(cancel(ITEM, 3));
+		alerts.onDecision(cancel(ITEM, 3));
+		alerts.onDecision(cancel(ITEM, 3));
+
+		verify(notifier, times(1)).notify(any(Notification.class), anyString());
+	}
+
+	/** detectedAtMillis is excluded from decision identity; it must not re-alert. */
+	@Test
+	public void detectedAtChangeIsSilent()
+	{
+		alerts.onDecision(new ActionDecision(ActionKind.S6, ActionStep.CANCEL, ITEM, 3, 1L));
+		alerts.onDecision(new ActionDecision(ActionKind.S6, ActionStep.CANCEL, ITEM, 3, 99_999L));
+
+		verify(notifier, times(1)).notify(any(Notification.class), anyString());
+	}
+
+	/** Nothing to do — stay silent. */
+	@Test
+	public void idleIsSilent()
+	{
+		alerts.onDecision(ActionDecision.IDLE);
+
+		verify(notifier, never()).notify(any(Notification.class), anyString());
+	}
+
+	/** A null decision must not throw. */
+	@Test
+	public void nullDecisionIsSilent()
+	{
+		alerts.onDecision(null);
+
+		verify(notifier, never()).notify(any(Notification.class), anyString());
+	}
+
+	/**
+	 * THE regression this class exists for: the Flip Finder queue rotates its suggested
+	 * buy every refresh, so the decision's itemId changes while the actionable fact —
+	 * a slot is free — does not. Alert once, not once per rotation.
+	 */
+	@Test
+	public void rotatingBuySuggestionAlertsOnce()
+	{
+		alerts.onDecision(placeBuy(ITEM));
+		now += 120_000L;
+		alerts.onDecision(placeBuy(OTHER_ITEM));
+		now += 120_000L;
+		alerts.onDecision(placeBuy(ITEM));
+
+		verify(notifier, times(1)).notify(any(Notification.class), anyString());
+	}
+
+	/** Distinct actions on the same item are distinct alerts. */
+	@Test
+	public void cancelThenCollectAlertsTwice()
+	{
+		alerts.onDecision(cancel(ITEM, 3));
+		alerts.onDecision(collect(ITEM, 3));
+
+		verify(notifier, times(2)).notify(any(Notification.class), anyString());
+	}
+
+	/** The same action on a different slot is a different alert. */
+	@Test
+	public void sameActionDifferentSlotAlertsTwice()
+	{
+		alerts.onDecision(cancel(ITEM, 3));
+		alerts.onDecision(cancel(ITEM, 5));
+
+		verify(notifier, times(2)).notify(any(Notification.class), anyString());
+	}
+
+	/** Going idle then re-detecting the same action re-alerts once the cooldown lapses. */
+	@Test
+	public void actionReturningAfterIdleReAlertsOnceCooldownLapses()
+	{
+		alerts.onDecision(cancel(ITEM, 3));
+		alerts.onDecision(ActionDecision.IDLE);
+		now += ActionAlertNotifier.COOLDOWN_MS;
+		alerts.onDecision(cancel(ITEM, 3));
+
+		verify(notifier, times(2)).notify(any(Notification.class), anyString());
+	}
+
+	/** Message text per step. */
+	@Test
+	public void messageNamesTheItemPerStep()
+	{
+		assertEquals("Cancel your Abyssal whip offer", ActionAlertNotifier.message(cancel(ITEM, 3), this::name));
+		assertEquals("Collect your Abyssal whip", ActionAlertNotifier.message(collect(ITEM, 3), this::name));
+		assertEquals("A Grand Exchange slot is free", ActionAlertNotifier.message(placeBuy(ITEM), this::name));
+		assertEquals("List Abyssal whip to sell",
+			ActionAlertNotifier.message(decision(ActionKind.SELL_WAITING, ActionStep.LIST, ITEM, -1), this::name));
+		assertEquals("Adjust the price of your Abyssal whip offer",
+			ActionAlertNotifier.message(decision(ActionKind.S4, ActionStep.REPRICE, ITEM, 3), this::name));
+	}
+
+	/** The alert-key table: PLACE_BUY is item-agnostic, LIST is per-item, the rest are per-offer. */
+	@Test
+	public void alertKeyTable()
+	{
+		assertNull(ActionAlertNotifier.alertKey(ActionDecision.IDLE));
+		assertNull(ActionAlertNotifier.alertKey(null));
+		assertEquals("PLACE_BUY", ActionAlertNotifier.alertKey(placeBuy(ITEM)));
+		assertEquals("PLACE_BUY", ActionAlertNotifier.alertKey(placeBuy(OTHER_ITEM)));
+		assertEquals("LIST:4151",
+			ActionAlertNotifier.alertKey(decision(ActionKind.SELL_WAITING, ActionStep.LIST, ITEM, -1)));
+		assertEquals("CANCEL:4151:3", ActionAlertNotifier.alertKey(cancel(ITEM, 3)));
+		assertEquals("COLLECT:4151:3", ActionAlertNotifier.alertKey(collect(ITEM, 3)));
+	}
+}

--- a/src/test/java/com/flipsmart/ActionAlertNotifierTest.java
+++ b/src/test/java/com/flipsmart/ActionAlertNotifierTest.java
@@ -35,6 +35,7 @@ public class ActionAlertNotifierTest
 	private Notifier notifier;
 	private FlipSmartConfig config;
 	private long now;
+	private boolean focused;
 	private ActionAlertNotifier alerts;
 
 	@Before
@@ -44,7 +45,8 @@ public class ActionAlertNotifierTest
 		config = mock(FlipSmartConfig.class);
 		when(config.actionAlert()).thenReturn(Notification.ON);
 		now = 1_000_000L;
-		alerts = new ActionAlertNotifier(notifier, config, this::name, () -> now);
+		focused = false;
+		alerts = new ActionAlertNotifier(notifier, config, this::name, () -> focused, () -> now);
 	}
 
 	private String name(int itemId)
@@ -245,6 +247,48 @@ public class ActionAlertNotifierTest
 		alerts.onDecision(cancel(OTHER_ITEM, 4));
 
 		verify(notifier, times(2)).notify(any(Notification.class), anyString());
+	}
+
+	/** While the client is focused RuneLite discards the notification, so we must not send one. */
+	@Test
+	public void focusedClientIsSilent()
+	{
+		focused = true;
+
+		alerts.onDecision(cancel(ITEM, 3));
+
+		verify(notifier, never()).notify(any(Notification.class), anyString());
+	}
+
+	/**
+	 * THE bug from live QA: an action that appears while the player is watching must not be
+	 * consumed. RuneLite throws the notification away when focused, so marking it delivered
+	 * strands the action — the player walks away and is never told. It must still fire once
+	 * they look away.
+	 */
+	@Test
+	public void alertSuppressedWhileFocusedStillFiresOnceUnfocused()
+	{
+		focused = true;
+		alerts.onDecision(collect(ITEM, 6));
+		alerts.onDecision(collect(ITEM, 6));
+		verify(notifier, never()).notify(any(Notification.class), anyString());
+
+		focused = false;
+		alerts.onDecision(collect(ITEM, 6));
+
+		verify(notifier, times(1)).notify(any(Notification.class), anyString());
+	}
+
+	/** Once delivered while away, the same pending action does not re-fire on later ticks. */
+	@Test
+	public void alertDeliveredWhileUnfocusedDoesNotRepeatOnTicks()
+	{
+		alerts.onDecision(collect(ITEM, 6));
+		alerts.onDecision(collect(ITEM, 6));
+		alerts.onDecision(collect(ITEM, 6));
+
+		verify(notifier, times(1)).notify(any(Notification.class), anyString());
 	}
 
 	/** The alert-key table: PLACE_BUY is item-agnostic, LIST is per-item, the rest are per-offer. */


### PR DESCRIPTION
## Summary

Adds sound + desktop notification when a Grand Exchange offer needs the player's action, so a player who isn't watching the client doesn't miss it. Uses RuneLite's own `Notifier` + `Notification` config type (same mechanism as Idle Notifier), so sound/desktop/volume inherit from the player's global notification settings and fire only while the client is unfocused.

## Changes

### ✨ New Features
- New `ActionAlertNotifier` fires a RuneLite `Notifier` alert when an offer needs the player's action: cancel, re-price, collect, list-a-collected-item, and "a Grand Exchange slot is free".
- New config item **Action Alert** (`actionAlert`, type `Notification`, default `Notification.ON`) in the Notifications section, wired through `FlipSmartConfig`, `FlipSmartPlugin`, and `plugin/ServiceWiring`.
- Alerts are keyed per action and cooldown-gated so they don't spam on every queue refresh.

### 🐛 Bug Fixes
- Suppressed alerts (client focused, RuneLite `Notifier` no-ops) are no longer marked as delivered — they now re-offer on the next game tick so the alert fires the moment the player alt-tabs away, instead of being silently dropped forever. Found during live in-game QA (4th commit, `0a1a2b0`).

### Design Notes
1. **Alert identity is deliberately coarser than `ActionDecision` equality.** `ActionResolver` builds the empty-slot buy from the Flip Finder queue's current suggestion, which rotates every refresh (~2 min). Keying on the decision would re-beep on every rotation, so `PLACE_BUY` is keyed item-agnostically — the actionable fact is "a slot is free", not which item.
2. **A 60s per-key cooldown** absorbs flapping: `S2` only exists while `hasSurfaceableBuy()` is true, so a queue refresh that momentarily empties it flaps PLACE_BUY -> COLLECT -> PLACE_BUY (different keys, which plain dedup can't absorb).
3. **Suppressed alerts are not consumed** (see Bug Fixes above, 4th commit). RuneLite's `Notifier` silently no-ops when the client is focused; the notifier previously marked the alert delivered anyway, stranding the action so it never fired once the player looked away. Now it returns without marking, and the game tick re-offers the pending decision so it lands the moment focus is lost.

**Nothing that renders is touched** — `GrandExchangeSlotOverlay`, `GeSlotWidgetDecorator`, `SpriteOutline`, `SlotBorderTint` are all untouched, so issue #981's native slot border carries zero regression risk.

### AC Deviations (needs product sign-off)

Product (@Scapenomics) has been asked on the issue; not yet confirmed at time of PR open.

- **AC1 (deviates):** the amber action highlight already exists and is unchanged. Colour does NOT encode action type (red=cancel/orange=adjust/green=collect), because the slot border already means wiki instabuy/instasell competitiveness (green=competitive, red=uncompetitive). Amber was originally chosen specifically to avoid that clash.
- **AC2 (dropped):** no 3-flash/5s-pause cadence; the existing continuous amber pulse is unchanged.
- **AC7 (partial):** one Action Alert toggle covers both sound and desktop. They are independently controllable only after ticking "Override global settings" in RuneLite's notification panel — we deliberately don't force `override=true`, as that would stomp the player's global notification prefs.
- AC3, AC4 were already satisfied by existing code. AC5, AC6, AC8 are met.

## Testing

### Automated Tests
- `./gradlew build` → BUILD SUCCESSFUL
- Full suite: 590 tests, 0 failures (80 classes)
- `ActionAlertNotifierTest`: 19 tests, 0 failures

### Manual Testing

This is in-game QA that requires a live RuneLite client + Grand Exchange session (Playwright/qa-verifier cannot drive an in-game client), so it will be verified manually:

- [x] Enable Flip Assist, let an offer need action, alt-tab away from RuneLite -> expect sound + desktop popup.
- [x] With RuneLite focused -> expect silence (unfocused-only by design).
- [x] Let an action appear while focused, then alt-tab -> expect the alert to fire on arrival (this is the 4th commit's regression fix).
- [x] Uncheck Action Alert -> expect silence.
- [x] Leave a GE slot empty and go AFK ~10 min -> expect exactly one "A Grand Exchange slot is free" alert, not one per queue refresh.

## API Changes

None.

## Frontend Impact

None.

## Database Migrations

None.

## Deployment Notes

- [ ] New RuneLite config item: **Action Alert** (`actionAlert`, `Notification`, default `ON`) in the Notifications section — no server-side or env changes required, ships with the plugin jar on next Plugin Hub release.
- [ ] No new dependencies.
- [ ] No configuration changes outside the new config item above.
- [ ] No database migration required.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (config item description)
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by teammate

## Related Issues

Closes Flip-Smart/flip-smart#1012

## Screenshots

N/A (no visual changes — overlay/widget rendering is untouched).

### 🩺 Codacy Quality Gate — fixed in this PR
- `be62aa5` PMD_category_java_errorprone_NullAssignment `ActionAlertNotifier.java:71` — suppressed via `@SuppressWarnings("PMD.NullAssignment")` (matches existing precedent in `FlipFinderPanel.java`); the null reset on an idle decision is intentional and load-bearing, not switched to a sentinel string.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `be62aa5` `ActionAlertNotifier.java:72` — same PMD null-assignment finding (2 comment threads on this line); suppressed rather than switched to an empty-string sentinel.
- `0a1a2b0` `ActionAlertNotifier.java:91` — cooldown-marked-before-delivery concern; already fixed by the PR's own "don't consume a suppressed alert" commit, posted against the pre-fix intermediate commit.
- `0a1a2b0` `ActionAlertNotifier.java:75` — dedup-blocks-re-offer concern; same pre-fix intermediate commit, same resolution.

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `ActionAlertNotifier.java:114` — nitpick that `itemNames.apply(...)` may return null; the wired implementation (`FlipSmartPlugin::getItemName` → `ItemUtils.getItemName`) already falls back to `"Unknown Item"` and never returns null.

