### PR TITLE
feat: Favorite Items plugin — Phase 2 (#1041)

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -770,6 +770,7 @@ public class FlipFinderPanel extends PluginPanel
 			}
 			else if (selectedIndex == TAB_FAVORITES)
 			{
+				updateFavoritesStatusLabel();
 				refreshFavoritesTab();
 			}
 		});
@@ -2571,6 +2572,14 @@ public class FlipFinderPanel extends PluginPanel
 		updateFavoritesPaginationControls(pages);
 		favoritesListContainer.revalidate();
 		favoritesListContainer.repaint();
+		updateFavoritesStatusLabel();
+	}
+
+	/** Update the footer status label with the current favorites count. */
+	private void updateFavoritesStatusLabel()
+	{
+		int count = currentFavorites.size();
+		statusLabel.setText(count == 1 ? "1 favorite" : count + " favorites");
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3268,16 +3268,7 @@ public class FlipFinderPanel extends PluginPanel
 		{
 			if (!Boolean.TRUE.equals(success))
 			{
-				// Roll back the optimistic change on failure.
-				if (wasFavorite)
-				{
-					favoriteItemIds.add(itemId);
-				}
-				else
-				{
-					favoriteItemIds.remove(itemId);
-				}
-				updateStarLabel(starLabel, itemId);
+				rollbackFavoriteToggle(wasFavorite, itemId, starLabel);
 			}
 			else if (tabbedPane.getSelectedIndex() == TAB_FAVORITES)
 			{
@@ -3286,20 +3277,23 @@ public class FlipFinderPanel extends PluginPanel
 		})).exceptionally(ex ->
 		{
 			log.warn("Favorite toggle failed for item {}", itemId, ex);
-			SwingUtilities.invokeLater(() ->
-			{
-				if (wasFavorite)
-				{
-					favoriteItemIds.add(itemId);
-				}
-				else
-				{
-					favoriteItemIds.remove(itemId);
-				}
-				updateStarLabel(starLabel, itemId);
-			});
+			SwingUtilities.invokeLater(() -> rollbackFavoriteToggle(wasFavorite, itemId, starLabel));
 			return null;
 		});
+	}
+
+	/** Undo the optimistic favorite-toggle flip after a failed add/remove call. */
+	private void rollbackFavoriteToggle(boolean wasFavorite, int itemId, JLabel starLabel)
+	{
+		if (wasFavorite)
+		{
+			favoriteItemIds.add(itemId);
+		}
+		else
+		{
+			favoriteItemIds.remove(itemId);
+		}
+		updateStarLabel(starLabel, itemId);
 	}
 
 	private void updateStarLabel(JLabel starLabel, int itemId)

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -20,9 +20,11 @@ import com.flipsmart.recommend.SmartSellPricer;
 import com.flipsmart.trading.ActiveFlipCardMetrics;
 import com.flipsmart.trading.RealizedFlipProfit;
 import com.flipsmart.ui.panel.CardWidgets;
+import com.flipsmart.ui.panel.FavoritesSort;
 import com.flipsmart.ui.panel.ItemNameFit;
 import com.flipsmart.ui.panel.LoginPanel;
 import com.flipsmart.ui.panel.PanelFormat;
+import com.flipsmart.ui.panel.Paginator;
 import com.flipsmart.session.SessionClock;
 import com.flipsmart.session.SessionStats;
 import com.flipsmart.session.SessionStatsView;
@@ -61,6 +63,8 @@ public class FlipFinderPanel extends PluginPanel
 	private static final String CONFIG_KEY_FLIP_STYLE = "flipStyle";
 	private static final String CONFIG_KEY_FLIP_TIMEFRAME = "flipTimeframe";
 	private static final String CONFIG_KEY_COMPLETED_SORT = "completedSort";
+	private static final String CONFIG_KEY_FAVORITES_SORT = "favoritesSort";
+	private static final int FAVORITES_PAGE_SIZE = 10;
 	private static final String CONFIG_KEY_MIN_PROFIT = "minProfit";
 	private static final String CONFIG_KEY_MIN_VOLUME = "minVolume";
 	private static final String CONFIG_KEY_ENABLE_FLIP_ASSISTANT = "enableFlipAssistant";
@@ -195,6 +199,15 @@ public class FlipFinderPanel extends PluginPanel
 	private CompletedSort completedSort = CompletedSort.RECENCY;
 	private final java.util.Map<CompletedSort, JLabel> completedSortTabs = new java.util.EnumMap<>(CompletedSort.class);
 
+	// Favorites tab sort + pagination controls
+	private FavoritesSort favoritesSort = FavoritesSort.PROFIT;
+	private int favoritesPage = 0;
+	private final java.util.Map<FavoritesSort, JLabel> favoritesSortTabs = new java.util.EnumMap<>(FavoritesSort.class);
+	private JLabel favoritesPageLabel;
+	private JLabel favoritesPrevPageLabel;
+	private JLabel favoritesNextPageLabel;
+	private JPanel favoritesPaginationRow;
+
 	// Login / auth subsystem (UI construction, credential + device-auth flow)
 	private transient LoginPanel loginPanel;
 	private JPanel mainPanel;
@@ -253,6 +266,9 @@ public class FlipFinderPanel extends PluginPanel
 
 		// Restore the persisted Completed-tab sort (defaults to Recency)
 		this.completedSort = loadCompletedSort();
+
+		// Restore the persisted Favorites-tab sort (defaults to Profit)
+		this.favoritesSort = loadFavoritesSort();
 
 		// Initialize flip style dropdown so it's available for both panels
 		flipStyleDropdown = new JComboBox<>(FlipSmartConfig.FlipStyle.values());
@@ -675,7 +691,9 @@ public class FlipFinderPanel extends PluginPanel
 		// BorderLayout leaves room for a sort row (NORTH) and pagination (SOUTH) around the list
 		JPanel favoritesTabPanel = new JPanel(new BorderLayout());
 		favoritesTabPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		favoritesTabPanel.add(buildFavoritesSortRow(), BorderLayout.NORTH);
 		favoritesTabPanel.add(favoritesScrollPane, BorderLayout.CENTER);
+		favoritesTabPanel.add(buildFavoritesPaginationRow(), BorderLayout.SOUTH);
 		tabbedPane.addTab("Favorites", favoritesTabPanel);
 
 		tabbedPane.addTab("Active Flips", activeFlipsScrollPane);
