### PR TITLE
fix(tracking): ledger round-trip hardening + active-flips display (#1095)

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2026,28 +2026,28 @@ public class FlipFinderPanel extends PluginPanel
 	}
 
 	/**
-	 * Determine if an active flip should be shown (not duplicated by pending orders)
-	 * 
-	 * Logic: If an item has ANY pending buy order in the GE, skip the active flip.
-	 * The pending order is the source of truth for items currently in buy slots.
-	 * Active flips should only show for COLLECTED items (no longer in GE, waiting to sell).
+	 * Determine if an active flip should be shown (not duplicated by pending orders).
+	 *
+	 * A pending BUY order for an item is already rendered in the pending-orders section above, so a
+	 * matching BUY-phase active flip would duplicate it and is skipped. But a SELLING flip (a lot the
+	 * player already bought and is now selling) is a distinct live position — the pending buy is a
+	 * separate re-buy of the same item started while the earlier lot is still selling. Hiding it lost
+	 * the sell-side tracking (only 7 of 8 flips ever showed). A selling flip is always shown.
 	 */
-	private boolean shouldShowActiveFlip(ActiveFlip flip, 
+	private boolean shouldShowActiveFlip(ActiveFlip flip,
 			java.util.Map<Integer, java.util.List<PendingOrder>> pendingByItemId)
 	{
 		java.util.List<PendingOrder> matchingPending = pendingByItemId.get(flip.getItemId());
-		
-		if (matchingPending == null || matchingPending.isEmpty())
+		boolean hasPendingBuy = matchingPending != null && !matchingPending.isEmpty();
+		boolean show = ActiveFlipDisplayFilter.showAlongsidePendingBuy(flip, hasPendingBuy);
+		if (!show)
 		{
-			// No pending buy orders for this item - show the active flip
-			return true;
+			// A buy-phase flip whose item is already in a GE buy slot: the pending-order row above is
+			// the source of truth, so skip the duplicate.
+			log.debug("Skipping buy-phase active flip {} - already shown as {} pending buy order(s) in GE",
+				flip.getItemName(), matchingPending.size());
 		}
-		
-		// There's a pending buy order for this item in the GE.
-		// Skip the active flip to avoid duplicates - the pending order panel shows the current state.
-		log.debug("Skipping active flip {} - has {} pending buy order(s) in GE",
-			flip.getItemName(), matchingPending.size());
-		return false;
+		return show;
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2040,7 +2040,7 @@ public class FlipFinderPanel extends PluginPanel
 		java.util.List<PendingOrder> matchingPending = pendingByItemId.get(flip.getItemId());
 		boolean hasPendingBuy = matchingPending != null && !matchingPending.isEmpty();
 		boolean show = ActiveFlipDisplayFilter.showAlongsidePendingBuy(flip, hasPendingBuy);
-		if (!show)
+		if (!show && log.isDebugEnabled())
 		{
 			// A buy-phase flip whose item is already in a GE buy slot: the pending-order row above is
 			// the source of truth, so skip the duplicate.

--- a/src/main/java/com/flipsmart/domain/flip/ActiveFlipDisplayFilter.java
+++ b/src/main/java/com/flipsmart/domain/flip/ActiveFlipDisplayFilter.java
@@ -52,4 +52,24 @@ public final class ActiveFlipDisplayFilter
 		return (activeItemIds != null && activeItemIds.contains(itemId))
 			|| (inventoryItemIds != null && inventoryItemIds.contains(itemId));
 	}
+
+	/**
+	 * Whether an active flip should still be shown when its item also has a pending BUY order that is
+	 * already rendered in the pending-orders section.
+	 *
+	 * A SELLING flip (a lot already bought and now being sold — {@code sellPlacedTime} set, or the
+	 * backend marks it {@code phase == "sell"}) is a distinct live position: the pending buy is a
+	 * separate re-buy of the same item started while the earlier lot is still selling, so the sell
+	 * must always be shown. Only a buy-phase flip duplicates the pending-order row and is hidden when
+	 * its item has a pending buy. Hiding selling flips is what dropped the 8th active flip.
+	 */
+	public static boolean showAlongsidePendingBuy(ActiveFlip flip, boolean itemHasPendingBuy)
+	{
+		if (flip == null)
+		{
+			return false;
+		}
+		boolean selling = flip.getSellPlacedTime() != null || "sell".equalsIgnoreCase(flip.getPhase());
+		return selling || !itemHasPendingBuy;
+	}
 }

--- a/src/main/java/com/flipsmart/trading/RoundTripLedger.java
+++ b/src/main/java/com/flipsmart/trading/RoundTripLedger.java
@@ -52,9 +52,9 @@ public final class RoundTripLedger
         /**
          * Fingerprint (slot:isBuy:cumulative) of the fill that most recently closed a cycle, or null
          * when the current position is open. Session-local ({@code transient}): it catches a
-         * re-delivery of the closing fill even after {@link #absorbedBySlotDir} was cleared on close —
-         * a Collect re-detect. Direction keeps a genuine new lot, which opens the next cycle in the
-         * opposite direction, from being falsely suppressed.
+         * re-delivery of the closing fill even after that slot's {@link #absorbedBySlotDir} baseline
+         * was reset on offer completion — a Collect re-detect. Direction keeps a genuine new lot, which
+         * opens the next cycle in the opposite direction, from being falsely suppressed.
          */
         public transient String lastClosingFingerprint;
 
@@ -173,12 +173,20 @@ public final class RoundTripLedger
                 e.absorbedBySlotDir.put(key, cumulativeQuantity);
             }
 
