### PR TITLE
test: #1052 golden-corpus offer-replay harness

### DIFF
--- a/src/test/java/com/flipsmart/trading/GoldenCorpusTest.java
+++ b/src/test/java/com/flipsmart/trading/GoldenCorpusTest.java
@@ -1,0 +1,119 @@
+package com.flipsmart.trading;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Mirrored golden-corpus regression harness.
+ *
+ * Replays the shared production offer-event fixtures — the same JSON files the
+ * backend golden-corpus suite asserts against — through the plugin's
+ * {@link RoundTripLedger} and asserts its zero-crossing round-trip
+ * segmentation. Distinct ids for back-to-back same-item round trips are the
+ * plugin-side guard against the fill over-count class.
+ *
+ * Each fixture's {@code plugin.round_trip_ids} list is the expected id
+ * {@link RoundTripLedger#recordFill} returns for each event, in order. A
+ * fixture whose invariant is backend-only (e.g. Collect-fill idempotency)
+ * carries {@code plugin.skip} and is not replayed here.
+ *
+ * Adding a case is one file: drop the shared JSON into
+ * {@code src/test/resources/golden_corpus/}; it is auto-discovered.
+ */
+@RunWith(Parameterized.class)
+public class GoldenCorpusTest
+{
+    private static final Path FIXTURES_DIR = Paths.get("src", "test", "resources", "golden_corpus");
+    private static final Gson GSON = new Gson();
+
+    private final String name;
+    private final JsonObject fixture;
+
+    public GoldenCorpusTest(String name, JsonObject fixture)
+    {
+        this.name = name;
+        this.fixture = fixture;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> fixtures() throws IOException
+    {
+        List<Object[]> cases = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(FIXTURES_DIR, "*.json"))
+        {
+            for (Path path : stream)
+            {
+                try (Reader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8))
+                {
+                    JsonObject obj = GSON.fromJson(reader, JsonObject.class);
+                    String name = obj.has("name") ? obj.get("name").getAsString() : path.getFileName().toString();
+                    cases.add(new Object[]{name, obj});
+                }
+            }
+        }
+        cases.sort((a, b) -> ((String) a[0]).compareTo((String) b[0]));
+        return cases;
+    }
+
+    @Test
+    public void corpusIsNonTrivial()
+    {
+        // Guards against a silently-empty resource dir masking a green run.
+        assertTrue("golden corpus fixtures should be present", fixture.has("events"));
+    }
+
+    @Test
+    public void roundTripSegmentationMatchesFixture()
+    {
+        JsonObject plugin = fixture.has("plugin") ? fixture.getAsJsonObject("plugin") : new JsonObject();
+        if (plugin.has("skip"))
+        {
+            return;
+        }
+
+        JsonArray expectedIds = plugin.getAsJsonArray("round_trip_ids");
+        assertTrue(
+            "[" + name + "] fixture must supply plugin.round_trip_ids or plugin.skip",
+            expectedIds != null);
+
+        RoundTripLedger ledger = new RoundTripLedger();
+        JsonArray events = fixture.getAsJsonArray("events");
+        assertEquals(
+            "[" + name + "] round_trip_ids length must match event count",
+            events.size(), expectedIds.size());
+
+        for (int i = 0; i < events.size(); i++)
+        {
+            JsonObject event = events.get(i).getAsJsonObject();
+            String rsn = event.has("rsn") ? event.get("rsn").getAsString() : "TestPlayer";
+            int itemId = event.get("item_id").getAsInt();
+            boolean isBuy = event.get("is_buy").getAsBoolean();
+            int quantity = event.get("quantity").getAsInt();
+
+            Integer actualId = ledger.recordFill(rsn, itemId, isBuy, quantity);
+            JsonElement expected = expectedIds.get(i);
+            assertEquals(
+                "[" + name + "] event[" + i + "] round-trip id",
+                Integer.valueOf(expected.getAsInt()), actualId);
+        }
+    }
+}

