### PR TITLE
feat: Exit Trades — sell-only modes (Regular Sell, Breakeven, Instant)

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -1814,6 +1814,10 @@ public class AutoRecommendService
 	 */
 	private void highlightItemSlot(int itemId)
 	{
+		if (exitOwnsOverlay())
+		{
+			return;
+		}
 		java.util.function.IntConsumer cb = onHighlightItemSlot;
 		if (cb != null)
 		{
@@ -1925,6 +1929,10 @@ public class AutoRecommendService
 	/** Track a skipped action's item and light its sticky orange box (AC7). */
 	private void keepStickyHighlight(int itemId)
 	{
+		if (exitOwnsOverlay())
+		{
+			return;
+		}
 		Integer slot = slotForLiveItem(itemId);
 		if (slot == null)
 		{
@@ -3035,10 +3043,9 @@ public class AutoRecommendService
 	 */
 	private void focusBuyOverlay(int itemId, String itemName, int buyPrice, int quantity, int sellPrice, String statusMsg)
 	{
-		if (plugin != null && plugin.getExitTradesController() != null
-			&& plugin.getExitTradesController().isActive())
+		if (exitSuppressesBuys())
 		{
-			return; // Exit Trades is sell-only; no new buy suggestions while active
+			return; // Exit Trades (any mode) is sell-only; no new buy suggestions while active
 		}
 		int priceOffset = config.priceOffset();
 		FocusedFlip focus = FocusedFlip.forBuy(itemId, itemName, buyPrice, quantity, sellPrice, priceOffset);
@@ -3050,8 +3057,31 @@ public class AutoRecommendService
 	// Callbacks
 	// =====================
 
+	/** Queue-driven Exit Trades (breakeven/instant) owns the overlay; auto-recommend stays fully silent. */
+	private boolean exitOwnsOverlay()
+	{
+		return plugin != null && plugin.getExitTradesController() != null
+			&& plugin.getExitTradesController().ownsOverlay();
+	}
+
+	/** Any Exit Trades mode (including REGULAR sell-only) suppresses new buy suggestions. */
+	private boolean exitSuppressesBuys()
+	{
+		return plugin != null && plugin.getExitTradesController() != null
+			&& plugin.getExitTradesController().isActive();
+	}
+
 	private void invokeFocusCallback(FocusedFlip focus)
 	{
+		if (exitOwnsOverlay())
+		{
+			return;
+		}
+		if (focus != null && focus.isBuying() && exitSuppressesBuys())
+		{
+			// Sell-only (any Exit Trades mode): drop buy focuses from every path, keep sells.
+			return;
+		}
 		Integer locked = queue.getLockedItemId();
 		if (locked != null && (focus == null || focus.getItemId() != locked))
 		{
@@ -3258,6 +3288,7 @@ public class AutoRecommendService
 			.surfaceableBuy(hasSurfaceable, surfaceableItemId)
 			.nowMillis(now)
 			.blockBuyForPendingSell(blockBuyForPendingSell, pendingSellItemId)
+			.buysSuppressed(exitSuppressesBuys())
 			.completedAwaitingCollection(completed)
 			.staleOffers(staleSnapshot)
 			.collectedAwaitingList(collected)

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -3035,6 +3035,11 @@ public class AutoRecommendService
 	 */
 	private void focusBuyOverlay(int itemId, String itemName, int buyPrice, int quantity, int sellPrice, String statusMsg)
 	{
+		if (plugin != null && plugin.getExitTradesController() != null
+			&& plugin.getExitTradesController().isActive())
+		{
+			return; // Exit Trades is sell-only; no new buy suggestions while active
+		}
 		int priceOffset = config.priceOffset();
 		FocusedFlip focus = FocusedFlip.forBuy(itemId, itemName, buyPrice, quantity, sellPrice, priceOffset);
 		invokeFocusCallback(focus);

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -13,6 +13,7 @@ import com.flipsmart.domain.flip.ActiveFlipLocalUpdater;
 import com.flipsmart.api.dto.BlocklistSummary;
 import com.flipsmart.domain.offer.OfferTransition;
 import com.flipsmart.domain.offer.PendingOrder;
+import com.flipsmart.exit.ExitTradesDialog;
 import com.flipsmart.recommend.SmartSellPricer;
 import com.flipsmart.trading.ActiveFlipCardMetrics;
 import com.flipsmart.trading.RealizedFlipProfit;
@@ -928,7 +929,7 @@ public class FlipFinderPanel extends PluginPanel
 			}
 			else
 			{
-				com.flipsmart.exit.ExitTradesDialog.open(this, plugin::startExitTrades);
+				ExitTradesDialog.open(this, plugin::startExitTrades);
 			}
 		});
 

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -807,6 +807,8 @@ public class FlipFinderPanel extends PluginPanel
 		body.add(Box.createVerticalStrut(6));
 		body.add(buildUpdateButtonRow());
 		body.add(Box.createVerticalStrut(6));
+		body.add(buildExitTradesRow());
+		body.add(Box.createVerticalStrut(6));
 		body.add(buildHideButtonsRow());
 
 		popup.add(body);
@@ -894,6 +896,30 @@ public class FlipFinderPanel extends PluginPanel
 		});
 
 		row.add(update);
+		return row;
+	}
+
+	private JPanel buildExitTradesRow()
+	{
+		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
+		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+		JButton exit = new JButton("Exit Trades…");
+		exit.setFont(FONT_PLAIN_12);
+		exit.setFocusable(false);
+		exit.setToolTipText("Unwind all open GE trades at breakeven or instant-sell prices");
+		exit.addActionListener(e -> {
+			if (activeSettingsPopup != null)
+			{
+				activeSettingsPopup.setVisible(false);
+			}
+			if (plugin.getExitTradesController() != null)
+			{
+				com.flipsmart.exit.ExitTradesDialog.open(this, plugin.getExitTradesController());
+			}
+		});
+
+		row.add(exit);
 		return row;
 	}
 

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -904,18 +904,31 @@ public class FlipFinderPanel extends PluginPanel
 		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
 		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 
-		JButton exit = new JButton("Exit Trades…");
+		boolean exitActive = plugin.getExitTradesController() != null
+			&& plugin.getExitTradesController().isActive();
+
+		JButton exit = new JButton(exitActive ? "Buy/Sell Mode" : "Exit Trades / Sell Only");
 		exit.setFont(FONT_PLAIN_12);
 		exit.setFocusable(false);
-		exit.setToolTipText("Unwind all open GE trades at breakeven or instant-sell prices");
+		exit.setToolTipText(exitActive
+			? "Leave sell-only mode and resume normal buy/sell recommendations"
+			: "Unwind all open GE trades at breakeven or instant-sell prices");
 		exit.addActionListener(e -> {
 			if (activeSettingsPopup != null)
 			{
 				activeSettingsPopup.setVisible(false);
 			}
-			if (plugin.getExitTradesController() != null)
+			if (plugin.getExitTradesController() == null)
 			{
-				com.flipsmart.exit.ExitTradesDialog.open(this, plugin.getExitTradesController());
+				return;
+			}
+			if (plugin.getExitTradesController().isActive())
+			{
+				plugin.exitSellOnlyMode();
+			}
+			else
+			{
+				com.flipsmart.exit.ExitTradesDialog.open(this, plugin::startExitTrades);
 			}
 		});
 
@@ -3081,6 +3094,12 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private void setFocus(FlipRecommendation rec, JPanel panel)
 	{
+		// Exit Trades (any mode) is sell-only — never focus a new buy while it's active.
+		if (plugin.getExitTradesController() != null && plugin.getExitTradesController().isActive())
+		{
+			return;
+		}
+
 		// Block new buy-side flips when free user has hit their slot limit
 		PlayerSession session = plugin.getSession();
 		if (session != null && !plugin.isPremium()

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -184,6 +184,10 @@ public class FlipSmartPlugin extends Plugin
 	@Getter
 	private AutoRecommendService autoRecommendService;
 
+	// Exit Trades controller (guided mass sell/cancel)
+	@Getter
+	private com.flipsmart.exit.ExitTradesController exitTradesController;
+
 	// Manual flip adjustment tracker (API-based staleness detection)
 	private ManualAdjustmentTracker manualAdjustmentTracker;
 
@@ -239,6 +243,8 @@ public class FlipSmartPlugin extends Plugin
 	private static final String CONFIG_GROUP = "flipsmart";
 	private static final String UNKNOWN_RSN_FALLBACK = "unknown";
 	private static final String AUTO_RECOMMEND_STATE_KEY_PREFIX = "autoRecommendState_";
+	private static final String EXIT_TRADES_STATE_KEY_PREFIX = "exitTradesState_";
+	private static final long EXIT_TRADES_MAX_AGE_MS = 7L * 24 * 60 * 60 * 1000; // 7 days
 	private static final String LAST_KNOWN_RSN_KEY = "lastKnownRsn";
 
 	// Flip Assist input listener for hotkey handling
@@ -696,6 +702,7 @@ public class FlipSmartPlugin extends Plugin
 		autoRecommendService = serviceWiring.initializeAutoRecommendService(this, config, flipAssistOverlay, geSlotOverlay, offerStore, notifier, clientUI);
 		activeOfferAdvisorService = serviceWiring.initializeActiveOfferAdvisor(this);
 		scheduler.startActiveOfferAdvisorTimer(session::isLoggedIntoRunescape, this::pollActiveOfferAdvisor);
+		exitTradesController = serviceWiring.initializeExitTradesController(this, flipAssistOverlay, offerStore);
 		manualAdjustmentTracker = serviceWiring.initializeManualAdjustmentTracker(this, config, flipAssistOverlay,
 			geSlotOverlay, inventoryHighlightOverlay, session, grandExchangeTracker, activeOfferAdvisorService, offerStore);
 		grandExchangeTracker.setOfferStore(offerStore);
@@ -982,6 +989,7 @@ public class FlipSmartPlugin extends Plugin
 		offlineSyncService.persistOfferState();
 		geHistoryService.reset();
 		persistAutoRecommendState();
+		persistExitTradesState();
 		geSlotDecorator.revertAll();
 
 		// Stop auto-recommend on logout
@@ -1074,6 +1082,7 @@ public class FlipSmartPlugin extends Plugin
 		offlineSyncService.preloadPersistedOffers();
 
 		restoreAutoRecommendState();
+		restoreExitTradesState();
 
 		// Start the refresh timer if not already running (needed for manual adjustment checks)
 		if (!scheduler.isAutoRecommendRefreshTimerRunning())
@@ -2098,6 +2107,98 @@ public class FlipSmartPlugin extends Plugin
 				break;
 			}
 		}
+	}
+
+	// =====================
+	// Exit Trades suppliers & persistence
+	// =====================
+
+	/**
+	 * Cost basis for a breakeven exit: the average price actually paid on the most
+	 * recent filled buy for {@code itemId}, derived from the offer store. Returns 0
+	 * when unknown, which drives {@code ExitPriceResolver} to the mid-price fallback.
+	 */
+	public int getExitBuyBasis(int itemId)
+	{
+		if (offerStore == null)
+		{
+			return 0;
+		}
+		com.flipsmart.domain.offer.OfferRecord best = null;
+		for (com.flipsmart.domain.offer.OfferRecord r : offerStore.forItem(itemId))
+		{
+			if (r.isBuy() && r.getFilledQuantity() > 0
+				&& (best == null
+					|| r.getEffectiveLastActivityAtMillis() > best.getEffectiveLastActivityAtMillis()))
+			{
+				best = r;
+			}
+		}
+		return best == null ? 0 : (int) (best.getSpent() / best.getFilledQuantity());
+	}
+
+	public int getExitInventoryQty(int itemId)
+	{
+		return activeFlipTracker != null ? activeFlipTracker.getInventoryCountForItem(itemId) : 0;
+	}
+
+	private String getExitTradesStateKey()
+	{
+		String rsn = session.getRsn();
+		if (rsn == null || rsn.isEmpty())
+		{
+			rsn = lastKnownRsn;
+		}
+		if (rsn == null || rsn.isEmpty())
+		{
+			return EXIT_TRADES_STATE_KEY_PREFIX + UNKNOWN_RSN_FALLBACK;
+		}
+		return EXIT_TRADES_STATE_KEY_PREFIX + rsn;
+	}
+
+	private void persistExitTradesState()
+	{
+		if (exitTradesController == null)
+		{
+			return;
+		}
+		com.flipsmart.exit.ExitTradesController.PersistedState state =
+			exitTradesController.getStateForPersistence(System.currentTimeMillis());
+		if (state == null)
+		{
+			// Nothing acted (AC6) or inactive: drop the run and clear any stale blob.
+			configManager.unsetConfiguration(CONFIG_GROUP, getExitTradesStateKey());
+			exitTradesController.clear();
+			return;
+		}
+		configManager.setConfiguration(CONFIG_GROUP, getExitTradesStateKey(), gson.toJson(state));
+	}
+
+	private void restoreExitTradesState()
+	{
+		if (exitTradesController == null)
+		{
+			return;
+		}
+		String json = configManager.getConfiguration(CONFIG_GROUP, getExitTradesStateKey());
+		if (json == null || json.isEmpty())
+		{
+			return;
+		}
+		try
+		{
+			com.flipsmart.exit.ExitTradesController.PersistedState state =
+				gson.fromJson(json, com.flipsmart.exit.ExitTradesController.PersistedState.class);
+			if (exitTradesController.restoreState(state, System.currentTimeMillis(), EXIT_TRADES_MAX_AGE_MS))
+			{
+				exitTradesController.surfaceCurrent(); // re-prompt pending slots (AC9 immediate resell)
+			}
+		}
+		catch (Exception e)
+		{
+			log.warn("Failed to restore exit-trades state: {}", e.getMessage());
+		}
+		configManager.unsetConfiguration(CONFIG_GROUP, getExitTradesStateKey());
 	}
 
 	// =====================

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -702,7 +702,7 @@ public class FlipSmartPlugin extends Plugin
 		autoRecommendService = serviceWiring.initializeAutoRecommendService(this, config, flipAssistOverlay, geSlotOverlay, offerStore, notifier, clientUI);
 		activeOfferAdvisorService = serviceWiring.initializeActiveOfferAdvisor(this);
 		scheduler.startActiveOfferAdvisorTimer(session::isLoggedIntoRunescape, this::pollActiveOfferAdvisor);
-		exitTradesController = serviceWiring.initializeExitTradesController(this, flipAssistOverlay, offerStore);
+		exitTradesController = serviceWiring.initializeExitTradesController(this, flipAssistOverlay, geSlotOverlay, offerStore);
 		manualAdjustmentTracker = serviceWiring.initializeManualAdjustmentTracker(this, config, flipAssistOverlay,
 			geSlotOverlay, inventoryHighlightOverlay, session, grandExchangeTracker, activeOfferAdvisorService, offerStore);
 		grandExchangeTracker.setOfferStore(offerStore);
@@ -2140,6 +2140,64 @@ public class FlipSmartPlugin extends Plugin
 	public int getExitInventoryQty(int itemId)
 	{
 		return activeFlipTracker != null ? activeFlipTracker.getInventoryCountForItem(itemId) : 0;
+	}
+
+	/**
+	 * Backend-computed exit sell price for {@code itemId} (the advisor's exit-at-breakeven,
+	 * stored in the session), used as the source of truth for breakeven mode. 0 when unknown.
+	 */
+	public int getExitBackendSellPrice(int itemId)
+	{
+		Integer price = session != null ? session.getRecommendedPrice(itemId) : null;
+		return price == null ? 0 : price;
+	}
+
+	/**
+	 * Begin an Exit Trades run. Runs on the client thread because surfacing re-validates against
+	 * live game state (inventory / offers), which must not be read from the Swing dialog thread.
+	 */
+	public void startExitTrades(com.flipsmart.exit.ExitTradesMode mode)
+	{
+		if (exitTradesController == null)
+		{
+			return;
+		}
+		clientThread.invoke(() ->
+		{
+			exitTradesController.start(mode);
+			// Clear any stale buy focus left over from auto-recommend so sell-only mode doesn't
+			// briefly flash a buy before the normal flow re-focuses (most visible in REGULAR).
+			if (flipAssistOverlay != null)
+			{
+				FocusedFlip current = flipAssistOverlay.getFocusedFlip();
+				if (current != null && current.isBuying())
+				{
+					flipAssistOverlay.setFocusedFlip(null);
+				}
+			}
+			exitTradesController.surfaceCurrent();
+		});
+	}
+
+	/** Leave Exit Trades (sell-only) mode: drop the run and hand the overlay back to auto-recommend. */
+	public void exitSellOnlyMode()
+	{
+		clientThread.invoke(() ->
+		{
+			if (exitTradesController != null)
+			{
+				exitTradesController.clear();
+			}
+			if (flipAssistOverlay != null)
+			{
+				flipAssistOverlay.setFocusedFlip(null);
+				flipAssistOverlay.setAutoStatusMessage("", 0);
+			}
+			if (geSlotOverlay != null)
+			{
+				geSlotOverlay.clearAllAdjustmentHighlights();
+			}
+		});
 	}
 
 	private String getExitTradesStateKey()

--- a/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
@@ -577,6 +577,14 @@ public class GrandExchangeSlotOverlay extends Overlay
 		if (step == FlipAssistOverlay.FlipAssistStep.SELECT_ITEM ||
 			step == FlipAssistOverlay.FlipAssistStep.SELL_ITEMS)
 		{
+			// During an Exit Trades re-list of an offer that still owns its slot, the item's own
+			// slot is already highlighted — don't also glow the sell button on empty slots.
+			if (step == FlipAssistOverlay.FlipAssistStep.SELL_ITEMS
+				&& plugin.getExitTradesController() != null
+				&& plugin.getExitTradesController().isModifyingActiveOffer())
+			{
+				return;
+			}
 			drawMainPanelButtonHighlights(graphics, step);
 			return;
 		}

--- a/src/main/java/com/flipsmart/api/dto/WikiPrice.java
+++ b/src/main/java/com/flipsmart/api/dto/WikiPrice.java
@@ -22,4 +22,21 @@ public class WikiPrice
 	{
 		return System.currentTimeMillis() - fetchedAt > WIKI_PRICE_CACHE_DURATION_MS;
 	}
+
+	/**
+	 * Midpoint of instant-buy and instant-sell, used as a safe exit fallback when
+	 * a mode's target price is unavailable. Degrades to whichever side is present.
+	 */
+	public int midPrice()
+	{
+		if (instaBuy <= 0)
+		{
+			return Math.max(instaSell, 0);
+		}
+		if (instaSell <= 0)
+		{
+			return instaBuy;
+		}
+		return (instaBuy + instaSell) / 2;
+	}
 }