@@ -2499,21 +2517,183 @@ public class FlipFinderPanel extends PluginPanel
 	private void populateFavorites()
 	{
 		favoritesListContainer.removeAll();
-		if (currentFavorites.isEmpty())
+		List<FavoriteItem> sorted = new ArrayList<>(currentFavorites);
+		sorted.sort(favoritesSort.comparator());
+		int pages = Paginator.pageCount(sorted.size(), FAVORITES_PAGE_SIZE);
+		if (favoritesPage > pages - 1)
+		{
+			favoritesPage = pages - 1;
+		}
+		if (favoritesPage < 0)
+		{
+			favoritesPage = 0;
+		}
+		List<FavoriteItem> visible = Paginator.page(sorted, favoritesPage, FAVORITES_PAGE_SIZE);
+		if (visible.isEmpty())
 		{
 			favoritesListContainer.add(CardWidgets.createStyledLabel("No favorites yet. Tap the star on any item.",
 				ColorScheme.LIGHT_GRAY_COLOR));
 		}
 		else
 		{
-			for (FavoriteItem item : currentFavorites)
+			for (FavoriteItem item : visible)
 			{
 				favoritesListContainer.add(createFavoriteCard(item));
 				favoritesListContainer.add(Box.createRigidArea(new Dimension(0, 4)));
 			}
 		}
+		updateFavoritesPaginationControls(pages);
 		favoritesListContainer.revalidate();
 		favoritesListContainer.repaint();
+	}
+
+	/**
+	 * Build the sort row shown above the Favorites list, mirroring the Completed-tab
+	 * sort idiom: tab-style labels, one per {@link FavoritesSort}.
+	 */
+	private JPanel buildFavoritesSortRow()
+	{
+		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 4));
+		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		row.setBorder(new EmptyBorder(0, 4, 0, 0));
+
+		JLabel sortByLabel = new JLabel("Sort:");
+		sortByLabel.setForeground(COLOR_TEXT_DIM_GRAY);
+		sortByLabel.setFont(new Font(FONT_ARIAL, Font.ITALIC, 10));
+		row.add(sortByLabel);
+
+		Font tabFont = new Font(FONT_ARIAL, Font.BOLD, 11);
+		EmptyBorder tabBorder = new EmptyBorder(2, 7, 2, 7);
+		Cursor handCursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR);
+		for (FavoritesSort sort : FavoritesSort.values())
+		{
+			JLabel tab = new JLabel(sort.getLabel());
+			tab.setFont(tabFont);
+			tab.setBorder(tabBorder);
+			tab.setCursor(handCursor);
+			tab.setOpaque(true);
+			tab.addMouseListener(new MouseAdapter()
+			{
+				@Override
+				public void mouseClicked(MouseEvent e)
+				{
+					selectFavoritesSort(sort);
+				}
+			});
+			favoritesSortTabs.put(sort, tab);
+			row.add(tab);
+		}
+
+		applyFavoritesSortTabStyles();
+		return row;
+	}
+
+	/** Persist the chosen sort, reset to page 0, restyle the tabs, and re-render the list. */
+	private void selectFavoritesSort(FavoritesSort sort)
+	{
+		if (sort == favoritesSort)
+		{
+			return;
+		}
+		favoritesSort = sort;
+		favoritesPage = 0;
+		configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_FAVORITES_SORT, sort.name());
+		applyFavoritesSortTabStyles();
+		populateFavorites();
+	}
+
+	/** Highlight the active sort tab (orange) and dim the others. */
+	private void applyFavoritesSortTabStyles()
+	{
+		for (java.util.Map.Entry<FavoritesSort, JLabel> entry : favoritesSortTabs.entrySet())
+		{
+			boolean selected = entry.getKey() == favoritesSort;
+			JLabel tab = entry.getValue();
+			tab.setForeground(selected ? Color.WHITE : COLOR_TEXT_DIM_GRAY);
+			tab.setBackground(selected ? ColorScheme.BRAND_ORANGE : ColorScheme.DARK_GRAY_COLOR);
+		}
+	}
+
+	/** Read the persisted Favorites-tab sort, defaulting to Profit. */
+	private FavoritesSort loadFavoritesSort()
+	{
+		String saved = configManager.getConfiguration(CONFIG_GROUP, CONFIG_KEY_FAVORITES_SORT);
+		if (saved != null)
+		{
+			try
+			{
+				return FavoritesSort.valueOf(saved);
+			}
+			catch (IllegalArgumentException ignored)
+			{
+				// Unknown/legacy value — fall through to the default.
+			}
+		}
+		return FavoritesSort.PROFIT;
+	}
+
+	/** Build the prev/page-label/next pagination row shown below the Favorites list. */
+	private JPanel buildFavoritesPaginationRow()
+	{
+		favoritesPaginationRow = new JPanel(new FlowLayout(FlowLayout.CENTER, 8, 4));
+		favoritesPaginationRow.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+		Font navFont = new Font(FONT_ARIAL, Font.BOLD, 12);
+		Cursor handCursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR);
+
+		favoritesPrevPageLabel = new JLabel("<");
+		favoritesPrevPageLabel.setFont(navFont);
+		favoritesPrevPageLabel.setForeground(Color.WHITE);
+		favoritesPrevPageLabel.setCursor(handCursor);
+		favoritesPrevPageLabel.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(MouseEvent e)
+			{
+				if (favoritesPage > 0)
+				{
+					favoritesPage--;
+					populateFavorites();
+				}
+			}
+		});
+
+		favoritesPageLabel = new JLabel("Page 1/1");
+		favoritesPageLabel.setFont(new Font(FONT_ARIAL, Font.PLAIN, 11));
+		favoritesPageLabel.setForeground(COLOR_TEXT_DIM_GRAY);
+
+		favoritesNextPageLabel = new JLabel(">");
+		favoritesNextPageLabel.setFont(navFont);
+		favoritesNextPageLabel.setForeground(Color.WHITE);
+		favoritesNextPageLabel.setCursor(handCursor);
+		favoritesNextPageLabel.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(MouseEvent e)
+			{
+				int pages = Paginator.pageCount(currentFavorites.size(), FAVORITES_PAGE_SIZE);
+				if (favoritesPage < pages - 1)
+				{
+					favoritesPage++;
+					populateFavorites();
+				}
+			}
+		});
+
+		favoritesPaginationRow.add(favoritesPrevPageLabel);
+		favoritesPaginationRow.add(favoritesPageLabel);
+		favoritesPaginationRow.add(favoritesNextPageLabel);
+		favoritesPaginationRow.setVisible(false);
+		return favoritesPaginationRow;
+	}
+
+	/** Update the "Page x/y" text, enable/disable prev/next, and hide the row for a single page. */
+	private void updateFavoritesPaginationControls(int pages)
+	{
+		favoritesPageLabel.setText("Page " + (favoritesPage + 1) + "/" + pages);
+		favoritesPrevPageLabel.setForeground(favoritesPage > 0 ? Color.WHITE : COLOR_TEXT_DIM_GRAY);
+		favoritesNextPageLabel.setForeground(favoritesPage < pages - 1 ? Color.WHITE : COLOR_TEXT_DIM_GRAY);
+		favoritesPaginationRow.setVisible(pages > 1);
 	}
 
 	private JPanel createFavoriteCard(FavoriteItem item)

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1223,7 +1223,7 @@ public class FlipFinderPanel extends PluginPanel
 
 		final boolean applyRecs = applyRecommendations;
 		apiClient.getPluginSyncAsync(cashStack, getInventoryGp(), flipStyle, limit, randomSeed, timeframe, rsn,
-			filledSlots, plugin.isMembersWorld()).thenAccept(sync ->
+			filledSlots, plugin.isMembersWorld(), false).thenAccept(sync ->
 		{
 			if (sync == null)
 			{
@@ -1496,7 +1496,7 @@ public class FlipFinderPanel extends PluginPanel
 		Integer filledSlots = getFilledSlots();
 
 		// Use unified /flip-finder endpoint with all parameters
-		apiClient.getFlipRecommendationsAsync(cashStack, flipStyle, limit, randomSeed, timeframe, rsn, filledSlots, plugin.isMembersWorld()).thenAccept(response ->
+		apiClient.getFlipRecommendationsAsync(cashStack, flipStyle, limit, randomSeed, timeframe, rsn, filledSlots, plugin.isMembersWorld(), false).thenAccept(response ->
 		{
 			handleRecommendationsResponse(response, scrollPos);
 		}).exceptionally(throwable ->

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -120,6 +120,9 @@ public class FlipFinderPanel extends PluginPanel
 	private static final Color COLOR_AUTO_RECOMMEND_BG = new Color(70, 55, 20);
 	private static final Color COLOR_AUTO_RECOMMEND_ACTIVE = new Color(200, 150, 0);
 
+	private static final Color STAR_ON_COLOR = new Color(255, 175, 45);
+	private static final Color STAR_OFF_COLOR = new Color(120, 120, 120);
+
 	// Yellow used for the completed-flip anomaly badge (HTML label markup).
 	private static final String COLOR_ANOMALY_HEX = "#FFCC33";
 	private static final int BADGE_SECOND_LINE_HEIGHT = 18;
@@ -226,6 +229,10 @@ public class FlipFinderPanel extends PluginPanel
 	private final java.util.concurrent.CopyOnWriteArrayList<BlocklistSummary> cachedBlocklists = new java.util.concurrent.CopyOnWriteArrayList<>();
 	private volatile long blocklistCacheTimestamp = 0;
 	private static final long BLOCKLIST_CACHE_TTL_MS = 5L * 60 * 1000; // 5 minutes
+
+	// Favorited item ids, hydrated from the sync payload. Card rebuilds are full removeAll(),
+	// so star fill is read from here at build time rather than stored on the widget.
+	private final java.util.Set<Integer> favoriteItemIds = new java.util.concurrent.CopyOnWriteArraySet<>();
 
 	public FlipFinderPanel(FlipSmartConfig config, FlipSmartApiClient apiClient, ItemManager itemManager, FlipSmartPlugin plugin, ConfigManager configManager)
 	{
@@ -1230,6 +1237,7 @@ public class FlipFinderPanel extends PluginPanel
 				showBundleError(applyRecs, recScrollPos, activeScrollPos, completedScrollPos, null);
 				return;
 			}
+			applyFavoriteItemIds(sync.getFavoriteItemIds());
 			// Each apply method hops to the EDT internally and null-skips a missing
 			// sub-payload, leaving that section's prior state untouched.
 			if (applyRecs)
@@ -2709,6 +2717,7 @@ public class FlipFinderPanel extends PluginPanel
 		JPanel iconsPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 1, 0));
 		iconsPanel.setOpaque(false);
 
+		iconsPanel.add(createStarIconLabel(itemId));
 		iconsPanel.add(createBlockIconLabel(itemId, itemName));
 		iconsPanel.add(createChartIconLabel(itemId));
 
@@ -2843,6 +2852,105 @@ public class FlipFinderPanel extends PluginPanel
 	 * Create a clickable block icon label that adds the item to a blocklist.
 	 * Uses a ban/circle-slash icon drawn with Java 2D graphics.
 	 */
+	public static boolean isFavorite(java.util.Set<Integer> favorites, int itemId)
+	{
+		return favorites != null && favorites.contains(itemId);
+	}
+
+	private void applyFavoriteItemIds(java.util.List<Integer> ids)
+	{
+		SwingUtilities.invokeLater(() ->
+		{
+			favoriteItemIds.clear();
+			if (ids != null)
+			{
+				favoriteItemIds.addAll(ids);
+			}
+		});
+	}
+
+	private JLabel createStarIconLabel(int itemId)
+	{
+		boolean filled = isFavorite(favoriteItemIds, itemId);
+		JLabel star = new JLabel(new ImageIcon(
+			PanelFormat.drawStarIcon(filled, filled ? STAR_ON_COLOR : STAR_OFF_COLOR)));
+		star.setCursor(new Cursor(Cursor.HAND_CURSOR));
+		star.setToolTipText(filled ? "Remove from favorites" : "Add to favorites");
+		star.setOpaque(false);
+		star.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(MouseEvent e)
+			{
+				e.consume();
+				handleStarClick(itemId, star);
+			}
+		});
+		return star;
+	}
+
+	private void handleStarClick(int itemId, JLabel starLabel)
+	{
+		boolean wasFavorite = isFavorite(favoriteItemIds, itemId);
+		// Optimistic flip of local state + icon.
+		if (wasFavorite)
+		{
+			favoriteItemIds.remove(itemId);
+		}
+		else
+		{
+			favoriteItemIds.add(itemId);
+		}
+		updateStarLabel(starLabel, itemId);
+
+		java.util.concurrent.CompletableFuture<Boolean> call = wasFavorite
+			? apiClient.removeFavoriteAsync(itemId)
+			: apiClient.addFavoriteAsync(itemId);
+
+		call.thenAccept(success -> SwingUtilities.invokeLater(() ->
+		{
+			if (!Boolean.TRUE.equals(success))
+			{
+				// Roll back the optimistic change on failure.
+				if (wasFavorite)
+				{
+					favoriteItemIds.add(itemId);
+				}
+				else
+				{
+					favoriteItemIds.remove(itemId);
+				}
+				updateStarLabel(starLabel, itemId);
+			}
+			// Task 4 adds an else-branch here to refresh the Favorites tab when it is
+			// the selected tab; TAB_FAVORITES / refreshFavoritesTab() do not exist yet.
+		})).exceptionally(ex ->
+		{
+			log.warn("Favorite toggle failed for item {}", itemId, ex);
+			SwingUtilities.invokeLater(() ->
+			{
+				if (wasFavorite)
+				{
+					favoriteItemIds.add(itemId);
+				}
+				else
+				{
+					favoriteItemIds.remove(itemId);
+				}
+				updateStarLabel(starLabel, itemId);
+			});
+			return null;
+		});
+	}
+
+	private void updateStarLabel(JLabel starLabel, int itemId)
+	{
+		boolean filled = isFavorite(favoriteItemIds, itemId);
+		starLabel.setIcon(new ImageIcon(
+			PanelFormat.drawStarIcon(filled, filled ? STAR_ON_COLOR : STAR_OFF_COLOR)));
+		starLabel.setToolTipText(filled ? "Remove from favorites" : "Add to favorites");
+	}
+
 	private JLabel createBlockIconLabel(int itemId, String itemName)
 	{
 		java.awt.image.BufferedImage blockIcon = PanelFormat.drawBlockIcon(new Color(180, 100, 100));

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -64,6 +64,7 @@ public class FlipFinderPanel extends PluginPanel
 	private static final String CONFIG_KEY_FLIP_TIMEFRAME = "flipTimeframe";
 	private static final String CONFIG_KEY_COMPLETED_SORT = "completedSort";
 	private static final String CONFIG_KEY_FAVORITES_SORT = "favoritesSort";
+	private static final String CONFIG_KEY_FLIP_ONLY_FAVORITES = "flipOnlyFavorites";
 	private static final int FAVORITES_PAGE_SIZE = 10;
 	private static final String CONFIG_KEY_MIN_PROFIT = "minProfit";
 	private static final String CONFIG_KEY_MIN_VOLUME = "minVolume";
@@ -208,6 +209,10 @@ public class FlipFinderPanel extends PluginPanel
 	private JLabel favoritesNextPageLabel;
 	private JPanel favoritesPaginationRow;
 
+	// Premium-gated "flip only from favorites" toggle
+	private boolean flipOnlyFavorites;
+	private JCheckBox flipOnlyFavoritesCheck;
+
 	// Login / auth subsystem (UI construction, credential + device-auth flow)
 	private transient LoginPanel loginPanel;
 	private JPanel mainPanel;
@@ -269,6 +274,9 @@ public class FlipFinderPanel extends PluginPanel
 
 		// Restore the persisted Favorites-tab sort (defaults to Profit)
 		this.favoritesSort = loadFavoritesSort();
+
+		// Restore the persisted "flip only from favorites" toggle
+		this.flipOnlyFavorites = loadFlipOnlyFavorites();
 
 		// Initialize flip style dropdown so it's available for both panels
 		flipStyleDropdown = new JComboBox<>(FlipSmartConfig.FlipStyle.values());
@@ -688,10 +696,17 @@ public class FlipFinderPanel extends PluginPanel
 		
 		tabbedPane.addTab("Recommended", recommendedScrollPane);
 
-		// BorderLayout leaves room for a sort row (NORTH) and pagination (SOUTH) around the list
+		// BorderLayout leaves room for a header (sort row + flip-only-favorites toggle, NORTH)
+		// and pagination (SOUTH) around the list
+		JPanel favoritesHeaderPanel = new JPanel();
+		favoritesHeaderPanel.setLayout(new BoxLayout(favoritesHeaderPanel, BoxLayout.Y_AXIS));
+		favoritesHeaderPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		favoritesHeaderPanel.add(buildFavoritesSortRow());
+		favoritesHeaderPanel.add(buildFlipOnlyFavoritesRow());
+
 		JPanel favoritesTabPanel = new JPanel(new BorderLayout());
 		favoritesTabPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
-		favoritesTabPanel.add(buildFavoritesSortRow(), BorderLayout.NORTH);
+		favoritesTabPanel.add(favoritesHeaderPanel, BorderLayout.NORTH);
 		favoritesTabPanel.add(favoritesScrollPane, BorderLayout.CENTER);
 		favoritesTabPanel.add(buildFavoritesPaginationRow(), BorderLayout.SOUTH);
 		tabbedPane.addTab("Favorites", favoritesTabPanel);
@@ -1207,6 +1222,15 @@ public class FlipFinderPanel extends PluginPanel
 			subscribeLabel.setText(SUBSCRIBE_MESSAGE);
 			subscribeLabel.setVisible(!apiClient.isPremium());
 		}
+
+		// A lapsed subscription should drop the checkbox back to unselected (and persist that)
+		// rather than leaving it checked while the resolved flag silently stops applying.
+		if (flipOnlyFavoritesCheck != null && flipOnlyFavoritesCheck.isSelected() && !apiClient.isPremium())
+		{
+			flipOnlyFavoritesCheck.setSelected(false);
+			flipOnlyFavorites = false;
+			configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_FLIP_ONLY_FAVORITES, flipOnlyFavorites);
+		}
 	}
 
 	/**
@@ -1278,8 +1302,9 @@ public class FlipFinderPanel extends PluginPanel
 		Integer filledSlots = getFilledSlots();
 
 		final boolean applyRecs = applyRecommendations;
+		boolean favoritesOnly = resolveFavoritesOnly(flipOnlyFavorites, plugin.isPremium());
 		apiClient.getPluginSyncAsync(cashStack, getInventoryGp(), flipStyle, limit, randomSeed, timeframe, rsn,
-			filledSlots, plugin.isMembersWorld(), false).thenAccept(sync ->
+			filledSlots, plugin.isMembersWorld(), favoritesOnly).thenAccept(sync ->
 		{
 			if (sync == null)
 			{
@@ -1553,7 +1578,8 @@ public class FlipFinderPanel extends PluginPanel
 		Integer filledSlots = getFilledSlots();
 
 		// Use unified /flip-finder endpoint with all parameters
-		apiClient.getFlipRecommendationsAsync(cashStack, flipStyle, limit, randomSeed, timeframe, rsn, filledSlots, plugin.isMembersWorld(), false).thenAccept(response ->
+		boolean favoritesOnly = resolveFavoritesOnly(flipOnlyFavorites, plugin.isPremium());
+		apiClient.getFlipRecommendationsAsync(cashStack, flipStyle, limit, randomSeed, timeframe, rsn, filledSlots, plugin.isMembersWorld(), favoritesOnly).thenAccept(response ->
 		{
 			handleRecommendationsResponse(response, scrollPos);
 		}).exceptionally(throwable ->
@@ -2630,6 +2656,60 @@ public class FlipFinderPanel extends PluginPanel
 			}
 		}
 		return FavoritesSort.PROFIT;
+	}
+
+	/**
+	 * Whether the recommendation feed should be restricted to favorited items. Free tier
+	 * never sends {@code favorites_only=true} to the API regardless of the local toggle state.
+	 */
+	public static boolean resolveFavoritesOnly(boolean toggleOn, boolean premium)
+	{
+		return toggleOn && premium;
+	}
+
+	/** Read the persisted "flip only from favorites" toggle, defaulting to off. */
+	private boolean loadFlipOnlyFavorites()
+	{
+		return Boolean.parseBoolean(configManager.getConfiguration(CONFIG_GROUP, CONFIG_KEY_FLIP_ONLY_FAVORITES));
+	}
+
+	/** Build the row holding the premium-gated "Flip only from favorites" checkbox. */
+	private JPanel buildFlipOnlyFavoritesRow()
+	{
+		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
+		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		row.setBorder(new EmptyBorder(0, 4, 4, 0));
+		row.add(buildFlipOnlyFavoritesCheck());
+		return row;
+	}
+
+	/** Build the "Flip only from favorites" checkbox, enforcing the premium gate (AC11). */
+	private JCheckBox buildFlipOnlyFavoritesCheck()
+	{
+		flipOnlyFavoritesCheck = new JCheckBox("Flip only from favorites");
+		flipOnlyFavoritesCheck.setSelected(flipOnlyFavorites);
+		flipOnlyFavoritesCheck.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		flipOnlyFavoritesCheck.setForeground(Color.LIGHT_GRAY);
+		flipOnlyFavoritesCheck.addActionListener(e ->
+		{
+			if (flipOnlyFavoritesCheck.isSelected() && !plugin.isPremium())
+			{
+				flipOnlyFavoritesCheck.setSelected(false);
+				showPremiumRequiredForFavoritesOnly();
+				return;
+			}
+			flipOnlyFavorites = flipOnlyFavoritesCheck.isSelected();
+			configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_FLIP_ONLY_FAVORITES, flipOnlyFavorites);
+			refresh(false);
+		});
+		return flipOnlyFavoritesCheck;
+	}
+
+	/** Short transient premium nudge for a blocked flip-only-favorites toggle attempt. */
+	private void showPremiumRequiredForFavoritesOnly()
+	{
+		subscribeLabel.setText("Flip only from favorites is a Premium feature.");
+		subscribeLabel.setVisible(true);
 	}
 
 	/** Build the prev/page-label/next pagination row shown below the Favorites list. */

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2537,6 +2537,8 @@ public class FlipFinderPanel extends PluginPanel
 		})).exceptionally(ex ->
 		{
 			log.warn("Failed to load favorites", ex);
+			SwingUtilities.invokeLater(() ->
+				showErrorInContainer(favoritesListContainer, "Favorites", "Failed to load favorites. Please try again."));
 			return null;
 		});
 	}

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3,6 +3,8 @@ import com.flipsmart.domain.flip.CompletedFlip;
 import com.flipsmart.domain.flip.FlipRecommendation;
 import com.flipsmart.api.dto.ActiveFlipsResponse;
 import com.flipsmart.api.dto.CompletedFlipsResponse;