--- a/src/test/resources/golden_corpus/01-consolidation-partial-sells.json
+++ b/src/test/resources/golden_corpus/01-consolidation-partial-sells.json
@@ -1,0 +1,21 @@
+{
+  "name": "consolidation-partial-sells",
+  "issue": 895,
+  "description": "One buy of 100 Aldarium, sold across three partial fills, must consolidate into a single flip with NET sell totals (2% GE tax applied per fill). Locks the full price/tax/profit breakdown.",
+  "rsns": ["TestPlayer"],
+  "events": [
+    {"is_buy": true,  "item_id": 28816, "item_name": "Aldarium", "quantity": 100, "price_per_item": 29000, "ge_slot": 0, "offset_seconds": -3600},
+    {"is_buy": false, "item_id": 28816, "item_name": "Aldarium", "quantity": 30,  "price_per_item": 29500, "ge_slot": 1, "offset_seconds": -1800},
+    {"is_buy": false, "item_id": 28816, "item_name": "Aldarium", "quantity": 40,  "price_per_item": 29500, "ge_slot": 1, "offset_seconds": -1200},
+    {"is_buy": false, "item_id": 28816, "item_name": "Aldarium", "quantity": 30,  "price_per_item": 29500, "ge_slot": 1, "offset_seconds": 0}
+  ],
+  "expected": {
+    "flip_count": 1,
+    "flips": [
+      {"item_id": 28816, "quantity": 100, "buy_total": 2900000, "sell_total": 2891000, "gross_profit": 50000, "ge_tax": 59000, "net_profit": -9000}
+    ]
+  },
+  "plugin": {
+    "round_trip_ids": [1, 1, 1, 1]
+  }
+}

--- a/src/test/resources/golden_corpus/02-consolidation-multiple-buys.json
+++ b/src/test/resources/golden_corpus/02-consolidation-multiple-buys.json
@@ -1,0 +1,21 @@
+{
+  "name": "consolidation-multiple-buys-single-sell",
+  "issue": 830,
+  "description": "Three partial buy fills (63 + 18 + 19 = 100) accumulate one open position, then a single sell of 100 closes it. Must be one flip whose buy_total is the weighted sum of all three buys.",
+  "rsns": ["TestPlayer"],
+  "events": [
+    {"is_buy": true,  "item_id": 28816, "item_name": "Aldarium", "quantity": 63,  "price_per_item": 29000, "ge_slot": 0, "offset_seconds": -7200},
+    {"is_buy": true,  "item_id": 28816, "item_name": "Aldarium", "quantity": 18,  "price_per_item": 29000, "ge_slot": 0, "offset_seconds": -6600},
+    {"is_buy": true,  "item_id": 28816, "item_name": "Aldarium", "quantity": 19,  "price_per_item": 29000, "ge_slot": 0, "offset_seconds": -6000},
+    {"is_buy": false, "item_id": 28816, "item_name": "Aldarium", "quantity": 100, "price_per_item": 29500, "ge_slot": 1, "offset_seconds": 0}
+  ],
+  "expected": {
+    "flip_count": 1,
+    "flips": [
+      {"item_id": 28816, "quantity": 100, "buy_total": 2900000}
+    ]
+  },
+  "plugin": {
+    "round_trip_ids": [1, 1, 1, 1]
+  }
+}

--- a/src/test/resources/golden_corpus/03-separate-round-trips-eye-of-ayak.json
+++ b/src/test/resources/golden_corpus/03-separate-round-trips-eye-of-ayak.json
@@ -1,0 +1,22 @@
+{
+  "name": "separate-round-trips-eye-of-ayak",
+  "issue": 830,
+  "description": "Scapenomics prod bug: two fully round-tripped trades of the same item inside the 24h window (buy 7 / sell 7, then buy 7 / sell 7). Each position returns to zero, so they must be TWO flips of 7 — not one merged flip of 14 (the 'traded 7, reported 14' over-count).",
+  "rsns": ["TestPlayer"],
+  "events": [
+    {"is_buy": true,  "item_id": 30626, "item_name": "Eye of ayak", "quantity": 7, "price_per_item": 9300000, "ge_slot": 0, "offset_seconds": -36000},
+    {"is_buy": false, "item_id": 30626, "item_name": "Eye of ayak", "quantity": 7, "price_per_item": 9500000, "ge_slot": 1, "offset_seconds": -32400},
+    {"is_buy": true,  "item_id": 30626, "item_name": "Eye of ayak", "quantity": 7, "price_per_item": 9400000, "ge_slot": 0, "offset_seconds": -7200},
+    {"is_buy": false, "item_id": 30626, "item_name": "Eye of ayak", "quantity": 7, "price_per_item": 9600000, "ge_slot": 1, "offset_seconds": -3600}
+  ],
+  "expected": {
+    "flip_count": 2,
+    "flips": [
+      {"item_id": 30626, "quantity": 7},
+      {"item_id": 30626, "quantity": 7}
+    ]
+  },
+  "plugin": {
+    "round_trip_ids": [1, 1, 2, 2]
+  }
+}

