### PR TITLE
Report inventory GP for the web Capital Active card

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1155,8 +1155,8 @@ public class FlipFinderPanel extends PluginPanel
 		Integer filledSlots = getFilledSlots();
 
 		final boolean applyRecs = applyRecommendations;
-		apiClient.getPluginSyncAsync(cashStack, flipStyle, limit, randomSeed, timeframe, rsn, filledSlots,
-			plugin.isMembersWorld()).thenAccept(sync ->
+		apiClient.getPluginSyncAsync(cashStack, getInventoryGp(), flipStyle, limit, randomSeed, timeframe, rsn,
+			filledSlots, plugin.isMembersWorld()).thenAccept(sync ->
 		{
 			if (sync == null)
 			{
@@ -2028,6 +2028,17 @@ public class FlipFinderPanel extends PluginPanel
 	{
 		// This will be overridden by the plugin
 		// For now, return null to get all recommendations
+		return null;
+	}
+
+	/**
+	 * The player's real inventory coins, reported for the web "Capital Active" card.
+	 * Deliberately separate from {@link #getCashStack()}, which the cashstack
+	 * override may replace with a user-supplied figure. Null means "unknown, do not
+	 * record"; zero is a real reading and must be sent as such.
+	 */
+	protected Integer getInventoryGp()
+	{
 		return null;
 	}
 

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -216,11 +216,16 @@ public class FlipSmartApiClient
 	}
 
 	public CompletableFuture<PluginSyncResponse> getPluginSyncAsync(
-		Integer cashStack, String flipStyle, int limit, Integer randomSeed, String timeframe, String rsn,
-		Integer filledSlots, boolean isMembersWorld)
+		Integer cashStack, Integer inventoryGp, String flipStyle, int limit, Integer randomSeed, String timeframe,
+		String rsn, Integer filledSlots, boolean isMembersWorld)
 	{
-		return flips.getPluginSyncAsync(cashStack, flipStyle, limit, randomSeed, timeframe, rsn,
+		return flips.getPluginSyncAsync(cashStack, inventoryGp, flipStyle, limit, randomSeed, timeframe, rsn,
 			filledSlots, isMembersWorld, config.minimumProfit(), config.minimumVolume());
+	}
+
+	public CompletableFuture<Boolean> pushRsnCapitalAsync(String rsn, int inventoryGp)
+	{
+		return flips.pushRsnCapitalAsync(rsn, inventoryGp);
 	}
 
 	@Deprecated(since = "1.5.0", forRemoval = true)

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -223,7 +223,7 @@ public class FlipSmartApiClient
 			filledSlots, isMembersWorld, config.minimumProfit(), config.minimumVolume());
 	}
 
-	public CompletableFuture<Boolean> pushRsnCapitalAsync(String rsn, int inventoryGp)
+	public CompletableFuture<Boolean> pushRsnCapitalAsync(String rsn, Integer inventoryGp)
 	{
 		return flips.pushRsnCapitalAsync(rsn, inventoryGp);
 	}

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -977,6 +977,7 @@ public class FlipSmartPlugin extends Plugin
 
 	public void handleLogoutState()
 	{
+		pushFinalCapitalSnapshot();
 		session.onLogout();
 		offlineSyncService.persistOfferState();
 		geHistoryService.reset();
@@ -1004,6 +1005,25 @@ public class FlipSmartPlugin extends Plugin
 		{
 			javax.swing.SwingUtilities.invokeLater(() -> flipFinderPanel.showLoggedOutOfGameState());
 		}
+	}
+
+	/**
+	 * Report the final inventory coins as the player leaves, so the web card does not
+	 * sit on a poll-interval-old reading for as long as they stay offline.
+	 *
+	 * Must run before {@link PlayerSession#onLogout()}, which clears the RSN. The
+	 * logged-in guard matters: this same handler runs for the login screen shown at
+	 * startup, where the cash stack is still zero and reporting it would overwrite a
+	 * real stored value. Async, so logout is never delayed.
+	 */
+	private void pushFinalCapitalSnapshot()
+	{
+		if (!session.isLoggedIntoRunescape())
+		{
+			return;
+		}
+
+		getCurrentRsnSafe().ifPresent(rsn -> apiClient.pushRsnCapitalAsync(rsn, session.getCurrentCashStack()));
 	}
 
 	public void handleLoggedInState()
@@ -1495,6 +1515,14 @@ public class FlipSmartPlugin extends Plugin
 					}
 				}
 				return session.getCurrentCashStack() > 0 ? session.getCurrentCashStack() : null;
