### PR TITLE
Add GP/Hour & Session Earnings Display

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -171,6 +171,7 @@ public class FlipFinderPanel extends PluginPanel
 	private final SessionClock sessionClock = new SessionClock(System.currentTimeMillis());
 	private final SessionStatsView sessionStatsView = new SessionStatsView();
 	private javax.swing.Timer sessionStatsTimer;
+	private SessionStats.ProfitBase sessionProfitBase = SessionStats.ProfitBase.EMPTY;
 	private final transient FlipSmartPlugin plugin;  // Reference to plugin to store recommended prices
 	
 	// Scroll panes for preserving scroll position during refresh
@@ -1077,7 +1078,7 @@ public class FlipFinderPanel extends PluginPanel
 		repaint();
 
 		startRefreshCountdownTimer();
-		renderSessionStats();
+		recomputeSessionProfitBase();
 		startSessionStatsTimer();
 
 		// Load data
@@ -1313,10 +1314,15 @@ public class FlipFinderPanel extends PluginPanel
 
 	private void renderSessionStats()
 	{
-		long now = System.currentTimeMillis();
-		sessionStatsView.render(SessionStats.compute(
-			currentCompletedFlips, currentActiveFlips,
-			sessionClock.startMs(), sessionClock.activeMs(now)));
+		sessionStatsView.render(SessionStats.snapshot(
+			sessionProfitBase, sessionClock.activeMs(System.currentTimeMillis())));
+	}
+
+	private void recomputeSessionProfitBase()
+	{
+		sessionProfitBase = SessionStats.computeBase(
+			currentCompletedFlips, currentActiveFlips, sessionClock.startMs());
+		renderSessionStats();
 	}
 
 	private void startSessionStatsTimer()
@@ -1636,7 +1642,7 @@ public class FlipFinderPanel extends PluginPanel
 				currentActiveFlips.clear();
 				currentActiveFlips.addAll(filtered);
 			}