--- a/src/test/resources/golden_corpus/04-multi-limit-accumulation-white-berries.json
+++ b/src/test/resources/golden_corpus/04-multi-limit-accumulation-white-berries.json
@@ -1,0 +1,22 @@
+{
+  "name": "multi-limit-accumulation-white-berries",
+  "issue": 830,
+  "description": "31k white-berries prod bug: three 13,000 buy-limit windows accumulate 39,000 before ANY sell, then sold across two fills. The position never liquidates mid-way, so all buys stay in one open position — ONE flip of 39,000, not split at each buy-limit boundary.",
+  "rsns": ["TestPlayer"],
+  "events": [
+    {"is_buy": true,  "item_id": 239, "item_name": "White berries", "quantity": 13000, "price_per_item": 200, "ge_slot": 0, "offset_seconds": -43200},
+    {"is_buy": true,  "item_id": 239, "item_name": "White berries", "quantity": 13000, "price_per_item": 200, "ge_slot": 0, "offset_seconds": -28800},
+    {"is_buy": true,  "item_id": 239, "item_name": "White berries", "quantity": 13000, "price_per_item": 200, "ge_slot": 0, "offset_seconds": -14400},
+    {"is_buy": false, "item_id": 239, "item_name": "White berries", "quantity": 20000, "price_per_item": 230, "ge_slot": 1, "offset_seconds": -3600},
+    {"is_buy": false, "item_id": 239, "item_name": "White berries", "quantity": 19000, "price_per_item": 230, "ge_slot": 1, "offset_seconds": 0}
+  ],
+  "expected": {
+    "flip_count": 1,
+    "flips": [
+      {"item_id": 239, "quantity": 39000}
+    ]
+  },
+  "plugin": {
+    "round_trip_ids": [1, 1, 1, 1, 1]
+  }
+}

--- a/src/test/resources/golden_corpus/05-interleaved-open-position.json
+++ b/src/test/resources/golden_corpus/05-interleaved-open-position.json
@@ -1,0 +1,21 @@
+{
+  "name": "interleaved-open-position",
+  "issue": 830,
+  "description": "Interleaved buy/sell that never drops holdings to zero (buy 100, sell 30, buy 100, sell 150). A buy-limit purchased AFTER the first sell must still consolidate because the earlier position is only partially sold — ONE flip of 180.",
+  "rsns": ["TestPlayer"],
+  "events": [
+    {"is_buy": true,  "item_id": 239, "item_name": "White berries", "quantity": 100, "price_per_item": 200, "ge_slot": 0, "offset_seconds": -14400},
+    {"is_buy": false, "item_id": 239, "item_name": "White berries", "quantity": 30,  "price_per_item": 230, "ge_slot": 1, "offset_seconds": -10800},
+    {"is_buy": true,  "item_id": 239, "item_name": "White berries", "quantity": 100, "price_per_item": 205, "ge_slot": 0, "offset_seconds": -7200},
+    {"is_buy": false, "item_id": 239, "item_name": "White berries", "quantity": 150, "price_per_item": 230, "ge_slot": 1, "offset_seconds": 0}
+  ],
+  "expected": {
+    "flip_count": 1,
+    "flips": [
+      {"item_id": 239, "quantity": 180}
+    ]
+  },
+  "plugin": {
+    "round_trip_ids": [1, 1, 1, 1]
+  }
+}

--- a/src/test/resources/golden_corpus/06-duplicate-collect-fill.json
+++ b/src/test/resources/golden_corpus/06-duplicate-collect-fill.json
@@ -1,0 +1,20 @@
+{
+  "name": "duplicate-collect-fill-watermark",
+  "issue": 974,
+  "description": "Cow prod bug: the Collect button churns the offer_id/timestamp and re-reports the SAME physical fill under a new idempotency key at the same cumulative FILL watermark. The watermark idempotency guard must drop the duplicate so the round trip is quantity 2, not 4.",
+  "rsns": ["ItIsCow"],
+  "events": [
+    {"is_buy": true,  "item_id": 8890, "item_name": "Cow", "quantity": 2, "price_per_item": 1000, "rsn": "ItIsCow", "ge_slot": 3, "total_quantity": 6, "offer_id": 8, "round_trip_id": 2, "idempotency_key": "ItIsCow:8:200:FILL:2", "offset_seconds": -7200},
+    {"is_buy": true,  "item_id": 8890, "item_name": "Cow", "quantity": 2, "price_per_item": 1000, "rsn": "ItIsCow", "ge_slot": 3, "total_quantity": 6, "offer_id": 8, "round_trip_id": 2, "idempotency_key": "ItIsCow:8:300:FILL:2", "offset_seconds": -7000},
+    {"is_buy": false, "item_id": 8890, "item_name": "Cow", "quantity": 2, "price_per_item": 1100, "rsn": "ItIsCow", "ge_slot": 4, "round_trip_id": 2, "idempotency_key": "ItIsCow:9:400:FILL:2", "offset_seconds": 0}
+  ],
+  "expected": {
+    "flip_count": 1,
+    "flips": [
+      {"item_id": 8890, "quantity": 2, "rsn": "ItIsCow"}
+    ]
+  },
+  "plugin": {
+    "skip": "Backend-only idempotency: the duplicate Collect fill is dropped by the watermark guard in transaction_service. Plugin-side dedup lives in OfferStore, not RoundTripLedger, so the raw round-trip ledger is not the mirror for this case."
+  }
+}

