### PR TITLE
feat: report account type on RSN sync (ironman detection)

### DIFF
--- a/src/main/java/com/flipsmart/AccountTypeMapper.java
+++ b/src/main/java/com/flipsmart/AccountTypeMapper.java
@@ -1,0 +1,16 @@
+package com.flipsmart;
+
+import java.util.Locale;
+import net.runelite.api.vars.AccountType;
+
+final class AccountTypeMapper
+{
+	private AccountTypeMapper()
+	{
+	}
+
+	static String toApiValue(AccountType accountType)
+	{
+		return accountType == null ? null : accountType.name().toLowerCase(Locale.ROOT);
+	}
+}

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -158,9 +158,9 @@ public class FlipSmartApiClient
 		transport.setAuthToken(token);
 	}
 
-	public CompletableFuture<Boolean> updateRSN(String rsn)
+	public CompletableFuture<Boolean> updateRSN(String rsn, String accountType)
 	{
-		return transport.updateRSN(rsn);
+		return transport.updateRSN(rsn, accountType);
 	}
 
 	public void clearAuth()

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -222,6 +222,9 @@ public class FlipSmartPlugin extends Plugin
 	// from any thread (Swing EDT, scheduler). Defaults to true so unlinked callers see more items.
 	private volatile boolean membersWorld = true;
 
+	// Cached account-type string — updated on the client thread, read from any thread.
+	private volatile String accountType = null;
+
 	// Cached GE location flag — updated each game tick on the client thread.
 	private volatile boolean atGrandExchange = false;
 
@@ -362,6 +365,20 @@ public class FlipSmartPlugin extends Plugin
 	public void updateMembersWorldCache()
 	{
 		membersWorld = client.getWorldType().contains(WorldType.MEMBERS);
+	}
+
+	/**
+	 * Refresh the cached account-type string from the Client API.
+	 * Must be called on the client thread.
+	 */
+	public void updateAccountTypeCache()
+	{
+		accountType = AccountTypeMapper.toApiValue(client.getAccountType());
+	}
+
+	public String getAccountType()
+	{
+		return accountType;
 	}
 
 	public int getFlipSlotLimit()
@@ -1038,6 +1055,7 @@ public class FlipSmartPlugin extends Plugin
 	{
 		log.debug("Player logged in");
 		updateMembersWorldCache();
+		updateAccountTypeCache();
 		session.onLoggedIn();
 		syncRSN();
 
@@ -1304,7 +1322,7 @@ public class FlipSmartPlugin extends Plugin
 			log.debug("RSN already pushed this session, skipping: {}", rsn);
 			return;
 		}
