### PR TITLE
Add collapsible/hide toggle for session stats (profit per hour display)

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -62,6 +62,7 @@ public class FlipFinderPanel extends PluginPanel
 	private static final String CONFIG_KEY_MIN_PROFIT = "minProfit";
 	private static final String CONFIG_KEY_MIN_VOLUME = "minVolume";
 	private static final String CONFIG_KEY_ENABLE_FLIP_ASSISTANT = "enableFlipAssistant";
+	private static final String CONFIG_KEY_SESSION_STATS_COLLAPSED = "sessionStatsCollapsed";
 	private static final String FILTER_TOOLTIP =
 		"Adding a minimum filter may limit the number of results you see.";
 
@@ -558,6 +559,10 @@ public class FlipFinderPanel extends PluginPanel
 		topPanel.add(statusPanel);
 		topPanel.add(overridePanel);
 		topPanel.add(sessionStatsView.getComponent());
+		// Restore the persisted collapsed state, then persist future toggles.
+		sessionStatsView.setCollapsed(config.sessionStatsCollapsed());
+		sessionStatsView.setToggleListener(collapsed ->
+			configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_SESSION_STATS_COLLAPSED, collapsed));
 		updateCashstackOverrideIndicator();
 
 		// Recommended flips list container

--- a/src/main/java/com/flipsmart/FlipSmartConfig.java
+++ b/src/main/java/com/flipsmart/FlipSmartConfig.java
@@ -73,6 +73,20 @@ public interface FlipSmartConfig extends Config
 		return "";
 	}
 
+	// Collapsed state of the session-stats block. Persisted so the choice
+	// survives logout/relaunch; needs @ConfigItem so the config proxy resolves
+	// the default (expanded) instead of returning null on unbox.
+	@ConfigItem(
+		keyName = "sessionStatsCollapsed",
+		name = "",
+		description = "Whether the session stats block is collapsed (do not edit manually)",
+		hidden = true
+	)
+	default boolean sessionStatsCollapsed()
+	{
+		return false;
+	}
+
 	// ============================================
 	// Flip Finder Section
 	// ============================================

--- a/src/main/java/com/flipsmart/session/SessionStatsView.java
+++ b/src/main/java/com/flipsmart/session/SessionStatsView.java
@@ -12,6 +12,7 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Dimension;
+import java.awt.Font;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.function.Consumer;
@@ -33,6 +34,9 @@ public final class SessionStatsView
 	private static final int ROW_HEIGHT = 18;
 	private static final String ARROW_EXPANDED = "▼";
 	private static final String ARROW_COLLAPSED = "▶";
+	// The panel inherits RuneLite's RuneScape pixel font, which lacks the
+	// triangle glyphs; Arial (as the rest of the panel uses) renders them.
+	private static final Font ARROW_FONT = new Font("Arial", Font.PLAIN, 11);
 
 	private final JPanel component = new JPanel();
 	private final JPanel body = new JPanel();
@@ -69,10 +73,11 @@ public final class SessionStatsView
 		header.setMaximumSize(new Dimension(Integer.MAX_VALUE, ROW_HEIGHT));
 		header.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 
-		JLabel title = new JLabel("Session");
+		JLabel title = new JLabel("Session Stats");
 		title.setForeground(Color.LIGHT_GRAY);
 
 		toggleArrow.setForeground(Color.LIGHT_GRAY);
+		toggleArrow.setFont(ARROW_FONT);
 
 		header.add(title, BorderLayout.WEST);
 		header.add(toggleArrow, BorderLayout.EAST);

--- a/src/main/java/com/flipsmart/session/SessionStatsView.java
+++ b/src/main/java/com/flipsmart/session/SessionStatsView.java
@@ -47,7 +47,7 @@ public final class SessionStatsView
 	private final JLabel projectedRateValue = new JLabel();
 
 	private boolean collapsed;
