### PR TITLE
feat: confidence badges on completed flips (#1049 AC4)

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3972,7 +3972,7 @@ public class FlipFinderPanel extends PluginPanel
 		StringBuilder tip = new StringBuilder(260);
 		if (flip.isQuantityAnomaly())
 		{
-			text.append("<span style='color:").append(COLOR_ANOMALY_HEX).append(";'>&#9888; Anomaly: Quantity Flagged</span>");
+			text.append("<span style='color:").append(COLOR_ANOMALY_HEX).append(";'>&#9888; Anomaly: Quantity Flagged (Edit)</span>");
 			tip.append("Recorded quantity looks higher than the item's 4h GE buy limit allows, so it may be over-counted. ");
 		}
 		if (flip.isPriceIsEstimated())
@@ -3981,7 +3981,7 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				text.append("<br>");
 			}
-			text.append("<span style='color:").append(COLOR_ANOMALY_HEX).append(";'>&#9888; Anomaly: Profit Flagged</span>");
+			text.append("<span style='color:").append(COLOR_ANOMALY_HEX).append(";'>&#9888; Anomaly: Profit Flagged (Edit)</span>");
 			tip.append("Price was recovered from offline trade history as a blended average, so the profit is an estimate. ");
 		}
 		text.append("</html>");

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3951,6 +3951,41 @@ public class FlipFinderPanel extends PluginPanel
 	}
 	
 	/**
+	 * Build a small, non-alarming confidence badge for a completed flip, or
+	 * {@code null} when the flip is fully confident (nothing to show).
+	 */
+	private JLabel buildConfidenceLabel(CompletedFlip flip)
+	{
+		if (!flip.isPriceIsEstimated() && !flip.isQuantityAnomaly())
+		{
+			return null;
+		}
+
+		StringBuilder text = new StringBuilder("<html>");
+		StringBuilder tip = new StringBuilder();
+		if (flip.isPriceIsEstimated())
+		{
+			text.append("<span style='color:#B4B4B4;'>~ Est. price</span>");
+			tip.append("Price was recovered from offline trade history as a blended average, so it's an estimate. ");
+		}
+		if (flip.isQuantityAnomaly())
+		{
+			if (flip.isPriceIsEstimated())
+			{
+				text.append("&nbsp;&nbsp;");
+			}
+			text.append("<span style='color:#C89600;'>&#9888; Qty flagged</span>");
+			tip.append("Recorded quantity looks higher than the item's 4h GE buy limit allows, so it may be over-counted.");
+		}
+		text.append("</html>");
+
+		JLabel label = new JLabel(text.toString());
+		label.setFont(FONT_PLAIN_12);
+		label.setToolTipText(tip.toString().trim());
+		return label;
+	}
+
+	/**
 	 * Create a panel for a completed flip
 	 */
 	private JPanel createCompletedFlipPanel(CompletedFlip flip)
@@ -4016,6 +4051,18 @@ public class FlipFinderPanel extends PluginPanel
 		// Add horizontal glue to prevent stretching
 		gbc.gridx = 2; gbc.gridy = 0; gbc.weightx = 1.0; gbc.fill = GridBagConstraints.HORIZONTAL;
 		detailsPanel.add(Box.createHorizontalGlue(), gbc);
+
+		// Confidence signal: badge flips whose price is an offline-history
+		// estimate or whose quantity looks over the GE buy limit, mirroring the
+		// web dashboard so a blended offline price isn't shown as exact.
+		JLabel confidenceLabel = buildConfidenceLabel(flip);
+		if (confidenceLabel != null)
+		{
+			gbc.gridx = 0; gbc.gridy = 3; gbc.gridwidth = 2; gbc.weightx = 0;
+			gbc.fill = GridBagConstraints.NONE; gbc.insets = new Insets(3, 0, 0, 0);
+			detailsPanel.add(confidenceLabel, gbc);
+			gbc.gridwidth = 1;
+		}
 
 		panel.add(topPanel, BorderLayout.NORTH);
 		panel.add(detailsPanel, BorderLayout.CENTER);

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -115,7 +115,11 @@ public class FlipFinderPanel extends PluginPanel
 	private static final Color COLOR_AUTO_RECOMMEND_BORDER = new Color(255, 185, 50);
 	private static final Color COLOR_AUTO_RECOMMEND_BG = new Color(70, 55, 20);
 	private static final Color COLOR_AUTO_RECOMMEND_ACTIVE = new Color(200, 150, 0);
