### PR TITLE
fix: #1054 slot-key RoundTripLedger to prevent round_trip_id poisoning

### DIFF
--- a/src/main/java/com/flipsmart/trading/RoundTripLedger.java
+++ b/src/main/java/com/flipsmart/trading/RoundTripLedger.java
@@ -52,6 +52,20 @@ public final class RoundTripLedger
         }
     }
 
+    /** Outcome of a guarded fill: the round-trip id, and whether the fill was a suppressed
+     *  duplicate the caller should not forward. */
+    public static final class FillResult
+    {
+        public final Integer roundTripId;
+        public final boolean duplicateSuppressed;
+
+        public FillResult(Integer roundTripId, boolean duplicateSuppressed)
+        {
+            this.roundTripId = roundTripId;
+            this.duplicateSuppressed = duplicateSuppressed;
+        }
+    }
+
     private final Object lock = new Object();
     private final Map<String, Map<Integer, Entry>> byRsn = new HashMap<>();
 
@@ -81,18 +95,32 @@ public final class RoundTripLedger
     public Integer recordFill(String rsn, int itemId, Integer slot, boolean isBuy,
                               int deltaQuantity, int cumulativeQuantity)
     {
+        return recordFillGuarded(rsn, itemId, slot, isBuy, deltaQuantity, cumulativeQuantity).roundTripId;
+    }
+
+    /**
+     * As {@link #recordFill(String, int, Integer, boolean, int, int)} but also reports whether the
+     * fill was recognised as a duplicate re-delivery and suppressed. The peek-based send guard in
+     * {@code TransactionLogger} cannot catch a duplicate <em>closing</em> fill — the genuine close
+     * already advanced the cycle, so the duplicate peeks a different id and its dedup key misses —
+     * so the caller relies on this flag to avoid forwarding a fill that would reach the backend
+     * stamped with the next cycle's id.
+     */
+    public FillResult recordFillGuarded(String rsn, int itemId, Integer slot, boolean isBuy,
+                                        int deltaQuantity, int cumulativeQuantity)
+    {
         synchronized (lock)
         {
             if (rsn == null || rsn.isEmpty())
             {
-                return null;
+                return new FillResult(null, false);
             }
             Entry e = entryFor(rsn, itemId);
 
             String fingerprint = slot == null ? null : slot + ":" + isBuy + ":" + cumulativeQuantity;
             if (fingerprint != null && fingerprint.equals(e.lastClosingFingerprint))
             {
-                return e.cycleId;
+                return new FillResult(e.cycleId, true);
             }
 
             e.heldQuantity += isBuy ? deltaQuantity : -deltaQuantity;
@@ -107,7 +135,7 @@ public final class RoundTripLedger
             {
                 e.lastClosingFingerprint = null;
             }
-            return roundTripId;
+            return new FillResult(roundTripId, false);
         }
     }
 

--- a/src/main/java/com/flipsmart/trading/RoundTripLedger.java
+++ b/src/main/java/com/flipsmart/trading/RoundTripLedger.java
@@ -17,6 +17,11 @@ import javax.inject.Singleton;
  * match a sell to buys strictly within one round trip instead of across unrelated
  * same-item positions. A full or over liquidation (held quantity returns to zero or
  * below) closes the current cycle; whatever follows starts a new one.
+ *
+ * The cycle id is deliberately item-scoped (not slot-scoped) so a round trip that spans
+ * several GE slots still matches. Slot is used only as a guard: a duplicate/phantom fill
+ * that repeats the exact fill which just closed a cycle is ignored so it cannot prematurely
+ * advance the cycle and poison the round-trip id of every later real fill.
  */
 @Singleton
 public final class RoundTripLedger