+import com.flipsmart.api.dto.FavoriteItem;
+import com.flipsmart.api.dto.FavoritesResponse;
 import com.flipsmart.api.dto.FlipFinderResponse;
 import com.flipsmart.api.dto.FlipStatisticsResponse;
 import com.flipsmart.api.dto.PluginSyncResponse;
@@ -155,13 +157,17 @@ public class FlipFinderPanel extends PluginPanel
 	private static final Font FONT_BOLD_16 = new Font(FONT_ARIAL, Font.BOLD, 16);
 
 	private static final int ACTIVE_FLIPS_PRICE_REFRESH_MS = 60_000;
-	private static final int TAB_ACTIVE_FLIPS = 1;
+	static final int TAB_RECOMMENDED = 0;
+	static final int TAB_FAVORITES = 1;
+	static final int TAB_ACTIVE_FLIPS = 2;
+	static final int TAB_COMPLETED = 3;
 
 	private final transient FlipSmartConfig config;
 	private final transient FlipSmartApiClient apiClient;
 	private final transient ItemManager itemManager;
 	private final transient ConfigManager configManager;
 	private final JPanel recommendedListContainer = new JPanel();
+	private final JPanel favoritesListContainer = new JPanel();
 	private final JPanel activeFlipsListContainer = new JPanel();
 	private final JPanel completedFlipsListContainer = new JPanel();
 	private final JLabel statusLabel = new JLabel("Loading...");
@@ -169,6 +175,7 @@ public class FlipFinderPanel extends PluginPanel
 	private final JComboBox<FlipSmartConfig.FlipStyle> flipStyleDropdown;
 	private final JComboBox<FlipSmartConfig.FlipTimeframe> flipTimeframeDropdown;
 	private final List<FlipRecommendation> currentRecommendations = new ArrayList<>();
+	private final List<FavoriteItem> currentFavorites = new ArrayList<>();
 	private final List<ActiveFlip> currentActiveFlips = new ArrayList<>();
 	private final List<CompletedFlip> currentCompletedFlips = new ArrayList<>();
 	private final JTabbedPane tabbedPane = new JTabbedPane();
@@ -180,6 +187,7 @@ public class FlipFinderPanel extends PluginPanel
 	
 	// Scroll panes for preserving scroll position during refresh
 	private JScrollPane recommendedScrollPane;
+	private JScrollPane favoritesScrollPane;
 	private JScrollPane activeFlipsScrollPane;
 	private JScrollPane completedFlipsScrollPane;
 
@@ -584,6 +592,18 @@ public class FlipFinderPanel extends PluginPanel
 		// Always show scrollbar so layout always accounts for it
 		recommendedScrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
 
+		// Favorites list container
+		favoritesListContainer.setLayout(new BoxLayout(favoritesListContainer, BoxLayout.Y_AXIS));
+		favoritesListContainer.setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		favoritesScrollPane = new JScrollPane(favoritesListContainer);
+		favoritesScrollPane.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		favoritesScrollPane.getVerticalScrollBar().setPreferredSize(new Dimension(8, 0));
+		favoritesScrollPane.setBorder(BorderFactory.createEmptyBorder());
+		favoritesScrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+		// Always show scrollbar so layout always accounts for it
+		favoritesScrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
+
 		// Active flips list container
 		activeFlipsListContainer.setLayout(new BoxLayout(activeFlipsListContainer, BoxLayout.Y_AXIS));
 		activeFlipsListContainer.setBackground(ColorScheme.DARK_GRAY_COLOR);
@@ -651,6 +671,13 @@ public class FlipFinderPanel extends PluginPanel
 		});
 		
 		tabbedPane.addTab("Recommended", recommendedScrollPane);