-			renderSessionStats();
+			recomputeSessionProfitBase();
 			if (flipsFromBackend != null)
 			{
 				log.debug("Loaded {} active flips ({} from backend, {} filtered)",
@@ -1794,7 +1800,7 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				currentCompletedFlips.addAll(response.getFlips());
 			}
-			renderSessionStats();
+			recomputeSessionProfitBase();
 
 			if (currentCompletedFlips.isEmpty())
 			{

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -21,6 +21,9 @@ import com.flipsmart.ui.panel.CardWidgets;
 import com.flipsmart.ui.panel.ItemNameFit;
 import com.flipsmart.ui.panel.LoginPanel;
 import com.flipsmart.ui.panel.PanelFormat;
+import com.flipsmart.session.SessionClock;
+import com.flipsmart.session.SessionStats;
+import com.flipsmart.session.SessionStatsView;
 import com.flipsmart.util.BuyPriceLookup;
 import com.flipsmart.util.GeTax;
 import com.flipsmart.util.GpUtils;
@@ -165,6 +168,9 @@ public class FlipFinderPanel extends PluginPanel
 	private final List<ActiveFlip> currentActiveFlips = new ArrayList<>();
 	private final List<CompletedFlip> currentCompletedFlips = new ArrayList<>();
 	private final JTabbedPane tabbedPane = new JTabbedPane();
+	private final SessionClock sessionClock = new SessionClock(System.currentTimeMillis());
+	private final SessionStatsView sessionStatsView = new SessionStatsView();
+	private javax.swing.Timer sessionStatsTimer;
 	private final transient FlipSmartPlugin plugin;  // Reference to plugin to store recommended prices
 	
 	// Scroll panes for preserving scroll position during refresh
@@ -550,6 +556,7 @@ public class FlipFinderPanel extends PluginPanel
 		topPanel.add(controlsPanel);
 		topPanel.add(statusPanel);
 		topPanel.add(overridePanel);
+		topPanel.add(sessionStatsView.getComponent());
 		updateCashstackOverrideIndicator();
 
 		// Recommended flips list container
@@ -1052,6 +1059,11 @@ public class FlipFinderPanel extends PluginPanel
 		{
 			activeFlipsPriceTimer.stop();
 		}
+		if (sessionStatsTimer != null)
+		{
+			sessionStatsTimer.stop();
+			sessionStatsTimer = null;
+		}
 	}
 
 	/**
@@ -1065,6 +1077,8 @@ public class FlipFinderPanel extends PluginPanel
 		repaint();
 
 		startRefreshCountdownTimer();
+		renderSessionStats();
+		startSessionStatsTimer();
 
 		// Load data
 		refresh();
@@ -1295,6 +1309,30 @@ public class FlipFinderPanel extends PluginPanel
 			refreshCountdownTimer.start();
 		}
 		updateRefreshCountdownLabel();
+	}
+
+	private void renderSessionStats()
+	{
+		long now = System.currentTimeMillis();
+		sessionStatsView.render(SessionStats.compute(
+			currentCompletedFlips, currentActiveFlips,
+			sessionClock.sessionStartMs(), sessionClock.activeMs(now)));
+	}
+
+	private void startSessionStatsTimer()
+	{
+		if (sessionStatsTimer == null)
+		{
+			sessionStatsTimer = new javax.swing.Timer(1000, e ->
+			{
+				sessionClock.update(plugin.isLoggedIntoRunescape(), System.currentTimeMillis());
+				renderSessionStats();
+			});
+		}
+		if (!sessionStatsTimer.isRunning())
+		{
+			sessionStatsTimer.start();
+		}
 	}
 
 	/**
@@ -1598,6 +1636,7 @@ public class FlipFinderPanel extends PluginPanel
 				currentActiveFlips.clear();
 				currentActiveFlips.addAll(filtered);
 			}
+			renderSessionStats();
 			if (flipsFromBackend != null)
 			{
 				log.debug("Loaded {} active flips ({} from backend, {} filtered)",
@@ -1755,6 +1794,7 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				currentCompletedFlips.addAll(response.getFlips());
 			}
+			renderSessionStats();
 
 			if (currentCompletedFlips.isEmpty())
 			{

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1316,7 +1316,7 @@ public class FlipFinderPanel extends PluginPanel
 		long now = System.currentTimeMillis();
 		sessionStatsView.render(SessionStats.compute(
 			currentCompletedFlips, currentActiveFlips,
-			sessionClock.sessionStartMs(), sessionClock.activeMs(now)));
+			sessionClock.startMs(), sessionClock.activeMs(now)));
 	}
 
 	private void startSessionStatsTimer()

--- a/src/main/java/com/flipsmart/session/SessionClock.java
+++ b/src/main/java/com/flipsmart/session/SessionClock.java
@@ -11,7 +11,8 @@ public final class SessionClock
 {
 	private final long sessionStartMs;
 	private long accumulatedActiveMs;
-	private Long loginStartMs;
+	private boolean loggedIn;
+	private long loginStartMs;
 
 	public SessionClock(long sessionStartMs)
 	{
@@ -25,20 +26,20 @@ public final class SessionClock
 
 	public void update(boolean loggedIn, long nowMs)
 	{
-		if (loggedIn && loginStartMs == null)
+		if (loggedIn && !this.loggedIn)
 		{
 			loginStartMs = nowMs;
 		}
-		else if (!loggedIn && loginStartMs != null)
+		else if (!loggedIn && this.loggedIn)
 		{
 			accumulatedActiveMs += Math.max(0L, nowMs - loginStartMs);
-			loginStartMs = null;
 		}
+		this.loggedIn = loggedIn;
 	}
 
 	public long activeMs(long nowMs)
 	{
-		long openSpan = loginStartMs != null ? Math.max(0L, nowMs - loginStartMs) : 0L;
+		long openSpan = loggedIn ? Math.max(0L, nowMs - loginStartMs) : 0L;
 		return accumulatedActiveMs + openSpan;
 	}
 }

--- a/src/main/java/com/flipsmart/session/SessionClock.java
+++ b/src/main/java/com/flipsmart/session/SessionClock.java
@@ -19,7 +19,7 @@ public final class SessionClock
 		this.sessionStartMs = sessionStartMs;
 	}
 
-	public long sessionStartMs()
+	public long startMs()
 	{
 		return sessionStartMs;
 	}

--- a/src/main/java/com/flipsmart/session/SessionClock.java
+++ b/src/main/java/com/flipsmart/session/SessionClock.java
@@ -1,0 +1,44 @@
+package com.flipsmart.session;
+
+/**
+ * Tracks the wall-clock session start and accumulated logged-in time, excluding
+ * spans the player was logged out. Poll {@link #update(boolean, long)} with the
+ * current login state; read elapsed logged-in time with {@link #activeMs(long)}.
+ * Pure and deterministic — every "now" is injected so it unit-tests without a
+ * real clock.
+ */
+public final class SessionClock
+{
+	private final long sessionStartMs;
+	private long accumulatedActiveMs;
+	private Long loginStartMs;
+
+	public SessionClock(long sessionStartMs)
+	{
+		this.sessionStartMs = sessionStartMs;
+	}
+
+	public long sessionStartMs()
+	{
+		return sessionStartMs;
+	}
+
+	public void update(boolean loggedIn, long nowMs)
+	{
+		if (loggedIn && loginStartMs == null)
+		{
+			loginStartMs = nowMs;
+		}
+		else if (!loggedIn && loginStartMs != null)
+		{
+			accumulatedActiveMs += Math.max(0L, nowMs - loginStartMs);
+			loginStartMs = null;
+		}
+	}
+
+	public long activeMs(long nowMs)
+	{
+		long openSpan = loginStartMs != null ? Math.max(0L, nowMs - loginStartMs) : 0L;
+		return accumulatedActiveMs + openSpan;
+	}
+}

--- a/src/main/java/com/flipsmart/session/SessionStats.java
+++ b/src/main/java/com/flipsmart/session/SessionStats.java
@@ -25,13 +25,23 @@ public final class SessionStats
 	{
 	}
 
+	public static ProfitBase computeBase(List<CompletedFlip> completed, List<ActiveFlip> active,
+										 long sessionStartMs)
+	{
+		return new ProfitBase(realisedProfit(completed, sessionStartMs), unrealisedProfit(active));
+	}
+
+	public static Snapshot snapshot(ProfitBase base, long activeMs)
+	{
+		long projected = base.realisedProfit + base.unrealisedProfit;
+		return new Snapshot(base.realisedProfit, projected, activeMs,
+			gpPerHour(base.realisedProfit, activeMs), gpPerHour(projected, activeMs));
+	}
+
 	public static Snapshot compute(List<CompletedFlip> completed, List<ActiveFlip> active,
 								   long sessionStartMs, long activeMs)
 	{
-		long realised = realisedProfit(completed, sessionStartMs);
-		long projected = realised + unrealisedProfit(active);
-		return new Snapshot(realised, projected, activeMs,
-			gpPerHour(realised, activeMs), gpPerHour(projected, activeMs));
+		return snapshot(computeBase(completed, active, sessionStartMs), activeMs);
 	}
 
 	static long realisedProfit(List<CompletedFlip> completed, long sessionStartMs)
@@ -92,6 +102,19 @@ public final class SessionStats
 		long minutes = (totalSeconds % 3600L) / 60L;
 		long seconds = totalSeconds % 60L;
 		return String.format(Locale.ROOT, "%02d:%02d:%02d", hours, minutes, seconds);
+	}
+
+	public static final class ProfitBase
+	{
+		public static final ProfitBase EMPTY = new ProfitBase(0L, 0L);
+		public final long realisedProfit;
+		public final long unrealisedProfit;
+
+		public ProfitBase(long realisedProfit, long unrealisedProfit)
+		{
+			this.realisedProfit = realisedProfit;
+			this.unrealisedProfit = unrealisedProfit;
+		}
 	}
 
 	public static final class Snapshot