-	private transient Consumer<Boolean> toggleListener;
+	private Consumer<Boolean> toggleListener;
 
 	public SessionStatsView()
 	{

--- a/src/main/java/com/flipsmart/session/SessionStatsView.java
+++ b/src/main/java/com/flipsmart/session/SessionStatsView.java
@@ -10,34 +10,81 @@ import javax.swing.SwingConstants;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Cursor;
 import java.awt.Dimension;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.function.Consumer;
 
 /**
- * The four-line session-performance block above the panel tabs: session profit,
- * session duration, realised GP/hour and projected GP/hour. Presentation only —
- * every figure comes from a {@link SessionStats.Snapshot}.
+ * The session-performance block above the panel tabs: session profit, session
+ * duration, realised GP/hour and projected GP/hour. Presentation only — every
+ * figure comes from a {@link SessionStats.Snapshot}.
+ *
+ * A header row carries a collapse arrow: clicking it hides the four data rows so
+ * users on smaller viewports can reclaim vertical space for the recommendation
+ * list. The collapsed state is applied via {@link #setCollapsed} and reported
+ * through {@link #setToggleListener} so the panel can persist it.
  */
 public final class SessionStatsView
 {
 	private static final Color COLOR_PROFIT_GREEN = new Color(100, 255, 100);
 	private static final Color COLOR_LOSS_RED = new Color(255, 100, 100);
 	private static final int ROW_HEIGHT = 18;
+	private static final String ARROW_EXPANDED = "▼";
+	private static final String ARROW_COLLAPSED = "▶";
 
 	private final JPanel component = new JPanel();
+	private final JPanel body = new JPanel();
+	private final JLabel toggleArrow = new JLabel(ARROW_EXPANDED, SwingConstants.RIGHT);
 	private final JLabel sessionProfitValue = new JLabel();
 	private final JLabel sessionDurationValue = new JLabel();
 	private final JLabel realisedRateValue = new JLabel();
 	private final JLabel projectedRateValue = new JLabel();
+
+	private boolean collapsed;
+	private transient Consumer<Boolean> toggleListener;
 
 	public SessionStatsView()
 	{
 		component.setLayout(new BoxLayout(component, BoxLayout.Y_AXIS));
 		component.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		component.setBorder(BorderFactory.createEmptyBorder(4, 10, 6, 10));
-		component.add(buildRow("Profit this session", sessionProfitValue));
-		component.add(buildRow("Session duration", sessionDurationValue));
-		component.add(buildRow("Realised GP/hour", realisedRateValue));
-		component.add(buildRow("Projected GP/hour", projectedRateValue));
+
+		component.add(buildHeader());
+
+		body.setLayout(new BoxLayout(body, BoxLayout.Y_AXIS));
+		body.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		body.add(buildRow("Profit this session", sessionProfitValue));
+		body.add(buildRow("Session duration", sessionDurationValue));
+		body.add(buildRow("Realised GP/hour", realisedRateValue));
+		body.add(buildRow("Projected GP/hour", projectedRateValue));
+		component.add(body);
+	}
+
+	private JPanel buildHeader()
+	{
+		JPanel header = new JPanel(new BorderLayout());
+		header.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		header.setMaximumSize(new Dimension(Integer.MAX_VALUE, ROW_HEIGHT));
+		header.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+
+		JLabel title = new JLabel("Session");
+		title.setForeground(Color.LIGHT_GRAY);
+
+		toggleArrow.setForeground(Color.LIGHT_GRAY);
+
+		header.add(title, BorderLayout.WEST);
+		header.add(toggleArrow, BorderLayout.EAST);
+		header.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mousePressed(MouseEvent e)
+			{
+				toggle();
+			}
+		});
+		return header;
 	}
 
 	private JPanel buildRow(String label, JLabel valueLabel)
@@ -56,6 +103,42 @@ public final class SessionStatsView
 	public Component getComponent()
 	{
 		return component;
+	}
+
+	public boolean isCollapsed()
+	{
+		return collapsed;
+	}
+
+	/** Notified with the new collapsed state whenever the user clicks the header. */
+	public void setToggleListener(Consumer<Boolean> listener)
+	{
+		this.toggleListener = listener;
+	}
+
+	/** Apply a collapsed state (e.g. restoring a persisted preference) without notifying the listener. */
+	public void setCollapsed(boolean value)
+	{
+		collapsed = value;
+		applyCollapsed();
+	}
+
+	private void toggle()
+	{
+		collapsed = !collapsed;
+		applyCollapsed();
+		if (toggleListener != null)
+		{
+			toggleListener.accept(collapsed);
+		}
+	}
+
+	private void applyCollapsed()
+	{
+		body.setVisible(!collapsed);
+		toggleArrow.setText(collapsed ? ARROW_COLLAPSED : ARROW_EXPANDED);
+		component.revalidate();
+		component.repaint();
 	}
 
 	public void render(SessionStats.Snapshot snapshot)

--- a/src/test/java/com/flipsmart/session/SessionStatsViewTest.java
+++ b/src/test/java/com/flipsmart/session/SessionStatsViewTest.java
@@ -15,7 +15,7 @@ public class SessionStatsViewTest
 	{
 		SessionStatsView view = new SessionStatsView();
 		assertFalse(view.isCollapsed());
-		assertTrue(view.getComponent().isVisible());
+		assertTrue(bodyPanel(view).isVisible());
 	}
 
 	@Test
@@ -45,6 +45,13 @@ public class SessionStatsViewTest
 		clickHeader(view);
 		assertFalse(view.isCollapsed());
 		assertEquals(Boolean.FALSE, notified.get());
+	}
+
+	/** The body panel is the root container's second child, after the header. */
+	private static java.awt.Component bodyPanel(SessionStatsView view)
+	{
+		java.awt.Container root = (java.awt.Container) view.getComponent();
+		return root.getComponent(1);
 	}
 
 	/** Drive the header's mouse listener the way a user click would. */

