### PR TITLE
feat: #1053 proactive GE history auto-backfill

### DIFF
--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -69,7 +69,7 @@ public class GEHistoryService
 
 	// Monotonic game-tick counter and the tick of the most recent read, used to
 	// throttle the proactive re-scan. Only touched on the client thread.
-	private volatile long tickCount = 0;
+	private volatile long tickCount;
 	private volatile long lastReadTick = -PROACTIVE_RESCAN_INTERVAL_TICKS;
 
 	@Inject

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -27,6 +27,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Reads the in-game GE History tab to recover actual fill prices for trades
  * completed while offline, then posts them to the API as is_history_backfill.
+ * <p>
+ * The read is triggered on multiple lifecycle points so it does not depend on
+ * the user acting on a one-shot chat nag: on the History WidgetLoaded, when an
+ * unverified offline fill is registered while the tab is already open, and by a
+ * throttled periodic re-scan for as long as the tab stays visible. All triggers
+ * only ever <em>read</em> the widget already on screen — the plugin never opens
+ * or drives the interface for the player.
  */
 @Slf4j
 @Singleton
@@ -40,6 +47,13 @@ public class GEHistoryService
 	// fixed-stride to handle variable-width rows.
 	private static final int GE_HISTORY_LIST_CHILD = 3;
 
+	// Minimum gap between reads triggered by the proactive re-scan, in game
+	// ticks (~0.6s each). Long enough that leaving the tab open does not spam
+	// POST /history-backfill-batch; short enough to pick up fills that land
+	// while the user is looking at the tab. Explicit WidgetLoaded/offline-fill
+	// reads are not throttled — only the periodic re-scan honours this.
+	private static final long PROACTIVE_RESCAN_INTERVAL_TICKS = 17;
+
 	private final Client client;
 	private final FlipSmartApiClient apiClient;
 	private final PlayerSession session;
@@ -52,6 +66,11 @@ public class GEHistoryService
 	private volatile boolean historyReadThisSession = false;
 	private volatile boolean chatPromptSent = false;
 	private volatile Runnable onBackfillComplete;
+
+	// Monotonic game-tick counter and the tick of the most recent read, used to
+	// throttle the proactive re-scan. Only touched on the client thread.
+	private volatile long tickCount = 0;
+	private volatile long lastReadTick = -PROACTIVE_RESCAN_INTERVAL_TICKS;
 
 	@Inject
 	public GEHistoryService(
@@ -79,15 +98,46 @@ public class GEHistoryService
 	/** Called from FlipSmartPlugin.onGameTick. */
 	public void onGameTick()
 	{
+		tickCount++;
 		int prev = pendingHistoryReadTicks.get();
-		if (prev <= 0)
+		if (prev > 0)
+		{
+			if (pendingHistoryReadTicks.decrementAndGet() == 0)
+			{
+				readHistoryNow();
+			}
+			return;
+		}
+		maybeProactiveRescan();
+	}
+
+	/**
+	 * Proactive lifecycle trigger: while the History tab stays visible, re-read
+	 * it on a throttled cadence so fills that land after the initial open are
+	 * still recovered without waiting for another WidgetLoaded or a manual nag.
+	 * Gated on offline sync so we never latch {@code historyReadThisSession}
+	 * before the reconciler has had a chance to register offline fills.
+	 */
+	private void maybeProactiveRescan()
+	{
+		if (!session.isOfflineSyncCompleted())
 		{
 			return;
 		}
-		if (pendingHistoryReadTicks.decrementAndGet() == 0)
+		if (tickCount - lastReadTick < PROACTIVE_RESCAN_INTERVAL_TICKS)
+		{
+			return;
+		}
+		if (isHistoryWidgetVisible())
 		{
 			readHistoryNow();
 		}
+	}
+
+	private boolean isHistoryWidgetVisible()
+	{
+		Widget listWidget = client.getWidget(InterfaceID.GE_HISTORY, GE_HISTORY_LIST_CHILD);
+		return listWidget != null && !listWidget.isHidden();
 	}
 
 	private void readHistoryNow()
@@ -97,6 +147,7 @@ public class GEHistoryService
 		// allowed to stay populated until reset() so future reads (e.g. user
 		// reopens History) can still see what we'd registered.
 		historyReadThisSession = true;
+		lastReadTick = tickCount;
 
 		Widget listWidget = client.getWidget(InterfaceID.GE_HISTORY, GE_HISTORY_LIST_CHILD);
 		if (listWidget == null)
@@ -120,7 +171,15 @@ public class GEHistoryService
 		{
 			log.debug("Registered offline fill for itemId={} (pending count {})",
 				itemId, pendingOfflineFillItemIds.size());
-			maybeSendChatPrompt();
+			if (isHistoryWidgetVisible())
+			{
+				// Tab is already open — scrape it directly instead of nagging.
+				pendingHistoryReadTicks.set(2);
+			}
+			else
+			{
+				maybeSendChatPrompt();
+			}
 		}
 	}
 