+
+		// BorderLayout leaves room for a sort row (NORTH) and pagination (SOUTH) around the list
+		JPanel favoritesTabPanel = new JPanel(new BorderLayout());
+		favoritesTabPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		favoritesTabPanel.add(favoritesScrollPane, BorderLayout.CENTER);
+		tabbedPane.addTab("Favorites", favoritesTabPanel);
+
 		tabbedPane.addTab("Active Flips", activeFlipsScrollPane);
 
 		// Completed tab carries a secondary sort row (Profit / Recency) above its list
@@ -684,7 +711,7 @@ public class FlipFinderPanel extends PluginPanel
 					itemCount == 1 ? "flip" : "flips",
 					PanelFormat.formatGP(invested)));
 			}
-			else if (selectedIndex == 2)
+			else if (selectedIndex == TAB_COMPLETED)
 			{
 				// Switched to Completed Flips tab — fetch 30-day aggregate stats
 				String rsn = plugin.getCurrentRsnSafe().orElse(null);
@@ -701,12 +728,16 @@ public class FlipFinderPanel extends PluginPanel
 					});
 				});
 			}
-			else if (selectedIndex == 0 && !currentRecommendations.isEmpty())
+			else if (selectedIndex == TAB_RECOMMENDED && !currentRecommendations.isEmpty())
 			{
 				// Switched back to Recommended tab, restore original status
 				FlipFinderResponse response = new FlipFinderResponse();
 				response.setRecommendations(currentRecommendations);
 				updateStatusLabel(response);
+			}
+			else if (selectedIndex == TAB_FAVORITES)
+			{
+				refreshFavoritesTab();
 			}
 		});
 
@@ -1790,7 +1821,7 @@ public class FlipFinderPanel extends PluginPanel
 	{
 		SwingUtilities.invokeLater(() ->
 		{
-			if (stats != null && tabbedPane.getSelectedIndex() == 2)
+			if (stats != null && tabbedPane.getSelectedIndex() == TAB_COMPLETED)
 			{
 				statusLabel.setText(String.format("%d flips (30d) | %s profit",
 					stats.getTotalFlips(),
@@ -2447,6 +2478,61 @@ public class FlipFinderPanel extends PluginPanel
 		recommendedListContainer.repaint();
 	}
 
+	/** Fetch the enriched favorites list and repaint the Favorites tab. */
+	void refreshFavoritesTab()
+	{
+		apiClient.getFavoritesAsync().thenAccept(resp -> SwingUtilities.invokeLater(() ->
+		{
+			currentFavorites.clear();
+			if (resp != null && resp.getItems() != null)
+			{
+				currentFavorites.addAll(resp.getItems());
+			}
+			populateFavorites();
+		})).exceptionally(ex ->
+		{
+			log.warn("Failed to load favorites", ex);
+			return null;
+		});
+	}
+
+	private void populateFavorites()
+	{
+		favoritesListContainer.removeAll();
+		if (currentFavorites.isEmpty())
+		{
+			favoritesListContainer.add(CardWidgets.createStyledLabel("No favorites yet. Tap the star on any item.",
+				ColorScheme.LIGHT_GRAY_COLOR));
+		}
+		else
+		{
+			for (FavoriteItem item : currentFavorites)
+			{
+				favoritesListContainer.add(createFavoriteCard(item));
+				favoritesListContainer.add(Box.createRigidArea(new Dimension(0, 4)));
+			}
+		}
+		favoritesListContainer.revalidate();
+		favoritesListContainer.repaint();
+	}
+
+	private JPanel createFavoriteCard(FavoriteItem item)
+	{
+		JPanel panel = CardWidgets.createBaseItemPanel(ColorScheme.DARKER_GRAY_COLOR, Integer.MAX_VALUE, false);
+		HeaderPanels header = createItemHeaderPanels(item.getItemId(), item.getItemName(), ColorScheme.DARKER_GRAY_COLOR);
+		JPanel details = CardWidgets.createDetailsPanel(ColorScheme.DARKER_GRAY_COLOR);
+		JLabel marginLabel = CardWidgets.createStyledLabel("Margin: " + PanelFormat.formatGP(item.getMargin()), Color.WHITE);
+		JLabel profitLabel = CardWidgets.createStyledLabel("Profit: " + PanelFormat.formatGP(item.getProfit()), Color.WHITE);
+		JLabel volumeLabel = CardWidgets.createStyledLabel(PanelFormat.formatVolumeText(item.getVolume()), Color.WHITE);
+		JLabel riskLabel = CardWidgets.createStyledLabel(
+			PanelFormat.formatRiskText((double) item.getRiskScore(), item.getRiskRating()),
+			PanelFormat.getRiskColor(item.getRiskScore()));
+		CardWidgets.addLabelsWithSpacing(details, marginLabel, profitLabel, volumeLabel, riskLabel);
+		panel.add(header.topPanel, BorderLayout.NORTH);
+		panel.add(details, BorderLayout.CENTER);
+		return panel;
+	}
+
 	/**
 	 * Create a panel for a single recommendation
 	 */
@@ -2922,8 +3008,10 @@ public class FlipFinderPanel extends PluginPanel
 				}
 				updateStarLabel(starLabel, itemId);
 			}
-			// Task 4 adds an else-branch here to refresh the Favorites tab when it is
-			// the selected tab; TAB_FAVORITES / refreshFavoritesTab() do not exist yet.
+			else if (tabbedPane.getSelectedIndex() == TAB_FAVORITES)
+			{
+				refreshFavoritesTab();
+			}
 		})).exceptionally(ex ->
 		{
 			log.warn("Favorite toggle failed for item {}", itemId, ex);
@@ -4424,7 +4512,7 @@ public class FlipFinderPanel extends PluginPanel
 			}
 
 			// Switch to Recommended tab
-			tabbedPane.setSelectedIndex(0);
+			tabbedPane.setSelectedIndex(TAB_RECOMMENDED);
 
 			// Start the 2-minute refresh timer
 			plugin.startAutoRecommendRefreshTimer();

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -720,7 +720,6 @@ public class FlipFinderPanel extends PluginPanel
 		favoritesControlsPanel.setLayout(new BoxLayout(favoritesControlsPanel, BoxLayout.Y_AXIS));
 		favoritesControlsPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
 		favoritesControlsPanel.add(buildFavoritesSortRow());
-		favoritesControlsPanel.add(buildFlipOnlyFavoritesRow());
 		favoritesControlsPanel.setVisible(false);
 
 		JPanel recommendedControls = new JPanel();
@@ -906,6 +905,7 @@ public class FlipFinderPanel extends PluginPanel
 				activeSettingsPopup = null;
 				minProfitSpinner = null;
 				minVolumeSpinner = null;
+				flipOnlyFavoritesCheck = null;
 			}
 
 			@Override
@@ -922,6 +922,8 @@ public class FlipFinderPanel extends PluginPanel
 		body.add(buildMinProfitRow());
 		body.add(Box.createVerticalStrut(6));
 		body.add(buildMinVolumeRow());
+		body.add(Box.createVerticalStrut(6));
+		body.add(buildFlipOnlyFavoritesRow());
 		body.add(Box.createVerticalStrut(6));
 		body.add(buildUpdateButtonRow());
 		body.add(Box.createVerticalStrut(6));
@@ -2847,21 +2849,32 @@ public class FlipFinderPanel extends PluginPanel
 		favoritesPaginationRow.setVisible(pages > 1);
 	}
 