--- a/src/main/java/com/flipsmart/api/dto/WikiPrice.java
+++ b/src/main/java/com/flipsmart/api/dto/WikiPrice.java
@@ -37,6 +37,6 @@ public class WikiPrice
 		{
 			return instaBuy;
 		}
-		return (instaBuy + instaSell) / 2;
+		return (int) (((long) instaBuy + instaSell) / 2);
 	}
 }

--- a/src/main/java/com/flipsmart/exit/ExitPhase.java
+++ b/src/main/java/com/flipsmart/exit/ExitPhase.java
@@ -3,7 +3,8 @@ package com.flipsmart.exit;
 public enum ExitPhase
 {
 	PENDING,           // sell offer awaiting relist
-	PENDING_CANCEL,    // buy offer awaiting cancel
-	CANCELLED_HOLDING, // buy cancelled, stock held, awaiting resell
+	PENDING_CANCEL,    // active buy offer awaiting cancel
+	AWAITING_COLLECT,  // buy cancelled/filled, bought items still in the GE slot awaiting collection
+	CANCELLED_HOLDING, // bought stock collected into inventory, awaiting resell
 	DONE
 }

--- a/src/main/java/com/flipsmart/exit/ExitPhase.java
+++ b/src/main/java/com/flipsmart/exit/ExitPhase.java
@@ -1,0 +1,9 @@
+package com.flipsmart.exit;
+
+public enum ExitPhase
+{
+	PENDING,           // sell offer awaiting relist
+	PENDING_CANCEL,    // buy offer awaiting cancel
+	CANCELLED_HOLDING, // buy cancelled, stock held, awaiting resell
+	DONE
+}

--- a/src/main/java/com/flipsmart/exit/ExitPriceResolver.java
+++ b/src/main/java/com/flipsmart/exit/ExitPriceResolver.java
@@ -1,0 +1,25 @@
+package com.flipsmart.exit;
+
+import com.flipsmart.api.dto.WikiPrice;
+import com.flipsmart.util.GeTax;
+
+/** Resolves the target exit sell price for a slot, per mode, with an AC8 mid-price fallback. */
+public final class ExitPriceResolver
+{
+	private ExitPriceResolver()
+	{
+	}
+
+	public static int resolve(ExitTradesMode mode, int itemId, int buyBasis, WikiPrice price)
+	{
+		if (mode == ExitTradesMode.BREAKEVEN && buyBasis > 0)
+		{
+			return GeTax.breakevenSellPrice(itemId, buyBasis);
+		}
+		if (mode == ExitTradesMode.INSTANT && price != null && price.instaSell > 0)
+		{
+			return price.instaSell;
+		}
+		return price == null ? 0 : price.midPrice();
+	}
+}

--- a/src/main/java/com/flipsmart/exit/ExitPriceResolver.java
+++ b/src/main/java/com/flipsmart/exit/ExitPriceResolver.java
@@ -10,11 +10,20 @@ public final class ExitPriceResolver
 	{
 	}
 