--- a/src/test/resources/golden_corpus/07-cross-rsn-isolation.json
+++ b/src/test/resources/golden_corpus/07-cross-rsn-isolation.json
@@ -1,0 +1,22 @@
+{
+  "name": "cross-rsn-isolation",
+  "issue": 984,
+  "description": "The same item is bought and sold on two RSNs of one account. Each RSN's round trip is independent — two flips, one per RSN, with no cross-RSN buy/sell matching.",
+  "rsns": ["TestPlayer", "AltAccount"],
+  "events": [
+    {"is_buy": true,  "item_id": 4151, "item_name": "Abyssal whip", "quantity": 5, "price_per_item": 2500000, "rsn": "TestPlayer", "ge_slot": 0, "offset_seconds": -7200},
+    {"is_buy": true,  "item_id": 4151, "item_name": "Abyssal whip", "quantity": 5, "price_per_item": 2500000, "rsn": "AltAccount", "ge_slot": 0, "offset_seconds": -7000},
+    {"is_buy": false, "item_id": 4151, "item_name": "Abyssal whip", "quantity": 5, "price_per_item": 2600000, "rsn": "TestPlayer", "ge_slot": 1, "offset_seconds": -3600},
+    {"is_buy": false, "item_id": 4151, "item_name": "Abyssal whip", "quantity": 5, "price_per_item": 2600000, "rsn": "AltAccount", "ge_slot": 1, "offset_seconds": 0}
+  ],
+  "expected": {
+    "flip_count": 2,
+    "flips": [
+      {"item_id": 4151, "quantity": 5},
+      {"item_id": 4151, "quantity": 5}
+    ]
+  },
+  "plugin": {
+    "round_trip_ids": [1, 1, 1, 1]
+  }
+}

--- a/src/test/resources/golden_corpus/README.md
+++ b/src/test/resources/golden_corpus/README.md
@@ -1,0 +1,21 @@
+# Golden-corpus fixtures (shared with the backend) — #1052
+
+These JSON fixtures are the **shared source of truth** for the fill-accounting
+regression corpus. The canonical copies live in the backend repo at
+`tests/golden_corpus/fixtures/`; the files here are kept identical.
+
+`GoldenCorpusTest` (in `src/test/java/com/flipsmart/trading/`) replays each
+fixture's `events` through `RoundTripLedger` and asserts the
+`plugin.round_trip_ids` segmentation — the plugin-side guard against the
+same-item over-count class (#647 → #830 → #974) that the backend harness guards
+from the flip-construction side.
+
+## Adding / updating a case (one file)
+
+1. Add or edit the JSON in the backend repo's `tests/golden_corpus/fixtures/`.
+2. Copy the identical file here.
+3. Ensure it carries a `plugin` block — either `round_trip_ids` (a list parallel
+   to `events` of the ledger cycle id each fill should return) or
+   `skip` with a reason when the case turns on a backend-only mechanism.
+
+See the backend `tests/golden_corpus/README.md` for the full fixture schema.


### PR DESCRIPTION
## Summary

Adds a **mirrored golden-corpus offer-replay harness** on the plugin side. It replays the same shared production offer-event fixtures the backend golden-corpus suite validates — through `RoundTripLedger` — and asserts its zero-crossing round-trip segmentation.

Distinct round-trip ids for back-to-back same-item positions (e.g. `[1,1,2,2]`) are the plugin-side guard against the fill over-count class: the exact mechanism where two fully round-tripped same-item trades must stay two flips, not collapse into one double-counted position. The fixtures are byte-identical to the backend's, giving both repos one source of truth.

Test-only; no plugin runtime code changes.

Closes Flip-Smart/flip-smart#1052

## Changes

- `src/test/java/com/flipsmart/trading/GoldenCorpusTest.java` — parameterized JUnit harness; auto-discovers every fixture and replays its events through `RoundTripLedger.recordFill`, asserting the `plugin.round_trip_ids` segmentation.
- `src/test/resources/golden_corpus/*.json` — the shared fixture set (7 cases), mirrored from the backend repo. Each carries a `plugin` block: `round_trip_ids` (parallel to `events`) or a `skip` reason for backend-only invariants (the Collect-fill idempotency case).
- `src/test/resources/golden_corpus/README.md` — how the fixtures stay in sync and the one-file step to add a case.

## Manual testing

```bash
./gradlew test --tests "com.flipsmart.trading.GoldenCorpusTest"   # BUILD SUCCESSFUL (14 executions)
./gradlew test                                                    # full suite green
```