+            int heldBefore = e.heldQuantity;
             e.heldQuantity += isBuy ? effectiveDelta : -effectiveDelta;
             int roundTripId = e.cycleId;
+            // Advance the cycle only on a genuine positive->zero crossing. If held was already zero — a
+            // fully-liquidated position still receiving sell fills (overselling externally-sourced stock,
+            // or a ledger drifted low) — don't re-close on every fill and run the cycle away.
+            boolean closed = heldBefore > 0 && e.heldQuantity <= 0;
             if (e.heldQuantity <= 0)
             {
-                e.cycleId++;
                 e.heldQuantity = 0;
+            }
+            if (closed)
+            {
+                e.cycleId++;
                 e.lastClosingFingerprint = fingerprint;
             }
             else

--- a/src/main/java/com/flipsmart/trading/RoundTripLedger.java
+++ b/src/main/java/com/flipsmart/trading/RoundTripLedger.java
@@ -43,7 +43,9 @@ public final class RoundTripLedger
          * and apply a zero delta instead of double-counting. Deliberately offer-id-AGNOSTIC — a relog
          * mints a fresh offer_id for the same slot, so keying on offer_id would miss the re-feed.
          * Direction is part of the key because a buy and a sell reuse the same slot with independent
-         * cumulatives. Cleared when the cycle closes. Lazily created so old persisted blobs deserialize.
+         * cumulatives. A slot's entry is reset when that slot's own offer completes (not on cycle
+         * close), so a still-filling sibling slot keeps its baseline. Lazily created so old persisted
+         * blobs deserialize.
          */
         public Map<Integer, Integer> absorbedBySlotDir;
 