--- a/src/test/java/com/flipsmart/session/SessionStatsViewTest.java
+++ b/src/test/java/com/flipsmart/session/SessionStatsViewTest.java
@@ -1,0 +1,64 @@
+package com.flipsmart.session;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+public class SessionStatsViewTest
+{
+	@Test
+	public void defaultsToExpanded()
+	{
+		SessionStatsView view = new SessionStatsView();
+		assertFalse(view.isCollapsed());
+		assertTrue(view.getComponent().isVisible());
+	}
+
+	@Test
+	public void restoringCollapsedStateDoesNotNotifyListener()
+	{
+		SessionStatsView view = new SessionStatsView();
+		AtomicReference<Boolean> notified = new AtomicReference<>(null);
+		view.setToggleListener(notified::set);
+
+		view.setCollapsed(true);
+
+		assertTrue(view.isCollapsed());
+		assertNull("programmatic restore must not fire the persist callback", notified.get());
+	}
+
+	@Test
+	public void toggleFlipsStateAndReportsIt()
+	{
+		SessionStatsView view = new SessionStatsView();
+		AtomicReference<Boolean> notified = new AtomicReference<>(null);
+		view.setToggleListener(notified::set);
+
+		clickHeader(view);
+		assertTrue(view.isCollapsed());
+		assertEquals(Boolean.TRUE, notified.get());
+
+		clickHeader(view);
+		assertFalse(view.isCollapsed());
+		assertEquals(Boolean.FALSE, notified.get());
+	}
+
+	/** Drive the header's mouse listener the way a user click would. */
+	private static void clickHeader(SessionStatsView view)
+	{
+		java.awt.Container root = (java.awt.Container) view.getComponent();
+		java.awt.Component header = root.getComponent(0);
+		java.awt.event.MouseListener[] listeners =
+			((javax.swing.JComponent) header).getMouseListeners();
+		java.awt.event.MouseEvent press = new java.awt.event.MouseEvent(
+			header, java.awt.event.MouseEvent.MOUSE_PRESSED, 0L, 0, 1, 1, 1, false);
+		for (java.awt.event.MouseListener listener : listeners)
+		{
+			listener.mousePressed(press);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a collapse/expand toggle to the session-performance block at the top of the FlipSmart panel, so players can hide the four session-stat rows (profit, duration, realised GP/hour, projected GP/hour) to reclaim vertical space for the recommendation list. The choice persists across logout/relaunch via a hidden RuneLite config item and defaults to expanded for new users.

## Changes

### ✨ New Features
- Clickable header row with a collapse arrow (▼ expanded / ▶ collapsed) added to the top of the session-stats block.
- Clicking the header hides/shows the four data rows (Profit this session, Session duration, Realised GP/hour, Projected GP/hour), which now live in a hideable `body` panel.
- `SessionStatsView` gains `setCollapsed(boolean)` (applies state without notifying, used for restoring persisted state), `isCollapsed()`, and `setToggleListener(Consumer<Boolean>)` (fires only on a genuine user click, used for persisting new state).
- `FlipFinderPanel` restores the persisted collapsed state on panel build and writes future toggles back via `configManager.setConfiguration`.
- New hidden `sessionStatsCollapsed` config item on `FlipSmartConfig` (default `false` = expanded) backs the persistence.

### ✅ Tests
- New `SessionStatsViewTest`: verifies the view defaults to expanded, that a programmatic `setCollapsed` restore does not fire the persist callback, and that a user click toggles the state and reports it through the listener.

## Testing

### Automated Tests
- `./gradlew clean build` — green locally (compile, checkstyle `:check`, and full test suite all pass).

### Manual Testing
- [ ] Open the FlipSmart panel while logged in — session stats block shows expanded with a ▼ arrow top-right.
- [ ] Click the arrow/header — the four rows collapse, arrow becomes ▶, vertical space is reclaimed.
- [ ] Click again — rows expand, arrow back to ▼.
- [ ] Collapse it, then log out and back in (or restart RuneLite) — block stays collapsed.
- [ ] Fresh config (or new user) — block starts expanded.

## Acceptance Criteria (Flip-Smart/flip-smart#1082)

- [x] AC1: drop-down arrow at top-right of the session stats section
- [x] AC2: clicking collapses the section
- [x] AC3: clicking again expands the section
- [x] AC4: state persists across sessions (logout/relaunch)
- [x] AC5: defaults to expanded for new users

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: New hidden config item `sessionStatsCollapsed` on the `flipsmart` config group (default `false`); no migration needed, existing users simply get the default on first load.
- [ ] Requires database migration: No

## Checklist

- [x] Tests added/updated
- [x] Code follows style guidelines (checkstyle passes)
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by teammate

## Related Issues

Closes Flip-Smart/flip-smart#1082


### 🩺 Codacy Quality Gate — fixed in this PR
- `4a74894` unnecessary-transient `src/main/java/com/flipsmart/session/SessionStatsView.java:50` — dropped the no-op `transient` keyword on `toggleListener` (class isn't `Serializable`).
- `51acbb6` assert-body-visibility `src/test/java/com/flipsmart/session/SessionStatsViewTest.java:18` — `defaultsToExpanded` now asserts the body panel's visibility instead of the always-visible root component.

Gate re-verified green at `51acbb6` (0 new quality-gate issues).

### 🤖 Codacy AI Reviewer — fixed in this PR
- `4a74894` `SessionStatsView.java:50` — removed unnecessary `transient` keyword.
- `51acbb6` `SessionStatsViewTest.java:18` — test now checks body-panel visibility, not the root component.

Both threads replied-to and marked resolved.