+	/**
+	 * Render a favorite with the same card as a recommendation — a favorite is the same kind
+	 * of item, so it gets the identical layout, colours, and click-to-focus behaviour. The
+	 * favorite's server-sent buy limit is the quantity its profit is sized to (one full cycle).
+	 */
 	private JPanel createFavoriteCard(FavoriteItem item)
 	{
-		JPanel panel = CardWidgets.createBaseItemPanel(ColorScheme.DARKER_GRAY_COLOR, Integer.MAX_VALUE, false);
-		HeaderPanels header = createItemHeaderPanels(item.getItemId(), item.getItemName(), ColorScheme.DARKER_GRAY_COLOR);
-		JPanel details = CardWidgets.createDetailsPanel(ColorScheme.DARKER_GRAY_COLOR);
-		JLabel marginLabel = CardWidgets.createStyledLabel("Margin: " + PanelFormat.formatGP(item.getMargin()), Color.WHITE);
-		JLabel profitLabel = CardWidgets.createStyledLabel("Profit: " + PanelFormat.formatGP(item.getProfit()), Color.WHITE);
-		JLabel volumeLabel = CardWidgets.createStyledLabel(PanelFormat.formatVolumeText(item.getVolume()), Color.WHITE);
-		JLabel riskLabel = CardWidgets.createStyledLabel(
-			PanelFormat.formatRiskText((double) item.getRiskScore(), item.getRiskRating()),
-			PanelFormat.getRiskColor(item.getRiskScore()));
-		CardWidgets.addLabelsWithSpacing(details, marginLabel, profitLabel, volumeLabel, riskLabel);
-		panel.add(header.topPanel, BorderLayout.NORTH);
-		panel.add(details, BorderLayout.CENTER);
-		return panel;
+		return createRecommendationPanel(favoriteAsRecommendation(item));
+	}
+
+	/** Map a favorite onto a {@link FlipRecommendation} so the recommendation renderer can draw it. */
+	private static FlipRecommendation favoriteAsRecommendation(FavoriteItem item)
+	{
+		int buy = item.getBuyPrice() != null ? item.getBuyPrice() : 0;
+		int quantity = item.getBuyLimit() != null && item.getBuyLimit() > 0 ? item.getBuyLimit() : 1;
+		FlipRecommendation rec = new FlipRecommendation();
+		rec.setItemId(item.getItemId());
+		rec.setItemName(item.getItemName());
+		rec.setRecommendedBuyPrice(buy);
+		rec.setRecommendedSellPrice(item.getSellPrice() != null ? item.getSellPrice() : 0);
+		rec.setRecommendedQuantity(quantity);
+		rec.setBuyLimit(quantity);
+		rec.setDailyVolume(item.getVolume());
+		rec.setRiskScore(item.getRiskScore());
+		rec.setRiskRating(item.getRiskRating());
+		return rec;
 	}
 
 	/**
@@ -2904,9 +2917,10 @@ public class FlipFinderPanel extends PluginPanel
 		int displayCost = displayBuyPrice * rec.getRecommendedQuantity();
 		double displayRoi = displayBuyPrice > 0 ? ((double)(displayMargin - geTax) / displayBuyPrice) * 100 : 0;
 
-		// Recommended Buy/Sell prices
-		JLabel priceLabel = new JLabel(PanelFormat.formatBuySellText(displayBuyPrice, displaySellPrice));
-		priceLabel.setForeground(Color.LIGHT_GRAY);
+		// Recommended Buy/Sell prices — buy blue, sell orange, bold (matches the Active-tab live-price row).
+		// White base foreground keeps the "Buy:"/"Sell:" label text (outside the coloured spans) legible.
+		JLabel priceLabel = new JLabel(PanelFormat.buySellHtml(displayBuyPrice, displaySellPrice));
+		priceLabel.setForeground(Color.WHITE);
 		priceLabel.setFont(FONT_PLAIN_12);
 
 		// Quantity

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -163,9 +163,8 @@ public class FlipFinderPanel extends PluginPanel
 
 	private static final int ACTIVE_FLIPS_PRICE_REFRESH_MS = 60_000;
 	static final int TAB_RECOMMENDED = 0;
-	static final int TAB_FAVORITES = 1;
-	static final int TAB_ACTIVE_FLIPS = 2;
-	static final int TAB_COMPLETED = 3;
+	static final int TAB_ACTIVE_FLIPS = 1;
+	static final int TAB_COMPLETED = 2;
 
 	private final transient FlipSmartConfig config;
 	private final transient FlipSmartApiClient apiClient;
@@ -208,6 +207,15 @@ public class FlipFinderPanel extends PluginPanel
 	private JLabel favoritesPrevPageLabel;
 	private JLabel favoritesNextPageLabel;
 	private JPanel favoritesPaginationRow;
+
+	// In-tab favorites view (toggled from within the Recommended tab, no separate tab)
+	private boolean favoritesViewActive;
+	private JButton favoritesToggleButton;
+	private JPanel favoritesControlsPanel;
+	private JPanel recommendedCardPanel;
+	private final CardLayout recommendedCardLayout = new CardLayout();
+	private static final String CARD_ALGORITHM = "algorithm";
+	private static final String CARD_FAVORITES = "favorites";
 
 	// Premium-gated "flip only from favorites" toggle
 	private boolean flipOnlyFavorites;
@@ -694,22 +702,44 @@ public class FlipFinderPanel extends PluginPanel
 			}
 		});
 		
-		tabbedPane.addTab("Recommended", recommendedScrollPane);
+		// The Recommended tab swaps between the algorithm list and the favorites list via a
+		// centered toggle button, so the favorites view no longer needs its own tab.
+		JPanel toggleBar = new JPanel(new FlowLayout(FlowLayout.CENTER, 0, 4));
+		toggleBar.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		favoritesToggleButton = new JButton("★ Favorites");
+		favoritesToggleButton.setFocusable(false);
+		favoritesToggleButton.setFont(FONT_PLAIN_11);
+		favoritesToggleButton.setMargin(new Insets(2, 10, 2, 10));
+		favoritesToggleButton.setForeground(STAR_ON_COLOR);
+		favoritesToggleButton.setToolTipText("Toggle between algorithm recommendations and your favorites");
+		favoritesToggleButton.addActionListener(e -> toggleFavoritesView());
+		toggleBar.add(favoritesToggleButton);
 
-		// BorderLayout leaves room for a header (sort row + flip-only-favorites toggle, NORTH)
-		// and pagination (SOUTH) around the list
-		JPanel favoritesHeaderPanel = new JPanel();
-		favoritesHeaderPanel.setLayout(new BoxLayout(favoritesHeaderPanel, BoxLayout.Y_AXIS));
-		favoritesHeaderPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
-		favoritesHeaderPanel.add(buildFavoritesSortRow());
-		favoritesHeaderPanel.add(buildFlipOnlyFavoritesRow());
+		// Favorites controls (sort row + flip-only checkbox), shown only in favorites view
+		favoritesControlsPanel = new JPanel();
+		favoritesControlsPanel.setLayout(new BoxLayout(favoritesControlsPanel, BoxLayout.Y_AXIS));
+		favoritesControlsPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		favoritesControlsPanel.add(buildFavoritesSortRow());
+		favoritesControlsPanel.add(buildFlipOnlyFavoritesRow());
+		favoritesControlsPanel.setVisible(false);
 
-		JPanel favoritesTabPanel = new JPanel(new BorderLayout());
-		favoritesTabPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
-		favoritesTabPanel.add(favoritesHeaderPanel, BorderLayout.NORTH);
-		favoritesTabPanel.add(favoritesScrollPane, BorderLayout.CENTER);
-		favoritesTabPanel.add(buildFavoritesPaginationRow(), BorderLayout.SOUTH);
-		tabbedPane.addTab("Favorites", favoritesTabPanel);
+		JPanel recommendedControls = new JPanel();
+		recommendedControls.setLayout(new BoxLayout(recommendedControls, BoxLayout.Y_AXIS));
+		recommendedControls.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		recommendedControls.add(toggleBar);
+		recommendedControls.add(favoritesControlsPanel);
+
+		recommendedCardPanel = new JPanel(recommendedCardLayout);
+		recommendedCardPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		recommendedCardPanel.add(recommendedScrollPane, CARD_ALGORITHM);
+		recommendedCardPanel.add(favoritesScrollPane, CARD_FAVORITES);
+
+		JPanel recommendedTabPanel = new JPanel(new BorderLayout());
+		recommendedTabPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		recommendedTabPanel.add(recommendedControls, BorderLayout.NORTH);
+		recommendedTabPanel.add(recommendedCardPanel, BorderLayout.CENTER);
+		recommendedTabPanel.add(buildFavoritesPaginationRow(), BorderLayout.SOUTH);
+		tabbedPane.addTab("Recommended", recommendedTabPanel);
 
 		tabbedPane.addTab("Active Flips", activeFlipsScrollPane);
 
@@ -767,11 +797,6 @@ public class FlipFinderPanel extends PluginPanel
 				FlipFinderResponse response = new FlipFinderResponse();
 				response.setRecommendations(currentRecommendations);
 				updateStatusLabel(response);
-			}
-			else if (selectedIndex == TAB_FAVORITES)
-			{
-				updateFavoritesStatusLabel();
-				refreshFavoritesTab();
 			}
 		});
 
@@ -2523,6 +2548,39 @@ public class FlipFinderPanel extends PluginPanel
 		recommendedListContainer.repaint();
 	}
 
+	/** Flip between the algorithm recommendations and the in-tab favorites view. */
+	private void toggleFavoritesView()
+	{
+		favoritesViewActive = !favoritesViewActive;
+		applyFavoritesViewState();
+		if (favoritesViewActive)
+		{
+			updateFavoritesStatusLabel();
+			refreshFavoritesTab();
+		}
+	}
+
+	/** Show/hide the favorites list, controls, pagination and update the toggle button for the current view. */
+	private void applyFavoritesViewState()
+	{
+		favoritesControlsPanel.setVisible(favoritesViewActive);
+		if (favoritesViewActive)
+		{
+			favoritesToggleButton.setText("Algorithm");
+			favoritesToggleButton.setForeground(Color.LIGHT_GRAY);
+			recommendedCardLayout.show(recommendedCardPanel, CARD_FAVORITES);
+		}
+		else
+		{
+			favoritesToggleButton.setText("★ Favorites");
+			favoritesToggleButton.setForeground(STAR_ON_COLOR);
+			recommendedCardLayout.show(recommendedCardPanel, CARD_ALGORITHM);
+			favoritesPaginationRow.setVisible(false);
+		}
+		recommendedCardPanel.revalidate();
+		recommendedCardPanel.repaint();
+	}
+
 	/** Fetch the enriched favorites list and repaint the Favorites tab. */
 	void refreshFavoritesTab()
 	{
@@ -2560,8 +2618,10 @@ public class FlipFinderPanel extends PluginPanel
 		List<FavoriteItem> visible = Paginator.page(sorted, favoritesPage, FAVORITES_PAGE_SIZE);
 		if (visible.isEmpty())
 		{
-			favoritesListContainer.add(CardWidgets.createStyledLabel("No favorites yet. Tap the star on any item.",
-				ColorScheme.LIGHT_GRAY_COLOR));
+			favoritesListContainer.add(createEmptyStatePanel(
+				"No favorites yet",
+				"<html><center>Tap the star on any item<br>to add it here</center></html>",
+				60));
 		}
 		else
 		{
@@ -3270,7 +3330,7 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				rollbackFavoriteToggle(wasFavorite, itemId, starLabel);
 			}
-			else if (tabbedPane.getSelectedIndex() == TAB_FAVORITES)
+			else if (tabbedPane.getSelectedIndex() == TAB_RECOMMENDED && favoritesViewActive)
 			{
 				refreshFavoritesTab();
 			}

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -3,6 +3,7 @@ import com.flipsmart.api.ApiHttpTransport;
 import com.flipsmart.api.endpoints.ActiveFlipEndpoints;
 import com.flipsmart.api.endpoints.BankSnapshotEndpoints;
 import com.flipsmart.api.endpoints.BlocklistEndpoints;
+import com.flipsmart.api.endpoints.FavoritesEndpoints;
 import com.flipsmart.api.endpoints.FlipsEndpoints;
 import com.flipsmart.api.endpoints.MarketDataEndpoints;
 import com.flipsmart.api.endpoints.MotdEndpoints;
@@ -12,6 +13,7 @@ import com.flipsmart.api.endpoints.TransactionEndpoints;
 import com.flipsmart.api.endpoints.WebhookEndpoints;
 import com.flipsmart.api.dto.ActiveFlipsResponse;
 import com.flipsmart.api.dto.CompletedFlipsResponse;
+import com.flipsmart.api.dto.FavoritesResponse;
 import com.flipsmart.api.dto.FlipAdjustmentResponse;
 import com.flipsmart.api.dto.OfferAdviceBatchResponse;
 import com.flipsmart.api.dto.BankSnapshotResult;
@@ -73,6 +75,7 @@ public class FlipSmartApiClient
 	private final WebhookEndpoints webhooks;
 	private final MotdEndpoints motd;
 	private final TradeStationEndpoints tradeStation;
+	private final FavoritesEndpoints favorites;
 
 	@Inject
 	public FlipSmartApiClient(FlipSmartConfig config, Gson gson, OkHttpClient okHttpClient)
@@ -97,6 +100,7 @@ public class FlipSmartApiClient
 		this.webhooks = new WebhookEndpoints(transport);
 		this.motd = new MotdEndpoints(transport);
 		this.tradeStation = new TradeStationEndpoints(transport);
+		this.favorites = new FavoritesEndpoints(transport);
 	}
 
 	// ============================================================================