-	
+
+	// Hex colors for the completed-flip confidence badge (HTML label markup)
+	private static final String COLOR_ESTIMATED_HEX = "#B4B4B4";
+	private static final String COLOR_WARNING_HEX = "#C89600";
+
 	// Website base URL for item pages
 	private static final String WEBSITE_ITEM_URL = "https://flipsmart.net/items/";
 
@@ -3965,7 +3969,7 @@ public class FlipFinderPanel extends PluginPanel
 		StringBuilder tip = new StringBuilder(200);
 		if (flip.isPriceIsEstimated())
 		{
-			text.append("<span style='color:#B4B4B4;'>~ Est. price</span>");
+			text.append("<span style='color:").append(COLOR_ESTIMATED_HEX).append(";'>~ Est. price</span>");
 			tip.append("Price was recovered from offline trade history as a blended average, so it's an estimate. ");
 		}
 		if (flip.isQuantityAnomaly())
@@ -3974,7 +3978,7 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				text.append("&nbsp;&nbsp;");
 			}
-			text.append("<span style='color:#C89600;'>&#9888; Qty flagged</span>");
+			text.append("<span style='color:").append(COLOR_WARNING_HEX).append(";'>&#9888; Qty flagged</span>");
 			tip.append("Recorded quantity looks higher than the item's 4h GE buy limit allows, so it may be over-counted.");
 		}
 		text.append("</html>");

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -116,12 +116,15 @@ public class FlipFinderPanel extends PluginPanel
 	private static final Color COLOR_AUTO_RECOMMEND_BG = new Color(70, 55, 20);
 	private static final Color COLOR_AUTO_RECOMMEND_ACTIVE = new Color(200, 150, 0);
 
-	// Hex colors for the completed-flip confidence badge (HTML label markup)
-	private static final String COLOR_ESTIMATED_HEX = "#B4B4B4";
-	private static final String COLOR_WARNING_HEX = "#C89600";
+	// Yellow used for the completed-flip anomaly badge (HTML label markup).
+	private static final String COLOR_ANOMALY_HEX = "#FFCC33";
+	private static final int BADGE_SECOND_LINE_HEIGHT = 18;
 
 	// Website base URL for item pages
 	private static final String WEBSITE_ITEM_URL = "https://flipsmart.net/items/";
+
+	// Deep-links a flagged flip to the website's Flip History edit flow.
+	private static final String FLIP_EDIT_URL = "https://flipsmart.net/dashboard/flips?adjust=";
 
 	// Discord invite link
 	private static final String DISCORD_INVITE_URL = "https://discord.gg/8CrcM9qYF9";
@@ -3965,27 +3968,37 @@ public class FlipFinderPanel extends PluginPanel
 			return null;
 		}
 
-		StringBuilder text = new StringBuilder(150).append("<html>");
-		StringBuilder tip = new StringBuilder(200);
-		if (flip.isPriceIsEstimated())
-		{
-			text.append("<span style='color:").append(COLOR_ESTIMATED_HEX).append(";'>~ Est. price</span>");
-			tip.append("Price was recovered from offline trade history as a blended average, so it's an estimate. ");
-		}
+		StringBuilder text = new StringBuilder(240).append("<html>");
+		StringBuilder tip = new StringBuilder(260);
 		if (flip.isQuantityAnomaly())
 		{
-			if (flip.isPriceIsEstimated())
+			text.append("<span style='color:").append(COLOR_ANOMALY_HEX).append(";'>&#9888; Anomaly: Quantity Flagged</span>");
+			tip.append("Recorded quantity looks higher than the item's 4h GE buy limit allows, so it may be over-counted. ");
+		}
+		if (flip.isPriceIsEstimated())
+		{
+			if (flip.isQuantityAnomaly())
 			{
-				text.append("&nbsp;&nbsp;");
+				text.append("<br>");
 			}
-			text.append("<span style='color:").append(COLOR_WARNING_HEX).append(";'>&#9888; Qty flagged</span>");
-			tip.append("Recorded quantity looks higher than the item's 4h GE buy limit allows, so it may be over-counted.");
+			text.append("<span style='color:").append(COLOR_ANOMALY_HEX).append(";'>&#9888; Anomaly: Profit Flagged</span>");
+			tip.append("Price was recovered from offline trade history as a blended average, so the profit is an estimate. ");
 		}
 		text.append("</html>");
 
 		JLabel label = new JLabel(text.toString());
 		label.setFont(FONT_PLAIN_12);
