### PR TITLE
fix: tracking-accuracy — offer over-count, breakeven fallback, manual sell-focus retry (#1089)

### DIFF
--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -417,6 +417,15 @@ public class FlipSmartPlugin extends Plugin
 		return flipFinderPanel != null ? flipFinderPanel.getCurrentActiveFlips() : null;
 	}
 
+	/**
+	 * Local OfferStore records for an item — the fallback source for the recorded
+	 * buy price when the backend-sourced active-flips snapshot is empty (#1089 D4).
+	 */
+	public java.util.List<com.flipsmart.domain.offer.OfferRecord> getOfferRecordsForItem(int itemId)
+	{
+		return offerStore.forItem(itemId);
+	}
+
 	public boolean isAutoRecommendActive()
 	{
 		return autoRecommendService != null && autoRecommendService.isActive();
@@ -1951,7 +1960,8 @@ public class FlipSmartPlugin extends Plugin
 	{
 		if (!offer.isBuy())
 		{
-			return BuyPriceLookup.findAverageBuyPrice(getCurrentActiveFlips(), offer.getItemId());
+			return BuyPriceLookup.findAverageBuyPriceWithFallback(
+				getCurrentActiveFlips(), offerStore.forItem(offer.getItemId()), offer.getItemId());
 		}
 		if (offer.getFilledQuantity() > 0 && offer.getSpent() > 0)
 		{

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -419,7 +419,7 @@ public class FlipSmartPlugin extends Plugin
 
 	/**
 	 * Local OfferStore records for an item — the fallback source for the recorded
-	 * buy price when the backend-sourced active-flips snapshot is empty (#1089 D4).
+	 * buy price when the backend-sourced active-flips snapshot is empty.
 	 */
 	public java.util.List<com.flipsmart.domain.offer.OfferRecord> getOfferRecordsForItem(int itemId)
 	{

--- a/src/main/java/com/flipsmart/GeOfferDescriptionService.java
+++ b/src/main/java/com/flipsmart/GeOfferDescriptionService.java
@@ -483,7 +483,8 @@ public class GeOfferDescriptionService
 
 	private String buildSellDescription(int itemId)
 	{
-		Integer recordedBuyPrice = BuyPriceLookup.findAverageBuyPrice(plugin.getCurrentActiveFlips(), itemId);
+		Integer recordedBuyPrice = BuyPriceLookup.findAverageBuyPriceWithFallback(
+			plugin.getCurrentActiveFlips(), plugin.getOfferRecordsForItem(itemId), itemId);
 		int sellPrice = Math.max(client.getVarbitValue(VarbitID.GE_NEWOFFER_PRICE), 0);
 		int quantity = Math.max(client.getVarbitValue(VarbitID.GE_NEWOFFER_QUANTITY), 0);
 		return GeOfferDescriptionFormatter.formatSellDescription(itemId, recordedBuyPrice, sellPrice, quantity);
@@ -491,7 +492,8 @@ public class GeOfferDescriptionService
 
 	private String buildSellDescriptionStatic(int itemId, int listedPrice, int totalQuantity)
 	{
-		Integer recordedBuyPrice = BuyPriceLookup.findAverageBuyPrice(plugin.getCurrentActiveFlips(), itemId);
+		Integer recordedBuyPrice = BuyPriceLookup.findAverageBuyPriceWithFallback(
+			plugin.getCurrentActiveFlips(), plugin.getOfferRecordsForItem(itemId), itemId);
 		return GeOfferDescriptionFormatter.formatSellDescription(
 			itemId, recordedBuyPrice, Math.max(listedPrice, 0), Math.max(totalQuantity, 0));
 	}

--- a/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
@@ -341,7 +341,8 @@ public class GrandExchangeSlotOverlay extends Overlay
 
 	private Integer getBuyPriceForItem(int itemId)
 	{
-		return BuyPriceLookup.findAverageBuyPrice(plugin.getCurrentActiveFlips(), itemId);
+		return BuyPriceLookup.findAverageBuyPriceWithFallback(
+			plugin.getCurrentActiveFlips(), plugin.getOfferRecordsForItem(itemId), itemId);
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -77,6 +77,10 @@ public class GrandExchangeTracker
 	private static final int SELL_FOCUS_RETRY_TICKS = 6;
 	private volatile int pendingSellFocusItemId = -1;
 	private int pendingSellFocusTicksLeft;
+	// #1089 D5: retry mode is fixed when armed, not read from the live auto state.
+	// A manual-armed retry re-issues the backend lookup each tick; an auto-armed
+	// one re-runs the local resolver and drops if auto-recommend is turned off.
+	private boolean pendingSellFocusManual;
 
 	/**
 	 * Bundles GE offer data passed from the plugin event handler.
@@ -801,9 +805,17 @@ public class GrandExchangeTracker
 			// arrive late or not show at all.
 			pendingSellFocusItemId = itemId;
 			pendingSellFocusTicksLeft = SELL_FOCUS_RETRY_TICKS;
+			pendingSellFocusManual = false;
 			return;
 		}
 
+		// Manual mode (#1089 D5): the backend active-flip snapshot lags the
+		// just-opened sell screen, so a single one-shot lookup returned no match
+		// and the sell target silently never filled. Arm the same bounded tick-
+		// retry auto mode gets, re-issuing the backend lookup until it resolves.
+		pendingSellFocusItemId = itemId;
+		pendingSellFocusTicksLeft = SELL_FOCUS_RETRY_TICKS;
+		pendingSellFocusManual = true;
 		tryAsyncSellFocus(itemId);
 	}
 
@@ -837,12 +849,27 @@ public class GrandExchangeTracker
 		{
 			return;
 		}
+		int itemId = pendingSellFocusItemId;
+
+		if (pendingSellFocusManual)
+		{
+			// Manual retry (#1089 D5): no local resolver, so re-issue the backend
+			// lookup each tick until it resolves (handleActiveFlipResponse clears
+			// pending on success) or the budget runs out.
+			pendingSellFocusTicksLeft--;
+			if (pendingSellFocusTicksLeft <= 0)
+			{
+				clearPendingSellFocus();
+			}
+			tryAsyncSellFocus(itemId);
+			return;
+		}
+
 		if (!isAutoRecommendActive())
 		{
 			clearPendingSellFocus();
 			return;
 		}
-		int itemId = pendingSellFocusItemId;
 		String itemName = ItemUtils.getItemName(itemManager, itemId);
 		AutoRecommendService.SellFocusResult result =
 			autoRecommendService.overrideFocusForSell(itemId, itemName);
@@ -867,6 +894,7 @@ public class GrandExchangeTracker
 	{
 		pendingSellFocusItemId = -1;
 		pendingSellFocusTicksLeft = 0;
+		pendingSellFocusManual = false;
 	}
 
 	private void handleActiveFlipResponse(
@@ -889,10 +917,13 @@ public class GrandExchangeTracker
 		if (offerStore.hasActiveSellOfferForItem(itemId))
 		{
 			log.debug("Sell already placed for {} - not overriding focus", matchingFlip.getItemName());
+			clearPendingSellFocus();
 			return;
 		}
 
 		setFocusForSell(matchingFlip, inventoryCount);
+		// The flip resolved — stop any manual tick-retry re-issuing the lookup (#1089 D5).
+		clearPendingSellFocus();
 
 		// Sync inventory-corrected quantity to API if inventory has more
 		if (inventoryCount > matchingFlip.getTotalQuantity() && inventoryCount > 0 && rsn != null)

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -77,7 +77,7 @@ public class GrandExchangeTracker
 	private static final int SELL_FOCUS_RETRY_TICKS = 6;
 	private volatile int pendingSellFocusItemId = -1;
 	private int pendingSellFocusTicksLeft;
-	// #1089 D5: retry mode is fixed when armed, not read from the live auto state.
+	// Retry mode is fixed when armed, not read from the live auto state.
 	// A manual-armed retry re-issues the backend lookup each tick; an auto-armed
 	// one re-runs the local resolver and drops if auto-recommend is turned off.
 	private boolean pendingSellFocusManual;
@@ -809,7 +809,7 @@ public class GrandExchangeTracker
 			return;
 		}
 
-		// Manual mode (#1089 D5): the backend active-flip snapshot lags the
+		// Manual mode: the backend active-flip snapshot lags the
 		// just-opened sell screen, so a single one-shot lookup returned no match
 		// and the sell target silently never filled. Arm the same bounded tick-
 		// retry auto mode gets, re-issuing the backend lookup until it resolves.
@@ -853,7 +853,7 @@ public class GrandExchangeTracker
 
 		if (pendingSellFocusManual)
 		{
-			// Manual retry (#1089 D5): no local resolver, so re-issue the backend
+			// Manual retry: no local resolver, so re-issue the backend
 			// lookup each tick until it resolves (handleActiveFlipResponse clears
 			// pending on success) or the budget runs out.
 			pendingSellFocusTicksLeft--;
@@ -922,7 +922,7 @@ public class GrandExchangeTracker
 		}
 
 		setFocusForSell(matchingFlip, inventoryCount);
-		// The flip resolved — stop any manual tick-retry re-issuing the lookup (#1089 D5).
+		// The flip resolved — stop any manual tick-retry re-issuing the lookup.
 		clearPendingSellFocus();
 
 		// Sync inventory-corrected quantity to API if inventory has more

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -80,7 +80,7 @@ public class GrandExchangeTracker
 	// Retry mode is fixed when armed, not read from the live auto state.
 	// A manual-armed retry re-issues the backend lookup each tick; an auto-armed
 	// one re-runs the local resolver and drops if auto-recommend is turned off.
-	private boolean pendingSellFocusManual;
+	private volatile boolean pendingSellFocusManual;
 
 	/**
 	 * Bundles GE offer data passed from the plugin event handler.
@@ -902,6 +902,17 @@ public class GrandExchangeTracker
 	{
 		if (response == null || response.getActiveFlips() == null)
 		{
+			return;
+		}
+
+		// A newer sell-focus session may have armed for a different item while
+		// this lookup was in flight (manual mode re-issues every tick). A stale
+		// response for the old item must not override or clear that session.
+		int currentPendingItemId = pendingSellFocusItemId;
+		if (currentPendingItemId >= 0 && currentPendingItemId != itemId)
+		{
+			log.debug("Dropping stale active-flip response for {} - pending item is now {}",
+				itemId, currentPendingItemId);
 			return;
 		}
 

--- a/src/main/java/com/flipsmart/trading/OfferReconciler.java
+++ b/src/main/java/com/flipsmart/trading/OfferReconciler.java
@@ -82,11 +82,18 @@ public final class OfferReconciler
 
     private static boolean matches(OfferRecord p, OfferSignal live)
     {
-        return p.getSlot() != null
+        // Identity is the live slot's (slot, item, direction) — NOT its mutable
+        // totalQuantity/price. The order's total and price legitimately drift
+        // (partial buys re-read a different total, a relist changes price), and
+        // requiring them to be equal made a still-live record fail to reattach:
+        // a fresh baseline-0 record then re-posted the whole cumulative on top of
+        // fills already recorded, a ~40% buy over-count (#1089 D1). Terminal
+        // records are finished history — a live slot showing their item is a
+        // reused slot holding a new offer, so they never reattach.
+        return !p.getState().isTerminal()
+            && p.getSlot() != null
             && p.getSlot() == live.slot
             && p.getItemId() == live.itemId
-            && p.isBuy() == live.isBuy()
-            && p.getTotalQuantity() == live.totalQuantity
-            && p.getPrice() == live.price;
+            && p.isBuy() == live.isBuy();
     }
 }

--- a/src/main/java/com/flipsmart/trading/OfferReconciler.java
+++ b/src/main/java/com/flipsmart/trading/OfferReconciler.java
@@ -87,7 +87,7 @@ public final class OfferReconciler
         // (partial buys re-read a different total, a relist changes price), and
         // requiring them to be equal made a still-live record fail to reattach:
         // a fresh baseline-0 record then re-posted the whole cumulative on top of
-        // fills already recorded, a ~40% buy over-count (#1089 D1). Terminal
+        // fills already recorded, a ~40% buy over-count. Terminal
         // records are finished history — a live slot showing their item is a
         // reused slot holding a new offer, so they never reattach.
         return !p.getState().isTerminal()

--- a/src/main/java/com/flipsmart/util/BuyPriceLookup.java
+++ b/src/main/java/com/flipsmart/util/BuyPriceLookup.java
@@ -1,5 +1,6 @@
 package com.flipsmart.util;
 import com.flipsmart.domain.flip.ActiveFlip;
+import com.flipsmart.domain.offer.OfferRecord;
 
 import java.util.List;
 
@@ -36,5 +37,51 @@ public final class BuyPriceLookup
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Resolve the recorded average buy price from the active-flips snapshot, and
+	 * when that is absent, fall back to the local {@link OfferRecord} store
+	 * (#1089 D4). The active-flips list is backend-sourced and can be empty for
+	 * reasons unrelated to whether the player holds the item — a refresh race,
+	 * the free-tier slot trim, or a plain gap — and when it is, breakeven/margin/
+	 * profit rendered "?" despite the buy sitting in the OfferStore. The offer
+	 * records carry the same cost basis, so the derived stats stay populated.
+	 *
+	 * @return the average buy price, or {@code null} if neither source knows the
+	 *         item.
+	 */
+	public static Integer findAverageBuyPriceWithFallback(
+		List<ActiveFlip> activeFlips, List<OfferRecord> offerRecords, int itemId)
+	{
+		Integer fromFlips = findAverageBuyPrice(activeFlips, itemId);
+		if (fromFlips != null)
+		{
+			return fromFlips;
+		}
+		return averageBuyPriceFromOffers(offerRecords, itemId);
+	}
+
+	/**
+	 * Quantity-weighted average buy price across the item's filled buy offers,
+	 * or {@code null} when none carry a fill. Sells and other items are ignored.
+	 */
+	static Integer averageBuyPriceFromOffers(List<OfferRecord> offerRecords, int itemId)
+	{
+		if (offerRecords == null)
+		{
+			return null;
+		}
+		long spent = 0;
+		long filled = 0;
+		for (OfferRecord r : offerRecords)
+		{
+			if (r != null && r.isBuy() && r.getItemId() == itemId && r.getFilledQuantity() > 0)
+			{
+				spent += r.getSpent();
+				filled += r.getFilledQuantity();
+			}
+		}
+		return filled > 0 ? (int) (spent / filled) : null;
 	}
 }

--- a/src/main/java/com/flipsmart/util/BuyPriceLookup.java
+++ b/src/main/java/com/flipsmart/util/BuyPriceLookup.java
@@ -82,6 +82,6 @@ public final class BuyPriceLookup
 				filled += r.getFilledQuantity();
 			}
 		}
-		return filled > 0 ? (int) (spent / filled) : null;
+		return filled > 0 ? (int) Math.round(spent / (double) filled) : null;
 	}
 }

--- a/src/main/java/com/flipsmart/util/BuyPriceLookup.java
+++ b/src/main/java/com/flipsmart/util/BuyPriceLookup.java
@@ -42,7 +42,7 @@ public final class BuyPriceLookup
 	/**
 	 * Resolve the recorded average buy price from the active-flips snapshot, and
 	 * when that is absent, fall back to the local {@link OfferRecord} store
-	 * (#1089 D4). The active-flips list is backend-sourced and can be empty for
+	 * The active-flips list is backend-sourced and can be empty for
 	 * reasons unrelated to whether the player holds the item — a refresh race,
 	 * the free-tier slot trim, or a plain gap — and when it is, breakeven/margin/
 	 * profit rendered "?" despite the buy sitting in the OfferStore. The offer

--- a/src/test/java/com/flipsmart/OfferReconcilerTest.java
+++ b/src/test/java/com/flipsmart/OfferReconcilerTest.java
@@ -140,4 +140,45 @@ public class OfferReconcilerTest
         assertEquals(1, plan.offlineCollected.size());
         assertTrue(plan.staleHistory.isEmpty());
     }
+
+    @Test
+    public void liveSlotMatchesDespiteTotalQuantityAndPriceDrift_reattachesNotMints()
+    {
+        // #1089 D1: the buy order's total_quantity drifted (7500 -> 11584) and its
+        // price nudged between persistence and the live read. The old exact-match
+        // on total+price then failed to reattach, so a fresh baseline-0 record
+        // re-posted the whole cumulative on top of fills already recorded — a ~40%
+        // over-count seen across 1,061 prod users. Identity is the live slot's
+        // (slot, item, direction), not its mutable total/price.
+        OfferRecord persisted = OfferRecord.newOffer(7L, 0, 536, "Dragon bones", true, 7500, 3284, NOW - 1000)
+            .withFill(3027, 3027L * 3284, OfferState.PARTIAL_FILL, NOW - 500);
+        OfferSignal drifted = new OfferSignal(
+            0, GrandExchangeOfferState.BUYING, 536, "Dragon bones", 11584, 3290, 4279, 4279L * 3284);
+
+        OfferReconciler.Plan plan = OfferReconciler.reconcile(
+            Collections.singletonList(persisted), Collections.singletonList(drifted), NOW);
+
+        assertEquals("must reattach despite total/price drift", 1, plan.reattached.size());
+        assertEquals(7L, plan.reattached.get(0).getOfferId());
+        assertEquals("recorded baseline preserved so the next fill logs only the delta",
+            3027, plan.reattached.get(0).getFilledQuantity());
+        assertTrue("no fresh baseline-0 record minted", plan.minted.isEmpty());
+    }
+
+    @Test
+    public void terminalRecordSameSlotAndItem_isNotReattached_mintsFresh()
+    {
+        // Loosening the match must not grab a COLLECTED leftover occupying the same
+        // slot+item: that is a reused slot holding a genuinely new offer, so it must
+        // mint fresh rather than resurrect finished history.
+        OfferRecord collected = OfferRecord.newOffer(9L, 0, 536, "Dragon bones", true, 7500, 3284, NOW - 3000)
+            .withFill(7500, 7500L * 3284, OfferState.FILLED, NOW - 2500)
+            .withState(OfferState.COLLECTED, NOW - 2000);
+
+        OfferReconciler.Plan plan = OfferReconciler.reconcile(
+            Collections.singletonList(collected), Collections.singletonList(live(0, 536, 100, 7500)), NOW);
+
+        assertTrue("terminal record must not reattach to a live slot", plan.reattached.isEmpty());
+        assertEquals(1, plan.minted.size());
+    }
 }

--- a/src/test/java/com/flipsmart/SellFocusRetryTest.java
+++ b/src/test/java/com/flipsmart/SellFocusRetryTest.java
@@ -119,4 +119,31 @@ public class SellFocusRetryTest
 		tracker.retryPendingSellFocusTick();
 		verify(autoRecommendService, times(1)).overrideFocusForSell(anyInt(), anyString());
 	}
+
+	@Test
+	public void manualMode_retriesBackendLookupAcrossTicks_thenStops()
+	{
+		// #1089 D5: with auto-recommend off, opening a sell screen must still retry
+		// the backend active-flip lookup across ticks. Before, manual mode issued a
+		// single one-shot lookup that silently failed when the backend snapshot
+		// lagged the just-opened screen, so the sell target never filled.
+		when(autoRecommendService.isActive()).thenReturn(false);
+
+		tracker.autoFocusOnActiveFlip(ITEM);   // manual path: 1 lookup + arms retry
+		verify(apiClient, times(1)).getActiveFlipsAsync(anyString());
+
+		for (int i = 0; i < RETRY_BUDGET_TICKS; i++)
+		{
+			tracker.retryPendingSellFocusTick();
+		}
+		// 1 (entry) + 6 (ticks) lookups, then the budget clears the pending retry.
+		verify(apiClient, times(1 + RETRY_BUDGET_TICKS)).getActiveFlipsAsync(anyString());
+
+		// Budget exhausted → further ticks are no-ops.
+		tracker.retryPendingSellFocusTick();
+		verify(apiClient, times(1 + RETRY_BUDGET_TICKS)).getActiveFlipsAsync(anyString());
+
+		// Manual mode never touches the auto-recommend local resolver.
+		verify(autoRecommendService, never()).overrideFocusForSell(anyInt(), anyString());
+	}
 }

--- a/src/test/java/com/flipsmart/SellFocusRetryTest.java
+++ b/src/test/java/com/flipsmart/SellFocusRetryTest.java
@@ -1,6 +1,8 @@
 package com.flipsmart;
 
 import com.flipsmart.api.dto.ActiveFlipsResponse;
+import com.flipsmart.domain.flip.ActiveFlip;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import net.runelite.client.game.ItemManager;
@@ -145,5 +147,37 @@ public class SellFocusRetryTest
 
 		// Manual mode never touches the auto-recommend local resolver.
 		verify(autoRecommendService, never()).overrideFocusForSell(anyInt(), anyString());
+	}
+
+	@Test
+	public void staleResponseForPreviousItem_doesNotClobberNewlyArmedItem()
+	{
+		// Manual mode re-issues the backend lookup every tick, so an old item's
+		// in-flight request can resolve after the player has already opened a
+		// sell screen for a different item. That stale response must not clear
+		// the newly-armed session's pending retry.
+		when(autoRecommendService.isActive()).thenReturn(false);
+		int otherItem = 995;
+
+		CompletableFuture<ActiveFlipsResponse> firstLookup = new CompletableFuture<>();
+		when(apiClient.getActiveFlipsAsync(anyString())).thenReturn(firstLookup);
+		tracker.autoFocusOnActiveFlip(ITEM);   // arms + fires lookup for ITEM
+
+		CompletableFuture<ActiveFlipsResponse> secondLookup = new CompletableFuture<>();
+		when(apiClient.getActiveFlipsAsync(anyString())).thenReturn(secondLookup);
+		tracker.autoFocusOnActiveFlip(otherItem);   // re-arms + fires lookup for otherItem
+
+		// The stale ITEM lookup resolves after otherItem is already pending.
+		ActiveFlip staleFlip = new ActiveFlip();
+		staleFlip.setItemId(ITEM);
+		staleFlip.setAverageBuyPrice(100);
+		staleFlip.setTotalQuantity(10);
+		ActiveFlipsResponse staleResponse = new ActiveFlipsResponse();
+		staleResponse.setActiveFlips(Collections.singletonList(staleFlip));
+		firstLookup.complete(staleResponse);
+
+		// otherItem's session must still be pending: a retry tick re-issues its lookup.
+		tracker.retryPendingSellFocusTick();
+		verify(apiClient, times(3)).getActiveFlipsAsync(anyString());
 	}
 }

--- a/src/test/java/com/flipsmart/util/BuyPriceLookupTest.java
+++ b/src/test/java/com/flipsmart/util/BuyPriceLookupTest.java
@@ -1,0 +1,74 @@
+package com.flipsmart.util;
+
+import com.flipsmart.domain.flip.ActiveFlip;
+import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.domain.offer.OfferState;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * #1089 D4: the offer-screen breakeven/margin and slot-hover P&L resolve the
+ * recorded buy price from the backend-sourced active-flips list. When that list
+ * is empty (refresh race, free-tier trim, or plain absence) the price came back
+ * null and every derived stat rendered "?", even though the buy is sitting in
+ * the local OfferStore. The fallback resolves the price from OfferStore so the
+ * stats stay populated.
+ */
+public class BuyPriceLookupTest
+{
+    private static ActiveFlip flip(int itemId, int avgBuy)
+    {
+        ActiveFlip f = new ActiveFlip();
+        f.setItemId(itemId);
+        f.setAverageBuyPrice(avgBuy);
+        return f;
+    }
+
+    private static OfferRecord buy(int itemId, int filled, long spent)
+    {
+        int price = filled > 0 ? (int) (spent / filled) : 0;
+        return OfferRecord.newOffer(1L, 0, itemId, "i" + itemId, true, filled, price, 0L)
+            .withFill(filled, spent, OfferState.PARTIAL_FILL, 0L);
+    }
+
+    @Test
+    public void activeFlipPresent_usesFlipPrice_ignoresFallback()
+    {
+        Integer p = BuyPriceLookup.findAverageBuyPriceWithFallback(
+            Collections.singletonList(flip(536, 3284)),
+            Collections.singletonList(buy(536, 100, 100L * 9999)),
+            536);
+        assertEquals(Integer.valueOf(3284), p);
+    }
+
+    @Test
+    public void activeFlipsEmpty_fallsBackToOfferStoreWeightedAverage()
+    {
+        // (3000*3284 + 1000*3300) / 4000 = 3288
+        List<OfferRecord> offers = asList(buy(536, 3000, 3000L * 3284), buy(536, 1000, 1000L * 3300));
+        Integer p = BuyPriceLookup.findAverageBuyPriceWithFallback(Collections.emptyList(), offers, 536);
+        assertEquals(Integer.valueOf(3288), p);
+    }
+
+    @Test
+    public void fallbackIgnoresSellsAndOtherItems()
+    {
+        OfferRecord otherItem = buy(999, 500, 500L * 100);
+        List<OfferRecord> offers = asList(buy(536, 1000, 1000L * 3284), otherItem);
+        Integer p = BuyPriceLookup.findAverageBuyPriceWithFallback(Collections.emptyList(), offers, 536);
+        assertEquals(Integer.valueOf(3284), p);
+    }
+
+    @Test
+    public void neitherSourceHasItem_returnsNull()
+    {
+        assertNull(BuyPriceLookup.findAverageBuyPriceWithFallback(
+            Collections.emptyList(), Collections.emptyList(), 536));
+    }
+}


### PR DESCRIPTION
## Summary

Plugin half of the #1089 tracking-accuracy bundle (the backend half is a sibling PR on `flip-smart`, a separate private repo). Three plugin defects fixed: a buy-offer over-count from over-strict offer reattachment matching, a blank breakeven/margin display when the active-flips snapshot is empty, and manual-mode sell-focus never retrying after a collect.

## Changes

### 🐛 Bug Fixes

- **D1 — buy over-count via away-fill re-mint.** `OfferReconciler.matches()` required the persisted record's `totalQuantity` AND `price` to equal the live slot's. Both drift legitimately (a partial buy re-reads a different total; a relist changes price), so a still-live record failed to reattach and a fresh baseline-0 record re-posted the whole cumulative fill on top of fills already recorded — a ~40% buy over-count (measured on prod: 11,749 offers / 1,061 users / ~302M phantom open units in the last 30 days). Fix: match on the stable slot+item+direction identity and never reattach a terminal record (a reused slot showing its item is a new offer).
- **D4 — breakeven/margin blank.** Offer-screen breakeven/margin and slot-hover P&L resolved the recorded buy price only from the backend-sourced active-flips snapshot; when that list is empty (refresh race, free-tier trim, or a gap) the value was null and every derived stat rendered "?", even though the buy sits in the local `OfferStore`. Added `BuyPriceLookup.findAverageBuyPriceWithFallback` (OfferStore quantity-weighted average), wired through all call sites (`GeOfferDescriptionService` x2, `GrandExchangeSlotOverlay`, `FlipSmartPlugin.avgBuyPriceFor`).
- **D5 — manual sell-focus never retried.** Auto-recommend retries sell-focus over a bounded tick budget when the just-finished collect hasn't settled; manual mode issued a single one-shot backend lookup and gave up on a null match, so the sell target silently never filled. Manual mode now arms the same retry (tracked separately so an auto-armed retry still drops when auto-recommend is toggled off).

### Notes / Deviations

The plan called for a second baseline-seed backstop layer for D1; on closer reading a *mint* means there is no persisted record to seed a baseline from, the login-burst already covers the login case, and the `matches()` fix prevents the record-drop that caused the over-count — adding the seed risked under-counting genuine new offline fills. This was intentionally **not** implemented.

## Testing

### Automated Tests

- ✅ `./gradlew test` → BUILD SUCCESSFUL (full suite)
- ✅ `OfferReconcilerTest`: reattach across total/price drift; terminal record not reattached
- ✅ `BuyPriceLookupTest`: OfferStore fallback weighted average; sells/other items ignored
- ✅ `SellFocusRetryTest`: manual mode retries across ticks then stops; existing auto tests preserved

### Manual Testing

- [ ] Verify buy offer reattaches correctly across a partial-fill total/price change without double-counting
- [ ] Verify breakeven/margin displays correctly when active-flips list is empty (e.g., right after login or a refresh gap)
- [ ] Verify manual-mode sell-focus retries and eventually resolves after a collect, matching auto-recommend behavior

Note: in-game QA is manual (Playwright can't drive a RuneLite client) — the user will test on their own account.

## API Changes

N/A — plugin-only change, no backend API surface touched by this PR (backend half ships as a separate sibling PR on `flip-smart`).

## Database Migrations

N/A — plugin-only change.

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: None
- [ ] Requires database migration: No
- Requires a new Plugin Hub release to reach players (standard plugin release cadence, not covered by this PR).

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by [teammate]

## Related Issues

Closes Flip-Smart/flip-smart#1089

## Screenshots

N/A — no UI changes.

## Codacy Resolution

### 🩺 Codacy Quality Gate

Gate was already `isUpToStandards=true` (0 new issues) at head. No FIX/CONFIG/DISMISS actions needed for Pass B.

### 🤖 Codacy AI Reviewer — fixed in this PR

- `e11b6cf` `src/main/java/com/flipsmart/util/BuyPriceLookup.java:85` — round instead of truncate the weighted average buy price, matching `FlipSmartPlugin.avgBuyPriceFor`
- `874ebef` `src/main/java/com/flipsmart/GrandExchangeTracker.java:937` — `handleActiveFlipResponse` now drops a stale response whose `itemId` no longer matches the pending sell-focus target (manual mode re-issues the lookup every tick, so an old item's in-flight request can resolve after a different item's session has armed); also made `pendingSellFocusManual` volatile alongside the already-volatile `pendingSellFocusItemId`. Covered by a new regression test that fails without the guard.

### 🤖 Codacy AI Reviewer — deferred (in-thread rationale)

- `src/main/java/com/flipsmart/GrandExchangeTracker.java:864` — re-issuing the backend lookup every manual-mode retry tick (2 duplicate threads). Intentional for #1089 D5; bounded to `SELL_FOCUS_RETRY_TICKS=6` (~3.6s), not unbounded. An in-flight guard is a reasonable hardening follow-up but out of scope here.
- `src/main/java/com/flipsmart/util/BuyPriceLookup.java:79` — `averageBuyPriceFromOffers` can average across historical, already-closed flip cycles for the same item, not just the current open position (`OfferStore` never evicts records). Correct scoping needs buy/sell matching, more than this two-source fallback was built to do. Tracked in Flip-Smart/flip-smart#1091.

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)

- `src/main/java/com/flipsmart/util/BuyPriceLookup.java:79` — item-ID re-check in `averageBuyPriceFromOffers` is technically redundant given today's callers pre-filter (`OfferStore.forItem`), but kept as a defensive guard since the method is package-visible, not private.
