### PR TITLE
feat: right-click context menu on item rows

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -895,24 +895,25 @@ public class FlipFinderPanel extends PluginPanel
 		menu.addSeparator();
 
 		boolean favorited = isFavorite(favoriteItemIds, itemId);
-		JMenuItem favoriteItem = new JMenuItem(favoriteMenuLabel(favorited));
-		favoriteItem.addActionListener(e -> handleStarClick(itemId, starLabel));
-		menu.add(favoriteItem);
+		boolean appendDismiss = includeDismiss && onDismiss != null;
+		List<String> labels = itemContextMenuLabels(favorited, appendDismiss);
+		// Actions align positionally with the core three labels itemContextMenuLabels always returns;
+		// dismiss (when present) is always the fourth/last entry.
+		List<Runnable> actions = List.of(
+			() -> handleStarClick(itemId, starLabel),
+			() -> handleBlockItemClick(itemId, itemName),
+			() -> LinkBrowser.browse(WEBSITE_ITEM_URL + itemId));
 
-		JMenuItem blockItem = new JMenuItem("Block this item");
-		blockItem.addActionListener(e -> handleBlockItemClick(itemId, itemName));
-		menu.add(blockItem);
-
-		JMenuItem graphItem = new JMenuItem("View Item Graph");
-		graphItem.addActionListener(e -> LinkBrowser.browse(WEBSITE_ITEM_URL + itemId));
-		menu.add(graphItem);
-
-		if (includeDismiss && onDismiss != null)
+		for (int i = 0; i < labels.size(); i++)
 		{
-			menu.addSeparator();
-			JMenuItem dismissItem = new JMenuItem("Dismiss from Active Flips");
-			dismissItem.addActionListener(e -> onDismiss.run());
-			menu.add(dismissItem);
+			if (appendDismiss && i == labels.size() - 1)
+			{
+				menu.addSeparator();
+			}
+			JMenuItem menuItem = new JMenuItem(labels.get(i));
+			Runnable action = i < actions.size() ? actions.get(i) : onDismiss;
+			menuItem.addActionListener(e -> action.run());
+			menu.add(menuItem);
 		}
 
 		menu.show(invoker, x, y);

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -4199,20 +4199,8 @@ public class FlipFinderPanel extends PluginPanel
 			{
 				if (e.isPopupTrigger())
 				{
-					JPopupMenu contextMenu = new JPopupMenu();
-					
-					// Add focus option
-					JMenuItem focusItem = new JMenuItem("Set as Flip Assist Focus (Sell)");
-					focusItem.addActionListener(ae -> setFocus(flip, panel));
-					contextMenu.add(focusItem);
-					
-					contextMenu.addSeparator();
-					
-					JMenuItem dismissItem = new JMenuItem("Dismiss from Active Flips");
-					dismissItem.addActionListener(ae -> dismissActiveFlip(flip));
-					contextMenu.add(dismissItem);
-					
-					contextMenu.show(e.getComponent(), e.getX(), e.getY());
+					showItemContextMenu(flip.getItemId(), flip.getItemName(), header.starLabel,
+						e.getComponent(), e.getX(), e.getY(), true, () -> dismissActiveFlip(flip));
 				}
 			}
 		});

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2789,9 +2789,9 @@ public class FlipFinderPanel extends PluginPanel
 		return isFavorited ? "Remove from favorites" : "Add to favorites";
 	}
 