-	public static int resolve(ExitTradesMode mode, int itemId, int buyBasis, WikiPrice price)
+	public static int resolve(ExitTradesMode mode, int itemId, int buyBasis, int backendBreakeven, WikiPrice price)
 	{
-		if (mode == ExitTradesMode.BREAKEVEN && buyBasis > 0)
+		if (mode == ExitTradesMode.BREAKEVEN)
 		{
-			return GeTax.breakevenSellPrice(itemId, buyBasis);
+			// Prefer the backend's exit-at-breakeven (source of truth for cost basis + tax);
+			// fall back to the client-side tax calc only when the backend price is unavailable.
+			if (backendBreakeven > 0)
+			{
+				return backendBreakeven;
+			}
+			if (buyBasis > 0)
+			{
+				return GeTax.breakevenSellPrice(itemId, buyBasis);
+			}
 		}
 		if (mode == ExitTradesMode.INSTANT && price != null && price.instaSell > 0)
 		{

--- a/src/main/java/com/flipsmart/exit/ExitSlotTarget.java
+++ b/src/main/java/com/flipsmart/exit/ExitSlotTarget.java
@@ -1,0 +1,40 @@
+package com.flipsmart.exit;
+
+import lombok.Getter;
+
+/** One occupied GE slot the Exit Trades flow must unwind. Phase mutates as the player acts. */
+@Getter
+public final class ExitSlotTarget
+{
+	private final int slot;
+	private final int itemId;
+	private final String itemName;
+	private final boolean buy;
+	private final int buyBasis;
+	private ExitPhase phase;
+
+	private ExitSlotTarget(int slot, int itemId, String itemName, boolean buy, int buyBasis, ExitPhase phase)
+	{
+		this.slot = slot;
+		this.itemId = itemId;
+		this.itemName = itemName;
+		this.buy = buy;
+		this.buyBasis = buyBasis;
+		this.phase = phase;
+	}
+
+	public static ExitSlotTarget sell(int slot, int itemId, String itemName, int buyBasis)
+	{
+		return new ExitSlotTarget(slot, itemId, itemName, false, buyBasis, ExitPhase.PENDING);
+	}
+
+	public static ExitSlotTarget buy(int slot, int itemId, String itemName, int buyBasis)
+	{
+		return new ExitSlotTarget(slot, itemId, itemName, true, buyBasis, ExitPhase.PENDING_CANCEL);
+	}
+
+	public void setPhase(ExitPhase phase)
+	{
+		this.phase = phase;
+	}
+}

--- a/src/main/java/com/flipsmart/exit/ExitSlotTarget.java
+++ b/src/main/java/com/flipsmart/exit/ExitSlotTarget.java
@@ -29,7 +29,7 @@ public final class ExitSlotTarget
 		return new ExitSlotTarget(slot, itemId, itemName, false, buyBasis, ExitPhase.PENDING);
 	}
 
-	public static ExitSlotTarget buy(int slot, int itemId, String itemName, int buyBasis)
+	public static ExitSlotTarget forBuy(int slot, int itemId, String itemName, int buyBasis)
 	{
 		return new ExitSlotTarget(slot, itemId, itemName, true, buyBasis, ExitPhase.PENDING_CANCEL);
 	}

--- a/src/main/java/com/flipsmart/exit/ExitSlotTarget.java
+++ b/src/main/java/com/flipsmart/exit/ExitSlotTarget.java
@@ -12,6 +12,7 @@ public final class ExitSlotTarget
 	private final boolean buy;
 	private final int buyBasis;
 	private ExitPhase phase;
+	private int heldQuantity; // stock bought from a cancelled/filled buy, remembered across the collect lag
 
 	private ExitSlotTarget(int slot, int itemId, String itemName, boolean buy, int buyBasis, ExitPhase phase)
 	{
@@ -36,5 +37,10 @@ public final class ExitSlotTarget
 	public void setPhase(ExitPhase phase)
 	{
 		this.phase = phase;
+	}
+
+	public void setHeldQuantity(int heldQuantity)
+	{
+		this.heldQuantity = heldQuantity;
 	}
 }

--- a/src/main/java/com/flipsmart/exit/ExitTradesController.java
+++ b/src/main/java/com/flipsmart/exit/ExitTradesController.java
@@ -1,0 +1,294 @@
+package com.flipsmart.exit;
+
+import com.flipsmart.FocusedFlip;
+import com.flipsmart.api.dto.WikiPrice;
+import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.domain.offer.OfferState;
+import com.flipsmart.trading.OfferStore;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+import java.util.function.IntUnaryOperator;
+
+/**
+ * Owns an in-progress Exit Trades run: a mode plus an ordered per-slot queue the player
+ * unwinds one slot at a time. Re-targets the existing sell-prompt system; never drives the GE.
+ */
+public final class ExitTradesController
+{
+	private static final int GE_SLOTS = 8;
+
+	private final OfferStore offerStore;
+	private IntUnaryOperator buyBasisSupplier = itemId -> 0;
+	private IntFunction<WikiPrice> wikiPriceSupplier = itemId -> null;
+	private IntUnaryOperator inventoryQtySupplier = itemId -> 0;
+	private Consumer<FocusedFlip> onFocusTarget = f -> { };
+	private Consumer<String> onStatusMessage = m -> { };
+	private Runnable onComplete = () -> { };
+
+	private boolean active;
+	private ExitTradesMode mode;
+	private final List<ExitSlotTarget> targets = new ArrayList<>();
+
+	public ExitTradesController(OfferStore offerStore)
+	{
+		this.offerStore = offerStore;
+	}
+
+	public void setBuyBasisSupplier(IntUnaryOperator supplier)
+	{
+		this.buyBasisSupplier = supplier;
+	}
+
+	public void setWikiPriceSupplier(IntFunction<WikiPrice> supplier)
+	{
+		this.wikiPriceSupplier = supplier;
+	}
+
+	public void setInventoryQtySupplier(IntUnaryOperator supplier)
+	{
+		this.inventoryQtySupplier = supplier;
+	}
+
+	public void setOnFocusTarget(Consumer<FocusedFlip> cb)
+	{
+		this.onFocusTarget = cb;
+	}
+
+	public void setOnStatusMessage(Consumer<String> cb)
+	{
+		this.onStatusMessage = cb;
+	}
+
+	public void setOnComplete(Runnable cb)
+	{
+		this.onComplete = cb;
+	}
+
+	public void start(ExitTradesMode mode)
+	{
+		this.mode = mode;
+		targets.clear();
+		for (int slot = 0; slot < GE_SLOTS; slot++)
+		{
+			OfferRecord r = offerStore.bySlot(slot);
+			if (r == null)
+			{
+				continue;
+			}
+			int basis = buyBasisSupplier.applyAsInt(r.getItemId());
+			targets.add(r.isBuy()
+				? ExitSlotTarget.buy(slot, r.getItemId(), r.getItemName(), basis)
+				: ExitSlotTarget.sell(slot, r.getItemId(), r.getItemName(), basis));
+		}
+		active = !targets.isEmpty();
+	}
+
+	public boolean isActive()
+	{
+		return active;
+	}
+
+	public ExitTradesMode getMode()
+	{
+		return mode;
+	}
+
+	public List<ExitSlotTarget> getTargets()
+	{
+		return Collections.unmodifiableList(targets);
+	}
+
+	public ExitSlotTarget currentTarget()
+	{
+		for (ExitSlotTarget t : targets)
+		{
+			if (t.getPhase() != ExitPhase.DONE)
+			{
+				return t;
+			}
+		}
+		return null;
+	}
+
+	public void clear()
+	{
+		active = false;
+		mode = null;
+		targets.clear();
+	}
+
+	/**
+	 * Advance the queue for {@code record}. Pure: only mutates target phases. Returns true
+	 * when a phase changed so the caller can re-surface the next prompt (see the wiring layer).
+	 */
+	public boolean onOfferChanged(OfferRecord record)
+	{
+		if (!active || record == null)
+		{
+			return false;
+		}
+		for (ExitSlotTarget t : targets)
+		{
+			if (t.getItemId() != record.getItemId())
+			{
+				continue;
+			}
+			if (t.getPhase() == ExitPhase.PENDING && !t.isBuy() && isFreshSell(record))
+			{
+				t.setPhase(ExitPhase.DONE);
+				return true;
+			}
+			if (t.getPhase() == ExitPhase.PENDING_CANCEL && t.isBuy()
+				&& record.isBuy() && isCancelled(record.getState()))
+			{
+				t.setPhase(record.getFilledQuantity() > 0
+					? ExitPhase.CANCELLED_HOLDING : ExitPhase.DONE);
+				return true;
+			}
+			if (t.getPhase() == ExitPhase.CANCELLED_HOLDING && isFreshSell(record))
+			{
+				t.setPhase(ExitPhase.DONE);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean isFreshSell(OfferRecord r)
+	{
+		return !r.isBuy() && r.getState() == OfferState.NEW;
+	}
+
+	private static boolean isCancelled(OfferState s)
+	{
+		return s == OfferState.CANCELLED_EMPTY || s == OfferState.CANCELLED_PARTIAL;
+	}
+
+	public int actedCount()
+	{
+		int n = 0;
+		for (ExitSlotTarget t : targets)
+		{
+			if (t.getPhase() == ExitPhase.DONE || t.getPhase() == ExitPhase.CANCELLED_HOLDING)
+			{
+				n++;
+			}
+		}
+		return n;
+	}
+
+	public void surfaceCurrent()
+	{
+		if (!active)
+		{
+			return;
+		}
+		ExitSlotTarget t = currentTarget();
+		if (t == null)
+		{
+			// Run finished: deactivate but keep DONE targets so a logout snapshot correctly
+			// resolves to "nothing to resume" (getStateForPersistence returns null when inactive).
+			active = false;
+			onComplete.run();
+			return;
+		}
+		if (t.getPhase() == ExitPhase.PENDING_CANCEL)
+		{
+			onFocusTarget.accept(null);
+			onStatusMessage.accept("Exit Trades: cancel the buy offer for " + t.getItemName());
+			return;
+		}
+		// PENDING (sell) or CANCELLED_HOLDING (resell bought stock)
+		int price = ExitPriceResolver.resolve(mode, t.getItemId(), t.getBuyBasis(),
+			wikiPriceSupplier.apply(t.getItemId()));
+		if (price <= 0)
+		{
+			onStatusMessage.accept("Exit Trades: no price data — skipping " + t.getItemName());
+			t.setPhase(ExitPhase.DONE);
+			surfaceCurrent();
+			return;
+		}
+		int qty = t.getPhase() == ExitPhase.CANCELLED_HOLDING
+			? Math.max(1, inventoryQtySupplier.applyAsInt(t.getItemId()))
+			: Math.max(1, offerQuantity(t.getSlot()));
+		onFocusTarget.accept(FocusedFlip.forSell(t.getItemId(), t.getItemName(), price, qty));
+		onStatusMessage.accept("Exit Trades: re-list " + t.getItemName() + " at " + price);
+	}
+
+	private int offerQuantity(int slot)
+	{
+		OfferRecord r = offerStore.bySlot(slot);
+		return r == null ? 0 : r.getTotalQuantity();
+	}
+
+	public static class PersistedTarget
+	{
+		int slot;
+		int itemId;
+		String itemName;
+		boolean buy;
+		int buyBasis;
+		String phase;
+	}
+
+	public static class PersistedState
+	{
+		ExitTradesMode mode;
+		List<PersistedTarget> pending;
+		long savedAtMillis;
+	}
+
+	/** Snapshot for logout persistence, or null when nothing was acted (AC6 discard). */
+	public PersistedState getStateForPersistence(long nowMillis)
+	{
+		if (!active || actedCount() == 0)
+		{
+			return null;
+		}
+		PersistedState s = new PersistedState();
+		s.mode = mode;
+		s.savedAtMillis = nowMillis;
+		s.pending = new ArrayList<>();
+		for (ExitSlotTarget t : targets)
+		{
+			if (t.getPhase() == ExitPhase.DONE)
+			{
+				continue; // DONE slots are real GE offers; nothing to resume
+			}
+			PersistedTarget p = new PersistedTarget();
+			p.slot = t.getSlot();
+			p.itemId = t.getItemId();
+			p.itemName = t.getItemName();
+			p.buy = t.isBuy();
+			p.buyBasis = t.getBuyBasis();
+			p.phase = t.getPhase().name();
+			s.pending.add(p);
+		}
+		return s;
+	}
+
+	public boolean restoreState(PersistedState state, long nowMillis, long maxAgeMs)
+	{
+		if (state == null || state.pending == null || state.pending.isEmpty()
+			|| nowMillis - state.savedAtMillis > maxAgeMs)
+		{
+			return false;
+		}
+		targets.clear();
+		mode = state.mode;
+		for (PersistedTarget p : state.pending)
+		{
+			ExitSlotTarget t = p.buy
+				? ExitSlotTarget.buy(p.slot, p.itemId, p.itemName, p.buyBasis)
+				: ExitSlotTarget.sell(p.slot, p.itemId, p.itemName, p.buyBasis);
+			t.setPhase(ExitPhase.valueOf(p.phase));
+			targets.add(t);
+		}
+		active = true;
+		return true;
+	}
+}

--- a/src/main/java/com/flipsmart/exit/ExitTradesController.java
+++ b/src/main/java/com/flipsmart/exit/ExitTradesController.java
@@ -118,7 +118,7 @@ public final class ExitTradesController
 			}
 			int basis = buyBasisSupplier.applyAsInt(r.getItemId());
 			targets.add(r.isBuy()
-				? ExitSlotTarget.buy(slot, r.getItemId(), r.getItemName(), basis)
+				? ExitSlotTarget.forBuy(slot, r.getItemId(), r.getItemName(), basis)
 				: ExitSlotTarget.sell(slot, r.getItemId(), r.getItemName(), basis));
 		}
 		active = !targets.isEmpty();
@@ -534,7 +534,7 @@ public final class ExitTradesController
 		for (PersistedTarget p : state.pending)
 		{
 			ExitSlotTarget t = p.buy
-				? ExitSlotTarget.buy(p.slot, p.itemId, p.itemName, p.buyBasis)
+				? ExitSlotTarget.forBuy(p.slot, p.itemId, p.itemName, p.buyBasis)
 				: ExitSlotTarget.sell(p.slot, p.itemId, p.itemName, p.buyBasis);
 			t.setPhase(ExitPhase.valueOf(p.phase));
 			targets.add(t);

--- a/src/main/java/com/flipsmart/exit/ExitTradesController.java
+++ b/src/main/java/com/flipsmart/exit/ExitTradesController.java
@@ -37,8 +37,11 @@ public final class ExitTradesController
 	private Runnable onClearHighlights = () -> { };
 	private Runnable onComplete = () -> { };
 
-	private boolean active;
-	private ExitTradesMode mode;
+	// active/mode are read across threads — the client thread (resolver, overlay focus), the Swing
+	// EDT (cog button, panel focus guard), and the render thread (isModifyingActiveOffer) — so the
+	// buy-suppression / ownsOverlay checks see a consistent value without a one-tick stale read.
+	private volatile boolean active;
+	private volatile ExitTradesMode mode;
 	private volatile boolean modifyingActiveOffer;
 	private final List<ExitSlotTarget> targets = new ArrayList<>();
 

--- a/src/main/java/com/flipsmart/exit/ExitTradesController.java
+++ b/src/main/java/com/flipsmart/exit/ExitTradesController.java
@@ -6,11 +6,14 @@ import com.flipsmart.domain.offer.OfferRecord;
 import com.flipsmart.domain.offer.OfferState;
 import com.flipsmart.trading.OfferStore;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import java.util.function.IntFunction;
 import java.util.function.IntUnaryOperator;
 
@@ -18,20 +21,25 @@ import java.util.function.IntUnaryOperator;
  * Owns an in-progress Exit Trades run: a mode plus an ordered per-slot queue the player
  * unwinds one slot at a time. Re-targets the existing sell-prompt system; never drives the GE.
  */
+@Slf4j
 public final class ExitTradesController
 {
 	private static final int GE_SLOTS = 8;
 
 	private final OfferStore offerStore;
 	private IntUnaryOperator buyBasisSupplier = itemId -> 0;
+	private IntUnaryOperator backendSellPriceSupplier = itemId -> 0;
 	private IntFunction<WikiPrice> wikiPriceSupplier = itemId -> null;
 	private IntUnaryOperator inventoryQtySupplier = itemId -> 0;
 	private Consumer<FocusedFlip> onFocusTarget = f -> { };
 	private BiConsumer<String, Integer> onStatusMessage = (m, id) -> { };
+	private IntConsumer onHighlightSlotForItem = itemId -> { };
+	private Runnable onClearHighlights = () -> { };
 	private Runnable onComplete = () -> { };
 
 	private boolean active;
 	private ExitTradesMode mode;
+	private volatile boolean modifyingActiveOffer;
 	private final List<ExitSlotTarget> targets = new ArrayList<>();
 
 	public ExitTradesController(OfferStore offerStore)
@@ -42,6 +50,12 @@ public final class ExitTradesController
 	public void setBuyBasisSupplier(IntUnaryOperator supplier)
 	{
 		this.buyBasisSupplier = supplier;
+	}
+
+	/** Backend-computed exit-at-breakeven sell price (source of truth); 0 when unknown. */
+	public void setBackendSellPriceSupplier(IntUnaryOperator supplier)
+	{
+		this.backendSellPriceSupplier = supplier;
 	}
 
 	public void setWikiPriceSupplier(IntFunction<WikiPrice> supplier)
@@ -64,6 +78,16 @@ public final class ExitTradesController
 		this.onStatusMessage = cb;
 	}
 
+	public void setOnHighlightSlotForItem(IntConsumer cb)
+	{
+		this.onHighlightSlotForItem = cb;
+	}
+
+	public void setOnClearHighlights(Runnable cb)
+	{
+		this.onClearHighlights = cb;
+	}
+
 	public void setOnComplete(Runnable cb)
 	{
 		this.onComplete = cb;
@@ -73,6 +97,15 @@ public final class ExitTradesController
 	{
 		this.mode = mode;
 		targets.clear();
+		modifyingActiveOffer = false;
+		if (mode == ExitTradesMode.REGULAR)
+		{
+			// Latched sell-only: no queue, no re-pricing. Just suppress buys and let the normal
+			// sell flow run until the player toggles back to Buy/Sell mode.
+			active = true;
+			log.debug("Exit Trades started: mode=REGULAR (buys suppressed, normal sell flow)");
+			return;
+		}
 		for (int slot = 0; slot < GE_SLOTS; slot++)
 		{
 			OfferRecord r = offerStore.bySlot(slot);
@@ -86,11 +119,21 @@ public final class ExitTradesController
 				: ExitSlotTarget.sell(slot, r.getItemId(), r.getItemName(), basis));
 		}
 		active = !targets.isEmpty();
+		log.debug("Exit Trades started: mode={} occupiedSlots={}", mode, targets.size());
 	}
 
 	public boolean isActive()
 	{
 		return active;
+	}
+
+	/**
+	 * Whether the exit flow owns the trading overlay (queue-driven breakeven/instant). REGULAR mode
+	 * is active for buy-suppression but hands the overlay to the normal sell flow, so it returns false.
+	 */
+	public boolean ownsOverlay()
+	{
+		return active && mode != ExitTradesMode.REGULAR;
 	}
 
 	public ExitTradesMode getMode()
@@ -119,7 +162,18 @@ public final class ExitTradesController
 	{
 		active = false;
 		mode = null;
+		modifyingActiveOffer = false;
 		targets.clear();
+	}
+
+	/**
+	 * True while the current prompt re-lists an offer that still occupies its own slot. The overlay
+	 * uses this to suppress the "click SELL on an empty slot" glow, which only applies to placing
+	 * freshly-collected stock — not to modifying an offer that already has a slot highlighted.
+	 */
+	public boolean isModifyingActiveOffer()
+	{
+		return active && modifyingActiveOffer;
 	}
 
 	/**
@@ -138,22 +192,64 @@ public final class ExitTradesController
 			{
 				continue;
 			}
+			// A finished sell (re-listed at the exit price, or sold on its own) closes a sell target.
 			if (t.getPhase() == ExitPhase.PENDING && !t.isBuy() && isFreshSell(record))
 			{
 				t.setPhase(ExitPhase.DONE);
+				log.debug("Exit Trades: slot {} item {} sell re-listed -> DONE", t.getSlot(), t.getItemId());
 				return true;
 			}
-			if (t.getPhase() == ExitPhase.PENDING_CANCEL && t.isBuy()
-				&& record.isBuy() && isCancelled(record.getState()))
-			{
-				t.setPhase(record.getFilledQuantity() > 0
-					? ExitPhase.CANCELLED_HOLDING : ExitPhase.DONE);
-				return true;
-			}
+			// Held stock re-listed closes a holding target.
 			if (t.getPhase() == ExitPhase.CANCELLED_HOLDING && isFreshSell(record))
 			{
 				t.setPhase(ExitPhase.DONE);
+				log.debug("Exit Trades: slot {} item {} held stock re-listed -> DONE", t.getSlot(), t.getItemId());
 				return true;
+			}
+			// Buy lifecycle: cancel/fill -> collect -> hold. Always re-surface so the prompt tracks it.
+			if (t.isBuy() && record.isBuy()
+				&& (t.getPhase() == ExitPhase.PENDING_CANCEL || t.getPhase() == ExitPhase.AWAITING_COLLECT))
+			{
+				ExitPhase next = nextBuyPhase(t.getPhase(), record);
+				if (next == ExitPhase.CANCELLED_HOLDING)
+				{
+					t.setHeldQuantity(record.getFilledQuantity()); // survive the inventory-update lag
+				}
+				if (next != t.getPhase())
+				{
+					t.setPhase(next);
+					log.debug("Exit Trades: slot {} item {} buy {} (filled {}) -> {}",
+						t.getSlot(), t.getItemId(), record.getState(), record.getFilledQuantity(), next);
+				}
+				return true;
+			}
+			// A sell that fully sold on its own needs its profit collected before the slot frees.
+			if (!t.isBuy() && !record.isBuy()
+				&& (t.getPhase() == ExitPhase.PENDING || t.getPhase() == ExitPhase.AWAITING_COLLECT))
+			{
+				if (record.getState() == OfferState.FILLED && t.getPhase() != ExitPhase.AWAITING_COLLECT)
+				{
+					t.setPhase(ExitPhase.AWAITING_COLLECT);
+					log.debug("Exit Trades: slot {} item {} sell filled -> AWAITING_COLLECT",
+						t.getSlot(), t.getItemId());
+					return true;
+				}
+				if (record.getState() == OfferState.COLLECTED)
+				{
+					t.setPhase(ExitPhase.DONE);
+					log.debug("Exit Trades: slot {} item {} sell profit collected -> DONE",
+						t.getSlot(), t.getItemId());
+					return true;
+				}
+				if (record.getState() == OfferState.CANCELLED_EMPTY
+					|| record.getState() == OfferState.CANCELLED_PARTIAL)
+				{
+					// Player cancelled the sell to modify it; stock is now in inventory. Re-surface so
+					// the prompt stays locked to re-listing this item (never falls back to a buy).
+					log.debug("Exit Trades: slot {} item {} sell cancelled — re-surfacing sell prompt",
+						t.getSlot(), t.getItemId());
+					return true;
+				}
 			}
 		}
 		return false;
@@ -164,9 +260,21 @@ public final class ExitTradesController
 		return !r.isBuy() && r.getState() == OfferState.NEW;
 	}
 
-	private static boolean isCancelled(OfferState s)
+	/** Next phase for a buy target as its offer progresses cancel/fill -> collect -> hold. */
+	private static ExitPhase nextBuyPhase(ExitPhase current, OfferRecord r)
 	{
-		return s == OfferState.CANCELLED_EMPTY || s == OfferState.CANCELLED_PARTIAL;
+		switch (r.getState())
+		{
+			case CANCELLED_EMPTY:
+				return ExitPhase.DONE; // cancelled with nothing bought
+			case COLLECTED:
+				return r.getFilledQuantity() > 0 ? ExitPhase.CANCELLED_HOLDING : ExitPhase.DONE;
+			case FILLED:
+			case CANCELLED_PARTIAL:
+				return ExitPhase.AWAITING_COLLECT; // bought items sit in the slot awaiting collection
+			default:
+				return current; // NEW / PARTIAL_FILL: still filling, keep prompting cancel
+		}
 	}
 
 	public int actedCount()
@@ -174,7 +282,8 @@ public final class ExitTradesController
 		int n = 0;
 		for (ExitSlotTarget t : targets)
 		{
-			if (t.getPhase() == ExitPhase.DONE || t.getPhase() == ExitPhase.CANCELLED_HOLDING)
+			ExitPhase p = t.getPhase();
+			if (p == ExitPhase.DONE || p == ExitPhase.CANCELLED_HOLDING || p == ExitPhase.AWAITING_COLLECT)
 			{
 				n++;
 			}
@@ -184,9 +293,9 @@ public final class ExitTradesController
 
 	public void surfaceCurrent()
 	{
-		if (!active)
+		if (!active || mode == ExitTradesMode.REGULAR)
 		{
-			return;
+			return; // REGULAR leaves the overlay to the normal sell flow
 		}
 		ExitSlotTarget t = currentTarget();
 		if (t == null)
@@ -194,36 +303,174 @@ public final class ExitTradesController
 			// Run finished: deactivate but keep DONE targets so a logout snapshot correctly
 			// resolves to "nothing to resume" (getStateForPersistence returns null when inactive).
 			active = false;
+			onClearHighlights.run();
+			log.debug("Exit Trades: run complete");
 			onComplete.run();
 			return;
 		}
-		if (t.getPhase() == ExitPhase.PENDING_CANCEL)
+
+		modifyingActiveOffer = false; // set true only when re-listing an offer that owns its slot
+
+		// Re-validate against live state: the snapshot is taken at start(), but by the time we
+		// reach a slot the offer may have sold, been cancelled, or been collected on its own.
+		OfferRecord live = offerStore.bySlot(t.getSlot());
+		boolean liveMatches = live != null && live.getItemId() == t.getItemId();
+
+		// Buy still occupying its slot: cancel it (still filling) or collect it (filled / cancelled-partial).
+		if (t.isBuy() && liveMatches
+			&& (t.getPhase() == ExitPhase.PENDING_CANCEL || t.getPhase() == ExitPhase.AWAITING_COLLECT))
 		{
 			onFocusTarget.accept(null);
-			onStatusMessage.accept("Exit Trades: cancel the buy offer for " + t.getItemName(), t.getItemId());
+			onHighlightSlotForItem.accept(t.getItemId());
+			boolean collect = t.getPhase() == ExitPhase.AWAITING_COLLECT
+				|| live.getState() == OfferState.FILLED
+				|| live.getState() == OfferState.CANCELLED_PARTIAL
+				|| live.getFilledQuantity() >= live.getTotalQuantity();
+			log.debug("Exit Trades: prompt {} slot {} item {}",
+				collect ? "collect" : "cancel", t.getSlot(), t.getItemId());
+			onStatusMessage.accept("Exit Trades: " + (collect ? "collect the bought " : "cancel the buy offer for ")
+				+ t.getItemName(), t.getItemId());
 			return;
 		}
-		// PENDING (sell) or CANCELLED_HOLDING (resell bought stock)
-		int price = ExitPriceResolver.resolve(mode, t.getItemId(), t.getBuyBasis(),
-			wikiPriceSupplier.apply(t.getItemId()));
+
+		// Sell offer still occupying its slot.
+		if (!t.isBuy() && liveMatches)
+		{
+			boolean sold = t.getPhase() == ExitPhase.AWAITING_COLLECT
+				|| live.getState() == OfferState.FILLED
+				|| live.getFilledQuantity() >= live.getTotalQuantity();
+			if (sold)
+			{
+				// Already sold on its own: collect the profit, nothing to re-list.
+				onFocusTarget.accept(null);
+				onHighlightSlotForItem.accept(t.getItemId());
+				if (t.getPhase() != ExitPhase.AWAITING_COLLECT)
+				{
+					t.setPhase(ExitPhase.AWAITING_COLLECT);
+				}
+				log.debug("Exit Trades: prompt collect-profit slot {} item {}", t.getSlot(), t.getItemId());
+				onStatusMessage.accept("Exit Trades: collect the profit for " + t.getItemName(), t.getItemId());
+				return;
+			}
+			// Still listed: re-list at the exit price — unless it's already at it.
+			int price = resolveExitPrice(t);
+			if (price > 0 && price == live.getPrice())
+			{
+				log.debug("Exit Trades: slot {} item {} already at exit price {} — skipping",
+					t.getSlot(), t.getItemId(), price);
+				t.setPhase(ExitPhase.DONE);
+				surfaceCurrent();
+				return;
+			}
+			modifyingActiveOffer = true; // offer owns its slot; suppress the empty-slot sell glow
+			surfaceSell(t, price, Math.max(1, live.getTotalQuantity()), true);
+			return;
+		}
+
+		// Bought stock collected into inventory: always prompt the sell. Don't skip on a momentary
+		// held==0 read — the inventory container can lag the collect event by a tick.
+		if (t.getPhase() == ExitPhase.CANCELLED_HOLDING)
+		{
+			int held = Math.max(inventoryQtySupplier.applyAsInt(t.getItemId()), t.getHeldQuantity());
+			surfaceSell(t, resolveExitPrice(t), Math.max(1, held), false);
+			return;
+		}
+
+		// No live offer here. If stock is held (buy collected out-of-band, or a sell cancelled leaving
+		// stock), sell it; otherwise the trade already resolved itself — skip.
+		int held = Math.max(0, inventoryQtySupplier.applyAsInt(t.getItemId()));
+		if (held > 0)
+		{
+			if (t.isBuy())
+			{
+				t.setPhase(ExitPhase.CANCELLED_HOLDING);
+				t.setHeldQuantity(held);
+			}
+			surfaceSell(t, resolveExitPrice(t), held, false);
+			return;
+		}
+
+		log.debug("Exit Trades: slot {} item {} no longer live and none held — skipping",
+			t.getSlot(), t.getItemId());
+		t.setPhase(ExitPhase.DONE);
+		surfaceCurrent();
+	}
+
+	/**
+	 * The player opened a sell setup screen for {@code itemId}. If it's a pending exit target, scope
+	 * the prompt to it so the on-screen item and the surfaced price match — this lets slots be worked
+	 * in any order and stops a stale queue-pointer prompt from showing the wrong item. Returns true
+	 * when handled. Runs on the client thread (reads offer/inventory state).
+	 */
+	public boolean onSellScreenOpened(int itemId)
+	{
+		if (!active)
+		{
+			return false;
+		}
+		for (ExitSlotTarget t : targets)
+		{
+			if (t.getItemId() != itemId
+				|| t.getPhase() == ExitPhase.DONE
+				|| t.getPhase() == ExitPhase.PENDING_CANCEL)
+			{
+				continue;
+			}
+			int price = resolveExitPrice(t);
+			if (price <= 0)
+			{
+				return false;
+			}
+			OfferRecord live = offerStore.bySlot(t.getSlot());
+			boolean ownsSlot = live != null && live.getItemId() == itemId && !live.isBuy();
+			int qty = ownsSlot
+				? Math.max(1, live.getTotalQuantity())
+				: Math.max(1, Math.max(inventoryQtySupplier.applyAsInt(itemId), t.getHeldQuantity()));
+			modifyingActiveOffer = ownsSlot;
+			if (ownsSlot)
+			{
+				onHighlightSlotForItem.accept(itemId);
+			}
+			else
+			{
+				onClearHighlights.run();
+			}
+			onFocusTarget.accept(FocusedFlip.forSell(itemId, t.getItemName(), price, qty));
+			onStatusMessage.accept("Exit Trades: re-list " + t.getItemName() + " at " + price, itemId);
+			log.debug("Exit Trades: scoped sell prompt to on-screen item {} @ {} (mode {})", itemId, price, mode);
+			return true;
+		}
+		return false;
+	}
+
+	private int resolveExitPrice(ExitSlotTarget t)
+	{
+		return ExitPriceResolver.resolve(mode, t.getItemId(), t.getBuyBasis(),
+			backendSellPriceSupplier.applyAsInt(t.getItemId()), wikiPriceSupplier.apply(t.getItemId()));
+	}
+
+	private void surfaceSell(ExitSlotTarget t, int price, int quantity, boolean highlightSlot)
+	{
 		if (price <= 0)
 		{
+			log.debug("Exit Trades: no price data for item {} slot {} — skipping", t.getItemId(), t.getSlot());
 			onStatusMessage.accept("Exit Trades: no price data — skipping " + t.getItemName(), t.getItemId());
 			t.setPhase(ExitPhase.DONE);
 			surfaceCurrent();
 			return;
 		}
-		int qty = t.getPhase() == ExitPhase.CANCELLED_HOLDING
-			? Math.max(1, inventoryQtySupplier.applyAsInt(t.getItemId()))
-			: Math.max(1, offerQuantity(t.getSlot()));
-		onFocusTarget.accept(FocusedFlip.forSell(t.getItemId(), t.getItemName(), price, qty));
+		if (highlightSlot)
+		{
+			onHighlightSlotForItem.accept(t.getItemId());
+		}
+		else
+		{
+			onClearHighlights.run();
+		}
+		log.debug("Exit Trades: prompt re-list slot {} item {} phase {} @ {} (mode {})",
+			t.getSlot(), t.getItemId(), t.getPhase(), price, mode);
+		onFocusTarget.accept(FocusedFlip.forSell(t.getItemId(), t.getItemName(), price, Math.max(1, quantity)));
 		onStatusMessage.accept("Exit Trades: re-list " + t.getItemName() + " at " + price, t.getItemId());
-	}
-
-	private int offerQuantity(int slot)
-	{
-		OfferRecord r = offerStore.bySlot(slot);
-		return r == null ? 0 : r.getTotalQuantity();
 	}
 
 	public static class PersistedTarget

--- a/src/main/java/com/flipsmart/exit/ExitTradesController.java
+++ b/src/main/java/com/flipsmart/exit/ExitTradesController.java
@@ -195,6 +195,15 @@ public final class ExitTradesController
 			{
 				continue;
 			}
+			// A record that still occupies a slot belongs to the target in that exact slot — this
+			// disambiguates the same item listed across two slots. A fresh re-list (NEW) can land in
+			// any slot, and terminal records (COLLECTED/CANCELLED_EMPTY) carry no slot, so both fall
+			// back to item-only matching.
+			if (record.getSlot() != null && !isFreshSell(record)
+				&& record.getSlot().intValue() != t.getSlot())
+			{
+				continue;
+			}
 			// A finished sell (re-listed at the exit price, or sold on its own) closes a sell target.
 			if (t.getPhase() == ExitPhase.PENDING && !t.isBuy() && isFreshSell(record))
 			{

--- a/src/main/java/com/flipsmart/exit/ExitTradesController.java
+++ b/src/main/java/com/flipsmart/exit/ExitTradesController.java
@@ -9,6 +9,7 @@ import com.flipsmart.trading.OfferStore;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
 import java.util.function.IntUnaryOperator;
@@ -26,7 +27,7 @@ public final class ExitTradesController
 	private IntFunction<WikiPrice> wikiPriceSupplier = itemId -> null;
 	private IntUnaryOperator inventoryQtySupplier = itemId -> 0;
 	private Consumer<FocusedFlip> onFocusTarget = f -> { };
-	private Consumer<String> onStatusMessage = m -> { };
+	private BiConsumer<String, Integer> onStatusMessage = (m, id) -> { };
 	private Runnable onComplete = () -> { };
 
 	private boolean active;
@@ -58,7 +59,7 @@ public final class ExitTradesController
 		this.onFocusTarget = cb;
 	}
 
-	public void setOnStatusMessage(Consumer<String> cb)
+	public void setOnStatusMessage(BiConsumer<String, Integer> cb)
 	{
 		this.onStatusMessage = cb;
 	}
@@ -199,7 +200,7 @@ public final class ExitTradesController
 		if (t.getPhase() == ExitPhase.PENDING_CANCEL)
 		{
 			onFocusTarget.accept(null);
-			onStatusMessage.accept("Exit Trades: cancel the buy offer for " + t.getItemName());
+			onStatusMessage.accept("Exit Trades: cancel the buy offer for " + t.getItemName(), t.getItemId());
 			return;
 		}
 		// PENDING (sell) or CANCELLED_HOLDING (resell bought stock)
@@ -207,7 +208,7 @@ public final class ExitTradesController
 			wikiPriceSupplier.apply(t.getItemId()));
 		if (price <= 0)
 		{
-			onStatusMessage.accept("Exit Trades: no price data — skipping " + t.getItemName());
+			onStatusMessage.accept("Exit Trades: no price data — skipping " + t.getItemName(), t.getItemId());
 			t.setPhase(ExitPhase.DONE);
 			surfaceCurrent();
 			return;
@@ -216,7 +217,7 @@ public final class ExitTradesController
 			? Math.max(1, inventoryQtySupplier.applyAsInt(t.getItemId()))
 			: Math.max(1, offerQuantity(t.getSlot()));
 		onFocusTarget.accept(FocusedFlip.forSell(t.getItemId(), t.getItemName(), price, qty));
-		onStatusMessage.accept("Exit Trades: re-list " + t.getItemName() + " at " + price);
+		onStatusMessage.accept("Exit Trades: re-list " + t.getItemName() + " at " + price, t.getItemId());
 	}
 
 	private int offerQuantity(int slot)

--- a/src/main/java/com/flipsmart/exit/ExitTradesDialog.java
+++ b/src/main/java/com/flipsmart/exit/ExitTradesDialog.java
@@ -1,0 +1,93 @@
+package com.flipsmart.exit;
+
+import net.runelite.client.ui.ColorScheme;
+
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.GridLayout;
+import java.awt.Window;
+
+/** Center-screen pop-up letting the player pick a Breakeven or Instant exit. */
+public final class ExitTradesDialog
+{
+	private ExitTradesDialog()
+	{
+	}
+
+	public static void open(Component parent, ExitTradesController controller)
+	{
+		Window owner = parent == null ? null : SwingUtilities.getWindowAncestor(parent);
+		JDialog dialog = new JDialog(owner, "Exit Trades", JDialog.ModalityType.APPLICATION_MODAL);
+		dialog.getContentPane().setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		dialog.setLayout(new BorderLayout(0, 8));
+
+		JLabel heading = new JLabel("How do you want to exit your open trades?");
+		heading.setForeground(Color.LIGHT_GRAY);
+		heading.setBorder(BorderFactory.createEmptyBorder(10, 12, 0, 12));
+		dialog.add(heading, BorderLayout.NORTH);
+
+		JPanel cards = new JPanel(new GridLayout(1, 2, 8, 0));
+		cards.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		cards.setBorder(BorderFactory.createEmptyBorder(8, 12, 12, 12));
+		cards.add(card("Exit Trades (Breakeven)",
+			"Targets a fair, near-no-loss exit price. May still instant-sell for a small profit if the margin moved in your favor.",
+			() -> {
+				controller.start(ExitTradesMode.BREAKEVEN);
+				controller.surfaceCurrent();
+				dialog.dispose();
+			}));
+		cards.add(card("Exit Trades (Instant)",
+			"Lists at the current instant-sell price for an immediate exit, regardless of profit or loss.",
+			() -> {
+				controller.start(ExitTradesMode.INSTANT);
+				controller.surfaceCurrent();
+				dialog.dispose();
+			}));
+		dialog.add(cards, BorderLayout.CENTER);
+
+		dialog.pack();
+		dialog.setMinimumSize(new Dimension(360, 190));
+		dialog.setLocationRelativeTo(owner);
+		dialog.setVisible(true);
+	}
+
+	private static JPanel card(String title, String description, Runnable onSelect)
+	{
+		JPanel panel = new JPanel();
+		panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+		panel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		panel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+		JLabel t = new JLabel(title);
+		t.setForeground(Color.WHITE);
+		t.setFont(t.getFont().deriveFont(Font.BOLD));
+		t.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+		JLabel d = new JLabel("<html><body style='width:150px'>" + description + "</body></html>");
+		d.setForeground(Color.LIGHT_GRAY);
+		d.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+		JButton choose = new JButton("Select");
+		choose.setFocusable(false);
+		choose.setAlignmentX(Component.LEFT_ALIGNMENT);
+		choose.addActionListener(e -> onSelect.run());
+
+		panel.add(t);
+		panel.add(Box.createVerticalStrut(6));
+		panel.add(d);
+		panel.add(Box.createVerticalStrut(8));
+		panel.add(choose);
+		return panel;
+	}
+}

--- a/src/main/java/com/flipsmart/exit/ExitTradesDialog.java
+++ b/src/main/java/com/flipsmart/exit/ExitTradesDialog.java
@@ -17,6 +17,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.GridLayout;
 import java.awt.Window;
+import java.util.function.Consumer;
 
 /** Center-screen pop-up letting the player pick a Breakeven or Instant exit. */
 public final class ExitTradesDialog
@@ -25,7 +26,11 @@ public final class ExitTradesDialog
 	{
 	}
 
-	public static void open(Component parent, ExitTradesController controller)
+	/**
+	 * @param onStart invoked with the chosen mode after the dialog closes. The caller is
+	 *               responsible for starting the run on the client thread (game-state reads).
+	 */
+	public static void open(Component parent, Consumer<ExitTradesMode> onStart)
 	{
 		Window owner = parent == null ? null : SwingUtilities.getWindowAncestor(parent);
 		JDialog dialog = new JDialog(owner, "Exit Trades", JDialog.ModalityType.APPLICATION_MODAL);
@@ -37,27 +42,31 @@ public final class ExitTradesDialog
 		heading.setBorder(BorderFactory.createEmptyBorder(10, 12, 0, 12));
 		dialog.add(heading, BorderLayout.NORTH);
 
-		JPanel cards = new JPanel(new GridLayout(1, 2, 8, 0));
+		JPanel cards = new JPanel(new GridLayout(1, 3, 8, 0));
 		cards.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		cards.setBorder(BorderFactory.createEmptyBorder(8, 12, 12, 12));
+		cards.add(card("Regular Sell",
+			"Sell-only: stops suggesting new buys but keeps the normal sell flow and prices. Stays on until you switch back to Buy/Sell mode.",
+			() -> {
+				dialog.dispose();
+				onStart.accept(ExitTradesMode.REGULAR);
+			}));
 		cards.add(card("Exit Trades (Breakeven)",
 			"Targets a fair, near-no-loss exit price. May still instant-sell for a small profit if the margin moved in your favor.",
 			() -> {
-				controller.start(ExitTradesMode.BREAKEVEN);
-				controller.surfaceCurrent();
 				dialog.dispose();
+				onStart.accept(ExitTradesMode.BREAKEVEN);
 			}));
 		cards.add(card("Exit Trades (Instant)",
 			"Lists at the current instant-sell price for an immediate exit, regardless of profit or loss.",
 			() -> {
-				controller.start(ExitTradesMode.INSTANT);
-				controller.surfaceCurrent();
 				dialog.dispose();
+				onStart.accept(ExitTradesMode.INSTANT);
 			}));
 		dialog.add(cards, BorderLayout.CENTER);
 
 		dialog.pack();
-		dialog.setMinimumSize(new Dimension(360, 190));
+		dialog.setMinimumSize(new Dimension(540, 190));
 		dialog.setLocationRelativeTo(owner);
 		dialog.setVisible(true);
 	}

--- a/src/main/java/com/flipsmart/exit/ExitTradesMode.java
+++ b/src/main/java/com/flipsmart/exit/ExitTradesMode.java
@@ -3,5 +3,6 @@ package com.flipsmart.exit;
 public enum ExitTradesMode
 {
 	BREAKEVEN,
-	INSTANT
+	INSTANT,
+	REGULAR // sell-only: suppress buys but leave the normal sell flow and its prices untouched
 }

--- a/src/main/java/com/flipsmart/exit/ExitTradesMode.java
+++ b/src/main/java/com/flipsmart/exit/ExitTradesMode.java
@@ -1,0 +1,7 @@
+package com.flipsmart.exit;
+
+public enum ExitTradesMode
+{
+	BREAKEVEN,
+	INSTANT
+}

--- a/src/main/java/com/flipsmart/plugin/EventRouter.java
+++ b/src/main/java/com/flipsmart/plugin/EventRouter.java
@@ -200,6 +200,16 @@ public class EventRouter
 			return;
 		}
 
+		// During queue-driven Exit Trades (breakeven/instant), the flow owns the focus. Scope the
+		// prompt to the item actually on the sell screen so working slots out of order never shows a
+		// stale queue-pointer item. REGULAR sell-only mode falls through to the normal sell flow.
+		if (plugin.getExitTradesController() != null && plugin.getExitTradesController().ownsOverlay())
+		{
+			plugin.getExitTradesController().onSellScreenOpened(openItemId);
+			plugin.maybeRecalc12hSellPrice(openItemId);
+			return;
+		}
+
 		grandExchangeTracker.autoFocusOnActiveFlip(openItemId);
 		plugin.maybeRecalc12hSellPrice(openItemId);
 	}