-		apiClient.updateRSN(rsn).thenAccept(confirmed ->
+		apiClient.updateRSN(rsn, accountType).thenAccept(confirmed ->
 		{
 			if (Boolean.TRUE.equals(confirmed))
 			{

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -223,7 +223,7 @@ public class FlipSmartPlugin extends Plugin
 	private volatile boolean membersWorld = true;
 
 	// Cached account-type string — updated on the client thread, read from any thread.
-	private volatile String accountType = null;
+	private volatile String accountType;
 
 	// Cached GE location flag — updated each game tick on the client thread.
 	private volatile boolean atGrandExchange = false;

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1308,6 +1308,7 @@ public class FlipSmartPlugin extends Plugin
 		{
 			log.debug("RSN synced: {}", rsn);
 		}
+		updateAccountTypeCache();
 		pushRsnIfNeeded(rsn);
 	}
 

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1323,7 +1323,6 @@ public class FlipSmartPlugin extends Plugin
 			log.debug("RSN already pushed this session, skipping: {}", rsn);
 			return;
 		}
-		updateAccountTypeCache();
 		apiClient.updateRSN(rsn, accountType).thenAccept(confirmed ->
 		{
 			if (Boolean.TRUE.equals(confirmed))

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1322,6 +1322,7 @@ public class FlipSmartPlugin extends Plugin
 			log.debug("RSN already pushed this session, skipping: {}", rsn);
 			return;
 		}
+		updateAccountTypeCache();
 		apiClient.updateRSN(rsn, accountType).thenAccept(confirmed ->
 		{
 			if (Boolean.TRUE.equals(confirmed))

--- a/src/main/java/com/flipsmart/api/ApiHttpTransport.java
+++ b/src/main/java/com/flipsmart/api/ApiHttpTransport.java
@@ -1098,14 +1098,14 @@ public class ApiHttpTransport
 		}
 
 		String apiUrl = getApiUrl();
-		StringBuilder url = new StringBuilder(String.format("%s/auth/rsn?rsn=%s", apiUrl, urlEncode(rsn)));
+		String url = String.format("%s/auth/rsn?rsn=%s", apiUrl, urlEncode(rsn));
 		if (accountType != null && !accountType.isEmpty())
 		{
-			url.append("&account_type=").append(urlEncode(accountType));
+			url += "&account_type=" + urlEncode(accountType);
 		}
 
 		Request.Builder requestBuilder = new Request.Builder()
-			.url(url.toString())
+			.url(url)
 			.put(RequestBody.create(JSON, ""));
 
 		return executeAuthenticatedAsync(requestBuilder, jsonData ->

--- a/src/main/java/com/flipsmart/api/ApiHttpTransport.java
+++ b/src/main/java/com/flipsmart/api/ApiHttpTransport.java
@@ -1090,7 +1090,7 @@ public class ApiHttpTransport
 	 *
 	 * @return future completing true only when the server confirmed the update
 	 */
-	public CompletableFuture<Boolean> updateRSN(String rsn)
+	public CompletableFuture<Boolean> updateRSN(String rsn, String accountType)
 	{
 		if (rsn == null || rsn.isEmpty())
 		{
@@ -1098,10 +1098,14 @@ public class ApiHttpTransport
 		}
 
 		String apiUrl = getApiUrl();
-		String url = String.format("%s/auth/rsn?rsn=%s", apiUrl, urlEncode(rsn));
+		StringBuilder url = new StringBuilder(String.format("%s/auth/rsn?rsn=%s", apiUrl, urlEncode(rsn)));
+		if (accountType != null && !accountType.isEmpty())
+		{
+			url.append("&account_type=").append(urlEncode(accountType));
+		}
 
 		Request.Builder requestBuilder = new Request.Builder()
-			.url(url)
+			.url(url.toString())
 			.put(RequestBody.create(JSON, ""));
 
 		return executeAuthenticatedAsync(requestBuilder, jsonData ->

--- a/src/test/java/com/flipsmart/AccountTypeMapperTest.java
+++ b/src/test/java/com/flipsmart/AccountTypeMapperTest.java
@@ -1,0 +1,27 @@
+package com.flipsmart;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import net.runelite.api.vars.AccountType;
+import org.junit.Test;
+
+public class AccountTypeMapperTest
+{
+	@Test
+	public void mapsEnumConstantsToLowercaseApiValues()
+	{
+		assertEquals("normal", AccountTypeMapper.toApiValue(AccountType.NORMAL));
+		assertEquals("ironman", AccountTypeMapper.toApiValue(AccountType.IRONMAN));
+		assertEquals("hardcore_ironman", AccountTypeMapper.toApiValue(AccountType.HARDCORE_IRONMAN));
+		assertEquals("ultimate_ironman", AccountTypeMapper.toApiValue(AccountType.ULTIMATE_IRONMAN));
+		assertEquals("group_ironman", AccountTypeMapper.toApiValue(AccountType.GROUP_IRONMAN));
+		assertEquals("hardcore_group_ironman", AccountTypeMapper.toApiValue(AccountType.HARDCORE_GROUP_IRONMAN));
+	}
+
+	@Test
+	public void nullMapsToNull()
+	{
+		assertNull(AccountTypeMapper.toApiValue(null));
+	}
+}


### PR DESCRIPTION
## Summary

Reports the logged-in player's OSRS account type (normal, ironman, hardcore ironman, ultimate ironman, group ironman, hardcore group ironman) as an extra query parameter on the plugin's existing once-per-session RSN sync call. This gives the backend the signal it needs to auto-disable flip recommendations for ironman-type accounts, which can't use the Grand Exchange the same way normal accounts can.

## Changes

### ✨ New Features
- Added `AccountTypeMapper.toApiValue(AccountType)` — a small, null-safe utility that maps `net.runelite.api.vars.AccountType` to the lowercase snake_case string the backend expects (e.g. `hardcore_group_ironman`). Null in, null out.
- `FlipSmartPlugin` now caches the player's account type on the client thread (`updateAccountTypeCache()`), mirroring the existing `membersWorld` / `updateMembersWorldCache()` pattern already used for other client-thread-only state. The cache is refreshed on login alongside the members-world cache.
- `ApiHttpTransport.updateRSN(String rsn, String accountType)` now accepts the account type and appends it as `&account_type=<urlEncoded>` to the RSN-sync request URL when non-null/non-empty. All call sites (`FlipSmartApiClient.updateRSN`, and the sync call site in `FlipSmartPlugin`) were updated to pass the cached value through.

### ✅ Tests
- New `AccountTypeMapperTest` (JUnit 4) covers all six `AccountType` enum constants mapping to their expected lowercase API strings, plus the null-in/null-out case.

## Testing

### Automated Tests
- All existing unit tests passing (`./gradlew clean build` — BUILD SUCCESSFUL, includes `:test` and `:check`)
- New `AccountTypeMapperTest` passing

### Manual Testing
- [ ] Log into RuneLite with a normal account, confirm RSN sync request includes `account_type=normal`
- [ ] Log into RuneLite with an ironman account, confirm RSN sync request includes `account_type=ironman`
- [ ] Confirm the plugin still functions normally against the current production backend (which does not yet read `account_type`) — the extra query param is silently ignored, no behavior change

## API Changes

**Modified request (client → backend)**:
- `PUT /auth/rsn?rsn=<rsn>` now optionally includes `&account_type=<value>` when the plugin has a cached account type for the logged-in player. This is purely additive — no existing parameters changed, no response shape changed.

**Breaking Changes**:
- None. This is backward-compatible: an older backend that doesn't recognize the `account_type` query param will simply ignore it. No version coordination is required between plugin and backend releases.

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: None
- [ ] Requires database migration: No (this PR is plugin-only; any backend schema/logic to consume `account_type` and act on it is tracked separately in the private backend repo issue linked below)

This plugin PR ships independently of the backend auto-disable logic — it only reports data. The backend PR that reads `account_type` and disables recommendations for ironman accounts is separate and tracked under issue #1013.

## Checklist

- [x] Tests added/updated
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [x] No GitHub issue-reference comments in plugin Java source (verified via diff scan)
- [ ] Reviewed by teammate

### 🩺 Codacy Quality Gate — fixed in this PR
- `e795db5` PMD_category_java_performance_RedundantFieldInitializer `src/main/java/com/flipsmart/FlipSmartPlugin.java:226` — dropped the no-op `= null` initializer on the volatile `accountType` field.
- `ad26451` PMD_category_java_performance_InsufficientStringBufferDeclaration `src/main/java/com/flipsmart/api/ApiHttpTransport.java:1101` — replaced the RSN-update URL `StringBuilder` with plain `String` concatenation, removing the undersized-capacity finding entirely.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `445ffa2` / `32f1644` `src/main/java/com/flipsmart/FlipSmartPlugin.java:1311` — refresh `updateAccountTypeCache()` in `syncRSN()` right before pushing, so the `onGameTick` retry path (premature first `LOGGED_IN` tick) can't push a stale account type. Landed in `syncRSN()` rather than `pushRsnIfNeeded()` directly because the latter is also called from the Discord auth-success callback, which runs off the client thread — `updateAccountTypeCache()` must stay on-thread.
- `445ffa2` `src/main/java/com/flipsmart/FlipSmartPlugin.java:226` — same fix as the quality-gate `RedundantFieldInitializer` finding above (`e795db5`); both channels flagged the same line.
- `ad26451` `src/main/java/com/flipsmart/api/ApiHttpTransport.java:1101` — same fix as the quality-gate `InsufficientStringBufferDeclaration` finding above; both channels flagged the same line.

## Related Issues

Closes Flip-Smart/flip-smart#1013