@@ -28,6 +33,13 @@ public final class RoundTripLedger
     {
         public int heldQuantity;
         public int cycleId;
+
+        /**
+         * Fingerprint (slot:isBuy:cumulative) of the fill that most recently closed a cycle,
+         * or null when the current position is open. Session-local guard state — {@code transient}
+         * so persistence keeps the same on-disk shape (held + cycle only) as before this field.
+         */
+        public transient String lastClosingFingerprint;
 
         public Entry()
         {
@@ -44,11 +56,30 @@ public final class RoundTripLedger
     private final Map<String, Map<Integer, Entry>> byRsn = new HashMap<>();
 
     /**
-     * Apply a fill of {@code deltaQuantity} for (rsn, itemId) and return the round-trip
-     * id it belongs to. Returns {@code null} when {@code rsn} can't be resolved — the
-     * caller sends no id in that case rather than guess.
+     * Slot-unaware overload retained for round-trip accounting that has no GE slot to key on
+     * (and for tests exercising pure zero-crossing semantics). Applies no duplicate-fill guard.
      */
     public Integer recordFill(String rsn, int itemId, boolean isBuy, int deltaQuantity)
+    {
+        return recordFill(rsn, itemId, null, isBuy, deltaQuantity, 0);
+    }
+
+    /**
+     * Apply a fill of {@code deltaQuantity} for (rsn, itemId) and return the round-trip id it
+     * belongs to. Returns {@code null} when {@code rsn} can't be resolved — the caller sends no
+     * id in that case rather than guess.
+     *
+     * The cycle id stays item-scoped so the backend can still match a sell to buys of the same
+     * item across whichever GE slots the round trip happened to use. {@code slot} and
+     * {@code cumulativeQuantity} add a slot-keyed guard: a fill byte-identical to the one that
+     * just closed the current cycle — a duplicate or phantom re-delivery, arriving with no
+     * genuine fill in between — is ignored, so it cannot drive held below zero and advance the
+     * cycle a second time. That premature zero-cross is what stamps a wrong round-trip id on
+     * every subsequent real fill; the server-side watermark can only dedup, it cannot un-poison
+     * an already-sent id. Passing a null {@code slot} disables the guard (see the overload).
+     */
+    public Integer recordFill(String rsn, int itemId, Integer slot, boolean isBuy,
+                              int deltaQuantity, int cumulativeQuantity)
     {
         synchronized (lock)
         {
@@ -57,12 +88,24 @@ public final class RoundTripLedger
                 return null;
             }
             Entry e = entryFor(rsn, itemId);
+
+            String fingerprint = slot == null ? null : slot + ":" + isBuy + ":" + cumulativeQuantity;
+            if (fingerprint != null && fingerprint.equals(e.lastClosingFingerprint))
+            {
+                return e.cycleId;
+            }
+
             e.heldQuantity += isBuy ? deltaQuantity : -deltaQuantity;
             int roundTripId = e.cycleId;
             if (e.heldQuantity <= 0)
             {
                 e.cycleId++;
                 e.heldQuantity = 0;
+                e.lastClosingFingerprint = fingerprint;
+            }
+            else
+            {
+                e.lastClosingFingerprint = null;
             }
             return roundTripId;
         }

--- a/src/main/java/com/flipsmart/trading/TransactionLogger.java
+++ b/src/main/java/com/flipsmart/trading/TransactionLogger.java
@@ -115,7 +115,8 @@ public final class TransactionLogger
             return;
         }
         int pricePerItem = newlyFilled > 0 ? (int) (newlySpent / newlyFilled) : 0;
-        Integer assignedRoundTripId = roundTripLedger.recordFill(rsn, r.getItemId(), r.isBuy(), newlyFilled);
+        Integer assignedRoundTripId = roundTripLedger.recordFill(
+            rsn, r.getItemId(), r.getSlot(), r.isBuy(), newlyFilled, r.getFilledQuantity());
         apiClient.recordTransactionAsync(baseBuilder(r, newlyFilled, pricePerItem, rsn, key).roundTripId(assignedRoundTripId).build());
     }
 

--- a/src/main/java/com/flipsmart/trading/TransactionLogger.java
+++ b/src/main/java/com/flipsmart/trading/TransactionLogger.java
@@ -115,9 +115,18 @@ public final class TransactionLogger
             return;
         }
         int pricePerItem = newlyFilled > 0 ? (int) (newlySpent / newlyFilled) : 0;