--- a/src/main/java/com/flipsmart/session/SessionStats.java
+++ b/src/main/java/com/flipsmart/session/SessionStats.java
@@ -7,6 +7,7 @@ import com.flipsmart.util.GpUtils;
 import com.flipsmart.util.TimeUtils;
 
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Pure session-performance math: realised profit from completed flips sold within
@@ -90,7 +91,7 @@ public final class SessionStats
 		long hours = totalSeconds / 3600L;
 		long minutes = (totalSeconds % 3600L) / 60L;
 		long seconds = totalSeconds % 60L;
-		return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+		return String.format(Locale.ROOT, "%02d:%02d:%02d", hours, minutes, seconds);
 	}
 
 	public static final class Snapshot

--- a/src/main/java/com/flipsmart/session/SessionStats.java
+++ b/src/main/java/com/flipsmart/session/SessionStats.java
@@ -1,0 +1,114 @@
+package com.flipsmart.session;
+
+import com.flipsmart.domain.flip.ActiveFlip;
+import com.flipsmart.domain.flip.CompletedFlip;
+import com.flipsmart.util.GeTax;
+import com.flipsmart.util.GpUtils;
+import com.flipsmart.util.TimeUtils;
+
+import java.util.List;
+
+/**
+ * Pure session-performance math: realised profit from completed flips sold within
+ * the session, projected profit including unrealised gains on open positions, and
+ * the derived GP/hour rates. No Swing, no I/O.
+ */
+public final class SessionStats
+{
+	/** Below this much logged-in time, GP/hour is too volatile to be meaningful. */
+	static final long MIN_ACTIVE_MS = 60_000L;
+	private static final long MS_PER_HOUR = 3_600_000L;
+	private static final String NOT_AVAILABLE = "—";
+
+	private SessionStats()
+	{
+	}
+
+	public static Snapshot compute(List<CompletedFlip> completed, List<ActiveFlip> active,
+								   long sessionStartMs, long activeMs)
+	{
+		long realised = realisedProfit(completed, sessionStartMs);
+		long projected = realised + unrealisedProfit(active);
+		return new Snapshot(realised, projected, activeMs,
+			gpPerHour(realised, activeMs), gpPerHour(projected, activeMs));
+	}
+
+	static long realisedProfit(List<CompletedFlip> completed, long sessionStartMs)
+	{
+		long sum = 0L;
+		for (CompletedFlip flip : completed)
+		{
+			if (TimeUtils.parseIsoToMillis(flip.getSellTime()) >= sessionStartMs)
+			{
+				sum += flip.getNetProfit();
+			}
+		}
+		return sum;
+	}
+
+	static long unrealisedProfit(List<ActiveFlip> active)
+	{
+		long sum = 0L;
+		for (ActiveFlip flip : active)
+		{
+			Integer recommendedSell = flip.getRecommendedSellPrice();
+			int heldQty = flip.getTotalQuantity();
+			if (recommendedSell == null || heldQty <= 0)
+			{
+				continue;
+			}
+			long tax = GeTax.taxFor(flip.getItemId(), recommendedSell);
+			long perItem = (long) recommendedSell - flip.getAverageBuyPrice() - tax;
+			sum += perItem * heldQty;
+		}
+		return sum;
+	}
+
+	static Long gpPerHour(long profit, long activeMs)
+	{
+		if (activeMs < MIN_ACTIVE_MS)
+		{
+			return null;
+		}
+		return profit * MS_PER_HOUR / activeMs;
+	}
+
+	public static String formatSignedGp(long amount)
+	{
+		String magnitude = GpUtils.formatGPSigned(amount);
+		return amount > 0 ? "+" + magnitude : magnitude;
+	}
+
+	public static String formatGpPerHour(Long perHour)
+	{
+		return perHour == null ? NOT_AVAILABLE : formatSignedGp(perHour);
+	}
+
+	public static String formatDuration(long ms)
+	{
+		long totalSeconds = Math.max(0L, ms) / 1000L;
+		long hours = totalSeconds / 3600L;
+		long minutes = (totalSeconds % 3600L) / 60L;
+		long seconds = totalSeconds % 60L;
+		return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+	}
+
+	public static final class Snapshot
+	{
+		public final long realisedProfit;
+		public final long projectedProfit;
+		public final long activeMs;
+		public final Long realisedGpPerHour;
+		public final Long projectedGpPerHour;
+
+		public Snapshot(long realisedProfit, long projectedProfit, long activeMs,
+						Long realisedGpPerHour, Long projectedGpPerHour)
+		{
+			this.realisedProfit = realisedProfit;
+			this.projectedProfit = projectedProfit;
+			this.activeMs = activeMs;
+			this.realisedGpPerHour = realisedGpPerHour;
+			this.projectedGpPerHour = projectedGpPerHour;
+		}
+	}
+}