--- a/src/main/java/com/flipsmart/plugin/ServiceWiring.java
+++ b/src/main/java/com/flipsmart/plugin/ServiceWiring.java
@@ -15,6 +15,7 @@ import com.flipsmart.ManualAdjustmentTracker;
 import com.flipsmart.OfflineSyncService;
 import com.flipsmart.PlayerSession;
 import com.flipsmart.GrandExchangeTracker;
+import com.flipsmart.exit.ExitTradesController;
 import com.flipsmart.trading.OfferStore;
 import com.flipsmart.trading.RoundTripLedger;
 import com.flipsmart.trading.TransactionLogger;
@@ -87,6 +88,32 @@ public class ServiceWiring
 			resp -> SwingUtilities.invokeLater(() -> plugin.handleActiveOfferHandoff(resp)),
 			itemId -> SwingUtilities.invokeLater(() -> plugin.clearActiveOfferSurface(itemId)));
 		return activeOfferAdvisorService;
+	}
+
+	/**
+	 * Construct the Exit Trades controller and wire it to the overlay and offer stream.
+	 * Prompts route through the same amber focus glow the sell flow already uses; the
+	 * offer listener advances the queue and re-surfaces the next slot's prompt on change.
+	 *
+	 * @return the constructed ExitTradesController
+	 */
+	public ExitTradesController initializeExitTradesController(FlipSmartPlugin plugin,
+		FlipAssistOverlay flipAssistOverlay, OfferStore offerStore)
+	{
+		ExitTradesController controller = new ExitTradesController(offerStore);
+		controller.setBuyBasisSupplier(plugin::getExitBuyBasis);
+		controller.setWikiPriceSupplier(plugin::getWikiPrice);
+		controller.setInventoryQtySupplier(plugin::getExitInventoryQty);
+		controller.setOnFocusTarget(flipAssistOverlay::setFocusedFlip);
+		controller.setOnStatusMessage(flipAssistOverlay::setAutoStatusMessage);
+		controller.setOnComplete(() -> flipAssistOverlay.setAutoStatusMessage("Exit Trades complete", 0));
+		offerStore.addListener(event -> {
+			if (controller.onOfferChanged(event.record))
+			{
+				controller.surfaceCurrent();
+			}
+		});
+		return controller;
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/plugin/ServiceWiring.java
+++ b/src/main/java/com/flipsmart/plugin/ServiceWiring.java
@@ -98,14 +98,17 @@ public class ServiceWiring
 	 * @return the constructed ExitTradesController
 	 */
 	public ExitTradesController initializeExitTradesController(FlipSmartPlugin plugin,
-		FlipAssistOverlay flipAssistOverlay, OfferStore offerStore)
+		FlipAssistOverlay flipAssistOverlay, GrandExchangeSlotOverlay geSlotOverlay, OfferStore offerStore)
 	{
 		ExitTradesController controller = new ExitTradesController(offerStore);
 		controller.setBuyBasisSupplier(plugin::getExitBuyBasis);
+		controller.setBackendSellPriceSupplier(plugin::getExitBackendSellPrice);
 		controller.setWikiPriceSupplier(plugin::getWikiPrice);
 		controller.setInventoryQtySupplier(plugin::getExitInventoryQty);
 		controller.setOnFocusTarget(flipAssistOverlay::setFocusedFlip);
 		controller.setOnStatusMessage(flipAssistOverlay::setAutoStatusMessage);
+		controller.setOnHighlightSlotForItem(plugin::highlightSlotForItem);
+		controller.setOnClearHighlights(geSlotOverlay::clearAllAdjustmentHighlights);
 		controller.setOnComplete(() -> flipAssistOverlay.setAutoStatusMessage("Exit Trades complete", 0));
 		offerStore.addListener(event -> {
 			if (controller.onOfferChanged(event.record))

--- a/src/main/java/com/flipsmart/recommend/ActionResolver.java
+++ b/src/main/java/com/flipsmart/recommend/ActionResolver.java
@@ -55,7 +55,7 @@ public final class ActionResolver {
         // strand the item we already own. Bounded by a grace window upstream so a permanently
         // unresolved price can't wedge trading.
         if (in.getFilledSlotCount() < in.getSlotLimit() && in.hasSurfaceableBuy()
-            && !in.isBlockBuyForPendingSell()) {
+            && !in.isBlockBuyForPendingSell() && !in.isBuysSuppressed()) {
             candidates.add(new ActionDecision(ActionKind.S2, ActionStep.PLACE_BUY,
                 in.getSurfaceableBuyItemId(), -1, in.getNowMillis()));
         }

--- a/src/main/java/com/flipsmart/recommend/ResolverInput.java
+++ b/src/main/java/com/flipsmart/recommend/ResolverInput.java
@@ -14,6 +14,7 @@ public final class ResolverInput {
     private final long nowMillis;
     private final boolean blockBuyForPendingSell;
     private final int pendingSellItemId;
+    private final boolean buysSuppressed;
     private final List<OfferRecord> completedAwaitingCollection;
     private final List<OfferRecord> staleOffers;
     private final List<CollectedItem> collectedAwaitingList;
@@ -26,6 +27,7 @@ public final class ResolverInput {
         this.nowMillis = b.nowMillis;
         this.blockBuyForPendingSell = b.blockBuy;
         this.pendingSellItemId = b.pendingSellItemId;
+        this.buysSuppressed = b.buysSuppressed;
         this.completedAwaitingCollection =
             Collections.unmodifiableList(new ArrayList<>(b.completedAwaitingCollection));
         this.staleOffers =
@@ -47,6 +49,11 @@ public final class ResolverInput {
      */
     public boolean isBlockBuyForPendingSell() { return blockBuyForPendingSell; }
     public int getPendingSellItemId() { return pendingSellItemId; }
+    /**
+     * True while Exit Trades sell-only mode is active. Suppresses new S2 buys entirely so the
+     * resolver falls through to the next collect/sell action instead of stalling on a buy.
+     */
+    public boolean isBuysSuppressed() { return buysSuppressed; }
     public List<OfferRecord> getCompletedAwaitingCollection() { return completedAwaitingCollection; }
     public List<OfferRecord> getStaleOffers() { return staleOffers; }
     public List<CollectedItem> getCollectedAwaitingList() { return collectedAwaitingList; }
@@ -61,6 +68,7 @@ public final class ResolverInput {
         private long nowMillis;
         private boolean blockBuy;
         private int pendingSellItemId = -1;
+        private boolean buysSuppressed;
         private List<OfferRecord> completedAwaitingCollection = new ArrayList<>();
         private List<OfferRecord> staleOffers = new ArrayList<>();
         private List<CollectedItem> collectedAwaitingList = new ArrayList<>();
@@ -74,6 +82,7 @@ public final class ResolverInput {
         public Builder blockBuyForPendingSell(boolean block, int itemId) {
             this.blockBuy = block; this.pendingSellItemId = itemId; return this;
         }
+        public Builder buysSuppressed(boolean v) { this.buysSuppressed = v; return this; }
         public Builder completedAwaitingCollection(List<OfferRecord> v) {
             this.completedAwaitingCollection = v; return this;
         }

--- a/src/test/java/com/flipsmart/WikiPriceMidPriceTest.java
+++ b/src/test/java/com/flipsmart/WikiPriceMidPriceTest.java
@@ -1,0 +1,27 @@
+package com.flipsmart;
+
+import com.flipsmart.api.dto.WikiPrice;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class WikiPriceMidPriceTest
+{
+	@Test
+	public void midpointOfBothSides()
+	{
+		assertEquals(150, new WikiPrice(200, 100).midPrice()); // (200+100)/2
+	}
+
+	@Test
+	public void fallsBackToPresentSideWhenOtherMissing()
+	{
+		assertEquals(100, new WikiPrice(0, 100).midPrice());
+		assertEquals(200, new WikiPrice(200, 0).midPrice());
+	}
+
+	@Test
+	public void zeroWhenBothMissing()
+	{
+		assertEquals(0, new WikiPrice(0, 0).midPrice());
+	}
+}

--- a/src/test/java/com/flipsmart/exit/ExitPriceResolverTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitPriceResolverTest.java
@@ -7,39 +7,47 @@ import static org.junit.Assert.assertEquals;
 public class ExitPriceResolverTest
 {
 	@Test
-	public void breakevenUsesGeTaxWhenBasisKnown()
+	public void breakevenPrefersBackendPrice()
 	{
-		// breakevenSellPrice(1000) = smallest S with S - floor(0.02S) >= 1000 => 1020
-		int p = ExitPriceResolver.resolve(ExitTradesMode.BREAKEVEN, 4151, 1000, new WikiPrice(1100, 950));
+		// Backend exit-at-breakeven wins over the client-side tax calc (which would give 1020).
+		int p = ExitPriceResolver.resolve(ExitTradesMode.BREAKEVEN, 4151, 1000, 3958998, new WikiPrice(1100, 950));
+		assertEquals(3958998, p);
+	}
+
+	@Test
+	public void breakevenUsesGeTaxWhenBackendMissing()
+	{
+		// No backend price: breakevenSellPrice(1000) = smallest S with S - floor(0.02S) >= 1000 => 1020
+		int p = ExitPriceResolver.resolve(ExitTradesMode.BREAKEVEN, 4151, 1000, 0, new WikiPrice(1100, 950));
 		assertEquals(1020, p);
 	}
 
 	@Test
 	public void instantUsesInstaSell()
 	{
-		int p = ExitPriceResolver.resolve(ExitTradesMode.INSTANT, 4151, 1000, new WikiPrice(1100, 950));
+		int p = ExitPriceResolver.resolve(ExitTradesMode.INSTANT, 4151, 1000, 0, new WikiPrice(1100, 950));
 		assertEquals(950, p);
 	}
 
 	@Test
-	public void breakevenFallsBackToMidWhenBasisMissing()
+	public void breakevenFallsBackToMidWhenBackendAndBasisMissing()
 	{
-		// no basis -> midPrice of (1100,950) = 1025
-		int p = ExitPriceResolver.resolve(ExitTradesMode.BREAKEVEN, 4151, 0, new WikiPrice(1100, 950));
+		// no backend, no basis -> midPrice of (1100,950) = 1025
+		int p = ExitPriceResolver.resolve(ExitTradesMode.BREAKEVEN, 4151, 0, 0, new WikiPrice(1100, 950));
 		assertEquals(1025, p);
 	}
 
 	@Test
 	public void instantFallsBackToMidWhenInstaSellMissing()
 	{
-		int p = ExitPriceResolver.resolve(ExitTradesMode.INSTANT, 4151, 0, new WikiPrice(1100, 0));
+		int p = ExitPriceResolver.resolve(ExitTradesMode.INSTANT, 4151, 0, 0, new WikiPrice(1100, 0));
 		assertEquals(1100, p); // midPrice degrades to present side
 	}
 
 	@Test
 	public void zeroWhenNoDataAtAll()
 	{
-		assertEquals(0, ExitPriceResolver.resolve(ExitTradesMode.INSTANT, 4151, 0, null));
-		assertEquals(0, ExitPriceResolver.resolve(ExitTradesMode.BREAKEVEN, 4151, 0, new WikiPrice(0, 0)));
+		assertEquals(0, ExitPriceResolver.resolve(ExitTradesMode.INSTANT, 4151, 0, 0, null));
+		assertEquals(0, ExitPriceResolver.resolve(ExitTradesMode.BREAKEVEN, 4151, 0, 0, new WikiPrice(0, 0)));
 	}
 }

--- a/src/test/java/com/flipsmart/exit/ExitPriceResolverTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitPriceResolverTest.java
@@ -1,0 +1,45 @@
+package com.flipsmart.exit;
+
+import com.flipsmart.api.dto.WikiPrice;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class ExitPriceResolverTest
+{
+	@Test
+	public void breakevenUsesGeTaxWhenBasisKnown()
+	{
+		// breakevenSellPrice(1000) = smallest S with S - floor(0.02S) >= 1000 => 1020
+		int p = ExitPriceResolver.resolve(ExitTradesMode.BREAKEVEN, 4151, 1000, new WikiPrice(1100, 950));
+		assertEquals(1020, p);
+	}
+
+	@Test
+	public void instantUsesInstaSell()
+	{
+		int p = ExitPriceResolver.resolve(ExitTradesMode.INSTANT, 4151, 1000, new WikiPrice(1100, 950));
+		assertEquals(950, p);
+	}
+
+	@Test
+	public void breakevenFallsBackToMidWhenBasisMissing()
+	{
+		// no basis -> midPrice of (1100,950) = 1025
+		int p = ExitPriceResolver.resolve(ExitTradesMode.BREAKEVEN, 4151, 0, new WikiPrice(1100, 950));
+		assertEquals(1025, p);
+	}
+
+	@Test
+	public void instantFallsBackToMidWhenInstaSellMissing()
+	{
+		int p = ExitPriceResolver.resolve(ExitTradesMode.INSTANT, 4151, 0, new WikiPrice(1100, 0));
+		assertEquals(1100, p); // midPrice degrades to present side
+	}
+
+	@Test
+	public void zeroWhenNoDataAtAll()
+	{
+		assertEquals(0, ExitPriceResolver.resolve(ExitTradesMode.INSTANT, 4151, 0, null));
+		assertEquals(0, ExitPriceResolver.resolve(ExitTradesMode.BREAKEVEN, 4151, 0, new WikiPrice(0, 0)));
+	}
+}

--- a/src/test/java/com/flipsmart/exit/ExitSlotTargetTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitSlotTargetTest.java
@@ -19,7 +19,7 @@ public class ExitSlotTargetTest
 	@Test
 	public void buyTargetStartsPendingCancel()
 	{
-		ExitSlotTarget t = ExitSlotTarget.buy(3, 4151, "Abyssal whip", 1_500_000);
+		ExitSlotTarget t = ExitSlotTarget.forBuy(3, 4151, "Abyssal whip", 1_500_000);
 		assertTrue(t.isBuy());
 		assertEquals(ExitPhase.PENDING_CANCEL, t.getPhase());
 	}

--- a/src/test/java/com/flipsmart/exit/ExitSlotTargetTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitSlotTargetTest.java
@@ -1,0 +1,34 @@
+package com.flipsmart.exit;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ExitSlotTargetTest
+{
+	@Test
+	public void sellTargetStartsPending()
+	{
+		ExitSlotTarget t = ExitSlotTarget.sell(0, 561, "Nature rune", 200);
+		assertFalse(t.isBuy());
+		assertEquals(ExitPhase.PENDING, t.getPhase());
+		assertEquals(200, t.getBuyBasis());
+	}
+
+	@Test
+	public void buyTargetStartsPendingCancel()
+	{
+		ExitSlotTarget t = ExitSlotTarget.buy(3, 4151, "Abyssal whip", 1_500_000);
+		assertTrue(t.isBuy());
+		assertEquals(ExitPhase.PENDING_CANCEL, t.getPhase());
+	}
+
+	@Test
+	public void phaseIsMutable()
+	{
+		ExitSlotTarget t = ExitSlotTarget.sell(1, 2, "x", 10);
+		t.setPhase(ExitPhase.DONE);
+		assertEquals(ExitPhase.DONE, t.getPhase());
+	}
+}

--- a/src/test/java/com/flipsmart/exit/ExitTradesControllerAdvanceTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitTradesControllerAdvanceTest.java
@@ -44,15 +44,43 @@ public class ExitTradesControllerAdvanceTest
 	}
 
 	@Test
-	public void buyCancelWithStockGoesHoldingThenDone()
+	public void buyCancelThenCollectThenResoldGoesDone()
 	{
 		seed(2, 4151, true);
 		controller.start(ExitTradesMode.INSTANT);
+		// Cancel a partially-filled buy: items still sit in the slot awaiting collection.
 		controller.onOfferChanged(rec(2, 4151, true, 3, OfferState.CANCELLED_PARTIAL));
-		assertEquals(ExitPhase.CANCELLED_HOLDING, controller.getTargets().get(0).getPhase());
+		assertEquals(ExitPhase.AWAITING_COLLECT, controller.getTargets().get(0).getPhase());
 		assertEquals(1, controller.actedCount());
 
+		// Collect the bought stock into inventory.
+		controller.onOfferChanged(rec(2, 4151, true, 3, OfferState.COLLECTED));
+		assertEquals(ExitPhase.CANCELLED_HOLDING, controller.getTargets().get(0).getPhase());
+
+		// Re-list the held stock as a sell.
 		controller.onOfferChanged(rec(2, 4151, false, 0, OfferState.NEW));
+		assertEquals(ExitPhase.DONE, controller.getTargets().get(0).getPhase());
+	}
+
+	@Test
+	public void fullyFilledBuyAwaitsCollectThenHolds()
+	{
+		seed(3, 4151, true);
+		controller.start(ExitTradesMode.INSTANT);
+		controller.onOfferChanged(rec(3, 4151, true, 10, OfferState.FILLED));
+		assertEquals(ExitPhase.AWAITING_COLLECT, controller.getTargets().get(0).getPhase());
+		controller.onOfferChanged(rec(3, 4151, true, 10, OfferState.COLLECTED));
+		assertEquals(ExitPhase.CANCELLED_HOLDING, controller.getTargets().get(0).getPhase());
+	}
+
+	@Test
+	public void soldSellAwaitsCollectThenDone()
+	{
+		seed(0, 561, false);
+		controller.start(ExitTradesMode.INSTANT);
+		controller.onOfferChanged(rec(0, 561, false, 10, OfferState.FILLED)); // sold on its own
+		assertEquals(ExitPhase.AWAITING_COLLECT, controller.getTargets().get(0).getPhase());
+		controller.onOfferChanged(rec(0, 561, false, 10, OfferState.COLLECTED)); // profit collected
 		assertEquals(ExitPhase.DONE, controller.getTargets().get(0).getPhase());
 	}
 

--- a/src/test/java/com/flipsmart/exit/ExitTradesControllerAdvanceTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitTradesControllerAdvanceTest.java
@@ -1,0 +1,76 @@
+package com.flipsmart.exit;
+
+import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.domain.offer.OfferState;
+import com.flipsmart.trading.OfferStore;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class ExitTradesControllerAdvanceTest
+{
+	private OfferStore store;
+	private ExitTradesController controller;
+
+	@Before
+	public void setUp()
+	{
+		store = new OfferStore();
+		controller = new ExitTradesController(store);
+		controller.setBuyBasisSupplier(itemId -> 1000);
+	}
+
+	private void seed(int slot, int itemId, boolean buy)
+	{
+		java.util.List<OfferRecord> existing = new java.util.ArrayList<>(store.export());
+		existing.add(OfferRecord.newOffer(2000L + slot, slot, itemId, "x", buy, 10, 100, 1L));
+		store.importRecords(existing);
+	}
+
+	private OfferRecord rec(int slot, int itemId, boolean buy, int filled, OfferState state)
+	{
+		OfferRecord r = OfferRecord.newOffer(9000L + slot, slot, itemId, "x", buy, 10, 100, 1L);
+		return r.withFill(filled, 0L, state, 2L);
+	}
+
+	@Test
+	public void sellRelistMarksDone()
+	{
+		seed(0, 561, false);
+		controller.start(ExitTradesMode.INSTANT);
+		controller.onOfferChanged(rec(0, 561, false, 0, OfferState.NEW));
+		assertEquals(ExitPhase.DONE, controller.getTargets().get(0).getPhase());
+		assertEquals(1, controller.actedCount());
+	}
+
+	@Test
+	public void buyCancelWithStockGoesHoldingThenDone()
+	{
+		seed(2, 4151, true);
+		controller.start(ExitTradesMode.INSTANT);
+		controller.onOfferChanged(rec(2, 4151, true, 3, OfferState.CANCELLED_PARTIAL));
+		assertEquals(ExitPhase.CANCELLED_HOLDING, controller.getTargets().get(0).getPhase());
+		assertEquals(1, controller.actedCount());
+
+		controller.onOfferChanged(rec(2, 4151, false, 0, OfferState.NEW));
+		assertEquals(ExitPhase.DONE, controller.getTargets().get(0).getPhase());
+	}
+
+	@Test
+	public void buyCancelWithNoStockGoesDone()
+	{
+		seed(1, 4151, true);
+		controller.start(ExitTradesMode.INSTANT);
+		controller.onOfferChanged(rec(1, 4151, true, 0, OfferState.CANCELLED_EMPTY));
+		assertEquals(ExitPhase.DONE, controller.getTargets().get(0).getPhase());
+	}
+
+	@Test
+	public void actedCountZeroBeforeAnyAction()
+	{
+		seed(0, 561, false);
+		seed(1, 4151, true);
+		controller.start(ExitTradesMode.INSTANT);
+		assertEquals(0, controller.actedCount());
+	}
+}

--- a/src/test/java/com/flipsmart/exit/ExitTradesControllerAdvanceTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitTradesControllerAdvanceTest.java
@@ -94,6 +94,19 @@ public class ExitTradesControllerAdvanceTest
 	}
 
 	@Test
+	public void sameItemAcrossTwoSlotsAttributesEventToCorrectSlot()
+	{
+		seed(0, 561, false); // sell item 561 in slot 0
+		seed(1, 561, false); // sell item 561 in slot 1 (same item, separate slot)
+		controller.start(ExitTradesMode.INSTANT);
+
+		// Slot 1's offer fills; only slot 1's target should advance, not slot 0's.
+		controller.onOfferChanged(rec(1, 561, false, 10, OfferState.FILLED));
+		assertEquals(ExitPhase.PENDING, controller.getTargets().get(0).getPhase());
+		assertEquals(ExitPhase.AWAITING_COLLECT, controller.getTargets().get(1).getPhase());
+	}
+
+	@Test
 	public void actedCountZeroBeforeAnyAction()
 	{
 		seed(0, 561, false);

--- a/src/test/java/com/flipsmart/exit/ExitTradesControllerQueueTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitTradesControllerQueueTest.java
@@ -11,6 +11,8 @@ import static org.junit.Assert.assertTrue;
 
 public class ExitTradesControllerQueueTest
 {
+	private static final String NATURE_RUNE = "Nature rune";
+
 	private OfferStore store;
 	private ExitTradesController controller;
 
@@ -32,7 +34,7 @@ public class ExitTradesControllerQueueTest
 	@Test
 	public void buildsQueueInSlotOrderSkippingEmpties()
 	{
-		place(0, 561, "Nature rune", false, 100, 1000);
+		place(0, 561, NATURE_RUNE, false, 100, 1000);
 		place(3, 4151, "Abyssal whip", true, 1_400_000, 1);
 		controller.start(ExitTradesMode.INSTANT);
 
@@ -48,8 +50,8 @@ public class ExitTradesControllerQueueTest
 	@Test
 	public void currentTargetIsFirstNonDone()
 	{
-		place(0, 561, "Nature rune", false, 100, 1000);
-		place(1, 561, "Nature rune", false, 100, 1000);
+		place(0, 561, NATURE_RUNE, false, 100, 1000);
+		place(1, 561, NATURE_RUNE, false, 100, 1000);
 		controller.start(ExitTradesMode.INSTANT);
 		controller.getTargets().get(0).setPhase(ExitPhase.DONE);
 		assertEquals(1, controller.currentTarget().getSlot());
@@ -58,7 +60,7 @@ public class ExitTradesControllerQueueTest
 	@Test
 	public void regularModeActiveWithNoQueueAndDoesNotOwnOverlay()
 	{
-		place(0, 561, "Nature rune", false, 100, 1000); // occupied slots are ignored in REGULAR
+		place(0, 561, NATURE_RUNE, false, 100, 1000); // occupied slots are ignored in REGULAR
 		controller.start(ExitTradesMode.REGULAR);
 		assertTrue(controller.isActive());       // suppresses buys
 		assertFalse(controller.ownsOverlay());   // hands overlay to the normal sell flow
@@ -71,7 +73,7 @@ public class ExitTradesControllerQueueTest
 	@Test
 	public void breakevenOwnsOverlay()
 	{
-		place(0, 561, "Nature rune", false, 100, 1000);
+		place(0, 561, NATURE_RUNE, false, 100, 1000);
 		controller.start(ExitTradesMode.BREAKEVEN);
 		assertTrue(controller.ownsOverlay());
 	}
@@ -79,7 +81,7 @@ public class ExitTradesControllerQueueTest
 	@Test
 	public void clearDeactivates()
 	{
-		place(0, 561, "Nature rune", false, 100, 1000);
+		place(0, 561, NATURE_RUNE, false, 100, 1000);
 		controller.start(ExitTradesMode.INSTANT);
 		controller.clear();
 		assertFalse(controller.isActive());

--- a/src/test/java/com/flipsmart/exit/ExitTradesControllerQueueTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitTradesControllerQueueTest.java
@@ -1,0 +1,67 @@
+package com.flipsmart.exit;
+
+import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.trading.OfferStore;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ExitTradesControllerQueueTest
+{
+	private OfferStore store;
+	private ExitTradesController controller;
+
+	@Before
+	public void setUp()
+	{
+		store = new OfferStore();
+		controller = new ExitTradesController(store);
+		controller.setBuyBasisSupplier(itemId -> itemId == 4151 ? 1_000_000 : 0);
+	}
+
+	private void place(int slot, int itemId, String name, boolean buy, int price, int qty)
+	{
+		java.util.List<OfferRecord> existing = new java.util.ArrayList<>(store.export());
+		existing.add(OfferRecord.newOffer(1000L + slot, slot, itemId, name, buy, qty, price, 1L));
+		store.importRecords(existing);
+	}
+
+	@Test
+	public void buildsQueueInSlotOrderSkippingEmpties()
+	{
+		place(0, 561, "Nature rune", false, 100, 1000);
+		place(3, 4151, "Abyssal whip", true, 1_400_000, 1);
+		controller.start(ExitTradesMode.INSTANT);
+
+		assertTrue(controller.isActive());
+		assertEquals(2, controller.getTargets().size());
+		assertEquals(0, controller.getTargets().get(0).getSlot());
+		assertEquals(3, controller.getTargets().get(1).getSlot());
+		assertFalse(controller.getTargets().get(0).isBuy());
+		assertTrue(controller.getTargets().get(1).isBuy());
+		assertEquals(1_000_000, controller.getTargets().get(1).getBuyBasis());
+	}
+
+	@Test
+	public void currentTargetIsFirstNonDone()
+	{
+		place(0, 561, "Nature rune", false, 100, 1000);
+		place(1, 561, "Nature rune", false, 100, 1000);
+		controller.start(ExitTradesMode.INSTANT);
+		controller.getTargets().get(0).setPhase(ExitPhase.DONE);
+		assertEquals(1, controller.currentTarget().getSlot());
+	}
+
+	@Test
+	public void clearDeactivates()
+	{
+		place(0, 561, "Nature rune", false, 100, 1000);
+		controller.start(ExitTradesMode.INSTANT);
+		controller.clear();
+		assertFalse(controller.isActive());
+		assertNull(controller.currentTarget());
+	}
+}

--- a/src/test/java/com/flipsmart/exit/ExitTradesControllerQueueTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitTradesControllerQueueTest.java
@@ -56,6 +56,27 @@ public class ExitTradesControllerQueueTest
 	}
 
 	@Test
+	public void regularModeActiveWithNoQueueAndDoesNotOwnOverlay()
+	{
+		place(0, 561, "Nature rune", false, 100, 1000); // occupied slots are ignored in REGULAR
+		controller.start(ExitTradesMode.REGULAR);
+		assertTrue(controller.isActive());       // suppresses buys
+		assertFalse(controller.ownsOverlay());   // hands overlay to the normal sell flow
+		assertEquals(0, controller.getTargets().size());
+		controller.surfaceCurrent();             // no-op; must not deactivate
+		assertTrue(controller.isActive());
+		assertNull(controller.currentTarget());
+	}
+
+	@Test
+	public void breakevenOwnsOverlay()
+	{
+		place(0, 561, "Nature rune", false, 100, 1000);
+		controller.start(ExitTradesMode.BREAKEVEN);
+		assertTrue(controller.ownsOverlay());
+	}
+
+	@Test
 	public void clearDeactivates()
 	{
 		place(0, 561, "Nature rune", false, 100, 1000);

--- a/src/test/java/com/flipsmart/exit/ExitTradesPersistenceTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitTradesPersistenceTest.java
@@ -61,7 +61,7 @@ public class ExitTradesPersistenceTest
 		seed(1, 999, true);
 		controller.start(ExitTradesMode.INSTANT);
 		controller.onOfferChanged(OfferRecord.newOffer(1L, 1, 999, "x", true, 10, 100, 1L)
-			.withFill(2, 0L, OfferState.CANCELLED_PARTIAL, 2L)); // slot1 buy -> CANCELLED_HOLDING
+			.withFill(2, 0L, OfferState.CANCELLED_PARTIAL, 2L)); // slot1 buy -> AWAITING_COLLECT
 		ExitTradesController.PersistedState s = controller.getStateForPersistence(5000L);
 
 		ExitTradesController fresh = new ExitTradesController(store);
@@ -69,7 +69,7 @@ public class ExitTradesPersistenceTest
 		assertTrue(fresh.isActive());
 		assertEquals(ExitTradesMode.INSTANT, fresh.getMode());
 		assertEquals(2, fresh.getTargets().size());
-		assertEquals(ExitPhase.CANCELLED_HOLDING,
+		assertEquals(ExitPhase.AWAITING_COLLECT,
 			fresh.getTargets().stream().filter(t -> t.getSlot() == 1).findFirst().get().getPhase());
 	}
 

--- a/src/test/java/com/flipsmart/exit/ExitTradesPersistenceTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitTradesPersistenceTest.java
@@ -1,0 +1,87 @@
+package com.flipsmart.exit;
+
+import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.domain.offer.OfferState;
+import com.flipsmart.trading.OfferStore;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ExitTradesPersistenceTest
+{
+	private OfferStore store;
+	private ExitTradesController controller;
+
+	@Before
+	public void setUp()
+	{
+		store = new OfferStore();
+		controller = new ExitTradesController(store);
+		controller.setBuyBasisSupplier(itemId -> 1000);
+	}
+
+	private void seed(int slot, int itemId, boolean buy)
+	{
+		java.util.List<OfferRecord> existing = new java.util.ArrayList<>(store.export());
+		existing.add(OfferRecord.newOffer(3000L + slot, slot, itemId, "x", buy, 10, 100, 1L));
+		store.importRecords(existing);
+	}
+
+	@Test
+	public void discardsWhenNothingActed()
+	{
+		seed(0, 561, false);
+		seed(1, 999, false);
+		controller.start(ExitTradesMode.INSTANT);
+		assertNull(controller.getStateForPersistence(5000L)); // AC6
+	}
+
+	@Test
+	public void persistsOnlyPendingTargetsAfterAction()
+	{
+		seed(0, 561, false);
+		seed(1, 999, false);
+		controller.start(ExitTradesMode.BREAKEVEN);
+		controller.onOfferChanged(OfferRecord.newOffer(1L, 0, 561, "x", false, 10, 100, 1L)); // slot 0 relisted -> DONE
+
+		ExitTradesController.PersistedState s = controller.getStateForPersistence(5000L);
+		assertEquals(ExitTradesMode.BREAKEVEN, s.mode);
+		assertEquals(1, s.pending.size());
+		assertEquals(999, s.pending.get(0).itemId);
+		assertEquals("PENDING", s.pending.get(0).phase);
+	}
+
+	@Test
+	public void restoreRoundTrip()
+	{
+		seed(0, 561, false);
+		seed(1, 999, true);
+		controller.start(ExitTradesMode.INSTANT);
+		controller.onOfferChanged(OfferRecord.newOffer(1L, 1, 999, "x", true, 10, 100, 1L)
+			.withFill(2, 0L, OfferState.CANCELLED_PARTIAL, 2L)); // slot1 buy -> CANCELLED_HOLDING
+		ExitTradesController.PersistedState s = controller.getStateForPersistence(5000L);
+
+		ExitTradesController fresh = new ExitTradesController(store);
+		assertTrue(fresh.restoreState(s, 6000L, 60_000L));
+		assertTrue(fresh.isActive());
+		assertEquals(ExitTradesMode.INSTANT, fresh.getMode());
+		assertEquals(2, fresh.getTargets().size());
+		assertEquals(ExitPhase.CANCELLED_HOLDING,
+			fresh.getTargets().stream().filter(t -> t.getSlot() == 1).findFirst().get().getPhase());
+	}
+
+	@Test
+	public void restoreRejectsExpired()
+	{
+		seed(0, 561, false);
+		controller.start(ExitTradesMode.INSTANT);
+		controller.getTargets().get(0).setPhase(ExitPhase.CANCELLED_HOLDING);
+		ExitTradesController.PersistedState s = controller.getStateForPersistence(1000L);
+		ExitTradesController fresh = new ExitTradesController(store);
+		assertFalse(fresh.restoreState(s, 1000L + 999_999L, 60_000L));
+		assertFalse(fresh.isActive());
+	}
+}

--- a/src/test/java/com/flipsmart/exit/ExitTradesSurfaceTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitTradesSurfaceTest.java
@@ -29,7 +29,7 @@ public class ExitTradesSurfaceTest
 		controller.setWikiPriceSupplier(itemId -> new WikiPrice(1100, 950));
 		controller.setInventoryQtySupplier(itemId -> 5);
 		controller.setOnFocusTarget(lastFocus::set);
-		controller.setOnStatusMessage(lastStatus::set);
+		controller.setOnStatusMessage((m, id) -> lastStatus.set(m));
 	}
 
 	private void seed(int slot, int itemId, boolean buy, int qty)

--- a/src/test/java/com/flipsmart/exit/ExitTradesSurfaceTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitTradesSurfaceTest.java
@@ -1,0 +1,63 @@
+package com.flipsmart.exit;
+
+import com.flipsmart.FocusedFlip;
+import com.flipsmart.api.dto.WikiPrice;
+import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.trading.OfferStore;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ExitTradesSurfaceTest
+{
+	private OfferStore store;
+	private ExitTradesController controller;
+	private final AtomicReference<FocusedFlip> lastFocus = new AtomicReference<>();
+	private final AtomicReference<String> lastStatus = new AtomicReference<>();
+
+	@Before
+	public void setUp()
+	{
+		store = new OfferStore();
+		controller = new ExitTradesController(store);
+		controller.setBuyBasisSupplier(itemId -> 1000);
+		controller.setWikiPriceSupplier(itemId -> new WikiPrice(1100, 950));
+		controller.setInventoryQtySupplier(itemId -> 5);
+		controller.setOnFocusTarget(lastFocus::set);
+		controller.setOnStatusMessage(lastStatus::set);
+	}
+
+	private void seed(int slot, int itemId, boolean buy, int qty)
+	{
+		java.util.List<OfferRecord> existing = new java.util.ArrayList<>(store.export());
+		existing.add(OfferRecord.newOffer(4000L + slot, slot, itemId, "Item", buy, qty, 100, 1L));
+		store.importRecords(existing);
+	}
+
+	@Test
+	public void sellTargetSurfacesInstantSellFocus()
+	{
+		seed(0, 561, false, 1000);
+		controller.start(ExitTradesMode.INSTANT);
+		controller.surfaceCurrent();
+		FocusedFlip f = lastFocus.get();
+		assertNotNull(f);
+		assertTrue(f.isSelling());
+		assertEquals(950, f.getCurrentStepPrice());
+		assertEquals(1000, f.getCurrentStepQuantity());
+	}
+
+	@Test
+	public void buyTargetPromptsCancelFirst()
+	{
+		seed(2, 4151, true, 10);
+		controller.start(ExitTradesMode.INSTANT);
+		controller.surfaceCurrent();
+		assertTrue(lastStatus.get().toLowerCase().contains("cancel"));
+	}
+}

--- a/src/test/java/com/flipsmart/exit/ExitTradesSurfaceTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitTradesSurfaceTest.java
@@ -7,9 +7,11 @@ import com.flipsmart.trading.OfferStore;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -19,17 +21,21 @@ public class ExitTradesSurfaceTest
 	private ExitTradesController controller;
 	private final AtomicReference<FocusedFlip> lastFocus = new AtomicReference<>();
 	private final AtomicReference<String> lastStatus = new AtomicReference<>();
+	private final AtomicBoolean completed = new AtomicBoolean(false);
+	private int inventory; // held qty returned for any item
 
 	@Before
 	public void setUp()
 	{
 		store = new OfferStore();
 		controller = new ExitTradesController(store);
+		inventory = 0;
 		controller.setBuyBasisSupplier(itemId -> 1000);
 		controller.setWikiPriceSupplier(itemId -> new WikiPrice(1100, 950));
-		controller.setInventoryQtySupplier(itemId -> 5);
+		controller.setInventoryQtySupplier(itemId -> inventory);
 		controller.setOnFocusTarget(lastFocus::set);
 		controller.setOnStatusMessage((m, id) -> lastStatus.set(m));
+		controller.setOnComplete(() -> completed.set(true));
 	}
 
 	private void seed(int slot, int itemId, boolean buy, int qty)
@@ -37,6 +43,11 @@ public class ExitTradesSurfaceTest
 		java.util.List<OfferRecord> existing = new java.util.ArrayList<>(store.export());
 		existing.add(OfferRecord.newOffer(4000L + slot, slot, itemId, "Item", buy, qty, 100, 1L));
 		store.importRecords(existing);
+	}
+
+	private void clearStore()
+	{
+		store.importRecords(new java.util.ArrayList<>());
 	}
 
 	@Test
@@ -59,5 +70,61 @@ public class ExitTradesSurfaceTest
 		controller.start(ExitTradesMode.INSTANT);
 		controller.surfaceCurrent();
 		assertTrue(lastStatus.get().toLowerCase().contains("cancel"));
+	}
+
+	@Test
+	public void staleTargetIsSkippedWhenNoOfferAndNoStock()
+	{
+		seed(0, 561, false, 1000);
+		controller.start(ExitTradesMode.INSTANT);
+		// The sell for 561 sold/was collected on its own before we reach it: no live offer, none held.
+		clearStore();
+		inventory = 0;
+		controller.surfaceCurrent();
+		assertEquals(ExitPhase.DONE, controller.getTargets().get(0).getPhase());
+		assertTrue(completed.get()); // nothing else pending -> run complete
+	}
+
+	@Test
+	public void onSellScreenScopesPromptToThatItem()
+	{
+		seed(0, 561, false, 1000);
+		seed(1, 999, false, 500);
+		controller.start(ExitTradesMode.INSTANT);
+		controller.surfaceCurrent(); // pointer surfaces slot 0 (item 561)
+
+		// Player opens slot 1's sell screen (item 999) out of order.
+		assertTrue(controller.onSellScreenOpened(999));
+		FocusedFlip f = lastFocus.get();
+		assertNotNull(f);
+		assertEquals(999, f.getItemId());
+		assertEquals(950, f.getCurrentStepPrice());
+		assertEquals(500, f.getCurrentStepQuantity());
+	}
+
+	@Test
+	public void onSellScreenIgnoresNonTargetItem()
+	{
+		seed(0, 561, false, 1000);
+		controller.start(ExitTradesMode.INSTANT);
+		assertFalse(controller.onSellScreenOpened(12345));
+	}
+
+	@Test
+	public void collectedBuySurfacesHeldStockSell()
+	{
+		seed(0, 4151, true, 10);
+		controller.start(ExitTradesMode.INSTANT);
+		// Buy filled and was collected: slot empty, but 5 sit in inventory to sell.
+		clearStore();
+		inventory = 5;
+		controller.surfaceCurrent();
+		assertEquals(ExitPhase.CANCELLED_HOLDING, controller.getTargets().get(0).getPhase());
+		FocusedFlip f = lastFocus.get();
+		assertNotNull(f);
+		assertTrue(f.isSelling());
+		assertEquals(4151, f.getItemId());
+		assertEquals(950, f.getCurrentStepPrice());
+		assertEquals(5, f.getCurrentStepQuantity());
 	}
 }

--- a/src/test/java/com/flipsmart/exit/ExitTradesSurfaceTest.java
+++ b/src/test/java/com/flipsmart/exit/ExitTradesSurfaceTest.java
@@ -7,6 +7,7 @@ import com.flipsmart.trading.OfferStore;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -69,7 +70,7 @@ public class ExitTradesSurfaceTest
 		seed(2, 4151, true, 10);
 		controller.start(ExitTradesMode.INSTANT);
 		controller.surfaceCurrent();
-		assertTrue(lastStatus.get().toLowerCase().contains("cancel"));
+		assertTrue(lastStatus.get().toLowerCase(Locale.ROOT).contains("cancel"));
 	}
 
 	@Test

--- a/src/test/java/com/flipsmart/recommend/ActionResolverBuysSuppressedTest.java
+++ b/src/test/java/com/flipsmart/recommend/ActionResolverBuysSuppressedTest.java
@@ -1,0 +1,47 @@
+package com.flipsmart.recommend;
+
+import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.domain.offer.OfferState;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class ActionResolverBuysSuppressedTest
+{
+	private final ActionResolver resolver = new ActionResolver();
+
+	@Test
+	public void suppressedBuysFallThroughToCollect()
+	{
+		OfferRecord completedSell = OfferRecord.newOffer(1L, 0, 561, "x", false, 10, 100, 1L)
+			.withFill(10, 0L, OfferState.FILLED, 2L); // completed sell awaiting collection (S5)
+		ResolverInput in = ResolverInput.builder()
+			.slotLimit(8)
+			.filledSlotCount(1)
+			.surfaceableBuy(true, 999) // a buy is available...
+			.nowMillis(100L)
+			.buysSuppressed(true)      // ...but sell-only mode suppresses it
+			.completedAwaitingCollection(Collections.singletonList(completedSell))
+			.build();
+
+		ActionDecision d = resolver.resolve(in);
+		assertEquals(ActionStep.COLLECT, d.getStep()); // not PLACE_BUY
+		assertEquals(561, d.getItemId());
+	}
+
+	@Test
+	public void unsuppressedBuyIsChosenWhenSoleCandidate()
+	{
+		ResolverInput in = ResolverInput.builder()
+			.slotLimit(8)
+			.filledSlotCount(1)
+			.surfaceableBuy(true, 999)
+			.nowMillis(100L)
+			.buysSuppressed(false)
+			.build();
+
+		assertEquals(ActionStep.PLACE_BUY, resolver.resolve(in).getStep());
+	}
+}


### PR DESCRIPTION
## Summary

Adds "Exit Trades" — a settings-cog entry that lets a player pause new buy recommendations and mass-exit every open Grand Exchange position, either at a backend-computed breakeven price or at the instant-sell price, without hand-working each slot.

> **Reviewer verdict: ship-with-watch.** A pre-merge `plugin-reviewer` probe found one high-confidence cross-thread visibility risk in the active/mode flags — it has already been fixed on this branch (fields made `volatile`). Two lower-confidence watch items remain for the ~54h post-merge window; see the collapsible review below for details.

## Changes

### ✨ New Features
- New "Exit Trades / Sell Only" entry in the settings-cog menu, opening a 3-mode dialog:
  - **Regular Sell** (default, leftmost) — suppresses new buy recommendations but keeps the normal sell flow and prices untouched.
  - **Exit Trades (Breakeven)** — re-lists every open trade at the backend-computed breakeven price (session recommended price from the API, with GeTax used only as a local fallback if the backend value is unavailable).
  - **Exit Trades (Instant)** — re-lists every open trade at the instant-sell price for a fast, guaranteed exit.
  - The cog button toggles to "Buy/Sell Mode" while any exit mode is active, giving a one-click way back to normal operation.
- Queue-driven breakeven/instant modes walk occupied GE slots in order and re-validate each slot against live state before acting: already-sold/collected slots are skipped, completed sells prompt a collect-profit step, and the full buy lifecycle (cancel → collect → sell held stock) is driven end-to-end per slot.
- Prompts are scoped to the item currently shown on the offer screen, so slots can be worked in any order rather than strictly sequentially.
- In-progress breakeven/instant runs persist across logout/login so a player can resume where they left off.

### 🐛 Bug Fixes
- Fixed a cross-thread visibility bug on the exit-trades active/mode fields (made `volatile`) found during pre-merge review — without this, a client-thread read of `active`/`mode` right after a toggle on another thread could see a stale value.

### ♻️ Refactoring
- Buys are suppressed in all three modes at two independent points: the focus chokepoint (existing hotkey-gated price-fill path) and by omitting the resolver's `PLACE_BUY` candidate entirely. The normal sell/collect flow for non-exit-trade offers is otherwise untouched.

## Testing

### Automated Tests
- ✅ `./gradlew build` passing (compiles cleanly + full JUnit suite green — 630 tests, 0 failures, 0 errors, 0 skipped across 89 test classes)

### Manual Testing
- [x] Breakeven mode: full run across multiple occupied GE slots, verifying each re-lists at the backend session-recommended price
- [x] Instant mode: full run verifying each slot re-lists at instant-sell price
- [x] Regular Sell mode: verified buys are suppressed while normal sell/collect flow and prices are unchanged
- [x] Slots worked out of order: prompts correctly scope to the item on the current offer screen regardless of slot order
- [x] Collect → sell lifecycle: verified for slots with a completed buy needing collection before re-listing
- [x] Same-price skip: verified a slot already at the target exit price is skipped rather than re-listed redundantly
- [x] Cog button toggle: verified "Exit Trades / Sell Only" ↔ "Buy/Sell Mode" label swap and correct return to normal buy/sell behavior on exit
- [x] Logout/login persistence: verified an in-progress breakeven/instant run resumes correctly after a client relog

## API Changes

None — this PR only consumes the existing backend session recommended-price field for breakeven pricing; no new endpoints are called.

## Database Migrations

Not applicable (plugin-only change).

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: New `@ConfigItem`-backed settings-cog entry only; no config migration needed
- [ ] Requires database migration: No

## Checklist

- [x] Tests added/updated (existing JUnit suite covers queue/phase/target resolution logic)
- [x] Documentation updated (N/A — no player-facing docs change required for this PR)
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by teammate

## Related Issues

Closes Flip-Smart/flip-smart#991

## Screenshots

Not included — this is a mode-toggle and re-listing flow with no new persistent UI beyond the existing dialog/overlay chrome; behavior was verified in-game per the manual testing checklist above.

---

<details>
<summary>🔎 plugin-reviewer (pre-merge probe)</summary>

Verdict: **ship-with-watch**. One high-confidence risk (cross-thread visibility of active/mode fields) was found and FIXED in this branch (made volatile). Watch items for ~54h post-merge:
- During a breakeven/instant run, confirm the overlay never briefly shows an item's *normal* recommended sell price instead of the exit price (would indicate the panel active-flip refresh overwriting the exit sell focus — the #757 deferred-focus race class; not observed across 10+ in-game runs but the path isn't explicitly gated).
- Decide whether REGULAR sell-only should persist across logout (currently it does not, since it has no queue — asymmetric with breakeven/instant which resume).

Full sections: scope frame, 5 ruminations (visibility 85%/fixed; panel-refresh overwrite 34%; REGULAR-not-persisted 30%; resolver/renderer divergence 12%; EventRouter #194 scoping 18%), invariant check (no guard/constant removed; GE tax literals untouched; blockBuyForPendingSell preserved), data-flow trace (backend price → resolver → FocusedFlip → existing fill), temporal-neighbor scan (#194 respected, #757 cluster probed, #188/#191 coexist).

</details>


### 🩺 Codacy Quality Gate — fixed in this PR
- `7a160d0` `PMD_category_java_errorprone_AvoidFieldNameMatchingMethodName` `src/main/java/com/flipsmart/exit/ExitSlotTarget.java:32` — renamed the static `buy(...)` factory to `forBuy(...)` so it no longer collides with the `buy` field; only the 4 construction call sites changed, no `isBuy()` gating logic touched.
- `8fd9791` `PMD_category_java_errorprone_UseLocaleWithCaseConversions` `src/test/java/com/flipsmart/exit/ExitTradesSurfaceTest.java:72` — added `Locale.ROOT` to the test's `toLowerCase()` call.
- `90cddfe` `PMD_category_java_errorprone_AvoidDuplicateLiterals` `src/test/java/com/flipsmart/exit/ExitTradesControllerQueueTest.java:35` — extracted the repeated `"Nature rune"` literal to a `NATURE_RUNE` constant.

### 🩺 Codacy Quality Gate — dismissed via API (noise)
- `Lizard_nloc-medium` / `Lizard_ccn-medium` / `PMD_category_java_design_NPathComplexity` (7 findings) on `ExitTradesController.onOfferChanged`, `.surfaceCurrent`, `.onSellScreenOpened` — inherently-complex GE state-machine methods; a complexity-driven extraction would touch buy/sell phase-transition logic directly and was intentionally not attempted (see high-risk trading-policy note below).
- `PMD_category_java_bestpractices_GuardLogStatement` (14 findings, all `log.debug`/`log.warn` calls in `ExitTradesController.java` and `FlipSmartPlugin.java`) — SLF4J's parameterized (`{}`) logging already defers string formatting; every flagged call's arguments are cheap getters, so a guard buys negligible real performance while adding branches/LOC to a file already over the Lizard length/complexity budget.
- `PMD_category_java_performance_AvoidInstantiatingObjectsInLoops` `ExitTradesController.java:513` — building a `PersistedTarget` list necessarily allocates one instance per iteration; no alternative shape avoids this.
- `PMD_category_java_errorprone_AvoidBranchingStatementAsLastInLoop` `ExitTradesController.java:444` (`onSellScreenOpened`) — idiomatic search-and-return-on-match loop; restructuring it touches the exact logic that scopes the sell prompt to a target, so it was left as-is rather than rewritten to satisfy the linter.
- `PMD_category_java_errorprone_AvoidFieldNameMatchingMethodName` `ResolverInput.java:71` (`buysSuppressed` builder field vs. fluent setter) — matches the existing unflagged fluent-builder convention used by every other field in the same `Builder` (`slotLimit`, `filledSlotCount`, `nowMillis`, etc.); only flagged because it's new in this PR, not because the pattern is wrong.

### 🩺 Codacy Quality Gate — dismissed via API (noise, reviewed after initial defer)
- `PMD_category_java_errorprone_NullAssignment` `src/main/java/com/flipsmart/exit/ExitTradesController.java:167` (`mode = null;` in `clear()`) — the automated resolver pass initially deferred this because it touches the `volatile mode` field made cross-thread-safe in `7ac906c`, rather than guess at a rewrite. On manual review: `clear()` resets three fields together (`active = false; mode = null; modifyingActiveOffer = false;`), and `null` is the idiomatic "no active run" sentinel already consumed by `getMode()`, `ownsOverlay()`, and `resolveExitPrice()`. PMD's `NullAssignment` rule flags any explicit null assignment regardless of context and is a known false-positive generator on reset/clear methods — there is no alternative shape (Optional, sentinel object) that would be an improvement here, only churn across every `mode` consumer. Dismissed via the Codacy API rather than rewritten; gate re-triggered via an empty commit (`296b55e`).

### 🩺 Codacy Quality Gate — fixed in this PR (AI Reviewer follow-up pass)
- `0957115` `src/main/java/com/flipsmart/FlipFinderPanel.java:931` — added an `ExitTradesDialog` import and dropped the fully-qualified reference in the button handler.
- `859f3c2` `src/main/java/com/flipsmart/api/dto/WikiPrice.java:40` — widened `midPrice()`'s sum to `long` before averaging so `instaBuy + instaSell` can't overflow `int` for high-value items.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `0957115` `src/main/java/com/flipsmart/FlipFinderPanel.java:931` — fully-qualified `ExitTradesDialog` reference replaced with an import.
- `859f3c2` `src/main/java/com/flipsmart/api/dto/WikiPrice.java:40` — `midPrice()` overflow guarded with a `long` cast.

### 🤖 Codacy AI Reviewer — already addressed (stale anchors)
- `src/test/java/com/flipsmart/exit/ExitTradesSurfaceTest.java:72` (2 comments) — `toLowerCase(Locale.ROOT)` was already applied by `8fd9791`; both comments anchored to a pre-fix revision.
- `src/main/java/com/flipsmart/exit/ExitSlotTarget.java:12` (2 comments) — the `buy`/`isBuy` naming clash was already resolved by `7a160d0`, which renamed the static factory to `forBuy()` instead of renaming the field.
- `src/main/java/com/flipsmart/exit/ExitTradesController.java:41` — `active`/`mode` were already made `volatile` by `7ac906c`; the comment anchored to a pre-fix revision.

### 🤖 Codacy AI Reviewer — deferred (in-thread rationale)
- `ExitTradesController.java:297` `surfaceCurrent()` (2 comments) — "too many responsibilities" / complexity. Real, but extraction risks churning a state machine with existing purpose-built test coverage (`ExitTradesSurfaceTest`, `ExitTradesControllerQueueTest`); out of scope for this PR.
- `ExitTradesController.java:197` `onOfferChanged()` (2 comments) — legitimate edge case: an item held across two GE slots can match the wrong target by itemId alone. The suggested guard only covers the buy `PENDING_CANCEL`/`AWAITING_COLLECT` branches; the sell branches carry the same risk and need the same treatment for a complete fix. Deferring a partial patch in favor of a dedicated follow-up.
- `ExitTradesController.java:186` `onOfferChanged()` NPath complexity — same root cause and same deferral rationale as the slot-matching comment above.

12 AI Reviewer threads triaged (2 fixed, 5 already-addressed, 5 deferred) — every thread replied in-thread and marked resolved.