@@ -209,23 +213,38 @@ public class FlipSmartApiClient
 
 	public CompletableFuture<FlipFinderResponse> getFlipRecommendationsAsync(
 		Integer cashStack, String flipStyle, int limit, Integer randomSeed, String timeframe, String rsn,
-		Integer filledSlots, boolean isMembersWorld)
+		Integer filledSlots, boolean isMembersWorld, boolean favoritesOnly)
 	{
 		return flips.getFlipRecommendationsAsync(cashStack, flipStyle, limit, randomSeed, timeframe, rsn,
-			filledSlots, isMembersWorld, config.minimumProfit(), config.minimumVolume());
+			filledSlots, isMembersWorld, config.minimumProfit(), config.minimumVolume(), favoritesOnly);
 	}
 
 	public CompletableFuture<PluginSyncResponse> getPluginSyncAsync(
 		Integer cashStack, Integer inventoryGp, String flipStyle, int limit, Integer randomSeed, String timeframe,
-		String rsn, Integer filledSlots, boolean isMembersWorld)
+		String rsn, Integer filledSlots, boolean isMembersWorld, boolean favoritesOnly)
 	{
 		return flips.getPluginSyncAsync(cashStack, inventoryGp, flipStyle, limit, randomSeed, timeframe, rsn,
-			filledSlots, isMembersWorld, config.minimumProfit(), config.minimumVolume());
+			filledSlots, isMembersWorld, config.minimumProfit(), config.minimumVolume(), favoritesOnly);
 	}
 
 	public CompletableFuture<Boolean> pushRsnCapitalAsync(String rsn, Integer inventoryGp)
 	{
 		return flips.pushRsnCapitalAsync(rsn, inventoryGp);
+	}
+
+	public CompletableFuture<FavoritesResponse> getFavoritesAsync()
+	{
+		return favorites.getFavoritesAsync();
+	}
+
+	public CompletableFuture<Boolean> addFavoriteAsync(int itemId)
+	{
+		return favorites.addFavoriteAsync(itemId);
+	}
+
+	public CompletableFuture<Boolean> removeFavoriteAsync(int itemId)
+	{
+		return favorites.removeFavoriteAsync(itemId);
 	}
 
 	@Deprecated(since = "1.5.0", forRemoval = true)

--- a/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
+++ b/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
@@ -475,7 +475,7 @@ public class ManualAdjustmentTracker
 		String timeframe = config.flipTimeframe().getApiValue();
 		String flipStyle = config.flipStyle().getApiValue();
 
-		apiClient.getFlipRecommendationsAsync(cashStack, flipStyle, 1, null, timeframe, rsn, filledSlots, isMembersWorld)
+		apiClient.getFlipRecommendationsAsync(cashStack, flipStyle, 1, null, timeframe, rsn, filledSlots, isMembersWorld, false)
 			.thenAccept(response -> handleReplacementResponse(response, state))
 			.exceptionally(e ->
 			{

--- a/src/main/java/com/flipsmart/api/dto/FavoriteItem.java
+++ b/src/main/java/com/flipsmart/api/dto/FavoriteItem.java
@@ -1,0 +1,35 @@
+package com.flipsmart.api.dto;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class FavoriteItem
+{
+	@SerializedName("item_id")
+	private int itemId;
+
+	@SerializedName("item_name")
+	private String itemName;
+
+	@SerializedName("icon_url")
+	private String iconUrl;
+
+	@SerializedName("buy_price")
+	private Integer buyPrice;
+
+	@SerializedName("sell_price")
+	private Integer sellPrice;
+
+	private int margin;
+
+	private int profit;
+
+	private int volume;
+
+	@SerializedName("risk_score")
+	private int riskScore;
+
+	@SerializedName("risk_rating")
+	private String riskRating;
+}

--- a/src/main/java/com/flipsmart/api/dto/FavoriteItem.java
+++ b/src/main/java/com/flipsmart/api/dto/FavoriteItem.java
@@ -21,6 +21,9 @@ public class FavoriteItem
 	@SerializedName("sell_price")
 	private Integer sellPrice;
 
+	@SerializedName("buy_limit")
+	private Integer buyLimit;
+
 	private int margin;
 
 	private int profit;

--- a/src/main/java/com/flipsmart/api/dto/FavoritesResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/FavoritesResponse.java
@@ -1,0 +1,12 @@
+package com.flipsmart.api.dto;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class FavoritesResponse
+{
+	private List<FavoriteItem> items;
+
+	private int count;
+}

--- a/src/main/java/com/flipsmart/api/dto/PluginSyncResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/PluginSyncResponse.java
@@ -30,6 +30,9 @@ public class PluginSyncResponse
 	@SerializedName("statistics")
 	private FlipStatisticsResponse statistics;
 
+	@SerializedName("favorite_item_ids")
+	private java.util.List<Integer> favoriteItemIds;
+
 	// The endpoint also returns `entitlements`, but the poll does not consume it:
 	// premium is sourced from the flip_finder payload (see FlipFinderPanel), and the
 	// EntitlementSnapshot shape has no top-level is_premium for this DTO to read.

--- a/src/main/java/com/flipsmart/api/endpoints/FavoritesEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/FavoritesEndpoints.java
@@ -1,0 +1,60 @@
+package com.flipsmart.api.endpoints;
+
+import com.flipsmart.api.ApiHttpTransport;
+import com.flipsmart.api.dto.FavoritesResponse;
+import java.util.concurrent.CompletableFuture;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+
+import static com.flipsmart.api.ApiHttpTransport.JSON;
+
+/**
+ * Favorites endpoints: list the enriched favorites, and star/un-star an item.
+ * Toggles are idempotent server-side, so callers may re-issue them safely.
+ */
+public class FavoritesEndpoints
+{
+	private final ApiHttpTransport transport;
+
+	public FavoritesEndpoints(ApiHttpTransport transport)
+	{
+		this.transport = transport;
+	}
+
+	static String favoritesListPath(String apiUrl)
+	{
+		return apiUrl + "/plugin/favorites";
+	}
+
+	static String favoritePath(String apiUrl, int itemId)
+	{
+		return apiUrl + "/plugin/favorites/" + itemId;
+	}
+
+	public CompletableFuture<FavoritesResponse> getFavoritesAsync()
+	{
+		Request.Builder requestBuilder = new Request.Builder()
+			.url(favoritesListPath(transport.getApiUrl()))
+			.get();
+		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
+			transport.parse(jsonData, FavoritesResponse.class));
+	}
+
+	public CompletableFuture<Boolean> addFavoriteAsync(int itemId)
+	{
+		Request.Builder requestBuilder = new Request.Builder()
+			.url(favoritePath(transport.getApiUrl(), itemId))
+			.post(RequestBody.create(JSON, "{}"));
+		return transport.executeAuthenticatedAsync(requestBuilder, jsonData -> Boolean.TRUE)
+			.exceptionally(e -> false);
+	}
+
+	public CompletableFuture<Boolean> removeFavoriteAsync(int itemId)
+	{
+		Request.Builder requestBuilder = new Request.Builder()
+			.url(favoritePath(transport.getApiUrl(), itemId))
+			.delete();
+		return transport.executeAuthenticatedAsync(requestBuilder, jsonData -> Boolean.TRUE)
+			.exceptionally(e -> false);
+	}
+}

--- a/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/FlipsEndpoints.java
@@ -91,7 +91,7 @@ public class FlipsEndpoints
 	 */
 	public CompletableFuture<FlipFinderResponse> getFlipRecommendationsAsync(
 		Integer cashStack, String flipStyle, int limit, Integer randomSeed, String timeframe, String rsn,
-		Integer filledSlots, boolean isMembersWorld, int minProfit, int minVolume)
+		Integer filledSlots, boolean isMembersWorld, int minProfit, int minVolume, boolean favoritesOnly)
 	{
 		String apiUrl = transport.getApiUrl();
 
@@ -100,6 +100,7 @@ public class FlipsEndpoints
 		urlBuilder.append(String.format("%s/flip-finder?limit=%d&flip_style=%s", apiUrl, limit, flipStyle));
 		appendSharedQueryParams(urlBuilder, cashStack, randomSeed, timeframe, rsn, filledSlots, isMembersWorld);
 		appendFilterParams(urlBuilder, minProfit, minVolume);
+		appendFavoritesOnly(urlBuilder, favoritesOnly);
 
 		String url = urlBuilder.toString();
 		Request.Builder requestBuilder = new Request.Builder()
@@ -166,6 +167,14 @@ public class FlipsEndpoints
 		}
 	}
 
+	static void appendFavoritesOnly(StringBuilder urlBuilder, boolean favoritesOnly)
+	{
+		if (favoritesOnly)
+		{
+			urlBuilder.append("&favorites_only=true");
+		}
+	}
+
 	/**
 	 * Append the player's real inventory coins for the web "Capital Active" card.
 	 * Unlike the filter params above, zero is sent rather than omitted: a player with
@@ -189,7 +198,7 @@ public class FlipsEndpoints
 	 */
 	public CompletableFuture<PluginSyncResponse> getPluginSyncAsync(
 		Integer cashStack, Integer inventoryGp, String flipStyle, int limit, Integer randomSeed, String timeframe,
-		String rsn, Integer filledSlots, boolean isMembersWorld, int minProfit, int minVolume)
+		String rsn, Integer filledSlots, boolean isMembersWorld, int minProfit, int minVolume, boolean favoritesOnly)
 	{
 		String apiUrl = transport.getApiUrl();
 
@@ -198,6 +207,7 @@ public class FlipsEndpoints
 		appendSharedQueryParams(urlBuilder, cashStack, randomSeed, timeframe, rsn, filledSlots, isMembersWorld);
 		appendFilterParams(urlBuilder, minProfit, minVolume);
 		appendInventoryGp(urlBuilder, inventoryGp);
+		appendFavoritesOnly(urlBuilder, favoritesOnly);
 
 		Request.Builder requestBuilder = new Request.Builder()
 			.url(urlBuilder.toString())

--- a/src/main/java/com/flipsmart/ui/panel/FavoritesSort.java
+++ b/src/main/java/com/flipsmart/ui/panel/FavoritesSort.java
@@ -1,0 +1,31 @@
+package com.flipsmart.ui.panel;
+
+import com.flipsmart.api.dto.FavoriteItem;
+import java.util.Comparator;
+
+public enum FavoritesSort
+{
+	PROFIT("Profit", Comparator.comparingInt(FavoriteItem::getProfit).reversed()),
+	VOLUME("Volume", Comparator.comparingInt(FavoriteItem::getVolume).reversed()),
+	ALPHABETICAL("A-Z", Comparator.comparing(
+		f -> f.getItemName() == null ? "" : f.getItemName(), String.CASE_INSENSITIVE_ORDER));
+
+	private final String label;
+	private final Comparator<FavoriteItem> comparator;
+
+	FavoritesSort(String label, Comparator<FavoriteItem> comparator)
+	{
+		this.label = label;
+		this.comparator = comparator;
+	}
+
+	public String getLabel()
+	{
+		return label;
+	}
+
+	public Comparator<FavoriteItem> comparator()
+	{
+		return comparator;
+	}
+}

--- a/src/main/java/com/flipsmart/ui/panel/FavoritesSort.java
+++ b/src/main/java/com/flipsmart/ui/panel/FavoritesSort.java
@@ -11,12 +11,12 @@ public enum FavoritesSort
 		f -> f.getItemName() == null ? "" : f.getItemName(), String.CASE_INSENSITIVE_ORDER));
 
 	private final String label;
-	private final Comparator<FavoriteItem> comparator;
+	private final Comparator<FavoriteItem> itemComparator;
 
-	FavoritesSort(String label, Comparator<FavoriteItem> comparator)
+	FavoritesSort(String label, Comparator<FavoriteItem> itemComparator)
 	{
 		this.label = label;
-		this.comparator = comparator;
+		this.itemComparator = itemComparator;
 	}
 
 	public String getLabel()
