### PR TITLE
fix(flips): widen completed-flip money DTOs to long (Part of #995)

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -648,8 +648,8 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				// Switched to Active Flips tab, update status
 				int itemCount = currentActiveFlips.size();
-				int invested = currentActiveFlips.stream()
-					.mapToInt(ActiveFlip::getTotalInvested)
+				long invested = currentActiveFlips.stream()
+					.mapToLong(ActiveFlip::getTotalInvested)
 					.sum();
 				statusLabel.setText(String.format("%d active %s | %s invested",
 					itemCount,
@@ -1609,8 +1609,8 @@ public class FlipFinderPanel extends PluginPanel
 		if (!currentActiveFlips.isEmpty())
 		{
 			int itemCount = currentActiveFlips.size();
-			int invested = currentActiveFlips.stream()
-				.mapToInt(ActiveFlip::getTotalInvested)
+			long invested = currentActiveFlips.stream()
+				.mapToLong(ActiveFlip::getTotalInvested)
 				.sum();
 			if (tabbedPane.getSelectedIndex() == TAB_ACTIVE_FLIPS)
 			{

--- a/src/main/java/com/flipsmart/api/dto/ActiveFlipsResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/ActiveFlipsResponse.java
@@ -19,6 +19,6 @@ public class ActiveFlipsResponse
 	private int totalItems;
 
 	@SerializedName("total_invested")
-	private int totalInvested;
+	private long totalInvested;
 }
 

--- a/src/main/java/com/flipsmart/api/dto/FlipStatisticsResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/FlipStatisticsResponse.java
@@ -17,7 +17,7 @@ public class FlipStatisticsResponse
 	private int successfulFlips;
 
 	@SerializedName("total_profit")
-	private int totalProfit;
+	private long totalProfit;
 
 	@SerializedName("success_rate")
 	private double successRate;

--- a/src/main/java/com/flipsmart/domain/flip/ActiveFlip.java
+++ b/src/main/java/com/flipsmart/domain/flip/ActiveFlip.java
@@ -25,7 +25,7 @@ public class ActiveFlip
 	private int averageBuyPrice;
 
 	@SerializedName("total_invested")
-	private int totalInvested;
+	private long totalInvested;
 
 	@SerializedName("first_buy_time")
 	private String firstBuyTime;

--- a/src/main/java/com/flipsmart/domain/flip/ActiveFlipLocalUpdater.java
+++ b/src/main/java/com/flipsmart/domain/flip/ActiveFlipLocalUpdater.java
@@ -56,7 +56,7 @@ public final class ActiveFlipLocalUpdater
 		flip.setTotalQuantity(filled);
 		flip.setOriginalQuantity(filled);
 		flip.setAverageBuyPrice(averageBuyPrice);
-		flip.setTotalInvested((int) Math.min(spent > 0 ? spent : (long) averageBuyPrice * filled, Integer.MAX_VALUE));
+		flip.setTotalInvested(spent > 0 ? spent : (long) averageBuyPrice * filled);
 		flip.setFirstBuyTime(nowIso);
 		flip.setLastBuyTime(nowIso);
 		flip.setTransactionCount(1);

--- a/src/main/java/com/flipsmart/domain/flip/CompletedFlip.java
+++ b/src/main/java/com/flipsmart/domain/flip/CompletedFlip.java
@@ -22,31 +22,31 @@ public class CompletedFlip
 	private int quantity;
 
 	@SerializedName("buy_price_per_item")
-	private int buyPricePerItem;
+	private long buyPricePerItem;
 
 	@SerializedName("buy_total")
-	private int buyTotal;
+	private long buyTotal;
 
 	@SerializedName("buy_time")
 	private String buyTime;
 
 	@SerializedName("sell_price_per_item")
-	private int sellPricePerItem;
+	private long sellPricePerItem;
 
 	@SerializedName("sell_total")
-	private int sellTotal;
+	private long sellTotal;
 
 	@SerializedName("sell_time")
 	private String sellTime;
 
 	@SerializedName("gross_profit")
-	private int grossProfit;
+	private long grossProfit;
 
 	@SerializedName("ge_tax")
-	private int geTax;
+	private long geTax;
 
 	@SerializedName("net_profit")
-	private int netProfit;
+	private long netProfit;
 
 	@SerializedName("roi_percent")
 	private double roiPercent;

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -47,7 +47,7 @@ public final class PanelFormat
 	/**
 	 * Format GP amount for display
 	 */
-	public static String formatGP(int amount)
+	public static String formatGP(long amount)
 	{
 		return GpUtils.formatGPSigned(amount);
 	}
@@ -55,7 +55,7 @@ public final class PanelFormat
 	/**
 	 * Format GP amount with commas for exact input (e.g., "1,234,567")
 	 */
-	public static String formatGPExact(int amount)
+	public static String formatGPExact(long amount)
 	{
 		return GpUtils.formatGPExact(amount);
 	}
@@ -208,7 +208,7 @@ public final class PanelFormat
 	{
 		String colour = realizedNet < 0 ? HEX_LOSS : HEX_PROFIT;
 		return htmlRow(coloured(HEX_PROFIT_LABEL, "Current Profit: ")
-			+ coloured(colour, GpUtils.formatGPSigned(clampInt(realizedNet))));
+			+ coloured(colour, GpUtils.formatGPSigned(realizedNet)));
 	}
 
 	/** Max Potential Profit: muted label + value coloured green (profit) / red (loss). */
@@ -216,13 +216,13 @@ public final class PanelFormat
 	{
 		String colour = maxProfit < 0 ? HEX_LOSS : HEX_PROFIT;
 		return htmlRow(coloured(HEX_MUTED, "Max Potential Profit: ")
-			+ coloured(colour, GpUtils.formatGPSigned(clampInt(maxProfit))));
+			+ coloured(colour, GpUtils.formatGPSigned(maxProfit)));
 	}
 
 	/** Tax: whole row in the muted secondary colour, matching the Potential label. */
 	public static String taxHtml(long total)
 	{
-		return htmlRow(coloured(HEX_MUTED, "Tax: " + formatGP(clampInt(total))));
+		return htmlRow(coloured(HEX_MUTED, "Tax: " + formatGP(total)));
 	}
 
 	/** Qty: progress/total in the muted secondary colour (e.g. "Qty: 3/5"). */
@@ -247,20 +247,6 @@ public final class PanelFormat
 	private static String bold(String text)
 	{
 		return "<b>" + text + "</b>";
-	}
-
-	/** Saturating cast of a long into the int range for the gp formatters. */
-	private static int clampInt(long v)
-	{
-		if (v > Integer.MAX_VALUE)
-		{
-			return Integer.MAX_VALUE;
-		}
-		if (v < Integer.MIN_VALUE)
-		{
-			return Integer.MIN_VALUE;
-		}
-		return (int) v;
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/util/GpUtils.java
+++ b/src/main/java/com/flipsmart/util/GpUtils.java
@@ -97,7 +97,7 @@ public final class GpUtils
 	 * @param amount The GP amount to format
 	 * @return Formatted string (e.g., "1.5M", "500K", "100")
 	 */
-	public static String formatGP(int amount)
+	public static String formatGP(long amount)
 	{
 		if (amount >= 1_000_000)
 		{
@@ -116,7 +116,7 @@ public final class GpUtils
 	 * @param amount The GP amount to format
 	 * @return Formatted string (e.g., "1.5M gp")
 	 */
-	public static String formatGPWithSuffix(int amount)
+	public static String formatGPWithSuffix(long amount)
 	{
 		return formatGP(amount) + " gp";
 	}
@@ -127,9 +127,9 @@ public final class GpUtils
 	 * @param amount The GP amount to format (can be negative)
 	 * @return Formatted string (e.g., "-1.5M", "500K", "100")
 	 */
-	public static String formatGPSigned(int amount)
+	public static String formatGPSigned(long amount)
 	{
-		int absAmount = Math.abs(amount);
+		long absAmount = Math.abs(amount);
 		String sign = amount < 0 ? "-" : "";
 
 		if (absAmount >= 1_000_000)
@@ -160,7 +160,7 @@ public final class GpUtils
 	 * @param amount The GP amount to format
 	 * @return Formatted string with commas (e.g., "1,234,567")
 	 */
-	public static String formatGPExact(int amount)
+	public static String formatGPExact(long amount)
 	{
 		return String.format("%,d", amount);
 	}

--- a/src/test/java/com/flipsmart/api/dto/SeamDtoDeserializationTest.java
+++ b/src/test/java/com/flipsmart/api/dto/SeamDtoDeserializationTest.java
@@ -79,6 +79,44 @@ public class SeamDtoDeserializationTest
 	}
 
 	@Test
+	public void completedFlipParsesMoneyValuesAboveInt4()
+	{
+		// A single high-value flip whose totals exceed Integer.MAX_VALUE (2,147,483,647).
+		// Gson parses the whole response, so one over-int flip that fails to deserialize
+		// throws JsonSyntaxException and drops the ENTIRE Flip History panel, not one row.
+		long buyTotal = 3_000_000_000L;
+		long sellTotal = 3_200_000_000L;
+		long grossProfit = 200_000_000_000L;
+		long geTax = 4_000_000_000L;
+		long netProfit = 196_000_000_000L;
+		long perItemPrice = 2_400_000_000L; // e.g. a party hat, > int4 for a single item
+		String json = "{\"count\":1,\"flips\":[{\"id\":1,\"item_id\":4151,\"item_name\":\"Third age\","
+			+ "\"quantity\":1,\"buy_price_per_item\":" + perItemPrice + ",\"buy_total\":" + buyTotal + ","
+			+ "\"sell_price_per_item\":" + perItemPrice + ",\"sell_total\":" + sellTotal + ","
+			+ "\"gross_profit\":" + grossProfit + ",\"ge_tax\":" + geTax + ",\"net_profit\":" + netProfit + "}]}";
+		CompletedFlipsResponse r = gson.fromJson(json, CompletedFlipsResponse.class);
+		com.flipsmart.domain.flip.CompletedFlip f = r.getFlips().get(0);
+		assertEquals(perItemPrice, f.getBuyPricePerItem());
+		assertEquals(buyTotal, f.getBuyTotal());
+		assertEquals(perItemPrice, f.getSellPricePerItem());
+		assertEquals(sellTotal, f.getSellTotal());
+		assertEquals(grossProfit, f.getGrossProfit());
+		assertEquals(geTax, f.getGeTax());
+		assertEquals(netProfit, f.getNetProfit());
+	}
+
+	@Test
+	public void flipStatisticsParsesProfitAboveInt4()
+	{
+		// /flips/statistics returns SUM(net_profit); Postgres SUM(int4) is bigint, so the API
+		// can already emit past-int4 totals for a >2.1b/month window regardless of column type.
+		String json = "{\"total_flips\":42,\"successful_flips\":30,\"total_profit\":5000000000,"
+			+ "\"success_rate\":0.714,\"average_roi\":12.5}";
+		FlipStatisticsResponse r = gson.fromJson(json, FlipStatisticsResponse.class);
+		assertEquals(5_000_000_000L, r.getTotalProfit());
+	}
+
+	@Test
 	public void blocklistsResponseMapsListCountAndNestedSnakeCaseKeys()
 	{
 		String json = "{\"count\":1,\"blocklists\":[{\"id\":7,\"name\":\"My list\","


### PR DESCRIPTION
**Part of #995** (backend closer: Flip-Smart/flip-smart#1003).

## Why

`CompletedFlip` typed all six money fields as Java `int` (max 2,147,483,647). It's a Gson **response** DTO, and Gson parses the whole response — so a single flip whose `buy_total`/`sell_total`/`net_profit` exceeds int4 throws `JsonSyntaxException: NumberFormatException` and drops the **entire** Flip History panel, not one row. Today the backend's int4 columns accidentally protect the plugin; the backend BIGINT widening (#995 / #1003) removes that protection, so the plugin must widen **first** (plugin-hub cadence = long pole).

The DTO widening is forward-compatible — it reads today's int-range values fine, so this ships safely ahead of the backend change.

## Also fixed (live bug, independent of the backend PR)

`/flips/statistics` returns `SUM(net_profit)`; Postgres `SUM(int4)` is already `bigint` and the API's Pydantic `int` is unbounded, so any user clearing >2.1b profit in the 30-day window already gets a thrown parse and a dead stats panel today. `FlipStatisticsResponse.totalProfit` → `long` fixes it.

## Changes

- `CompletedFlip`: 7 money fields → `long`
- `FlipStatisticsResponse.totalProfit`, `ActiveFlipsResponse.totalInvested`, `ActiveFlip.totalInvested` → `long`
- `GpUtils` display formatters + `PanelFormat.formatGP/formatGPExact` → `long`; deleted `PanelFormat.clampInt` (it was capping Current Profit / Tax / Max Potential card rows at 2.1B)
- `ActiveFlipLocalUpdater`: dropped the saturating `(int)` clamp on `totalInvested`
- `FlipFinderPanel`: two aggregate-invested sums `mapToInt`→`mapToLong`
- `GpUtils.parseGp` left `int` — the coin **stack** stays int post-Jagex; only GE trade values widen (tracked in #1018)

## Testing

### Automated Tests
- New `SeamDtoDeserializationTest` cases: a `CompletedFlip` and a `FlipStatistics` profit both above int4 deserialize to correct `long` values (these fail with `JsonSyntaxException` on the pre-change `int` fields — verified RED before the fix).
- `./gradlew build` green (compile + checkstyle + full test suite).

### Manual Testing
- [ ] Flip History panel renders a flip with `buy_total`/`net_profit` > 2.1B without the panel going blank.
- [ ] Stats panel shows a >2.1b 30-day total without breaking.

## API Changes

None — this is a client-side DTO widening only. No plugin→API contract change.

## Database Migrations

None in this repo. The corresponding backend migration is tracked separately in Flip-Smart/flip-smart#1003.

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: None
- [ ] Requires database migration: No (plugin repo has no DB)
- Sequencing: this PR must merge and ship via plugin-hub **before** Flip-Smart/flip-smart#1003 deploys, since plugin-hub release cadence is slower than backend deploys and the backend widening removes the int4 ceiling that currently protects the plugin from overflow.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (N/A — no public API surface changed)
- [x] Code follows style guidelines (checkstyle clean)
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by teammate

## Related Issues

Part of #995
Related to Flip-Smart/flip-smart#1003

---



Codacy: no open signals at `9f6f003` (quality gate green, 0 new issues; 0 AI Reviewer comments).