@@ -90,7 +92,7 @@ public final class RoundTripLedger
      */
     public Integer recordFill(String rsn, int itemId, boolean isBuy, int deltaQuantity)
     {
-        return recordFill(rsn, itemId, null, isBuy, deltaQuantity, 0);
+        return recordFill(rsn, itemId, null, isBuy, deltaQuantity, 0, false);
     }
 
     /**
@@ -104,13 +106,13 @@ public final class RoundTripLedger
      * {@link #recordFillGuarded}). Passing a null {@code slot} keeps the legacy delta-based path.
      */
     public Integer recordFill(String rsn, int itemId, Integer slot, boolean isBuy,
-                              int deltaQuantity, int cumulativeQuantity)
+                              int deltaQuantity, int cumulativeQuantity, boolean offerComplete)
     {
-        return recordFillGuarded(rsn, itemId, slot, isBuy, deltaQuantity, cumulativeQuantity).roundTripId;
+        return recordFillGuarded(rsn, itemId, slot, isBuy, deltaQuantity, cumulativeQuantity, offerComplete).roundTripId;
     }
 
     /**
-     * As {@link #recordFill(String, int, Integer, boolean, int, int)} but also reports whether the
+     * As {@link #recordFill(String, int, Integer, boolean, int, int, boolean)} but also reports whether the
      * fill was recognised as an already-absorbed re-delivery and suppressed.
      *
      * <p>For a slot-keyed fill the delta folded into {@code heldQuantity} is derived from the offer's
@@ -127,7 +129,7 @@ public final class RoundTripLedger
      * round-trip accounting that has no GE slot to key on and for tests exercising pure zero-crossing.
      */
     public FillResult recordFillGuarded(String rsn, int itemId, Integer slot, boolean isBuy,
-                                        int deltaQuantity, int cumulativeQuantity)
+                                        int deltaQuantity, int cumulativeQuantity, boolean offerComplete)
     {
         synchronized (lock)
         {
@@ -178,16 +180,22 @@ public final class RoundTripLedger
                 e.cycleId++;
                 e.heldQuantity = 0;
                 e.lastClosingFingerprint = fingerprint;
-                // Position fully liquidated: drop per-slot cumulative baselines so the next round trip
-                // starts fresh even when a new offer reuses a slot at a coincidentally-equal cumulative.
-                if (e.absorbedBySlotDir != null)
-                {
-                    e.absorbedBySlotDir.clear();
-                }
             }
             else
             {
                 e.lastClosingFingerprint = null;
+            }
+            // Reset THIS slot's baselines once its own offer is done filling (COMPLETED / CANCELLED),
+            // so the next offer reusing the slot rebaselines from zero even at a coincidentally-equal
+            // cumulative. Sibling slots are deliberately left intact: a same-item offer still filling in
+            // another slot must keep its baseline, or its next fill would re-count its whole cumulative
+            // instead of just the increment when held momentarily crosses zero. Resetting on offer
+            // completion rather than on cycle close is what distinguishes a finished slot from a
+            // still-open sibling — the ledger has no per-slot open/closed view otherwise.
+            if (offerComplete && slot != null && e.absorbedBySlotDir != null)
+            {
+                e.absorbedBySlotDir.remove(slot * 2);
+                e.absorbedBySlotDir.remove(slot * 2 + 1);
             }
             return new FillResult(roundTripId, false);
         }

--- a/src/main/java/com/flipsmart/trading/TransactionLogger.java
+++ b/src/main/java/com/flipsmart/trading/TransactionLogger.java
@@ -115,8 +115,14 @@ public final class TransactionLogger
             return;
         }
         int pricePerItem = newlyFilled > 0 ? (int) (newlySpent / newlyFilled) : 0;
+        // The offer is done filling (so its slot's cumulative baseline may reset) once it is no longer
+        // NEW or PARTIAL_FILL — i.e. FILLED, collected, or cancelled. A still-filling offer keeps its
+        // baseline so a sibling slot of the same item is never double-counted on a mid-fill close.
+        com.flipsmart.domain.offer.OfferState state = r.getState();
+        boolean offerComplete = state != com.flipsmart.domain.offer.OfferState.NEW
+            && state != com.flipsmart.domain.offer.OfferState.PARTIAL_FILL;
         RoundTripLedger.FillResult fill = roundTripLedger.recordFillGuarded(
-            rsn, r.getItemId(), r.getSlot(), r.isBuy(), newlyFilled, r.getFilledQuantity());
+            rsn, r.getItemId(), r.getSlot(), r.isBuy(), newlyFilled, r.getFilledQuantity(), offerComplete);
         if (fill.duplicateSuppressed)
         {
             // A duplicate/phantom closing fill (Collect re-detection under a churned offer_id) that

--- a/src/test/java/com/flipsmart/domain/flip/ActiveFlipDisplayFilterTest.java
+++ b/src/test/java/com/flipsmart/domain/flip/ActiveFlipDisplayFilterTest.java
@@ -97,4 +97,32 @@ public class ActiveFlipDisplayFilterTest
 
 		assertTrue(result.isEmpty());
 	}