@@ -193,6 +252,8 @@ public class GEHistoryService
 		historyReadThisSession = false;
 		pendingHistoryReadTicks.set(0);
 		chatPromptSent = false;
+		tickCount = 0;
+		lastReadTick = -PROACTIVE_RESCAN_INTERVAL_TICKS;
 	}
 
 	private List<GEHistoryEntry> parseHistoryEntries(Widget listWidget)

--- a/src/test/java/com/flipsmart/GEHistoryServiceTest.java
+++ b/src/test/java/com/flipsmart/GEHistoryServiceTest.java
@@ -3,22 +3,29 @@ package com.flipsmart;
 import com.flipsmart.domain.offer.OfferRecord;
 import com.flipsmart.trading.OfferStore;
 import net.runelite.api.Client;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.widgets.Widget;
 import net.runelite.client.chat.ChatMessageManager;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link GEHistoryService}'s widget-text parsing helpers.
@@ -195,5 +202,105 @@ public class GEHistoryServiceTest
 		svc.registerOfflineFill(28924);
 		assertTrue(svc.hasUnverifiedOfflineFills());
 		verify(chatMessageManager, times(1)).queue(any());
+	}
+
+	// ----- proactive auto-backfill (#1053) ----------------------------
+
+	private Widget headerWidget(String text)
+	{
+		Widget w = mock(Widget.class);
+		when(w.getText()).thenReturn(text);
+		return w;
+	}
+
+	private Widget itemWidget(int itemId, int qty)
+	{
+		Widget w = mock(Widget.class);
+		when(w.getItemId()).thenReturn(itemId);
+		when(w.getItemQuantity()).thenReturn(qty);
+		return w;
+	}
+
+	private Widget priceWidget(String text)
+	{
+		Widget w = mock(Widget.class);
+		when(w.getText()).thenReturn(text);
+		return w;
+	}
+
+	/** A visible History list widget holding one "Bought:" row (4151 x5 @ 2,000). */
+	private Widget visibleHistoryList()
+	{
+		Widget header = headerWidget("Bought:");
+		Widget item = itemWidget(4151, 5);
+		Widget price = priceWidget(GE_YELLOW + "10,000 coins</col><br>= 2,000 each");
+		Widget[] rows = new Widget[]{header, item, price};
+		Widget list = mock(Widget.class);
+		when(list.isHidden()).thenReturn(false);
+		when(list.getDynamicChildren()).thenReturn(rows);
+		return list;
+	}
+
+	@Test
+	public void offlineFillWithHistoryTabOpenScrapesInsteadOfNagging()
+	{
+		Client client = mock(Client.class);
+		Widget list = visibleHistoryList();
+		when(client.getWidget(InterfaceID.GE_HISTORY, 3)).thenReturn(list);
+		ChatMessageManager chat = mock(ChatMessageManager.class);
+		GEHistoryService svc = new GEHistoryService(
+			client, mock(FlipSmartApiClient.class), mock(PlayerSession.class), chat, new OfferStore());
+
+		svc.registerOfflineFill(4151);
+
+		// Tab is already open, so we schedule a scrape rather than nagging.
+		verify(chat, never()).queue(any());
+	}
+
+	@Test
+	public void proactiveRescanPostsBackfillWhileHistoryVisibleWithoutNag()
+	{
+		Client client = mock(Client.class);
+		Widget list = visibleHistoryList();
+		when(client.getWidget(InterfaceID.GE_HISTORY, 3)).thenReturn(list);
+
+		PlayerSession session = mock(PlayerSession.class);
+		when(session.isOfflineSyncCompleted()).thenReturn(true);
+		when(session.getRsnSafe()).thenReturn(Optional.of("Zezima"));
+
+		FlipSmartApiClient api = mock(FlipSmartApiClient.class);
+		when(api.recordHistoryBackfillBatchAsync(eq("Zezima"), anyList()))
+			.thenReturn(CompletableFuture.completedFuture(null));
+
+		GEHistoryService svc = new GEHistoryService(
+			client, api, session, mock(ChatMessageManager.class), new OfferStore());
+
+		// No WidgetLoaded, no manual prompt — a plain tick with the tab visible
+		// must trigger a read + backfill post.
+		svc.onGameTick();
+
+		verify(api, times(1)).recordHistoryBackfillBatchAsync(eq("Zezima"), anyList());
+	}
+
+	@Test
+	public void proactiveRescanGatedUntilOfflineSyncCompletes()
+	{
+		Client client = mock(Client.class);
+		Widget list = visibleHistoryList();
+		when(client.getWidget(InterfaceID.GE_HISTORY, 3)).thenReturn(list);
+
+		PlayerSession session = mock(PlayerSession.class);
+		when(session.isOfflineSyncCompleted()).thenReturn(false);
+
+		FlipSmartApiClient api = mock(FlipSmartApiClient.class);
+		GEHistoryService svc = new GEHistoryService(
+			client, api, session, mock(ChatMessageManager.class), new OfferStore());
+
+		for (int i = 0; i < 40; i++)
+		{
+			svc.onGameTick();
+		}
+
+		verify(api, never()).recordHistoryBackfillBatchAsync(any(), anyList());
 	}
 }