@@ -26,6 +26,6 @@ public enum FavoritesSort
 
 	public Comparator<FavoriteItem> comparator()
 	{
-		return comparator;
+		return itemComparator;
 	}
 }

--- a/src/main/java/com/flipsmart/ui/panel/Paginator.java
+++ b/src/main/java/com/flipsmart/ui/panel/Paginator.java
@@ -1,0 +1,36 @@
+package com.flipsmart.ui.panel;
+
+import java.util.Collections;
+import java.util.List;
+
+/** Client-side paging helper: pure, so it is unit-tested directly. */
+public final class Paginator
+{
+	private Paginator()
+	{
+	}
+
+	public static int pageCount(int total, int pageSize)
+	{
+		if (total <= 0)
+		{
+			return 1;
+		}
+		return (total + pageSize - 1) / pageSize;
+	}
+
+	public static <T> List<T> page(List<T> items, int pageIndex, int pageSize)
+	{
+		if (items == null || items.isEmpty())
+		{
+			return Collections.emptyList();
+		}
+		int from = pageIndex * pageSize;
+		if (from >= items.size() || pageIndex < 0)
+		{
+			return Collections.emptyList();
+		}
+		int to = Math.min(from + pageSize, items.size());
+		return items.subList(from, to);
+	}
+}

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -5,6 +5,7 @@ import java.awt.AlphaComposite;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.Polygon;
 import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 import javax.swing.JPanel;
@@ -357,6 +358,41 @@ public final class PanelFormat
 
 		g.dispose();
 		return icon;
+	}
+
+	/**
+	 * Draw a five-point star onto a 16x16 image. Filled paints the favorite state;
+	 * an unfilled star strokes the outline only for the not-favorited state.
+	 */
+	public static BufferedImage drawStarIcon(boolean filled, Color color)
+	{
+		BufferedImage image = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = createTransparentIconGraphics(image);
+		int[] xs = new int[10];
+		int[] ys = new int[10];
+		double cx = 8;
+		double cy = 8;
+		double outer = 7;
+		double inner = 2.9;
+		for (int i = 0; i < 10; i++)
+		{
+			double r = (i % 2 == 0) ? outer : inner;
+			double a = Math.toRadians(-90 + i * 36);
+			xs[i] = (int) Math.round(cx + r * Math.cos(a));
+			ys[i] = (int) Math.round(cy + r * Math.sin(a));
+		}
+		Polygon star = new Polygon(xs, ys, 10);
+		g.setColor(color);
+		if (filled)
+		{
+			g.fillPolygon(star);
+		}
+		else
+		{
+			g.drawPolygon(star);
+		}
+		g.dispose();
+		return image;
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
+++ b/src/main/java/com/flipsmart/ui/panel/PanelFormat.java
@@ -21,7 +21,6 @@ public final class PanelFormat
 	private static final Color COLOR_YELLOW = new Color(255, 255, 100);
 	private static final Color COLOR_LOSS_RED = new Color(255, 100, 100);
 
-	private static final String FORMAT_BUY_SELL = "Buy: %s | Sell: %s";
 	private static final String FORMAT_PROFIT_COST = "Profit: %s | Cost: %s";
 	private static final String FORMAT_MARGIN_ROI = "Margin: %s (%.1f%% ROI)";
 	private static final String FORMAT_MARGIN_ROI_LOSS = "Margin: %s (%.1f%% ROI) - Loss";
@@ -178,22 +177,21 @@ public final class PanelFormat
 		return String.format(FORMAT_PROFIT_COST, profitText, formatGP(totalCost));
 	}
 
-	/**
-	 * Format buy/sell prices text for display
-	 */
-	public static String formatBuySellText(int buyPrice, Integer sellPrice)
-	{
-		String sellText = sellPrice != null && sellPrice > 0
-			? formatGPExact(sellPrice)
-			: "N/A";
-		return String.format(FORMAT_BUY_SELL, formatGPExact(buyPrice), sellText);
-	}
-
 	/** Top "live" price row: market low (blue) | market high (orange), both bold; label stays plain. */
 	public static String livePriceHtml(int low, int high)
 	{
 		return htmlRow("Live Price: " + bold(coloured(HEX_PRICE_LOW, formatGPExact(low)))
 			+ " | " + bold(coloured(HEX_PRICE_HIGH, formatGPExact(high))));
+	}
+
+	/** Buy/Sell row styled like the live-price row: buy price blue, sell price orange, both bold. */
+	public static String buySellHtml(int buyPrice, Integer sellPrice)
+	{
+		String sellSpan = sellPrice != null && sellPrice > 0
+			? bold(coloured(HEX_PRICE_HIGH, formatGPExact(sellPrice)))
+			: "N/A";
+		return htmlRow("Buy: " + bold(coloured(HEX_PRICE_LOW, formatGPExact(buyPrice)))
+			+ " | Sell: " + sellSpan);
 	}
 
 	/** Live Margin: gross market spread coloured green (profit) / red (loss), with ROI. No "+" prefix. */

--- a/src/test/java/com/flipsmart/FavoritesDtoParsingTest.java
+++ b/src/test/java/com/flipsmart/FavoritesDtoParsingTest.java
@@ -1,0 +1,46 @@
+package com.flipsmart;
+
+import com.flipsmart.api.dto.FavoriteItem;
+import com.flipsmart.api.dto.FavoritesResponse;
+import com.flipsmart.api.dto.PluginSyncResponse;
+import com.google.gson.Gson;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class FavoritesDtoParsingTest
+{
+	private final Gson gson = new Gson();
+
+	@Test
+	public void parsesFavoritesResponse()
+	{
+		String json = "{\"items\":[{\"item_id\":4151,\"item_name\":\"Abyssal whip\",\"icon_url\":\"http://x/w.png\","
+			+ "\"buy_price\":1900000,\"sell_price\":2000000,\"margin\":80000,\"profit\":5600000,"
+			+ "\"volume\":5000000,\"risk_score\":20,\"risk_rating\":\"Very Low\"}],\"count\":1}";
+		FavoritesResponse r = gson.fromJson(json, FavoritesResponse.class);
+		assertEquals(1, r.getCount());
+		FavoriteItem item = r.getItems().get(0);
+		assertEquals(4151, item.getItemId());
+		assertEquals("Abyssal whip", item.getItemName());
+		assertEquals(80000, item.getMargin());
+		assertEquals(5600000, item.getProfit());
+		assertEquals(5000000, item.getVolume());
+		assertEquals("Very Low", item.getRiskRating());
+		assertEquals(2000000, item.getSellPrice().intValue());
+		assertEquals(1900000, item.getBuyPrice().intValue());
+	}
+
+	@Test
+	public void parsesFavoriteItemIdsFromSync()
+	{
+		String json = "{\"version\":1,\"favorite_item_ids\":[4151,561],\"flip_finder\":null}";
+		PluginSyncResponse sync = gson.fromJson(json, PluginSyncResponse.class);
+		assertNotNull(sync.getFavoriteItemIds());
+		assertEquals(2, sync.getFavoriteItemIds().size());
+		assertTrue(sync.getFavoriteItemIds().contains(4151));
+		assertTrue(sync.getFavoriteItemIds().contains(561));
+	}
+}

--- a/src/test/java/com/flipsmart/FavoritesDtoParsingTest.java
+++ b/src/test/java/com/flipsmart/FavoritesDtoParsingTest.java
@@ -18,7 +18,7 @@ public class FavoritesDtoParsingTest
 	public void parsesFavoritesResponse()
 	{
 		String json = "{\"items\":[{\"item_id\":4151,\"item_name\":\"Abyssal whip\",\"icon_url\":\"http://x/w.png\","
-			+ "\"buy_price\":1900000,\"sell_price\":2000000,\"margin\":80000,\"profit\":5600000,"
+			+ "\"buy_price\":1900000,\"sell_price\":2000000,\"buy_limit\":70,\"margin\":80000,\"profit\":5600000,"
 			+ "\"volume\":5000000,\"risk_score\":20,\"risk_rating\":\"Very Low\"}],\"count\":1}";
 		FavoritesResponse r = gson.fromJson(json, FavoritesResponse.class);
 		assertEquals(1, r.getCount());
@@ -31,6 +31,7 @@ public class FavoritesDtoParsingTest
 		assertEquals("Very Low", item.getRiskRating());
 		assertEquals(2000000, item.getSellPrice().intValue());
 		assertEquals(1900000, item.getBuyPrice().intValue());
+		assertEquals(70, item.getBuyLimit().intValue());
 	}
 
 	@Test

--- a/src/test/java/com/flipsmart/FavoritesSortAndPaginationTest.java
+++ b/src/test/java/com/flipsmart/FavoritesSortAndPaginationTest.java
@@ -1,0 +1,71 @@
+package com.flipsmart;
+
+import com.flipsmart.api.dto.FavoriteItem;
+import com.flipsmart.ui.panel.FavoritesSort;
+import com.flipsmart.ui.panel.Paginator;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FavoritesSortAndPaginationTest
+{
+	private FavoriteItem item(String name, int profit, int volume)
+	{
+		FavoriteItem i = new FavoriteItem();
+		i.setItemName(name);
+		i.setProfit(profit);
+		i.setVolume(volume);
+		return i;
+	}
+
+	@Test
+	public void profitSortsHighToLow()
+	{
+		List<FavoriteItem> list = new ArrayList<>();
+		list.add(item("A", 100, 1));
+		list.add(item("B", 300, 1));
+		list.add(item("C", 200, 1));
+		list.sort(FavoritesSort.PROFIT.comparator());
+		assertEquals("B", list.get(0).getItemName());
+		assertEquals("C", list.get(1).getItemName());
+		assertEquals("A", list.get(2).getItemName());
+	}
+
+	@Test
+	public void volumeSortsHighToLow()
+	{
+		List<FavoriteItem> list = new ArrayList<>();
+		list.add(item("A", 1, 50));
+		list.add(item("B", 1, 90));
+		list.sort(FavoritesSort.VOLUME.comparator());
+		assertEquals("B", list.get(0).getItemName());
+	}
+
+	@Test
+	public void alphabeticalSortsAtoZCaseInsensitive()
+	{
+		List<FavoriteItem> list = new ArrayList<>();
+		list.add(item("banana", 1, 1));
+		list.add(item("Apple", 1, 1));
+		list.sort(FavoritesSort.ALPHABETICAL.comparator());
+		assertEquals("Apple", list.get(0).getItemName());
+		assertEquals("banana", list.get(1).getItemName());
+	}
+
+	@Test
+	public void paginationSlicesAndCountsPages()
+	{
+		List<Integer> items = new ArrayList<>();
+		for (int i = 0; i < 23; i++)
+		{
+			items.add(i);
+		}
+		assertEquals(3, Paginator.pageCount(23, 10));
+		assertEquals(10, Paginator.page(items, 0, 10).size());
+		assertEquals(3, Paginator.page(items, 2, 10).size()); // last partial page
+		assertEquals(0, Paginator.page(items, 5, 10).size()); // out-of-range page
+		assertEquals(1, Paginator.pageCount(0, 10)); // empty still one page
+	}
+}