+			}
+
+			@Override
+			protected Integer getInventoryGp()
+			{
+				// Never the override: this is the reported figure, not the one
+				// recommendations are built from. Zero is reported as zero.
+				return session.isLoggedIntoRunescape() ? session.getCurrentCashStack() : null;
 			}
 
 			@Override

--- a/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
@@ -167,14 +167,29 @@ public class FlipsEndpoints
 	}
 
 	/**
+	 * Append the player's real inventory coins for the web "Capital Active" card.
+	 * Unlike the filter params above, zero is sent rather than omitted: a player with
+	 * everything deployed into offers genuinely holds none, and dropping that would
+	 * leave the stored figure overstated indefinitely. Null alone means "unknown".
+	 * Kept off {@code appendSharedQueryParams} because /flip-finder has no use for it.
+	 */
+	static void appendInventoryGp(StringBuilder urlBuilder, Integer inventoryGp)
+	{
+		if (inventoryGp != null)
+		{
+			urlBuilder.append(String.format("&inventory_gp=%d", inventoryGp));
+		}
+	}
+
+	/**
 	 * Fetch the bundled 2-minute poll ({@code GET /plugin/sync}) in one round-trip:
 	 * recommendations, active flips, completed flips, statistics and entitlements.
 	 * Query parameters mirror {@link #getFlipRecommendationsAsync} so the same
 	 * panel inputs drive both.
 	 */
 	public CompletableFuture<PluginSyncResponse> getPluginSyncAsync(
-		Integer cashStack, String flipStyle, int limit, Integer randomSeed, String timeframe, String rsn,
-		Integer filledSlots, boolean isMembersWorld, int minProfit, int minVolume)
+		Integer cashStack, Integer inventoryGp, String flipStyle, int limit, Integer randomSeed, String timeframe,
+		String rsn, Integer filledSlots, boolean isMembersWorld, int minProfit, int minVolume)
 	{
 		String apiUrl = transport.getApiUrl();
 
@@ -182,6 +197,7 @@ public class FlipsEndpoints
 		urlBuilder.append(String.format("%s/plugin/sync?limit=%d&flip_style=%s", apiUrl, limit, flipStyle));
 		appendSharedQueryParams(urlBuilder, cashStack, randomSeed, timeframe, rsn, filledSlots, isMembersWorld);
 		appendFilterParams(urlBuilder, minProfit, minVolume);
+		appendInventoryGp(urlBuilder, inventoryGp);
 
 		Request.Builder requestBuilder = new Request.Builder()
 			.url(urlBuilder.toString())
@@ -189,6 +205,27 @@ public class FlipsEndpoints
 
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
 			transport.parse(jsonData, PluginSyncResponse.class));