### PR DESCRIPTION
## Summary

Makes the GE History backfill **proactive** so recovering true fill prices for offline/mobile trades no longer depends on the user acting on a one-shot chat nag. The GE History scraper (`GEHistoryService`, widget group 383 → `POST /transactions/history-backfill-batch`) is our only source of true fill prices for trades completed offline or on another device — but today it fires once per session via a chat prompt and latches. This turns up the dial on already-shipped code: it adds automatic, **read-only** lifecycle triggers that keep scraping the History tab whenever it is on screen.

No new architecture, no synthetic input, fully additive and backwards-compatible (Plugin Hub compliant). Every trigger only *reads* the widget already rendered — the plugin never opens or drives the interface for the player.

Closes Flip-Smart/flip-smart#1053

## Changes

- **Throttled periodic re-scan while the History tab is visible** (`onGameTick` → `maybeProactiveRescan`). As long as the History list widget is present and not hidden, the service re-reads it on a ~10s cadence (17 game ticks), recovering fills that land *after* the tab was opened without waiting for another `WidgetLoaded` event or a manual prompt. This is the additional automatic lifecycle point (AC1) and removes the once-per-session latch on reads (AC2).
- **Immediate scrape instead of a nag when the tab is already open** (`registerOfflineFill`). If the reconciler registers an unverified offline fill while the History tab is visible, we schedule a direct read rather than queuing the chat prompt.
- **Gating & throttling for safety:** the periodic re-scan is gated on `session.isOfflineSyncCompleted()` so we never latch `historyReadThisSession` before the reconciler has run, and a `lastReadTick`/`tickCount` throttle keeps repeated reads from spamming the backfill endpoint. Explicit `WidgetLoaded`/offline-fill reads are unthrottled for responsiveness; only the periodic re-scan honours the interval.
- **Tests:** added 3 unit tests — offline fill with tab open scrapes instead of nagging; a plain tick with the tab visible posts a backfill batch (no `WidgetLoaded`, no prompt); the proactive re-scan stays gated until offline sync completes. All 17 `GEHistoryServiceTest` cases green; `./gradlew build` passes.

## Manual testing (in-game — deferred to reviewer)

In-game RuneLite QA cannot be driven headlessly, so please verify:

1. **Offline-fill recovery without a manual nag:** Place a buy/sell offer, log out, let it fill (or fill it on mobile/another device), then log back in with the plugin. Once offline sync completes, open the Grand Exchange **History** tab and leave it open. Within ~10s the plugin should scrape it and the trade should reflect its true fill price in Active/Completed Flips — without needing the chat prompt.
2. **Re-scan is not latched to once-per-session:** With the History tab open, complete another trade so a new row appears. Confirm the new row is picked up on the next re-scan (leave the tab visible ~10s) rather than being ignored because History was already read once.
3. **Already-open path skips the nag:** Have the History tab open at the moment offline fills are detected on login; confirm no "[FlipSmart] Offline trades detected…" chat nag fires (the tab is scraped directly instead).
4. **Endpoint not spammed:** Leave the History tab open for a minute; confirm backfill POSTs are throttled (roughly one per ~10s at most), not one per tick.
5. **No client driving:** Confirm the plugin never opens the History tab or clicks anything for you — it only reads when you have the tab open.

### 🩺 Codacy Quality Gate — fixed in this PR
- `a337bea` PMD_RedundantFieldInitializer `GEHistoryService.java:72` — dropped the redundant `= 0` on `tickCount` (long fields default to 0)

### 🤖 Codacy AI Reviewer — fixed in this PR
- `a337bea` `GEHistoryService.java:72` — same redundant-initializer finding, resolved by the quality-gate fix above

### 🤖 Codacy AI Reviewer — deferred (in-thread rationale)
- `GEHistoryService.java:150` — keeping `historyReadThisSession`/`lastReadTick` set before the `listWidget == null` check; matches pre-existing intentional design (see in-thread reply) to avoid retry-storm gating

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `GEHistoryService.java:174` — `isHistoryWidgetVisible()` in `registerOfflineFill` only ever runs on the client thread today; all call sites route through `clientThread.invokeLater` in `OfflineSyncService`