--- a/src/test/java/com/flipsmart/FavoritesStarStateTest.java
+++ b/src/test/java/com/flipsmart/FavoritesStarStateTest.java
@@ -1,0 +1,36 @@
+package com.flipsmart;
+
+import com.flipsmart.ui.panel.PanelFormat;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class FavoritesStarStateTest
+{
+	@Test
+	public void drawStarIconReturnsSizedImageForBothStates()
+	{
+		BufferedImage filled = PanelFormat.drawStarIcon(true, Color.ORANGE);
+		BufferedImage empty = PanelFormat.drawStarIcon(false, Color.LIGHT_GRAY);
+		assertNotNull(filled);
+		assertNotNull(empty);
+		assertEquals(16, filled.getWidth());
+		assertEquals(16, filled.getHeight());
+	}
+
+	@Test
+	public void isFavoriteReflectsSetMembership()
+	{
+		Set<Integer> favs = new HashSet<>();
+		favs.add(4151);
+		assertTrue(com.flipsmart.FlipFinderPanel.isFavorite(favs, 4151));
+		assertFalse(com.flipsmart.FlipFinderPanel.isFavorite(favs, 561));
+	}
+}

--- a/src/test/java/com/flipsmart/FavoritesTabIndexTest.java
+++ b/src/test/java/com/flipsmart/FavoritesTabIndexTest.java
@@ -1,0 +1,17 @@
+package com.flipsmart;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FavoritesTabIndexTest
+{
+	@Test
+	public void tabOrderIsRecommendedFavoritesActiveCompleted()
+	{
+		assertEquals(0, FlipFinderPanel.TAB_RECOMMENDED);
+		assertEquals(1, FlipFinderPanel.TAB_FAVORITES);
+		assertEquals(2, FlipFinderPanel.TAB_ACTIVE_FLIPS);
+		assertEquals(3, FlipFinderPanel.TAB_COMPLETED);
+	}
+}

--- a/src/test/java/com/flipsmart/FavoritesTabIndexTest.java
+++ b/src/test/java/com/flipsmart/FavoritesTabIndexTest.java
@@ -7,11 +7,10 @@ import static org.junit.Assert.assertEquals;
 public class FavoritesTabIndexTest
 {
 	@Test
-	public void tabOrderIsRecommendedFavoritesActiveCompleted()
+	public void tabOrderIsRecommendedActiveCompleted()
 	{
 		assertEquals(0, FlipFinderPanel.TAB_RECOMMENDED);
-		assertEquals(1, FlipFinderPanel.TAB_FAVORITES);
-		assertEquals(2, FlipFinderPanel.TAB_ACTIVE_FLIPS);
-		assertEquals(3, FlipFinderPanel.TAB_COMPLETED);
+		assertEquals(1, FlipFinderPanel.TAB_ACTIVE_FLIPS);
+		assertEquals(2, FlipFinderPanel.TAB_COMPLETED);
 	}
 }

--- a/src/test/java/com/flipsmart/FlipOnlyFavoritesGateTest.java
+++ b/src/test/java/com/flipsmart/FlipOnlyFavoritesGateTest.java
@@ -1,0 +1,18 @@
+package com.flipsmart;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FlipOnlyFavoritesGateTest
+{
+	@Test
+	public void favoritesOnlyRequiresBothToggleAndPremium()
+	{
+		assertTrue(FlipFinderPanel.resolveFavoritesOnly(true, true));
+		assertFalse(FlipFinderPanel.resolveFavoritesOnly(true, false)); // free tier never sends it
+		assertFalse(FlipFinderPanel.resolveFavoritesOnly(false, true));
+		assertFalse(FlipFinderPanel.resolveFavoritesOnly(false, false));
+	}
+}

--- a/src/test/java/com/flipsmart/api/endpoints/FavoritesEndpointsTest.java
+++ b/src/test/java/com/flipsmart/api/endpoints/FavoritesEndpointsTest.java
@@ -1,0 +1,31 @@
+package com.flipsmart.api.endpoints;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FavoritesEndpointsTest
+{
+	@Test
+	public void appendFavoritesOnlyAddsParamOnlyWhenTrue()
+	{
+		StringBuilder on = new StringBuilder("http://x/flip-finder?limit=10");
+		FlipsEndpoints.appendFavoritesOnly(on, true);
+		assertTrue(on.toString().endsWith("&favorites_only=true"));
+
+		StringBuilder off = new StringBuilder("http://x/flip-finder?limit=10");
+		FlipsEndpoints.appendFavoritesOnly(off, false);
+		assertFalse(off.toString().contains("favorites_only"));
+	}
+
+	@Test
+	public void favoriteTogglePathsAreCorrect()
+	{
+		assertEquals("http://api/plugin/favorites/4151",
+			FavoritesEndpoints.favoritePath("http://api", 4151));
+		assertEquals("http://api/plugin/favorites",
+			FavoritesEndpoints.favoritesListPath("http://api"));
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 of the Favorite Items feature: star/unstar any Recommended, Active Flip, or Completed item, browse favorites in a dedicated tab with live margin/profit/volume/risk, and (for premium subscribers) restrict the recommendation feed to favorites only. This is the plugin half of the three-phase rollout tracked in Flip-Smart/flip-smart#1041; the backend half already shipped in Flip-Smart/flip-smart#1085, and the web half will follow in a later PR.

## Changes

### ✨ New Features

- **Star toggle** on every Recommended / Active Flips / Completed row — wired once into the shared card header so all three lists get it for free.
- **Filled star indicator** wherever a favorited item appears (including inside the Favorites tab itself), driven off the same shared favorite-state lookup as the toggle.
- **New Favorites tab** at index 1 — tab order is now Recommended, Favorites, Active Flips, Completed. Each favorited item's card mirrors the Recommended card: live margin, profit, volume, and risk.
- **Pagination** on the Favorites tab at 10 items per page.
- **Sort filters** on the Favorites tab — Profit, Volume, and Alphabetical, each best-result-first.
- **Premium-gated "Flip only from favorites" checkbox** — when a premium user enables it, the recommendation feed is restricted to favorited items only (via a new `favorites_only` query param on the recommendations call). Free-tier users who try to enable it are blocked with an explanatory message instead of silently no-oping.

### ♻️ Refactoring

- Extracted `Paginator` and `PanelFormat` helpers in `ui/panel/` so pagination and card-formatting logic isn't duplicated between the Recommended and Favorites tabs.

## API Client / DTO Changes

- New DTOs: `FavoriteItem`, `FavoritesResponse`; `PluginSyncResponse` now carries `favorite_item_ids`.
- New `FavoritesEndpoints` (list / add / remove), consuming the backend surface shipped in Flip-Smart/flip-smart#1085.
- `FlipsEndpoints` recommendations call now accepts a `favorites_only` query param.

## Testing

### Automated Tests

- `./gradlew build` green — full compile + JUnit suite passes, no warnings or errors in the build output.
- New unit tests added:
  - `FavoritesDtoParsingTest` — DTO (de)serialization for `FavoriteItem` / `FavoritesResponse` / sync payload.
  - `FavoritesEndpointsTest` — endpoint URL/path construction for list/add/remove.
  - `FavoritesStarStateTest` — star fill state / icon resolution given a favorites set.
  - `FavoritesSortAndPaginationTest` — sort comparators (Profit/Volume/Alphabetical) and paginator page-slicing.
  - `FavoritesTabIndexTest` — tab ordering (Recommended, Favorites, Active Flips, Completed).
  - `FlipOnlyFavoritesGateTest` — premium-gate resolver (premium+enabled → filtered feed; free-tier → blocked with message).

This repo has no separate lint/typecheck Gradle task — Codacy handles static-analysis/style review on the PR itself.

### Manual Testing (in-game QA required)

Swing/interactive UI behavior can't be exercised by Playwright (browser-only) or headless JUnit, so the following need manual verification in a running RuneLite client:

- [ ] Star toggle appears and persists (survives tab switch) on a Recommended row, an Active Flip row, and a Completed row.
- [ ] Starring an item from any tab surfaces it (filled star) in the new Favorites tab.
- [ ] Favorites tab shows live margin / profit / volume / risk matching what the Recommended card would show for the same item.
- [ ] Pagination on the Favorites tab correctly pages at 10 items, including the last (partial) page.
- [ ] Sort filters (Profit / Volume / Alphabetical) reorder the Favorites tab best-first and persist across a re-render.
- [ ] Premium user: enabling "Flip only from favorites" restricts the Recommended feed to favorited items only.
- [ ] Free-tier user: attempting to enable "Flip only from favorites" is blocked with the expected message and the feed is unaffected.

## Deployment Notes

- No new environment variables, dependencies, or configuration changes.
- Depends on the backend endpoints from Flip-Smart/flip-smart#1085 already being live — no coordinated deploy required, this is purely additive on the plugin side.
- Pending a future RuneLite Plugin Hub release to reach players (bundled with other queued plugin work per existing release cadence).

## Checklist

- [x] Tests added/updated
- [x] Code follows style guidelines (no issue-ref comments, no narrative comments, per plugin LOC-budget rules)
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [ ] Manual in-game QA (see checklist above)
- [ ] Reviewed by teammate

## Related Issues

Flip-Smart/flip-smart#1041 (Phase 2 of 3 — issue stays open until the web phase ships)
Backend Phase 1: Flip-Smart/flip-smart#1085


### 🩺 Codacy Quality Gate — fixed in this PR
- `f7f9bce` PMD_AvoidFieldNameMatchingMethodName `src/main/java/com/flipsmart/ui/panel/FavoritesSort.java:14` — renamed the field to `itemComparator` to stop colliding with the `comparator()` accessor.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `f7f9bce` `FavoritesSort.java:14` — same fix as above; resolves two separate AI Reviewer comments on this line.
- `cd9ab0c` `FlipFinderPanel.java:2537` — `refreshFavoritesTab()`'s failure branch now calls the existing `showErrorInContainer` helper instead of only logging, so a failed fetch shows an error state like the other tabs.
- `4b63935` `FlipFinderPanel.java:3284` — extracted the duplicated optimistic-toggle rollback (success-failure and exceptionally branches) into a `rollbackFavoriteToggle` helper.

### 🤖 Codacy AI Reviewer — deferred (in-thread rationale)
- `FlipsEndpoints.java:93` — shared-request-object refactor for `getFlipRecommendationsAsync`/`getPluginSyncAsync`; query-building is already deduplicated via helper methods, remaining boilerplate spans the whole endpoints class and predates this PR.
- `FlipSmartApiClient.java:222` — same request-object suggestion for the facade's wide parameter lists; pre-existing pattern, this PR only adds one boolean.

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `FlipFinderPanel.java:775` — claimed the footer status label isn't updated on switching to the Favorites tab; it already is (`updateFavoritesStatusLabel()` on tab switch and again once the list hydrates), added in `bdeaf39` which the review pass appears to have analyzed before it landed.