-	static java.util.List<String> itemContextMenuLabels(boolean isFavorited, boolean includeDismiss)
+	static List<String> itemContextMenuLabels(boolean isFavorited, boolean includeDismiss)
 	{
-		java.util.List<String> labels = new java.util.ArrayList<>(java.util.List.of(
+		List<String> labels = new ArrayList<>(List.of(
 			favoriteMenuLabel(isFavorited), "Block this item", "View Item Graph"));
 		if (includeDismiss)
 		{

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -875,6 +875,49 @@ public class FlipFinderPanel extends PluginPanel
 	private JSpinner minProfitSpinner;
 	private JSpinner minVolumeSpinner;
 
+	private void showItemContextMenu(int itemId, String itemName, JLabel starLabel,
+		java.awt.Component invoker, int x, int y)
+	{
+		showItemContextMenu(itemId, itemName, starLabel, invoker, x, y, false, null);
+	}
+
+	private void showItemContextMenu(int itemId, String itemName, JLabel starLabel,
+		java.awt.Component invoker, int x, int y, boolean includeDismiss, Runnable onDismiss)
+	{
+		JPopupMenu menu = new JPopupMenu();
+		menu.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+		JLabel header = new JLabel(itemName);
+		header.setFont(new Font(FONT_ARIAL, Font.BOLD, 12));
+		header.setForeground(Color.WHITE);
+		header.setBorder(new EmptyBorder(2, 6, 2, 6));
+		menu.add(header);
+		menu.addSeparator();
+
+		boolean favorited = isFavorite(favoriteItemIds, itemId);
+		JMenuItem favoriteItem = new JMenuItem(favoriteMenuLabel(favorited));
+		favoriteItem.addActionListener(e -> handleStarClick(itemId, starLabel));
+		menu.add(favoriteItem);
+
+		JMenuItem blockItem = new JMenuItem("Block this item");
+		blockItem.addActionListener(e -> handleBlockItemClick(itemId, itemName));
+		menu.add(blockItem);
+
+		JMenuItem graphItem = new JMenuItem("View Item Graph");
+		graphItem.addActionListener(e -> LinkBrowser.browse(WEBSITE_ITEM_URL + itemId));
+		menu.add(graphItem);
+
+		if (includeDismiss && onDismiss != null)
+		{
+			menu.addSeparator();
+			JMenuItem dismissItem = new JMenuItem("Dismiss from Active Flips");
+			dismissItem.addActionListener(e -> onDismiss.run());
+			menu.add(dismissItem);
+		}
+
+		menu.show(invoker, x, y);
+	}
+
 	private void showSettingsPopout(JComponent anchor)
 	{
 		// A click on the gear while the pop-out is open first dismisses it
@@ -3092,12 +3135,14 @@ public class FlipFinderPanel extends PluginPanel
 		final JPanel namePanel;
 		/** Pixels a wrapped name adds beyond one line; 0 when the name fits on one. */
 		final int extraNameHeight;
+		final JLabel starLabel;
 
-		HeaderPanels(JPanel topPanel, JPanel namePanel, int extraNameHeight)
+		HeaderPanels(JPanel topPanel, JPanel namePanel, int extraNameHeight, JLabel starLabel)
 		{
 			this.topPanel = topPanel;
 			this.namePanel = namePanel;
 			this.extraNameHeight = extraNameHeight;
+			this.starLabel = starLabel;
 		}
 	}
 
@@ -3165,7 +3210,8 @@ public class FlipFinderPanel extends PluginPanel
 		JPanel iconsPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 1, 0));
 		iconsPanel.setOpaque(false);
 
-		iconsPanel.add(createStarIconLabel(itemId));
+		JLabel starLabel = createStarIconLabel(itemId);
+		iconsPanel.add(starLabel);
 		iconsPanel.add(createBlockIconLabel(itemId, itemName));
 		iconsPanel.add(createChartIconLabel(itemId));
 
@@ -3199,7 +3245,7 @@ public class FlipFinderPanel extends PluginPanel
 			topPanel.add(iconsPanel, BorderLayout.EAST);
 		}
 
-		return new HeaderPanels(topPanel, namePanel, extraNameHeight);
+		return new HeaderPanels(topPanel, namePanel, extraNameHeight, starLabel);
 	}
 	
 	/**

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2741,6 +2741,22 @@ public class FlipFinderPanel extends PluginPanel
 		return toggleOn && premium;
 	}
 
+	static String favoriteMenuLabel(boolean isFavorited)
+	{
+		return isFavorited ? "Remove from favorites" : "Add to favorites";
+	}
+
+	static java.util.List<String> itemContextMenuLabels(boolean isFavorited, boolean includeDismiss)
+	{
+		java.util.List<String> labels = new java.util.ArrayList<>(java.util.List.of(
+			favoriteMenuLabel(isFavorited), "Block this item", "View Item Graph"));
+		if (includeDismiss)
+		{
+			labels.add("Dismiss from Active Flips");
+		}
+		return labels;
+	}
+
 	/** Read the persisted "flip only from favorites" toggle, defaulting to off. */
 	private boolean loadFlipOnlyFavorites()
 	{

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -3036,7 +3036,7 @@ public class FlipFinderPanel extends PluginPanel
 					return;
 				}
 				// Double-click: toggle the focus/expand hint (right-click now opens the context menu)