-        Integer assignedRoundTripId = roundTripLedger.recordFill(
+        RoundTripLedger.FillResult fill = roundTripLedger.recordFillGuarded(
             rsn, r.getItemId(), r.getSlot(), r.isBuy(), newlyFilled, r.getFilledQuantity());
-        apiClient.recordTransactionAsync(baseBuilder(r, newlyFilled, pricePerItem, rsn, key).roundTripId(assignedRoundTripId).build());
+        if (fill.duplicateSuppressed)
+        {
+            // A duplicate/phantom closing fill (Collect re-detection under a churned offer_id) that
+            // the peek-based dedup above can't catch: the genuine close already advanced the cycle,
+            // so this fill's peeked id — and thus its dedup key — differs from the original's. The
+            // ledger recognised it as a byte-identical re-delivery and mutated nothing; forwarding
+            // it would stamp the backend with the next cycle's id, so drop it here.
+            return;
+        }
+        apiClient.recordTransactionAsync(baseBuilder(r, newlyFilled, pricePerItem, rsn, key).roundTripId(fill.roundTripId).build());
     }
 
     /**

--- a/src/test/java/com/flipsmart/trading/RoundTripLedgerTest.java
+++ b/src/test/java/com/flipsmart/trading/RoundTripLedgerTest.java
@@ -70,6 +70,70 @@ public class RoundTripLedgerTest
     }
 
     @Test
+    public void duplicateSellFill_cannotPrematurelyAdvanceCycle()
+    {
+        // One clean lot on slot 0: buy 10, sell 10 — held returns to zero, cycle closes.
+        int buy = ledger.recordFill(RSN, ITEM, 0, true, 10, 10);
+        int sell = ledger.recordFill(RSN, ITEM, 0, false, 10, 10);
+        assertEquals("buy and sell of one lot share the round trip", buy, sell);
+
+        int afterLiquidation = ledger.peekRoundTripId(RSN, ITEM);
+        assertNotEquals("a clean liquidation opens the next cycle", sell, afterLiquidation);
+
+        // A phantom re-delivery of the exact closing sell (same slot, same cumulative) reaches
+        // the ledger before client-side suppression catches it. It must NOT drive held negative
+        // and advance the cycle a second time.
+        int phantom = ledger.recordFill(RSN, ITEM, 0, false, 10, 10);
+        assertEquals("the duplicate is ignored and returns the still-open cycle id",
+            afterLiquidation, phantom);
+        assertEquals("the duplicate did not advance the cycle",
+            afterLiquidation, (int) ledger.peekRoundTripId(RSN, ITEM));
+
+        // The next genuine buy lands in the un-poisoned cycle the phantom tried to skip past.
+        int nextBuy = ledger.recordFill(RSN, ITEM, 0, true, 10, 10);
+        assertEquals("the round trip after a phantom is the one the phantom tried to skip",
+            afterLiquidation, nextBuy);
+    }
+
+    @Test
+    public void concurrentSameItemInTwoSlots_shareCycleAndAreNotFalselyDeduped()
+    {
+        int buyA = ledger.recordFill(RSN, ITEM, 0, true, 10, 10);
+        int buyB = ledger.recordFill(RSN, ITEM, 1, true, 5, 5);
+        assertEquals("two open buys of the same item are one round trip", buyA, buyB);
+
+        int sellA = ledger.recordFill(RSN, ITEM, 0, false, 10, 10);
+        assertEquals("selling one slot while the other is still open stays in the cycle",
+            buyA, sellA);
+
+        int sellB = ledger.recordFill(RSN, ITEM, 1, false, 5, 5);
+        assertEquals("only the final zero-cross closes it — still the same round trip",
+            buyA, sellB);
+
+        int next = ledger.peekRoundTripId(RSN, ITEM);
+        assertNotEquals("the fully liquidated position opens the next cycle", sellB, next);
+    }
+
+    @Test
+    public void identicalFillInASubsequentCycle_isNotFalselySuppressed()
+    {
+        ledger.recordFill(RSN, ITEM, 0, true, 10, 10);
+        int firstSell = ledger.recordFill(RSN, ITEM, 0, false, 10, 10);
+
+        // A genuine new position reusing the same slot and quantity is preceded by a real buy,
+        // so it must build held again — the guard only ever suppresses an immediate re-delivery.
+        int secondBuy = ledger.recordFill(RSN, ITEM, 0, true, 10, 10);
+        assertNotEquals("the new cycle is distinct from the closed one", firstSell, secondBuy);
+
+        int secondSell = ledger.recordFill(RSN, ITEM, 0, false, 10, 10);
+        assertEquals("the genuine repeat sell is applied within its own cycle",
+            secondBuy, secondSell);
+
+        int third = ledger.peekRoundTripId(RSN, ITEM);
+        assertNotEquals("the genuine repeat still closes its cycle normally", secondSell, third);
+    }
+
+    @Test
     public void differentItems_areTrackedIndependently()
     {
         int itemABuy = ledger.recordFill(RSN, ITEM, true, 5);

--- a/src/test/java/com/flipsmart/trading/TransactionLoggerTest.java
+++ b/src/test/java/com/flipsmart/trading/TransactionLoggerTest.java
@@ -33,8 +33,6 @@ public class TransactionLoggerTest
     private static final int ITEM = 4151;
 
     private FlipSmartApiClient apiClient;
-    private PlayerSession session;
-    private RoundTripLedger ledger;
     private TransactionLogger logger;
 
     @Before
@@ -43,9 +41,9 @@ public class TransactionLoggerTest
         apiClient = mock(FlipSmartApiClient.class);
         when(apiClient.recordTransactionAsync(any(TransactionRequest.class)))
             .thenReturn(CompletableFuture.completedFuture(null));
-        session = mock(PlayerSession.class);
+        PlayerSession session = mock(PlayerSession.class);
         when(session.getRecommendedPrice(anyInt())).thenReturn(null);
-        ledger = new RoundTripLedger();
+        RoundTripLedger ledger = new RoundTripLedger();
         logger = new TransactionLogger(apiClient, session, () -> Optional.of(RSN), ledger);
     }
 

--- a/src/test/java/com/flipsmart/trading/TransactionLoggerTest.java
+++ b/src/test/java/com/flipsmart/trading/TransactionLoggerTest.java
@@ -1,0 +1,125 @@
+package com.flipsmart.trading;
+
+import com.flipsmart.FlipSmartApiClient;
+import com.flipsmart.PlayerSession;
+import com.flipsmart.api.dto.TransactionRequest;
+import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.domain.offer.OfferState;
+import com.flipsmart.domain.offer.OfferTransition;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Send-layer behaviour of the round-trip guard: a duplicate/phantom closing fill that the
+ * peek-based dedup cannot catch must not be forwarded to the backend (#1054).
+ */
+public class TransactionLoggerTest
+{
+    private static final String RSN = "Zezima";
+    private static final int ITEM = 4151;
+
+    private FlipSmartApiClient apiClient;
+    private PlayerSession session;
+    private RoundTripLedger ledger;
+    private TransactionLogger logger;
+
+    @Before
+    public void setUp()
+    {
+        apiClient = mock(FlipSmartApiClient.class);
+        when(apiClient.recordTransactionAsync(any(TransactionRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(null));
+        session = mock(PlayerSession.class);
+        when(session.getRecommendedPrice(anyInt())).thenReturn(null);
+        ledger = new RoundTripLedger();
+        logger = new TransactionLogger(apiClient, session, () -> Optional.of(RSN), ledger);
+    }
+
+    /** A fully-filled offer whose only fill delivery carries the whole quantity. */
+    private OfferRecord completed(long offerId, int slot, boolean buy, int qty, int price, long createdAt)
+    {
+        return OfferRecord.newOffer(offerId, slot, ITEM, "Abyssal whip", buy, qty, price, createdAt)
+            .withFill(qty, (long) qty * price, OfferState.FILLED, createdAt + 1);
+    }
+
+    private void deliverFill(OfferRecord r, int newlyFilled, long newlySpent)
+    {
+        logger.onOfferEvent(new OfferEvent(OfferTransition.Kind.COMPLETED, r, newlyFilled, newlySpent));
+    }
+
+    private List<TransactionRequest> sentRequests(int expectedCount)
+    {
+        ArgumentCaptor<TransactionRequest> cap = ArgumentCaptor.forClass(TransactionRequest.class);
+        verify(apiClient, times(expectedCount)).recordTransactionAsync(cap.capture());
+        return cap.getAllValues();
+    }
+
+    @Test
+    public void duplicateClosingFill_underChurnedOfferId_isNotForwarded()
+    {
+        // Clean lot on slot 0: buy 10 then sell 10 closes the cycle.
+        deliverFill(completed(1L, 0, true, 10, 100, 1_000L), 10, 1_000L);
+        deliverFill(completed(2L, 0, false, 10, 110, 2_000L), 10, 1_100L);
+
+        // The exact closing sell is re-delivered under a CHURNED offer_id (a Collect re-detect):
+        // same slot + cumulative, new offer_id + timestamp. The peek-based dedup can't catch it —
+        // the real close already advanced the cycle, so this fill peeks a different round-trip id
+        // and its normalized key differs. Only the ledger guard recognises it.
+        deliverFill(completed(3L, 0, false, 10, 110, 3_000L), 10, 1_100L);
+
+        // Two sends (buy + sell), not three — the phantom was dropped.
+        List<TransactionRequest> sent = sentRequests(2);
+        assertEquals("buy and sell of the one lot both forwarded", 2, sent.size());
+        assertEquals("buy and sell share the round trip id",
+            sent.get(0).roundTripId, sent.get(1).roundTripId);
+    }
+
+    @Test
+    public void genuineRepeatRoundTrip_forwardsEveryFill()
+    {
+        // buy -> sell (closes) -> genuine new buy (opens next cycle) -> sell (closes) on the same slot.
+        deliverFill(completed(1L, 0, true, 10, 100, 1_000L), 10, 1_000L);
+        deliverFill(completed(2L, 0, false, 10, 110, 2_000L), 10, 1_100L);
+        deliverFill(completed(3L, 0, true, 10, 100, 3_000L), 10, 1_000L);
+        deliverFill(completed(4L, 0, false, 10, 110, 4_000L), 10, 1_100L);
+
+        // All four forwarded — the guard only suppresses an immediate byte-identical re-delivery,
+        // never a genuine repeat separated by a real intervening fill.
+        List<TransactionRequest> sent = sentRequests(4);
+        assertEquals(4, sent.size());
+        assertEquals("first lot's buy and sell share a cycle",
+            sent.get(0).roundTripId, sent.get(1).roundTripId);
+        assertEquals("second lot's buy and sell share a cycle",
+            sent.get(2).roundTripId, sent.get(3).roundTripId);
+        assertEquals("the two round trips get distinct ids",
+            (int) sent.get(0).roundTripId + 1, (int) sent.get(2).roundTripId);
+    }
+
+    @Test
+    public void concurrentSameItemTwoSlots_forwardsBothClosingFills()
+    {
+        // Two open buys of the same item in different slots — one round trip across slots.
+        deliverFill(completed(1L, 0, true, 10, 100, 1_000L), 10, 1_000L);
+        deliverFill(completed(2L, 1, true, 5, 100, 1_500L), 5, 500L);
+        // Liquidate both; the guard must not treat the slot-1 close as a duplicate of the slot-0 one.
+        deliverFill(completed(3L, 0, false, 10, 110, 2_000L), 10, 1_100L);
+        deliverFill(completed(4L, 1, false, 5, 110, 2_500L), 5, 550L);
+
+        List<TransactionRequest> sent = sentRequests(4);
+        assertEquals("all four fills across two slots forwarded", 4, sent.size());
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a latent identity-corruption bug in the plugin's round-trip ledger. `RoundTripLedger` assigns the durable `round_trip_id` stamped on every GE transaction. A duplicate or phantom sell fill — the class #974 targets — could reach the ledger before client-side suppression caught it, drive held quantity below zero, and prematurely advance the cycle id. Every subsequent real fill of that item was then stamped with a wrong `round_trip_id`. The server-side watermark dedup (keyed on `round_trip_id + ge_slot`) can only drop a duplicate; it cannot un-poison an id that was already computed and sent.

Closes Flip-Smart/flip-smart#1054

## Root cause
`recordFill(rsn, itemId, isBuy, delta)` keyed the ledger on `(rsn, itemId)` only and advanced `cycleId` whenever `heldQuantity <= 0`. A re-delivered closing sell arrives when `held` is already 0 (the cycle just closed), so it drove `held` negative, clamped to 0, and incremented `cycleId` a second time. Nothing distinguished a phantom re-delivery from a genuine new fill.

## Fix
- `recordFill` gains a slot-keyed overload `(rsn, itemId, slot, isBuy, delta, cumulative)`. It records the fingerprint `slot:isBuy:cumulative` of the fill that closed the current cycle, and **ignores** a later fill byte-identical to it when no genuine fill has intervened — the exact signature of a duplicate/phantom re-delivery. Such a fill returns the current (un-advanced) cycle id and mutates nothing.
- The cycle id stays **item-scoped**, not slot-scoped. This is deliberate: a real round trip can span several GE slots (buy in one slot, sell in another), and the backend must still match them under one `round_trip_id`. Keying the whole ledger by slot would break that matching whenever slots vary between trips. Slot is used only as a duplicate-detection guard, matching the backend watermark's `ge_slot` scoping.
- `TransactionLogger.recordFill` now passes `r.getSlot()` and `r.getFilledQuantity()` (cumulative) so the guard is active in production. The legacy slot-unaware overload is retained (guard disabled) for pure round-trip accounting.
- `Entry.lastClosingFingerprint` is `transient`, so the persisted on-disk shape (held + cycle only) is unchanged — backwards compatible with existing serialized ledger state and the server-side watermark path.

### Tests (`RoundTripLedgerTest`)
- `duplicateSellFill_cannotPrematurelyAdvanceCycle` — reproduces the poisoning: buy 10 / sell 10 closes the cycle, then a phantom re-delivery of the exact closing sell is ignored, the cycle does not advance, and the next genuine buy lands in the correct (un-poisoned) cycle.
- `concurrentSameItemInTwoSlots_shareCycleAndAreNotFalselyDeduped` — two open buys of the same item in different slots share one round trip and are not falsely deduped; only the final zero-cross closes it.
- `identicalFillInASubsequentCycle_isNotFalselySuppressed` — a genuine new position reusing the same slot and quantity (with a real buy in between) is applied normally; the guard only suppresses an immediate re-delivery.

`./gradlew test` and `./gradlew build` both green.

## Manual testing (in-game — deferred to reviewer)
Full in-game RuneLite QA cannot be driven headlessly, so please verify against a live client:
1. Buy an item fully in one GE slot, collect, then sell the full quantity in the same slot. Confirm the buy and sell transactions carry the **same** `round_trip_id` on the backend.
2. Force / observe a duplicate sell fill event (e.g. a Collect that re-detects an already-completed sell) immediately after a full liquidation. Confirm no extra `round_trip_id` gap appears and the next buy of that item reuses the expected next cycle id.
3. Run two concurrent offers of the same item in two different slots through a full round trip. Confirm all four fills share one `round_trip_id`.
4. Confirm a genuine second round trip of the same item (buy → sell → buy → sell in the same slot) produces two distinct `round_trip_id`s — the guard must not suppress the genuine repeat.


### 🩺 Codacy Quality Gate — fixed in this PR
- `d50488d` `PMD_category_java_design_SingularField` `TransactionLoggerTest.java:36-37` — `session` and `ledger` fields were written only in `setUp()` and never referenced from any `@Test` method; converted to local variables in `setUp()`. `apiClient` and `logger` stay fields since they're genuinely used across test methods.

### 🩺 Codacy Quality Gate — dismissed via API (noise)
- `PMD_category_java_errorprone_NullAssignment` `RoundTripLedger.java:108` — `e.lastClosingFingerprint = null` is the duplicate-fingerprint guard clearing itself when a position reopens; PMD's null-assignment style rule doesn't distinguish intentional sentinel resets from real smells. Not moving to `Optional`/empty-string sentinel — needless allocation churn on a per-fill hot path.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `1deb487` `TransactionLogger.java:118` — previously deferred (see below for original rationale). `recordFillGuarded` now returns `FillResult{roundTripId, duplicateSuppressed}`; `TransactionLogger.recordFill` checks `fill.duplicateSuppressed` and drops the send unconditionally when true, independent of the pre-fill peeked cycle id/normalized dedup key. The ledger's own duplicate determination is now consulted post-hoc at the send site, closing the gap this comment flagged. See `TransactionLoggerTest.duplicateClosingFill_underChurnedOfferId_isNotForwarded`.

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `RoundTripLedger.java:95` — reviewer suggested returning `e.cycleId - 1` for the duplicate-guard branch so it "matches the cycle it actually closed." `RoundTripLedgerTest.duplicateSellFill_cannotPrematurelyAdvanceCycle` (added in this PR) asserts the opposite: the phantom must return the still-open cycle id. Applying the suggestion regresses that test and reopens the cycle the guard is meant to keep closed.
- `RoundTripLedger.java:108` / `:136` — same null-assignment concern as the quality-gate finding above; intentional guard reset, not a defect.

<details>
<summary>Original (superseded) deferred rationale for TransactionLogger.java:118</summary>

Client-side send suppression peeks `roundTripId` before calling `recordFill`; for a duplicate closing fill arriving via a churned offer_id, that peek already reflects the post-increment cycle, so the normalized dedup key misses the one built pre-increment for the original fill and the duplicate isn't suppressed. It falls through to `recordFill`, whose guard stops local state from re-advancing but still returns the new (not-yet-real) cycle id, so the resend can go out stamped with a cycle that has no buys yet. Superseded by the `1deb487` fix above.

</details>