+
+	// A selling lot and a pending re-buy of the same item are distinct positions — the sell must
+	// never be hidden by the pending buy, or the 8th active flip is lost.
+
+	@Test
+	public void sellingFlipIsShownEvenWithAPendingBuyOfTheSameItem()
+	{
+		ActiveFlip selling = flip(1, "Dharok's greataxe");
+		selling.setPhase("sell");
+		assertTrue("a sell-phase flip is a distinct live position, shown alongside a pending re-buy",
+			ActiveFlipDisplayFilter.showAlongsidePendingBuy(selling, true));
+
+		ActiveFlip sellPlaced = flip(1, "Dharok's greataxe");
+		sellPlaced.setSellPlacedTime("2026-07-24T23:00:00Z");
+		assertTrue("a flip with a sell already placed is shown alongside a pending re-buy",
+			ActiveFlipDisplayFilter.showAlongsidePendingBuy(sellPlaced, true));
+	}
+
+	@Test
+	public void buyPhaseFlipIsHiddenWhenItsItemHasAPendingBuy()
+	{
+		ActiveFlip buying = flip(2, "Blue moon tassets");
+		buying.setPhase("buy");
+		assertTrue("a buy-phase flip with no pending buy is shown",
+			ActiveFlipDisplayFilter.showAlongsidePendingBuy(buying, false));
+		assertTrue("a buy-phase flip whose item is already a pending buy row is hidden as a duplicate",
+			!ActiveFlipDisplayFilter.showAlongsidePendingBuy(buying, true));
+	}
 }

--- a/src/test/java/com/flipsmart/trading/RoundTripLedgerTest.java
+++ b/src/test/java/com/flipsmart/trading/RoundTripLedgerTest.java
@@ -70,6 +70,24 @@ public class RoundTripLedgerTest
     }
 
     @Test