-				if (e.getClickCount() == 2)
+				if (e.getButton() == MouseEvent.BUTTON1 && e.getClickCount() == 2)
 				{
 					expanded = toggleExpandedState(panel, expanded);
 					panel.revalidate();

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -4665,6 +4665,7 @@ public class FlipFinderPanel extends PluginPanel
 		HeaderPanels header = createItemHeaderPanels(flip.getItemId(), flip.getItemName(), backgroundColor);
 		allowForWrappedName(panel, header.extraNameHeight);
 		JPanel topPanel = header.topPanel;
+		final JLabel completedStarLabel = header.starLabel;
 
 		// Details section with profit/loss info - use GridBagLayout for tighter column spacing
 		JPanel detailsPanel = new JPanel(new GridBagLayout());
@@ -4745,6 +4746,11 @@ public class FlipFinderPanel extends PluginPanel
 			@Override
 			public void mouseClicked(MouseEvent e)
 			{
+				// Right-click opens the context menu (handled in mousePressed/mouseReleased); left-click expands.
+				if (e.getButton() != MouseEvent.BUTTON1 || e.isPopupTrigger())
+				{
+					return;
+				}
 				if (!expanded)
 				{
 					// Add extra details
@@ -4788,6 +4794,27 @@ public class FlipFinderPanel extends PluginPanel
 
 				panel.revalidate();
 				panel.repaint();
+			}
+
+			@Override
+			public void mousePressed(MouseEvent e)
+			{
+				maybeShowCompletedMenu(e);
+			}
+
+			@Override
+			public void mouseReleased(MouseEvent e)
+			{
+				maybeShowCompletedMenu(e);
+			}
+
+			private void maybeShowCompletedMenu(MouseEvent e)
+			{
+				if (e.isPopupTrigger())
+				{
+					showItemContextMenu(flip.getItemId(), flip.getItemName(), completedStarLabel,
+						e.getComponent(), e.getX(), e.getY());
+				}
 			}
 		});
 

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -2955,7 +2955,7 @@ public class FlipFinderPanel extends PluginPanel
 		panel.add(detailsPanel, BorderLayout.CENTER);
 
 		// Add mouse listener for interactions
-		addRecommendationPanelListeners(panel, rec);
+		addRecommendationPanelListeners(panel, rec, header.starLabel);
 
 		return panel;
 	}
@@ -3019,7 +3019,7 @@ public class FlipFinderPanel extends PluginPanel
 	/**
 	 * Add mouse listeners for recommendation panel (focus, expand, hover)
 	 */