-		label.setToolTipText(tip.toString().trim());
+		label.setToolTipText(tip.append("Click to edit this trade on the website.").toString());
+		label.setCursor(new Cursor(Cursor.HAND_CURSOR));
+		final int flipId = flip.getId();
+		label.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(MouseEvent e)
+			{
+				LinkBrowser.browse(FLIP_EDIT_URL + flipId);
+			}
+		});
 		return label;
 	}
 
@@ -4066,6 +4079,10 @@ public class FlipFinderPanel extends PluginPanel
 			gbc.fill = GridBagConstraints.NONE; gbc.insets = new Insets(3, 0, 0, 0);
 			detailsPanel.add(confidenceLabel, gbc);
 			gbc.gridwidth = 1;
+			if (flip.isPriceIsEstimated() && flip.isQuantityAnomaly())
+			{
+				allowForWrappedName(panel, BADGE_SECOND_LINE_HEIGHT);
+			}
 		}
 
 		panel.add(topPanel, BorderLayout.NORTH);

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3961,8 +3961,8 @@ public class FlipFinderPanel extends PluginPanel
 			return null;
 		}
 
-		StringBuilder text = new StringBuilder("<html>");
-		StringBuilder tip = new StringBuilder();
+		StringBuilder text = new StringBuilder(150).append("<html>");
+		StringBuilder tip = new StringBuilder(200);
 		if (flip.isPriceIsEstimated())
 		{
 			text.append("<span style='color:#B4B4B4;'>~ Est. price</span>");

--- a/src/main/java/com/flipsmart/domain/flip/CompletedFlip.java
+++ b/src/main/java/com/flipsmart/domain/flip/CompletedFlip.java
@@ -56,5 +56,15 @@ public class CompletedFlip
 
 	@SerializedName("is_successful")
 	private boolean isSuccessful;
+
+	// True when the recorded price came from an offline history backfill (a
+	// blended average, not a live per-fill observation) — shown as an estimate.
+	@SerializedName("price_is_estimated")
+	private boolean priceIsEstimated;
+
+	// True when matched buy legs exceed the item's 4h GE buy limit (possible
+	// over-count from a re-emitted offer).
+	@SerializedName("quantity_anomaly")
+	private boolean quantityAnomaly;
 }
 


### PR DESCRIPTION
## Summary
Completes **AC4 of Flip-Smart/flip-smart#1049** — surfaces the trade-confidence signal in the plugin's Completed Flips panel, mirroring the website.

## Changes
- `CompletedFlip` DTO now deserializes `price_is_estimated` + `quantity_anomaly` (already served by the backend — no backend change needed).
- `createCompletedFlipPanel` renders a **yellow ⚠ anomaly badge** on flagged flips: **"Anomaly: Quantity Flagged (Edit)"** (quantity over 4h GE buy limit) and **"Anomaly: Profit Flagged (Edit)"** (offline blended-average price). Renders nothing for confident flips; adds room for a second line when both apply.
- The badge is **clickable** and deep-links to the website's Flip History edit flow: `/dashboard/flips?adjust=<flipId>`. The Adjust Trade modal that this URL auto-opens is tracked in **Flip-Smart/flip-smart#1058** (AC14); until then the link lands on Flip History.

Passive display only — no synthetic input, no config, no game overlay. Plugin-Hub compliant.

## Manual testing (in-game)
1. A flip flagged `quantity_anomaly` shows a yellow "⚠ Anomaly: Quantity Flagged (Edit)" badge; `price_is_estimated` shows "⚠ Anomaly: Profit Flagged (Edit)".
2. Clicking the badge opens `flipsmart.net/dashboard/flips?adjust=<flipId>` in the browser.
3. A confident flip shows no badge; row layout unchanged.

Closes Flip-Smart/flip-smart#1049