+    public void oversellPastZeroDoesNotRepeatedlyReclose()
+    {
+        // A fully-liquidated position (held at zero) that keeps receiving sell fills — overselling
+        // externally-sourced stock, or a ledger drifted low — must not re-close the cycle on every
+        // fill and run the round-trip id away.
+        ledger.recordFill(RSN, ITEM, 0, true, 5, 5, true);
+        int sell = ledger.recordFill(RSN, ITEM, 0, false, 5, 5, true);   // held 5 -> 0: one genuine close
+        int afterFirstClose = ledger.peekRoundTripId(RSN, ITEM);
+        assertNotEquals("the genuine liquidation closes the cycle once", sell, afterFirstClose);
+
+        // Extra sell fills arriving while held is already zero must NOT advance the cycle again.
+        ledger.recordFill(RSN, ITEM, 1, false, 100, 100, false);
+        ledger.recordFill(RSN, ITEM, 1, false, 100, 200, false);
+        assertEquals("overselling past zero does not repeatedly re-close the cycle",
+            afterFirstClose, (int) ledger.peekRoundTripId(RSN, ITEM));
+    }
+
+    @Test
     public void duplicateSellFill_cannotPrematurelyAdvanceCycle()
     {
         // One clean lot on slot 0: buy 10, sell 10 — held returns to zero, cycle closes.

--- a/src/test/java/com/flipsmart/trading/RoundTripLedgerTest.java
+++ b/src/test/java/com/flipsmart/trading/RoundTripLedgerTest.java
@@ -73,8 +73,8 @@ public class RoundTripLedgerTest
     public void duplicateSellFill_cannotPrematurelyAdvanceCycle()
     {
         // One clean lot on slot 0: buy 10, sell 10 — held returns to zero, cycle closes.
-        int buy = ledger.recordFill(RSN, ITEM, 0, true, 10, 10);
-        int sell = ledger.recordFill(RSN, ITEM, 0, false, 10, 10);
+        int buy = ledger.recordFill(RSN, ITEM, 0, true, 10, 10, true);
+        int sell = ledger.recordFill(RSN, ITEM, 0, false, 10, 10, true);
         assertEquals("buy and sell of one lot share the round trip", buy, sell);
 
         int afterLiquidation = ledger.peekRoundTripId(RSN, ITEM);
@@ -83,14 +83,14 @@ public class RoundTripLedgerTest
         // A phantom re-delivery of the exact closing sell (same slot + direction + cumulative) reaches
         // the ledger before client-side suppression catches it. It must NOT drive held negative and
         // advance the cycle a second time.
-        int phantom = ledger.recordFill(RSN, ITEM, 0, false, 10, 10);
+        int phantom = ledger.recordFill(RSN, ITEM, 0, false, 10, 10, true);
         assertEquals("the duplicate is ignored and returns the still-open cycle id",
             afterLiquidation, phantom);
         assertEquals("the duplicate did not advance the cycle",
             afterLiquidation, (int) ledger.peekRoundTripId(RSN, ITEM));
 
         // The next genuine buy opens the un-poisoned cycle the phantom tried to skip past.
-        int nextBuy = ledger.recordFill(RSN, ITEM, 0, true, 10, 10);
+        int nextBuy = ledger.recordFill(RSN, ITEM, 0, true, 10, 10, true);
         assertEquals("the round trip after a phantom is the one the phantom tried to skip",
             afterLiquidation, nextBuy);
     }
@@ -98,15 +98,15 @@ public class RoundTripLedgerTest
     @Test
     public void concurrentSameItemInTwoSlots_shareCycleAndAreNotFalselyDeduped()
     {
-        int buyA = ledger.recordFill(RSN, ITEM, 0, true, 10, 10);
-        int buyB = ledger.recordFill(RSN, ITEM, 1, true, 5, 5);
+        int buyA = ledger.recordFill(RSN, ITEM, 0, true, 10, 10, true);
+        int buyB = ledger.recordFill(RSN, ITEM, 1, true, 5, 5, true);
         assertEquals("two open buys of the same item are one round trip", buyA, buyB);
 
-        int sellA = ledger.recordFill(RSN, ITEM, 0, false, 10, 10);
+        int sellA = ledger.recordFill(RSN, ITEM, 0, false, 10, 10, true);
         assertEquals("selling one slot while the other is still open stays in the cycle",
             buyA, sellA);
 
-        int sellB = ledger.recordFill(RSN, ITEM, 1, false, 5, 5);
+        int sellB = ledger.recordFill(RSN, ITEM, 1, false, 5, 5, true);
         assertEquals("only the final zero-cross closes it — still the same round trip",
             buyA, sellB);
 
@@ -117,16 +117,17 @@ public class RoundTripLedgerTest
     @Test
     public void identicalFillInASubsequentCycle_isNotFalselySuppressed()
     {
-        ledger.recordFill(RSN, ITEM, 0, true, 10, 10);
-        int firstSell = ledger.recordFill(RSN, ITEM, 0, false, 10, 10);
+        ledger.recordFill(RSN, ITEM, 0, true, 10, 10, true);
+        int firstSell = ledger.recordFill(RSN, ITEM, 0, false, 10, 10, true);
 
-        // A genuine new position reusing the same slot and quantity builds held again: the close
-        // cleared the absorbed baselines, so the new cycle's fills are absorbed from zero — suppression
-        // only ever catches a re-delivery of an already-absorbed cumulative within the open cycle.
-        int secondBuy = ledger.recordFill(RSN, ITEM, 0, true, 10, 10);
+        // A genuine new position reusing the same slot and quantity builds held again: completing the
+        // first lot reset slot 0's baselines, so the new cycle's fills are absorbed from zero —
+        // suppression only ever catches a re-delivery of an already-absorbed cumulative within an
+        // open offer.
+        int secondBuy = ledger.recordFill(RSN, ITEM, 0, true, 10, 10, true);
         assertNotEquals("the new cycle is distinct from the closed one", firstSell, secondBuy);
 
-        int secondSell = ledger.recordFill(RSN, ITEM, 0, false, 10, 10);
+        int secondSell = ledger.recordFill(RSN, ITEM, 0, false, 10, 10, true);
         assertEquals("the genuine repeat sell is applied within its own cycle",
             secondBuy, secondSell);
 
@@ -135,10 +136,35 @@ public class RoundTripLedgerTest
     }
 
     @Test
+    public void closingOneSlotDoesNotWipeAStillFillingSiblingSlot()
+    {
+        // Same item in two slots: slot 0 buys 100 (offer complete), slot 1 buys 100 but is STILL
+        // FILLING (offer not complete), so slot 1's baseline must be retained.
+        ledger.recordFill(RSN, ITEM, 0, true, 100, 100, true);
+        ledger.recordFill(RSN, ITEM, 1, true, 100, 100, false);
+
+        // A 200-unit sell on slot 0 liquidates the position: held hits zero and the cycle closes while
+        // slot 1's buy is still open. Resetting every slot on close (rather than only completed offers'
+        // slots) would wipe slot 1's baseline, so its next fill would re-count its whole cumulative.
+        ledger.recordFill(RSN, ITEM, 0, false, 200, 200, true);
+
+        // slot 1's buy fills 50 more (cumulative 100 -> 150): only 50 new units should enter held.
+        ledger.recordFill(RSN, ITEM, 1, true, 50, 150, true);
+
+        // If the sibling baseline survived, held is exactly 50, so selling 50 closes the next cycle.
+        // If it was wiped, held would be 150 and this sell would leave 100 open — no close.
+        int sellRt = ledger.recordFill(RSN, ITEM, 1, false, 50, 50, true);
+        int after = ledger.peekRoundTripId(RSN, ITEM);
+        assertNotEquals("a still-filling sibling slot keeps its baseline through another slot's close",
+            sellRt, after);
+    }
+
+    @Test
     public void relogDoesNotDoubleCountAnOpenBuy()
     {
-        // Session 1: a buy fills to cumulative 1324 on slot 4 — held becomes 1324.
-        ledger.recordFill(RSN, ITEM, 4, true, 1324, 1324);
+        // Session 1: a still-open buy fills to cumulative 1324 on slot 4 — held becomes 1324. Not
+        // complete, so its baseline is retained for the re-feed to match against.
+        ledger.recordFill(RSN, ITEM, 4, true, 1324, 1324, false);
 
         // Persist + restart (relog / rebuild): held, cycle, and per-slot absorbed cumulative restore.
         Map<Integer, RoundTripLedger.Entry> exported = ledger.export(RSN);
@@ -149,11 +175,11 @@ public class RoundTripLedgerTest
         // rebuilt OfferStore has no baseline yet and the GE signal looks like a fresh 1324 fill. A
         // relog mints a fresh offer_id for the slot, so the guard must match on (slot, cumulative)
         // alone — never offer_id — or this is added on top of the restored held (the double-count).
-        restarted.recordFill(RSN, ITEM, 4, true, 1324, 1324);
+        restarted.recordFill(RSN, ITEM, 4, true, 1324, 1324, false);
 
-        // Proof the true held is still 1324, not 2648: selling exactly 1324 must close the cycle.
+        // Proof the true held is still 1324, not 2648: selling exactly 1324 (completing) closes the cycle.
         int cycleBefore = restarted.peekRoundTripId(RSN, ITEM);
-        restarted.recordFill(RSN, ITEM, 4, false, 1324, 1324);
+        restarted.recordFill(RSN, ITEM, 4, false, 1324, 1324, true);
         int cycleAfter = restarted.peekRoundTripId(RSN, ITEM);
         assertNotEquals("selling the true held must close the round trip — no relog double-count",
             cycleBefore, cycleAfter);


### PR DESCRIPTION
## Summary

Three coupled tracking-accuracy fixes validated live on RSN dumbridge3 tonight: (1) a concurrent-slot ledger baseline bug that could double-count fills when the same item sits in two GE slots simultaneously, (2) an active-flips display bug that hid a selling flip whenever its item also had a pending re-buy order, and (3) a round-trip cycle guard that prevented cycle-id runaway on overselling/drifted-ledger positions held at zero.

## Changes

### 🐛 Bug Fixes

1. **#1095 — concurrent-slot baseline (`b1e2261`).** The prior relog fix (#1092/#212) cleared the *entire* absorbed-cumulative map on cycle close. If the same item is held in two GE slots at once and one slot's cycle closes while the sibling slot is still filling, the sibling's baseline was wiped, causing its next fill to re-count its whole cumulative quantity (double-count). Fix: a slot's baseline now resets only when THAT slot's own offer completes (FILLED / collected / cancelled, signalled by `offerComplete` derived from the record's `OfferState`) — not on cycle close — so a still-filling sibling keeps its correct baseline. This preserves relog re-feed idempotency, the #830 golden corpus, the churned-offer_id closing-duplicate guard, and the `twoCycleSequence` test.

2. **Active-flips display drops the 8th flip (`8031091`).** The active-flips panel hid any active flip whose item had a pending buy order — but an item can legitimately be actively SELLING while also carrying a pending re-buy for the next round trip. Hiding the sell lost visibility into that flip entirely (only 7 of 8 active flips rendered for the affected user). Fix: a selling flip (sell order placed, or backend-reported `phase == "sell"`) is now always shown via the new `ActiveFlipDisplayFilter.showAlongsidePendingBuy`; only a genuine buy-phase duplicate of an already-shown item is skipped. Verified live: the user now sees all 8 active flips.

3. **Round-trip cycle runaway on zero-crossing (`d96cb0c`).** A fully-liquidated position (ledger held at zero) that keeps receiving sell fills — from overselling or a drifted-low ledger — was re-closing the round-trip cycle on every additional fill, running the cycle id away indefinitely. Fix: the cycle now advances only on a genuine positive-to-zero crossing (`heldBefore > 0 && heldQuantity <= 0`), not on every fill received while already at zero. Verified live: a drifted Earth orb position drained 2,675 units with the cycle id pinned (no runaway); genuine closes on other items still fired correctly.

## Testing

### Automated Tests
- ✅ `./gradlew clean build` — BUILD SUCCESSFUL, all 708 tests passing, 0 failures

### Manual Testing (live, dumbridge3 tonight)
- [x] Relog re-feed suppressed (no double-count) with concurrent GE slots on the same item
- [x] All 8 active flips visible in the panel, including a selling flip with a pending re-buy
- [x] Drifted Earth orb position (2,675 units drained) held the round-trip cycle id pinned, no runaway
- [x] Genuine cycle closes on other items still fire as expected

## API Changes

N/A — plugin-only change, no backend API surface touched.

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: None
- [ ] Requires database migration: No
- Not yet in a plugin-hub release; will need a plugin-hub pin bump in a follow-up per the existing release process (separate agent/process, not part of this PR).

## Checklist

- [x] Tests added/updated
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by [teammate]

## Related Issues

Closes Flip-Smart/flip-smart#1095

### 🩺 Codacy Quality Gate — fixed in this PR
- `9d356ee` PMD_category_java_bestpractices_GuardLogStatement `FlipFinderPanel.java:2047` — guarded the buy-phase-skip debug log with `log.isDebugEnabled()` so `matchingPending.size()`/`flip.getItemName()` aren't evaluated when debug logging is off.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `9d356ee` `FlipFinderPanel.java:2047-2048` — same debug-log guard, resolves both duplicate AI Reviewer comments on this line (same fix as the quality-gate finding above).

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `RoundTripLedger.java:207` — reset-on-`offerComplete` timing is the #1095 fix itself; reverting to cycle-close reset reintroduces the bug.
- `TransactionLogger.java:123` — `offerComplete` derived from terminal `OfferState` is the #1095 fix's trigger; same disposition as above.
- `RoundTripLedger.java:199` — `absorbedBySlotDir` is deliberately keyed by slot/dir (not offer id) for relog robustness (#1092); per-slot removal on `offerComplete` is the #1095 fix distinguishing a finished slot from a still-open sibling, not a double-count risk.