+	}
+
+	/**
+	 * Flush the last-known inventory coins as the player logs out, so the web
+	 * "Capital Active" card does not sit on a reading up to a poll-interval old
+	 * for the whole time they are offline. Recurring reporting rides
+	 * {@link #getPluginSyncAsync} instead, so this fires once per session.
+	 * Best-effort: failures are swallowed rather than delaying logout.
+	 */
+	public CompletableFuture<Boolean> pushRsnCapitalAsync(String rsn, int inventoryGp)
+	{
+		JsonObject body = new JsonObject();
+		body.addProperty("rsn", rsn);
+		body.addProperty("inventory_gp", inventoryGp);
+
+		Request.Builder requestBuilder = new Request.Builder()
+			.url(String.format("%s/rsn/capital", transport.getApiUrl()))
+			.post(RequestBody.create(JSON, body.toString()));
+
+		return transport.executeAuthenticatedAsync(requestBuilder, jsonData -> Boolean.TRUE)
+			.exceptionally(e -> false);
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
@@ -214,7 +214,7 @@ public class FlipsEndpoints
 	 * {@link #getPluginSyncAsync} instead, so this fires once per session.
 	 * Best-effort: failures are swallowed rather than delaying logout.
 	 */
-	public CompletableFuture<Boolean> pushRsnCapitalAsync(String rsn, int inventoryGp)
+	public CompletableFuture<Boolean> pushRsnCapitalAsync(String rsn, Integer inventoryGp)
 	{
 		JsonObject body = new JsonObject();
 		body.addProperty("rsn", rsn);

--- a/src/test/java/com/flipsmart/api/endpoints/FlipsEndpointsInventoryGpTest.java
+++ b/src/test/java/com/flipsmart/api/endpoints/FlipsEndpointsInventoryGpTest.java
@@ -1,0 +1,37 @@
+package com.flipsmart.api.endpoints;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * The inventory_gp param feeding the web "Capital Active" card. Zero is a real
+ * reading and must survive to the wire — the neighbouring filter params omit zero,
+ * so the difference is deliberate and easy to "tidy" away by mistake.
+ */
+public class FlipsEndpointsInventoryGpTest
+{
+	@Test
+	public void appendsWhenPresent()
+	{
+		StringBuilder sb = new StringBuilder();
+		FlipsEndpoints.appendInventoryGp(sb, 50_000_000);
+		assertEquals("&inventory_gp=50000000", sb.toString());
+	}
+
+	@Test
+	public void sendsZeroRatherThanOmittingIt()
+	{
+		StringBuilder sb = new StringBuilder();
+		FlipsEndpoints.appendInventoryGp(sb, 0);
+		assertEquals("&inventory_gp=0", sb.toString());
+	}
+
+	@Test
+	public void omitsWhenUnknown()
+	{
+		StringBuilder sb = new StringBuilder();
+		FlipsEndpoints.appendInventoryGp(sb, null);
+		assertEquals("", sb.toString());
+	}
+}


### PR DESCRIPTION
## Summary

Issue #1014's website "Capital Active" card understated deployed capital because it excluded the GP sitting in the player's inventory. This PR is the **plugin** leg of a 3-PR set (backend + plugin + frontend) — it reports real inventory coins to the API so the card can include them. This adds no new recurring API call: the plugin already reports inventory coins on the existing `/plugin/sync` poll (~5 min while logged in, scoped by RSN); the backend simply discarded the value. The only additions are one query param on that existing call, plus a single fire-and-forget flush at logout.

## Changes

### ✨ New Features
- `FlipsEndpoints.getPluginSyncAsync` now takes `inventoryGp`, appended via a new package-private `appendInventoryGp` helper (mirrors the existing `appendFilterParams` seam so it is unit-testable). Kept off `appendSharedQueryParams` because `/flip-finder` has no use for it.
- `FlipsEndpoints.pushRsnCapitalAsync` — new `POST /rsn/capital` call, best-effort, failures swallowed.
- `FlipFinderPanel.getInventoryGp()` — new protected seam alongside `getCashStack()`, overridden in `FlipSmartPlugin` to read the session cash stack directly (never the override), returning null when not logged in.
- `FlipSmartPlugin.pushFinalCapitalSnapshot()` — fires at logout.

### ✅ Tests
- 3 new tests (`FlipsEndpointsInventoryGpTest`) pinning that `0` is SENT rather than omitted — the neighbouring filter params omit zero, so this difference is deliberate and easy to "tidy" away by mistake in a future refactor.

## Why a new `inventory_gp` param instead of reusing `cash_stack`

- The Cashstack Override config deliberately replaces `cash_stack` with a user-supplied figure — that is its documented purpose ("suggest flips based on this value instead of your actual inventory cash"). It is a recommendations input, not a measurement, so reporting it as inventory GP would be wrong whenever the override is on.
- `cash_stack` sends null when the player holds no coins, so "everything is in offers" is indistinguishable from "no data".
- `inventory_gp` is sourced from the session cash stack directly, so the override never reaches it, and it sends `0` as `0` (distinguishable from null/no-data).

## Ordering considerations

Two ordering traps a reviewer or future refactorer needs to know about, or the metric silently corrupts:

1. `session.onLogout()` clears the RSN (`this.rsn = null`, per issue #549/#556) and runs first in `handleLogoutState()`. The flush is therefore placed BEFORE it, or it would have no RSN to attach.
2. `handleLogoutState()` also runs for the login screen shown at client startup, where the cash stack is still 0. Without the `session.isLoggedIntoRunescape()` guard, merely launching the client would push a bogus 0 and overwrite a real stored value.

## Known limitations

Players who hide the Flip Finder panel report no capital — `runFlipFinderRefreshBody` no-ops when `config.showFlipFinder()` is false — so the ~5-minute reporting is not universal across all logged-in players. Accepted by the user for this pass; not blocking.

## Testing

### Automated Tests
- Build: `./gradlew clean build` — BUILD SUCCESSFUL
- Full test suite: 593 tests, all passing, including the 3 new `FlipsEndpointsInventoryGpTest` tests
- `check` task (includes test verification) — passing; no checkstyle task is configured in this repo

### Manual Testing
Plugin QA is manual/in-game — Playwright cannot drive a RuneLite client, so no automated QA agent runs against this PR.

- [x] With the Cashstack Override ENABLED, confirm the reported inventory GP still reflects real coins and not the override figure
- [x] Drop all coins into offers and confirm the card goes to 0 rather than sticking at the last non-zero value
- [x] Log out and confirm a final value lands (i.e., the logout flush works)

## API Changes

**New outbound calls (client-side, consuming API endpoints introduced by the backend PR):**
- `GET /plugin/sync` — new optional `inventory_gp` query param appended to the existing poll
- `POST /rsn/capital` — new best-effort call fired once at logout

No new endpoints are introduced by this repo; both are consumed from the backend PR's contract.

## Deployment Notes

- This plugin PR depends on the backend PR (introducing the `inventory_gp` param + `/rsn/capital` endpoint) merging and deploying first.
- Until the backend PR ships, this plugin change is inert/harmless — best-effort, failures swallowed — but provides no value.
- No plugin-side config or env changes.

## Checklist

- [x] Tests added/updated
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by teammate

## Related Issues

Closes Flip-Smart/flip-smart#1014

## Design Doc

https://github.com/Flip-Smart/flip-smart-claude/blob/docs/capital-active-1014-spec/docs/capital-active-1014-design.md

---

### 🩺 Codacy Quality Gate

Green throughout — 0 new issues at 18f40ed and still 0 new issues at ee0ec3c after the AI Reviewer fix below.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `ee0ec3c` `FlipsEndpoints.java:217` / `FlipSmartApiClient.java:226` — widened `pushRsnCapitalAsync`'s `inventoryGp` param from `int` to `Integer` for consistency with the sync API's other params; pure type change, no behavior difference (the only call site always passes a definite reading).

### 🤖 Codacy AI Reviewer — deferred (in-thread rationale)
- `FlipSmartApiClient.java:218` — `getPluginSyncAsync` now takes 9 params; bundling into a request DTO is a legitimate maintainability suggestion but touches the call site in `FlipFinderPanel` plus both API client layers, out of scope for this PR.

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `FlipSmartPlugin.java:1525` — suggestion to only report `inventoryGp` when `> 0` would reintroduce the exact override-bypass/lost-zero bug #1014 fixes; `getInventoryGp()` is deliberately gated on login state (not the `>0` heuristic `getCashStack()` uses) so a genuine empty inventory reports as `0`, not `null`.