--- a/src/main/java/com/flipsmart/session/SessionStatsView.java
+++ b/src/main/java/com/flipsmart/session/SessionStatsView.java
@@ -1,0 +1,83 @@
+package com.flipsmart.session;
+
+import net.runelite.client.ui.ColorScheme;
+
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+
+/**
+ * The four-line session-performance block above the panel tabs: session profit,
+ * session duration, realised GP/hour and projected GP/hour. Presentation only —
+ * every figure comes from a {@link SessionStats.Snapshot}.
+ */
+public final class SessionStatsView
+{
+	private static final Color COLOR_PROFIT_GREEN = new Color(100, 255, 100);
+	private static final Color COLOR_LOSS_RED = new Color(255, 100, 100);
+	private static final int ROW_HEIGHT = 18;
+
+	private final JPanel component = new JPanel();
+	private final JLabel sessionProfitValue = new JLabel();
+	private final JLabel sessionDurationValue = new JLabel();
+	private final JLabel realisedRateValue = new JLabel();
+	private final JLabel projectedRateValue = new JLabel();
+
+	public SessionStatsView()
+	{
+		component.setLayout(new BoxLayout(component, BoxLayout.Y_AXIS));
+		component.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		component.setBorder(BorderFactory.createEmptyBorder(4, 10, 6, 10));
+		component.add(buildRow("Profit this session", sessionProfitValue));
+		component.add(buildRow("Session duration", sessionDurationValue));
+		component.add(buildRow("Realised GP/hour", realisedRateValue));
+		component.add(buildRow("Projected GP/hour", projectedRateValue));
+	}
+
+	private JPanel buildRow(String label, JLabel valueLabel)
+	{
+		JPanel row = new JPanel(new BorderLayout());
+		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		row.setMaximumSize(new Dimension(Integer.MAX_VALUE, ROW_HEIGHT));
+		JLabel name = new JLabel(label);
+		name.setForeground(Color.LIGHT_GRAY);
+		valueLabel.setHorizontalAlignment(SwingConstants.RIGHT);
+		row.add(name, BorderLayout.WEST);
+		row.add(valueLabel, BorderLayout.EAST);
+		return row;
+	}
+
+	public Component getComponent()
+	{
+		return component;
+	}
+
+	public void render(SessionStats.Snapshot snapshot)
+	{
+		sessionProfitValue.setText(SessionStats.formatSignedGp(snapshot.realisedProfit));
+		sessionProfitValue.setForeground(profitColor(snapshot.realisedProfit));
+
+		sessionDurationValue.setText(SessionStats.formatDuration(snapshot.activeMs));
+		sessionDurationValue.setForeground(Color.WHITE);
+
+		applyRate(realisedRateValue, snapshot.realisedGpPerHour);
+		applyRate(projectedRateValue, snapshot.projectedGpPerHour);
+	}
+
+	private void applyRate(JLabel label, Long perHour)
+	{
+		label.setText(SessionStats.formatGpPerHour(perHour));
+		label.setForeground(perHour == null ? Color.LIGHT_GRAY : profitColor(perHour));
+	}
+
+	private Color profitColor(long amount)
+	{
+		return amount < 0 ? COLOR_LOSS_RED : COLOR_PROFIT_GREEN;
+	}
+}

