### PR TITLE
feat: source GE overlay prices from FlipSmart backend, drop direct wiki fetch

### DIFF
--- a/src/main/java/com/flipsmart/api/endpoints/MarketDataEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/MarketDataEndpoints.java
@@ -8,15 +8,9 @@ import com.flipsmart.api.dto.WikiPrice;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.Call;
-import okhttp3.Callback;
 import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -31,7 +25,6 @@ import java.util.function.Consumer;
 @Slf4j
 public class MarketDataEndpoints
 {
-	private static final String WIKI_PRICES_URL = "https://prices.runescape.wiki/api/v1/osrs/latest";
 	private static final long WIKI_PRICE_CACHE_DURATION_MS = 60_000; // 1 minute cache
 
 	// In-memory cache of per-item 24h daily volume — short TTL so price-volume swings
@@ -46,7 +39,6 @@ public class MarketDataEndpoints
 
 	private final ApiHttpTransport transport;
 	private final Gson gson;
-	private final OkHttpClient httpClient;
 
 	// Cache for wiki prices: itemId -> WikiPrice
 	private final Map<Integer, WikiPrice> wikiPriceCache = new ConcurrentHashMap<>();
@@ -63,7 +55,6 @@ public class MarketDataEndpoints
 	{
 		this.transport = transport;
 		this.gson = transport.getGson();
-		this.httpClient = transport.getHttpClient();
 	}
 
 	/**
@@ -97,42 +88,19 @@ public class MarketDataEndpoints
 			return;
 		}
 
-		Request request = new Request.Builder()
-			.url(WIKI_PRICES_URL)
-			.header("User-Agent", "FlipSmart RuneLite Plugin - github.com/flipsmart")
-			.get()
-			.build();
+		String url = String.format("%s/plugin/prices", transport.getApiUrl());
+		Request.Builder requestBuilder = new Request.Builder()
+			.url(url)
+			.get();
 
-		httpClient.newCall(request).enqueue(new Callback()
+		CompletableFuture<Void> future = transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
 		{
-			@Override
-			public void onFailure(Call call, IOException e)
-			{
-				log.warn("Failed to fetch wiki prices: {}", e.getMessage());
-				wikiPriceFetchInProgress.set(false);
-			}
-
-			@Override
-			public void onResponse(Call call, Response response) throws IOException
-			{
-				try (ResponseBody responseBody = response.body())
-				{
-					if (!response.isSuccessful() || responseBody == null)
-					{
-						log.warn("Wiki price API returned error: {}", response.code());
-						return;
-					}
-
-					String json = responseBody.string();
-					parseWikiPriceResponse(json);
-					lastWikiPriceFetch.set(System.currentTimeMillis());
-				}
-				finally
-				{
-					wikiPriceFetchInProgress.set(false);
-				}
-			}
+			parseWikiPriceResponse(jsonData);
+			lastWikiPriceFetch.set(System.currentTimeMillis());
+			return null;
 		});
+
+		future.whenComplete((result, ex) -> wikiPriceFetchInProgress.set(false));
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/api/endpoints/MarketDataEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/MarketDataEndpoints.java
@@ -88,6 +88,8 @@ public class MarketDataEndpoints
 			return;
 		}
 
+		lastWikiPriceFetch.set(now);
+
 		String url = String.format("%s/plugin/prices", transport.getApiUrl());
 		Request.Builder requestBuilder = new Request.Builder()
 			.url(url)
@@ -96,7 +98,6 @@ public class MarketDataEndpoints
 		CompletableFuture<Void> future = transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
 		{
 			parseWikiPriceResponse(jsonData);
-			lastWikiPriceFetch.set(System.currentTimeMillis());
 			return null;
 		});
 

--- a/src/main/java/com/flipsmart/api/endpoints/MarketDataEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/MarketDataEndpoints.java
@@ -99,7 +99,7 @@ public class MarketDataEndpoints
 		{
 			parseWikiPriceResponse(jsonData);
 			return null;
-		});
+		}, error -> log.warn("Failed to fetch wiki prices: {}", error));
 
 		future.whenComplete((result, ex) -> wikiPriceFetchInProgress.set(false));
 	}

--- a/src/main/java/com/flipsmart/api/endpoints/MarketDataEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/MarketDataEndpoints.java
@@ -110,6 +110,10 @@ public class MarketDataEndpoints
 	private void parseWikiPriceResponse(String json)
 	{
 		JsonObject root = gson.fromJson(json, JsonObject.class);
+		if (root == null)
+		{
+			return;
+		}
 		JsonObject data = root.getAsJsonObject("data");
 
 		if (data == null)


### PR DESCRIPTION
## Summary

Repoints the GE-overlay price source from a direct OSRS Wiki `/latest` call to FlipSmart's always-warm backend endpoint `GET /plugin/prices` (added in a companion backend PR), so overlay prices come from one canonical source and match backend recommendations. This is the plugin half of issue #946.

## Changes

### ♻️ Refactoring
- `fetchWikiPrices()` in `MarketDataEndpoints.java` now calls `{apiUrl}/plugin/prices` through `transport.executeAuthenticatedAsync(...)`, so the call rides the shared auth + `ApiBackoffGate`, like every other backend call. Previously it was the only raw, un-authenticated `httpClient.newCall(...)` in this class.
- Removed the raw-HTTP path: the `WIKI_PRICES_URL` constant, the `httpClient` field and its constructor assignment, and 6 now-unused imports (`Call`, `Callback`, `OkHttpClient`, `Response`, `ResponseBody`, `IOException`). Net −32 LOC.
- Unchanged: `parseWikiPriceResponse`, the `WikiPrice` DTO, the 60s cache expiry, the once-per-minute rate limit, and the in-flight dedup flag — the backend response shape is identical to the Wiki's, so all 6 `getWikiPrice(itemId)` consumers keep working unchanged (GE slot overlay, search-preview description, auto-recommend sell fallback, 12h sell recalc, competitiveness calc, active-offer advisor poll).
- Graceful degradation: on a degraded or unauthenticated backend the fetch fails soft (future completes null, parser never runs), the cache expires at 60s, and consumers fall back to the GE guide price — an accepted single-source-of-truth tradeoff.

## Testing

### Automated Tests
- ✅ `./gradlew clean build` green (compile + Checkstyle + full test suite)

### Manual Testing
- N/A for this PR — in-game QA against the live GE overlay happens after the companion backend PR is deployed, and is done manually by the team, not as part of this PR's review.

## API Changes

This repo does not define any endpoints. This PR **consumes** an existing backend endpoint, `GET /plugin/prices`, added in a companion `flip-smart` PR. No endpoints are added, modified, or removed in this repo.

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: None
- [ ] Requires database migration: No
- ⚠️ Behavior depends on the companion backend PR (`GET /plugin/prices`) being deployed first. Until then, `fetchWikiPrices()` will fail soft against a 404 and consumers fall back to the GE guide price — no crash, just stale/degraded overlay pricing until the backend ships.

## Checklist

- [x] Tests added/updated (existing suite covers this class; no new test surface introduced)
- [x] Code follows style guidelines (Checkstyle passing)
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by teammate

## Related Issues

Closes Flip-Smart/flip-smart#946

### 🤖 Codacy AI Reviewer — fixed in this PR
- `58ca4cb` `MarketDataEndpoints.java:99` — 1-minute rate limit was only re-armed on a successful fetch; moved the `lastWikiPriceFetch` update to the top of `fetchWikiPrices()` so a failed request doesn't cause it to re-fire on the next render frame.
- `cba9f79` `MarketDataEndpoints.java:98` — added a null check on the parsed JSON root in `parseWikiPriceResponse` to avoid an NPE on an empty response body.
- `048eeae` `MarketDataEndpoints.java:103` — restored warn-level error logging on fetch failure via the transport's `errorHandler` parameter (the literal `whenComplete(ex)` suggestion doesn't fire in this codebase — `ApiHttpTransport.executeAsync` always completes the future normally with `null` on error, never exceptionally).