-	private void addRecommendationPanelListeners(JPanel panel, FlipRecommendation rec)
+	private void addRecommendationPanelListeners(JPanel panel, FlipRecommendation rec, JLabel starLabel)
 	{
 		panel.addMouseListener(new MouseAdapter()
 		{
@@ -3028,27 +3028,39 @@ public class FlipFinderPanel extends PluginPanel
 			@Override
 			public void mouseClicked(MouseEvent e)
 			{
-				handleRecommendationClick(e, panel, rec);
-			}
-
-			private void handleRecommendationClick(MouseEvent e, JPanel panel, FlipRecommendation rec)
-			{
 				// Left click: set as Flip Assist focus
-				if (e.getButton() == MouseEvent.BUTTON1 && e.getClickCount() == 1)
+				if (e.getButton() == MouseEvent.BUTTON1 && e.getClickCount() == 1 && !e.isPopupTrigger())
 				{
 					setFocus(rec, panel);
 					return;
 				}
-				
-				// Right click or double click: toggle focus hint
-				if (e.getButton() != MouseEvent.BUTTON3 && e.getClickCount() != 2)
+				// Double-click: toggle the focus/expand hint (right-click now opens the context menu)
+				if (e.getClickCount() == 2)
 				{
-					return;
+					expanded = toggleExpandedState(panel, expanded);
+					panel.revalidate();
+					panel.repaint();
 				}
+			}
 
-				expanded = toggleExpandedState(panel, expanded);
-				panel.revalidate();
-				panel.repaint();
+			@Override
+			public void mousePressed(MouseEvent e)
+			{
+				maybeShowMenu(e);
+			}
+
+			@Override
+			public void mouseReleased(MouseEvent e)
+			{
+				maybeShowMenu(e);
+			}
+
+			private void maybeShowMenu(MouseEvent e)
+			{
+				if (e.isPopupTrigger())
+				{
+					showItemContextMenu(rec.getItemId(), rec.getItemName(), starLabel, panel, e.getX(), e.getY());
+				}
 			}
 
 			@Override

--- a/src/test/java/com/flipsmart/ItemContextMenuLabelsTest.java
+++ b/src/test/java/com/flipsmart/ItemContextMenuLabelsTest.java
@@ -1,0 +1,39 @@
+package com.flipsmart;
+
+import java.util.List;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class ItemContextMenuLabelsTest
+{
+	@Test
+	public void favoriteLabelReflectsState()
+	{
+		assertEquals("Add to favorites", FlipFinderPanel.favoriteMenuLabel(false));
+		assertEquals("Remove from favorites", FlipFinderPanel.favoriteMenuLabel(true));
+	}
+
+	@Test
+	public void sharedCoreOrderForNonFavorited()
+	{
+		assertEquals(
+			List.of("Add to favorites", "Block this item", "View Item Graph"),
+			FlipFinderPanel.itemContextMenuLabels(false, false));
+	}
+
+	@Test
+	public void favoritedShowsRemove()
+	{
+		assertEquals(
+			List.of("Remove from favorites", "Block this item", "View Item Graph"),
+			FlipFinderPanel.itemContextMenuLabels(true, false));
+	}
+
+	@Test
+	public void activeFlipsAppendsDismiss()
+	{
+		assertEquals(
+			List.of("Add to favorites", "Block this item", "View Item Graph", "Dismiss from Active Flips"),
+			FlipFinderPanel.itemContextMenuLabels(false, true));
+	}
+}


### PR DESCRIPTION
## Summary

Adds a right-click context menu to item rows on the Recommended, Favorites, Active Flips, and Completed tabs, replacing the previous per-tab ad-hoc right-click handling with one shared menu builder. The menu surfaces favorites toggling, blocking, and Item Graph navigation consistently everywhere an item row appears.

## Changes

### ✨ New Features
- Right-click on any item row (Recommended, Favorites, Active Flips, Completed) now opens a context menu with an item-name header, followed by:
  - **Add to favorites** / **Remove from favorites** (label toggles based on current star state)
  - **Block this item**
  - **View Item Graph**
  - Active Flips additionally keeps **Dismiss from Active Flips**
- Menu construction is centralized in one shared `showItemContextMenu` builder that reuses existing plugin logic (`handleStarClick`, `handleBlockItemClick`, `LinkBrowser.browse`) so behavior is consistent across all four tabs.

### ♻️ Refactoring
- Recommended/Favorites: double-click now triggers the row-expand hint (moved off right-click, which is now reserved for the context menu). Left-click (Flip Assist focus) is unchanged.
- Completed: left-click still expands the row (Duration/GE Tax) — unchanged.
- Active Flips: left-click still sets sell focus — unchanged. The old standalone "Set as Flip Assist Focus (Sell)" menu item was dropped since it duplicated left-click behavior.
- Added `ItemContextMenuLabelsTest` covering the dynamic favorites label helper.

## Testing

### Automated Tests
- `./gradlew build` — compile + full JUnit suite green (includes new `ItemContextMenuLabelsTest`)

### Manual Testing (in-game — plugin UI isn't unit-testable)
- [ ] On each of the four tabs, right-click an item row → menu shows the item-name header + Add/Remove favorites, Block this item, View Item Graph (Active Flips also shows Dismiss from Active Flips)
- [ ] "Add to favorites" on an unstarred item fills the row star and adds it to the ★ Favorites view; right-clicking a starred item shows "Remove from favorites" and un-stars it
- [ ] "Block this item" opens the existing block confirmation/selection dialog
- [ ] "View Item Graph" opens https://flipsmart.net/items/<id> in the browser
- [ ] Regression: Recommended/Favorites left-click still sets focus, double-click still expands
- [ ] Regression: Completed left-click still expands (Duration/GE Tax)
- [ ] Regression: Active Flips left-click still sets sell focus, and Dismiss still works

## API Changes

None — plugin-only change, no backend or webapp changes.

## Deployment Notes

- No environment variables, dependencies, or configuration changes.
- No database migrations.
- Standard plugin-hub release cadence applies once merged (not bundled with this PR).

## Checklist

- [x] Tests added/updated
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by teammate
- [ ] Manual in-game QA (see checklist above)

## Related Issues

Closes Flip-Smart/flip-smart#1042

---

### 🩺 Codacy Quality Gate
Zero new issues throughout — gate was green (`gate_ok=true`, `new=0`) at every check, no fixes/config/dismissals needed on this pass.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `50adf60` FlipFinderPanel.java:2801 — `showItemContextMenu` now builds its `JMenuItem`s from `itemContextMenuLabels` instead of duplicating the label strings inline, so the helper (and its unit tests) actually drive the production menu
- `d170ade` FlipFinderPanel.java:3038 — Restricted the Recommended/Favorites double-click expand toggle to `BUTTON1` so a double right-click no longer also toggles the expand hint

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- FlipFinderPanel.java:885 (×2 duplicate comments) — "Set as Flip Assist Focus (Sell)" claimed removed from the Active Flips menu; left-click on that row still calls `setFocus(flip, panel)`, unchanged by this PR — action remains reachable, no regression
- FlipFinderPanel.java:879 — nitpick on fully-qualified `java.awt.Component`; matches the project's existing convention (already used the same way elsewhere in this file, pre-dating this PR)