--- a/src/test/java/com/flipsmart/session/SessionClockTest.java
+++ b/src/test/java/com/flipsmart/session/SessionClockTest.java
@@ -1,0 +1,52 @@
+package com.flipsmart.session;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class SessionClockTest
+{
+	@Test
+	public void noLoggedInTimeBeforeFirstLogin()
+	{
+		SessionClock clock = new SessionClock(1_000L);
+		assertEquals(1_000L, clock.sessionStartMs());
+		assertEquals(0L, clock.activeMs(50_000L));
+	}
+
+	@Test
+	public void accruesOpenLoggedInSpan()
+	{
+		SessionClock clock = new SessionClock(1_000L);
+		clock.update(true, 1_000L);
+		assertEquals(3_000L, clock.activeMs(4_000L));
+	}
+
+	@Test
+	public void freezesAccrualWhileLoggedOut()
+	{
+		SessionClock clock = new SessionClock(1_000L);
+		clock.update(true, 1_000L);
+		clock.update(false, 4_000L);
+		assertEquals(3_000L, clock.activeMs(9_999L));
+	}
+
+	@Test
+	public void resumesAccrualAfterRelogin()
+	{
+		SessionClock clock = new SessionClock(1_000L);
+		clock.update(true, 1_000L);
+		clock.update(false, 4_000L);
+		clock.update(true, 5_000L);
+		assertEquals(4_000L, clock.activeMs(6_000L));
+	}
+
+	@Test
+	public void repeatedLoggedInUpdatesDoNotResetOpenSpan()
+	{
+		SessionClock clock = new SessionClock(1_000L);
+		clock.update(true, 1_000L);
+		clock.update(true, 2_000L);
+		assertEquals(2_000L, clock.activeMs(3_000L));
+	}
+}

--- a/src/test/java/com/flipsmart/session/SessionClockTest.java
+++ b/src/test/java/com/flipsmart/session/SessionClockTest.java
@@ -10,7 +10,7 @@ public class SessionClockTest
 	public void noLoggedInTimeBeforeFirstLogin()
 	{
 		SessionClock clock = new SessionClock(1_000L);
-		assertEquals(1_000L, clock.sessionStartMs());
+		assertEquals(1_000L, clock.startMs());
 		assertEquals(0L, clock.activeMs(50_000L));
 	}
 

--- a/src/test/java/com/flipsmart/session/SessionStatsTest.java
+++ b/src/test/java/com/flipsmart/session/SessionStatsTest.java
@@ -96,6 +96,36 @@ public class SessionStatsTest
 	}
 
 	@Test
+	public void computeBaseCapturesRealisedAndUnrealisedSeparately()
+	{
+		SessionStats.ProfitBase base = SessionStats.computeBase(
+			Collections.singletonList(completed("2026-07-22T13:00:00Z", 1000)),
+			Collections.singletonList(active(4151, 200, 100, 10)),
+			SESSION_START);
+		assertEquals(1000L, base.realisedProfit);
+		assertEquals(960L, base.unrealisedProfit);
+	}
+
+	@Test
+	public void snapshotDerivesProjectedAndRatesFromBase()
+	{
+		SessionStats.Snapshot snap = SessionStats.snapshot(
+			new SessionStats.ProfitBase(1000L, 960L), 3_600_000L);
+		assertEquals(1000L, snap.realisedProfit);
+		assertEquals(1960L, snap.projectedProfit);
+		assertEquals(Long.valueOf(1000L), snap.realisedGpPerHour);
+		assertEquals(Long.valueOf(1960L), snap.projectedGpPerHour);
+	}
+
+	@Test
+	public void emptyBaseIsZeroed()
+	{
+		SessionStats.Snapshot snap = SessionStats.snapshot(SessionStats.ProfitBase.EMPTY, 3_600_000L);
+		assertEquals(0L, snap.realisedProfit);
+		assertEquals(0L, snap.projectedProfit);
+	}
+
+	@Test
 	public void formatsSignedGpDurationAndRate()
 	{
 		assertEquals("+1.2M", SessionStats.formatSignedGp(1_200_000L));

--- a/src/test/java/com/flipsmart/session/SessionStatsTest.java
+++ b/src/test/java/com/flipsmart/session/SessionStatsTest.java
@@ -1,0 +1,109 @@
+package com.flipsmart.session;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.flipsmart.domain.flip.ActiveFlip;
+import com.flipsmart.domain.flip.CompletedFlip;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+public class SessionStatsTest
+{
+	private static final long SESSION_START =
+		Instant.parse("2026-07-22T12:00:00Z").toEpochMilli();
+
+	private static CompletedFlip completed(String sellTime, long netProfit)
+	{
+		CompletedFlip f = new CompletedFlip();
+		f.setSellTime(sellTime);
+		f.setNetProfit(netProfit);
+		return f;
+	}
+
+	private static ActiveFlip active(int itemId, Integer recSell, int avgBuy, int qty)
+	{
+		ActiveFlip a = new ActiveFlip();
+		a.setItemId(itemId);
+		a.setRecommendedSellPrice(recSell);
+		a.setAverageBuyPrice(avgBuy);
+		a.setTotalQuantity(qty);
+		return a;
+	}
+
+	@Test
+	public void realisedProfitCountsOnlyFlipsSoldWithinSession()
+	{
+		long realised = SessionStats.realisedProfit(Arrays.asList(
+			completed("2026-07-22T11:00:00Z", 500),   // before session start
+			completed("2026-07-22T13:00:00Z", 1000)), // after
+			SESSION_START);
+		assertEquals(1000L, realised);
+	}
+
+	@Test
+	public void realisedProfitExcludesUnparseableSellTimes()
+	{
+		long realised = SessionStats.realisedProfit(
+			Collections.singletonList(completed(null, 999)), SESSION_START);
+		assertEquals(0L, realised);
+	}
+
+	@Test
+	public void unrealisedProfitValuesHeldQtyAtRecommendedSellMinusTax()
+	{
+		// (200 - 100 - 4 tax) * 10 = 960
+		long unrealised = SessionStats.unrealisedProfit(
+			Collections.singletonList(active(4151, 200, 100, 10)));
+		assertEquals(960L, unrealised);
+	}
+
+	@Test
+	public void unrealisedProfitSkipsNullTargetAndEmptyQty()
+	{
+		long unrealised = SessionStats.unrealisedProfit(Arrays.asList(
+			active(4151, null, 100, 10),
+			active(4151, 200, 100, 0)));
+		assertEquals(0L, unrealised);
+	}
+
+	@Test
+	public void gpPerHourIsNullBelowMinimumSessionTime()
+	{
+		assertNull(SessionStats.gpPerHour(1000L, 59_999L));
+	}
+
+	@Test
+	public void gpPerHourScalesProfitToAnHour()
+	{
+		assertEquals(Long.valueOf(2000L), SessionStats.gpPerHour(1000L, 1_800_000L));
+	}
+
+	@Test
+	public void computeCombinesRealisedAndProjected()
+	{
+		SessionStats.Snapshot snap = SessionStats.compute(
+			Collections.singletonList(completed("2026-07-22T13:00:00Z", 1000)),
+			Collections.singletonList(active(4151, 200, 100, 10)),
+			SESSION_START, 3_600_000L);
+		assertEquals(1000L, snap.realisedProfit);
+		assertEquals(1960L, snap.projectedProfit);   // 1000 + 960
+		assertEquals(Long.valueOf(1000L), snap.realisedGpPerHour);
+		assertEquals(Long.valueOf(1960L), snap.projectedGpPerHour);
+	}
+
+	@Test
+	public void formatsSignedGpDurationAndRate()
+	{
+		assertEquals("+1.2M", SessionStats.formatSignedGp(1_200_000L));
+		assertEquals("-1.5M", SessionStats.formatSignedGp(-1_500_000L));
+		assertEquals("0", SessionStats.formatSignedGp(0L));
+		assertEquals("01:47:12", SessionStats.formatDuration((1L * 3600 + 47 * 60 + 12) * 1000));
+		assertEquals("00:00:00", SessionStats.formatDuration(0L));
+		assertEquals("—", SessionStats.formatGpPerHour(null));
+		assertEquals("+684.0K", SessionStats.formatGpPerHour(684_000L));
+	}
+}


### PR DESCRIPTION
## Summary

Feature #1015 adds a compact 4-line session-performance block mounted above the panel's Recommended/Active/Completed tabs: Profit this session, Session duration, Realised GP/hour, Projected GP/hour. Profit and rate values are color-coded (green when >= 0, red when < 0); both GP/hour figures show "—" until roughly 60 seconds of logged-in time have accumulated. Plugin-only change with zero API impact.

## Changes

### ✨ New Features
- `com.flipsmart.session.SessionClock` — accumulates logged-in time only (excludes logged-out spans); pure, unit-tested, every "now" is injected so it tests without a real clock.
- `com.flipsmart.session.SessionStats` — pure session profit / projection / GP-hour math, formatters, and the `Snapshot` value object; unit-tested. Realised = sum of net profit of completed flips sold within the session; Projected = realised + sum of open-flip `(recommendedSell - avgBuy - GE tax) * heldQty` valued at target.
- `com.flipsmart.session.SessionStatsView` — presentation-only Swing block rendering the 4 rows, color-coded profit/rate values.
- `FlipFinderPanel` wiring — mounts the block above the tabs, a 1s Swing timer polls login state and re-renders, recompute is also triggered on each completed/active-flips sync, and the timer is stopped in `shutdown()`.

### Data source note
Sourced entirely from the hardened backend flip data landed under epic #933 (the ticket's original CSV-ledger-rebuild prerequisite was deliberately dropped after the epic #933 reframing — see the reworded AC8/AC9 on issue #1015).

## Testing

### Automated Tests
- ✅ `./gradlew clean build` — BUILD SUCCESSFUL
- ✅ 671 tests, 0 failures, 0 errors (includes 13 new tests across `SessionClockTest` and `SessionStatsTest`)
- ✅ A whole-branch senior code review was already run against this branch and returned READY TO MERGE with no Critical or Important findings.

### Manual Testing
In-game QA is user-driven (RuneLite is not Playwright-drivable); check off after manual verification:

- [ ] Block appears above the Recommended/Active/Completed tabs (AC1/AC2)
- [ ] Session duration ticks while logged in, freezes on logout, resets on RuneLite restart (AC3/AC7)
- [ ] Realised profit + GP/hour update after an in-session flip completes (AC4)
- [ ] Projected GP/hour >= realised when open positions have targets above cost (AC5)
- [ ] Green/red coloring correct for profit and rate values (AC6)
- [ ] Both rates show "—" for the first ~60s of a session

## API Changes

None. Reads only fields already present on `CompletedFlip` / `ActiveFlip` via the existing sync (`currentCompletedFlips` / `currentActiveFlips`). Zero endpoint or schema changes — fully backwards-compatible with old and new clients.

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: None
- [ ] Requires database migration: No

Ships on the plugin-hub release cadence and will batch with the pending epic #933 plugin release. No plugin-hub MR is opened as part of this PR — that's a separate release with its own cooldown, handled later.

## Checklist

- [x] Tests added/updated
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by teammate

### 🩺 Codacy Quality Gate — fixed in this PR
- `269bb2a` PMD_category_java_errorprone_NullAssignment `SessionClock.java:35` — refactored `loginStartMs` from a nullable boxed `Long` to a primitive `long` + `loggedIn` boolean flag, removing the null assignment.
- `23dc17b` PMD_category_java_errorprone_AvoidFieldNameMatchingMethodName `SessionClock.java:12` — renamed the accessor `sessionStartMs()` → `startMs()` to resolve the field/method name collision (matches the existing getter-less `activeMs()` style).
- `5f65a5b` Semgrep_codacy.java.i18n.no-hardcoded-decimal-format `SessionStats.java:93` — added `Locale.ROOT` to the duration `String.format` call.

### 🩺 Codacy Quality Gate — dismissed via API (noise)
- PMD_category_java_errorprone_NullAssignment `FlipFinderPanel.java:1065` — `sessionStatsTimer = null;` follows the exact same null-after-stop idiom already used two lines above for `refreshCountdownTimer` (pre-existing, unflagged) in the same `shutdown()` method. Null is the correct/idiomatic sentinel for an optional Swing `Timer` reference here; flagging only the new line would create an inconsistent pattern within one method.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `269bb2a` `SessionClock.java:35` — eliminated the `loginStartMs` null assignment (primitive + boolean flag).
- `23dc17b` `SessionClock.java:12` — resolved the field/method name collision by renaming the accessor to `startMs()`.
- `5f65a5b` `SessionStats.java:93` — added `Locale.ROOT` to the duration formatter (2 duplicate comments on the same line, both addressed by this commit).
- `46cf7e3` `SessionStats.java:41` (HIGH) — landed the caching design from Flip-Smart/flip-smart#1072 (now closed): `SessionStats.computeBase()` runs the full realised/unrealised-profit scan only on sync (startup + active/completed-flips response); the 1s UI timer calls the new cheap `SessionStats.snapshot()` instead of re-scanning. `SessionStatsTest` (11 cases) confirms numbers are unchanged.
- `46cf7e3` `SessionStats.java:45` (MEDIUM) — superseded by the same commit: the backward-iteration/early-break suggestion (which depended on an unconfirmed backend ordering guarantee) is no longer needed since the full scan doesn't run every tick anymore.

## Related Issues

Closes Flip-Smart/flip-smart#1015


