### PR TITLE
Push live GE/inventory state to backend for accurate Active Flips tracking

### DIFF
--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -5,6 +5,7 @@ import com.flipsmart.api.endpoints.BankSnapshotEndpoints;
 import com.flipsmart.api.endpoints.BlocklistEndpoints;
 import com.flipsmart.api.endpoints.FavoritesEndpoints;
 import com.flipsmart.api.endpoints.FlipsEndpoints;
+import com.flipsmart.api.endpoints.LiveStateEndpoints;
 import com.flipsmart.api.endpoints.MarketDataEndpoints;
 import com.flipsmart.api.endpoints.MotdEndpoints;
 import com.flipsmart.api.endpoints.OfferActionEndpoints;
@@ -15,6 +16,7 @@ import com.flipsmart.api.dto.ActiveFlipsResponse;
 import com.flipsmart.api.dto.CompletedFlipsResponse;
 import com.flipsmart.api.dto.FavoritesResponse;
 import com.flipsmart.api.dto.FlipAdjustmentResponse;
+import com.flipsmart.api.dto.LiveStateSnapshot;
 import com.flipsmart.api.dto.OfferAdviceBatchResponse;
 import com.flipsmart.api.dto.BankSnapshotResult;
 import com.flipsmart.api.dto.TimeframeFlipFinderResponse;
@@ -76,6 +78,7 @@ public class FlipSmartApiClient
 	private final MotdEndpoints motd;
 	private final TradeStationEndpoints tradeStation;
 	private final FavoritesEndpoints favorites;
+	private final LiveStateEndpoints liveState;
 
 	@Inject
 	public FlipSmartApiClient(FlipSmartConfig config, Gson gson, OkHttpClient okHttpClient)
@@ -101,6 +104,7 @@ public class FlipSmartApiClient
 		this.motd = new MotdEndpoints(transport);
 		this.tradeStation = new TradeStationEndpoints(transport);
 		this.favorites = new FavoritesEndpoints(transport);
+		this.liveState = new LiveStateEndpoints(transport);
 	}
 
 	// ============================================================================
@@ -483,6 +487,15 @@ public class FlipSmartApiClient
 	public CompletableFuture<Boolean> pushTradeStationSlotsAsync(String rsn, java.util.List<Integer> itemIds)
 	{
 		return tradeStation.pushTradeStationSlotsAsync(rsn, itemIds);
+	}
+
+	// ============================================================================
+	// Live state
+	// ============================================================================
+
+	public CompletableFuture<Boolean> pushLiveStateAsync(String rsn, String capturedAtIso, LiveStateSnapshot snapshot)
+	{
+		return liveState.pushLiveStateAsync(rsn, capturedAtIso, snapshot);
 	}
 
 	// ============================================================================

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1,5 +1,6 @@
 package com.flipsmart;
 import com.flipsmart.api.dto.WikiPrice;
+import com.flipsmart.api.dto.LiveStateSnapshot;
 import com.flipsmart.api.dto.SellPriceCheckRequest;
 import com.flipsmart.domain.offer.OfferSignal;
 import com.flipsmart.api.dto.OfferAdviceResponse;
@@ -172,6 +173,9 @@ public class FlipSmartPlugin extends Plugin
 
 	@Inject
 	private TradeStationSlotPushService tradeStationSlotPushService;
+
+	@Inject
+	private LiveStatePushService liveStatePushService;
 
 	@Inject
 	private Gson gson;
@@ -970,6 +974,10 @@ public class FlipSmartPlugin extends Plugin
 
 		// Shut down the trade-station snapshot pusher's executor.
 		tradeStationSlotPushService.shutdown();
+
+		// Final absolute snapshot so the dashboard doesn't sit on a stale mid-session state.
+		liveStatePushService.pushNow(buildLiveStateSnapshot());
+		liveStatePushService.shutdown();
 	}
 
 	@Subscribe
@@ -1186,6 +1194,14 @@ public class FlipSmartPlugin extends Plugin
 		}
 
 		scheduleOneShot(PluginScheduler.STALE_FLIP_CLEANUP_DELAY_MS, this::performStaleFlipCleanup);
+
+		// Post-login settle point: GE state is trustworthy now, and a player who
+		// changes nothing this session still needs a fresh push.
+		scheduleOneShot(PluginScheduler.STALE_FLIP_CLEANUP_DELAY_MS, () ->
+		{
+			liveStatePushService.markReady();
+			liveStatePushService.pushNow(buildLiveStateSnapshot());
+		});
 
 		if (autoRecommendService != null && autoRecommendService.isActive())
 		{
@@ -1443,6 +1459,34 @@ public class FlipSmartPlugin extends Plugin
 	}
 
 	/**
+	 * Build the live GE slot / inventory / collected-item snapshot pushed to the
+	 * backend. Reads only thread-safe collaborators (synchronized OfferStore,
+	 * a concurrent collected-items set, and a volatile inventory-id snapshot),
+	 * so it is safe to call from any thread.
+	 */
+	private LiveStateSnapshot buildLiveStateSnapshot()
+	{
+		java.util.List<LiveStateSnapshot.SlotState> slots = new java.util.ArrayList<>();
+		for (com.flipsmart.domain.offer.OfferRecord offer : offerStore.liveOffers())
+		{
+			if (offer.getSlot() == null)
+			{
+				continue;
+			}
+			slots.add(new LiveStateSnapshot.SlotState(
+				offer.getSlot(),
+				offer.getItemId(),
+				offer.getItemName(),
+				offer.isBuy(),
+				String.valueOf(offer.getState()),
+				offer.getTotalQuantity(),
+				offer.getFilledQuantity(),
+				offer.getPrice()));
+		}
+		return new LiveStateSnapshot(slots, getInventoryFlipItemIds(), session.getCollectedItemIds());
+	}
+
+	/**
 	 * GE offer-changed handler body. Kept on the plugin because it builds
 	 * {@link GrandExchangeTracker.OfferContext}, a package-private type. The router
 	 * delegates straight here.
@@ -1486,6 +1530,9 @@ public class FlipSmartPlugin extends Plugin
 				System.currentTimeMillis());
 			return;
 		}
+
+		// Past the burst window, this event reflects real GE state — push it.
+		liveStatePushService.schedulePush(buildLiveStateSnapshot());
 
 		grandExchangeTracker.handleOfferChanged(GrandExchangeTracker.OfferContext.builder()
 			.slot(slot)
@@ -1701,6 +1748,7 @@ public class FlipSmartPlugin extends Plugin
 			session.setCashStack(0);
 			inventoryFlipItemIds = java.util.Collections.emptySet();
 			inventoryFlipItemCounts = java.util.Collections.emptyMap();
+			liveStatePushService.markNotReady();
 			return;
 		}
 
@@ -1724,6 +1772,7 @@ public class FlipSmartPlugin extends Plugin
 		}
 		inventoryFlipItemIds = java.util.Collections.unmodifiableSet(currentInventoryIds);
 		inventoryFlipItemCounts = java.util.Collections.unmodifiableMap(currentInventoryCounts);
+		liveStatePushService.schedulePush(buildLiveStateSnapshot());
 
 		if (totalCash != session.getCurrentCashStack())
 		{

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -771,8 +771,6 @@ public class FlipSmartPlugin extends Plugin
 		// Sync webhook config to backend if configured
 		webhookSyncService.syncIfChanged();
 
-		// Keeps the dashboard's "as of" freshness advancing while online with
-		// unchanged GE state, and gives a failed push a bounded retry.
 		liveStatePushService.startHeartbeat(this::buildLiveStateSnapshot);
 
 		// Note: Cash stack and RSN will be synced when player logs in via onGameStateChanged

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1058,6 +1058,7 @@ public class FlipSmartPlugin extends Plugin
 	public void handleLogoutState()
 	{
 		pushFinalCapitalSnapshot();
+		liveStatePushService.markNotReady();
 		session.onLogout();
 		offlineSyncService.persistOfferState();
 		geHistoryService.reset();
@@ -1531,9 +1532,6 @@ public class FlipSmartPlugin extends Plugin
 			return;
 		}
 
-		// Past the burst window, this event reflects real GE state — push it.
-		liveStatePushService.schedulePush(buildLiveStateSnapshot());
-
 		grandExchangeTracker.handleOfferChanged(GrandExchangeTracker.OfferContext.builder()
 			.slot(slot)
 			.itemId(itemId)
@@ -1545,6 +1543,10 @@ public class FlipSmartPlugin extends Plugin
 			.isBuy(OfferSignal.isBuyState(state))
 			.state(state)
 			.build());
+
+		// Snapshot after handleOfferChanged, not before: it is what applies this
+		// event to offerStore, so pushing earlier would publish the pre-event state.
+		liveStatePushService.schedulePush(buildLiveStateSnapshot());
 	}
 
 	@Subscribe

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -771,6 +771,10 @@ public class FlipSmartPlugin extends Plugin
 		// Sync webhook config to backend if configured
 		webhookSyncService.syncIfChanged();
 
+		// Keeps the dashboard's "as of" freshness advancing while online with
+		// unchanged GE state, and gives a failed push a bounded retry.
+		liveStatePushService.startHeartbeat(this::buildLiveStateSnapshot);
+
 		// Note: Cash stack and RSN will be synced when player logs in via onGameStateChanged
 		// Don't access client data during startup - must be on client thread
 	}

--- a/src/main/java/com/flipsmart/LiveStatePushService.java
+++ b/src/main/java/com/flipsmart/LiveStatePushService.java
@@ -19,11 +19,8 @@ import lombok.extern.slf4j.Slf4j;
  * so the web dashboard can tell an open position from a finished one.
  *
  * Debounced because a single fill produces a burst of offer events. The payload
- * is absolute, so a dropped push costs freshness, never correctness.
- *
- * A periodic heartbeat pushes on a bounded clock even when nothing changes, so
- * "as of" freshness on the dashboard keeps advancing for an online player sitting
- * on unchanged offers, and a failed push gets a bounded retry.
+ * is absolute, so a dropped push costs freshness, never correctness. Also heartbeats
+ * on a bounded clock — see {@link #startHeartbeat}.
  */
 @Slf4j
 @Singleton

--- a/src/main/java/com/flipsmart/LiveStatePushService.java
+++ b/src/main/java/com/flipsmart/LiveStatePushService.java
@@ -117,7 +117,10 @@ public class LiveStatePushService
 			}
 			catch (RuntimeException e)
 			{
-				log.debug("Live-state heartbeat threw: {}", e.getMessage());
+				if (log.isDebugEnabled())
+				{
+					log.debug("Live-state heartbeat threw: {}", e.getMessage());
+				}
 			}
 		}, HEARTBEAT_INTERVAL_MS, HEARTBEAT_INTERVAL_MS, TimeUnit.MILLISECONDS);
 		ScheduledFuture<?> previous = heartbeat.getAndSet(next);
@@ -183,7 +186,10 @@ public class LiveStatePushService
 		}
 		catch (RuntimeException e)
 		{
-			log.debug("Live-state push threw: {}", e.getMessage());
+			if (log.isDebugEnabled())
+			{
+				log.debug("Live-state push threw: {}", e.getMessage());
+			}
 		}
 	}
 

--- a/src/main/java/com/flipsmart/LiveStatePushService.java
+++ b/src/main/java/com/flipsmart/LiveStatePushService.java
@@ -64,12 +64,12 @@ public class LiveStatePushService
 
 	public void schedulePush(LiveStateSnapshot snapshot)
 	{
-		ScheduledFuture<?> existing = pending.get();
-		if (existing != null)
+		ScheduledFuture<?> next = scheduler.schedule(() -> doPush(snapshot), DEBOUNCE_MS, TimeUnit.MILLISECONDS);
+		ScheduledFuture<?> previous = pending.getAndSet(next);
+		if (previous != null)
 		{
-			existing.cancel(false);
+			previous.cancel(false);
 		}
-		pending.set(scheduler.schedule(() -> doPush(snapshot), DEBOUNCE_MS, TimeUnit.MILLISECONDS));
 	}
 
 	public void pushNow(LiveStateSnapshot snapshot)
@@ -110,12 +110,17 @@ public class LiveStatePushService
 		try
 		{
 			apiClient.pushLiveStateAsync(rsn, Instant.now().toString(), snapshot)
-				.exceptionally(e ->
+				.whenComplete((ok, err) ->
 				{
-					log.debug("Live-state push failed: {}", e.getMessage());
-					return false;
+					if (err == null && Boolean.TRUE.equals(ok))
+					{
+						lastPushed.set(snapshot);
+					}
+					else
+					{
+						log.debug("Live-state push failed: {}", err != null ? err.getMessage() : ok);
+					}
 				});
-			lastPushed.set(snapshot);
 		}
 		catch (RuntimeException e)
 		{

--- a/src/main/java/com/flipsmart/LiveStatePushService.java
+++ b/src/main/java/com/flipsmart/LiveStatePushService.java
@@ -30,6 +30,7 @@ public class LiveStatePushService
 
 	private final AtomicReference<ScheduledFuture<?>> pending = new AtomicReference<>();
 	private final AtomicReference<LiveStateSnapshot> lastPushed = new AtomicReference<>();
+	private final AtomicReference<LiveStateSnapshot> lastSent = new AtomicReference<>();
 	private volatile boolean ready;
 
 	@Inject
@@ -109,14 +110,16 @@ public class LiveStatePushService
 		}
 		try
 		{
+			lastSent.set(snapshot);
 			apiClient.pushLiveStateAsync(rsn, Instant.now().toString(), snapshot)
 				.whenComplete((ok, err) ->
 				{
-					if (err == null && Boolean.TRUE.equals(ok))
+					boolean succeeded = err == null && Boolean.TRUE.equals(ok);
+					if (succeeded && snapshot == lastSent.get())
 					{
 						lastPushed.set(snapshot);
 					}
-					else
+					else if (!succeeded)
 					{
 						log.debug("Live-state push failed: {}", err != null ? err.getMessage() : ok);
 					}

--- a/src/main/java/com/flipsmart/LiveStatePushService.java
+++ b/src/main/java/com/flipsmart/LiveStatePushService.java
@@ -179,23 +179,25 @@ public class LiveStatePushService
 		{
 			lastSent.set(snapshot);
 			apiClient.pushLiveStateAsync(rsn, Instant.now().toString(), snapshot)
-				.whenComplete((ok, err) ->
-				{
-					boolean succeeded = err == null && Boolean.TRUE.equals(ok);
-					if (succeeded && snapshot == lastSent.get())
-					{
-						lastPushed.set(snapshot);
-						lastSuccessfulPushAt.set(clock.getAsLong());
-					}
-					else if (!succeeded)
-					{
-						log.debug("Live-state push failed: {}", err != null ? err.getMessage() : ok);
-					}
-				});
+				.whenComplete((ok, err) -> handlePushOutcome(snapshot, ok, err));
 		}
 		catch (RuntimeException e)
 		{
 			log.debug("Live-state push threw: {}", e.getMessage());
+		}
+	}
+
+	private void handlePushOutcome(LiveStateSnapshot snapshot, Boolean ok, Throwable err)
+	{
+		boolean succeeded = err == null && Boolean.TRUE.equals(ok);
+		if (succeeded && snapshot == lastSent.get())
+		{
+			lastPushed.set(snapshot);
+			lastSuccessfulPushAt.set(clock.getAsLong());
+		}
+		else if (!succeeded)
+		{
+			log.debug("Live-state push failed: {}", err != null ? err.getMessage() : ok);
 		}
 	}
 }

--- a/src/main/java/com/flipsmart/LiveStatePushService.java
+++ b/src/main/java/com/flipsmart/LiveStatePushService.java
@@ -8,7 +8,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -17,27 +20,43 @@ import lombok.extern.slf4j.Slf4j;
  *
  * Debounced because a single fill produces a burst of offer events. The payload
  * is absolute, so a dropped push costs freshness, never correctness.
+ *
+ * A periodic heartbeat pushes on a bounded clock even when nothing changes, so
+ * "as of" freshness on the dashboard keeps advancing for an online player sitting
+ * on unchanged offers, and a failed push gets a bounded retry.
  */
 @Slf4j
 @Singleton
 public class LiveStatePushService
 {
 	private static final long DEBOUNCE_MS = 1_500L;
+	private static final long HEARTBEAT_INTERVAL_MS = 60_000L;
+	private static final long HEARTBEAT_STALE_AFTER_MS = 600_000L;
+	private static final long NEVER_PUSHED = -1L;
 
 	private final FlipSmartApiClient apiClient;
 	private final PlayerSession session;
+	private final LongSupplier clock;
 	private final ScheduledExecutorService scheduler; // NOPMD DoNotUseThreads - desktop plugin, not J2EE
 
 	private final AtomicReference<ScheduledFuture<?>> pending = new AtomicReference<>();
+	private final AtomicReference<ScheduledFuture<?>> heartbeat = new AtomicReference<>();
 	private final AtomicReference<LiveStateSnapshot> lastPushed = new AtomicReference<>();
 	private final AtomicReference<LiveStateSnapshot> lastSent = new AtomicReference<>();
+	private final AtomicLong lastSuccessfulPushAt = new AtomicLong(NEVER_PUSHED);
 	private volatile boolean ready;
 
 	@Inject
 	public LiveStatePushService(FlipSmartApiClient apiClient, PlayerSession session)
 	{
+		this(apiClient, session, System::currentTimeMillis);
+	}
+
+	LiveStatePushService(FlipSmartApiClient apiClient, PlayerSession session, LongSupplier clock)
+	{
 		this.apiClient = apiClient;
 		this.session = session;
+		this.clock = clock;
 		this.scheduler = Executors.newSingleThreadScheduledExecutor(r ->
 		{
 			Thread t = new Thread(r, "flipsmart-live-state-push"); // NOPMD DoNotUseThreads
@@ -65,7 +84,7 @@ public class LiveStatePushService
 
 	public void schedulePush(LiveStateSnapshot snapshot)
 	{
-		ScheduledFuture<?> next = scheduler.schedule(() -> doPush(snapshot), DEBOUNCE_MS, TimeUnit.MILLISECONDS);
+		ScheduledFuture<?> next = scheduler.schedule(() -> doPush(snapshot, false), DEBOUNCE_MS, TimeUnit.MILLISECONDS);
 		ScheduledFuture<?> previous = pending.getAndSet(next);
 		if (previous != null)
 		{
@@ -80,7 +99,35 @@ public class LiveStatePushService
 		{
 			existing.cancel(false);
 		}
-		doPush(snapshot);
+		doPush(snapshot, false);
+	}
+
+	/**
+	 * Start the freshness heartbeat. No offer or inventory event fires while the
+	 * player's GE state is genuinely unchanged, so nothing else advances the
+	 * backend's "as of" timestamp for that (common) steady state, and nothing
+	 * else gives a failed push a bounded retry. The supplier is called off the
+	 * client thread on every tick; it must be safe for that (it is — see
+	 * {@code FlipSmartPlugin#buildLiveStateSnapshot}).
+	 */
+	public void startHeartbeat(Supplier<LiveStateSnapshot> snapshotSupplier)
+	{
+		ScheduledFuture<?> next = scheduler.scheduleAtFixedRate(() ->
+		{
+			try
+			{
+				heartbeatTick(snapshotSupplier);
+			}
+			catch (RuntimeException e)
+			{
+				log.debug("Live-state heartbeat threw: {}", e.getMessage());
+			}
+		}, HEARTBEAT_INTERVAL_MS, HEARTBEAT_INTERVAL_MS, TimeUnit.MILLISECONDS);
+		ScheduledFuture<?> previous = heartbeat.getAndSet(next);
+		if (previous != null)
+		{
+			previous.cancel(false);
+		}
 	}
 
 	public void shutdown()
@@ -90,10 +137,33 @@ public class LiveStatePushService
 		{
 			existing.cancel(false);
 		}
+		ScheduledFuture<?> existingHeartbeat = heartbeat.getAndSet(null);
+		if (existingHeartbeat != null)
+		{
+			existingHeartbeat.cancel(false);
+		}
 		scheduler.shutdownNow(); // NOPMD DoNotUseThreads
 	}
 
-	private void doPush(LiveStateSnapshot snapshot)
+	/**
+	 * Package-private so tests can drive a tick deterministically instead of
+	 * waiting on {@link #HEARTBEAT_INTERVAL_MS} of real scheduler time.
+	 */
+	void heartbeatTick(Supplier<LiveStateSnapshot> snapshotSupplier)
+	{
+		if (!ready || !session.getRsnSafe().isPresent())
+		{
+			return;
+		}
+		long lastSuccess = lastSuccessfulPushAt.get();
+		if (lastSuccess != NEVER_PUSHED && clock.getAsLong() - lastSuccess < HEARTBEAT_STALE_AFTER_MS)
+		{
+			return;
+		}
+		doPush(snapshotSupplier.get(), true);
+	}
+
+	private void doPush(LiveStateSnapshot snapshot, boolean bypassDedup)
 	{
 		if (!ready)
 		{
@@ -104,7 +174,7 @@ public class LiveStatePushService
 		{
 			return;
 		}
-		if (snapshot.equals(lastPushed.get()))
+		if (!bypassDedup && snapshot.equals(lastPushed.get()))
 		{
 			return;
 		}
@@ -118,6 +188,7 @@ public class LiveStatePushService
 					if (succeeded && snapshot == lastSent.get())
 					{
 						lastPushed.set(snapshot);
+						lastSuccessfulPushAt.set(clock.getAsLong());
 					}
 					else if (!succeeded)
 					{

--- a/src/main/java/com/flipsmart/LiveStatePushService.java
+++ b/src/main/java/com/flipsmart/LiveStatePushService.java
@@ -1,0 +1,125 @@
+package com.flipsmart;
+
+import com.flipsmart.api.dto.LiveStateSnapshot;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.time.Instant;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Pushes the player's live GE slot, inventory and collected state to the backend
+ * so the web dashboard can tell an open position from a finished one.
+ *
+ * Debounced because a single fill produces a burst of offer events. The payload
+ * is absolute, so a dropped push costs freshness, never correctness.
+ */
+@Slf4j
+@Singleton
+public class LiveStatePushService
+{
+	private static final long DEBOUNCE_MS = 1_500L;
+
+	private final FlipSmartApiClient apiClient;
+	private final PlayerSession session;
+	private final ScheduledExecutorService scheduler; // NOPMD DoNotUseThreads - desktop plugin, not J2EE
+
+	private final AtomicReference<ScheduledFuture<?>> pending = new AtomicReference<>();
+	private final AtomicReference<LiveStateSnapshot> lastPushed = new AtomicReference<>();
+	private volatile boolean ready;
+
+	@Inject
+	public LiveStatePushService(FlipSmartApiClient apiClient, PlayerSession session)
+	{
+		this.apiClient = apiClient;
+		this.session = session;
+		this.scheduler = Executors.newSingleThreadScheduledExecutor(r ->
+		{
+			Thread t = new Thread(r, "flipsmart-live-state-push"); // NOPMD DoNotUseThreads
+			t.setDaemon(true);
+			return t;
+		});
+	}
+
+	/**
+	 * Allow pushes. Called once the GE login burst has settled — before that the
+	 * client's slot state is not yet trustworthy and an early snapshot would
+	 * briefly hide real positions.
+	 */
+	public void markReady()
+	{
+		ready = true;
+	}
+
+	/** Block pushes and forget the dedup baseline, so the next session re-pushes in full. */
+	public void markNotReady()
+	{
+		ready = false;
+		lastPushed.set(null);
+	}
+
+	public void schedulePush(LiveStateSnapshot snapshot)
+	{
+		ScheduledFuture<?> existing = pending.get();
+		if (existing != null)
+		{
+			existing.cancel(false);
+		}
+		pending.set(scheduler.schedule(() -> doPush(snapshot), DEBOUNCE_MS, TimeUnit.MILLISECONDS));
+	}
+
+	public void pushNow(LiveStateSnapshot snapshot)
+	{
+		ScheduledFuture<?> existing = pending.getAndSet(null);
+		if (existing != null)
+		{
+			existing.cancel(false);
+		}
+		doPush(snapshot);
+	}
+
+	public void shutdown()
+	{
+		ScheduledFuture<?> existing = pending.getAndSet(null);
+		if (existing != null)
+		{
+			existing.cancel(false);
+		}
+		scheduler.shutdownNow(); // NOPMD DoNotUseThreads
+	}
+
+	private void doPush(LiveStateSnapshot snapshot)
+	{
+		if (!ready)
+		{
+			return;
+		}
+		String rsn = session.getRsnSafe().orElse(null);
+		if (rsn == null)
+		{
+			return;
+		}
+		if (snapshot.equals(lastPushed.get()))
+		{
+			return;
+		}
+		try
+		{
+			apiClient.pushLiveStateAsync(rsn, Instant.now().toString(), snapshot)
+				.exceptionally(e ->
+				{
+					log.debug("Live-state push failed: {}", e.getMessage());
+					return false;
+				});
+			lastPushed.set(snapshot);
+		}
+		catch (RuntimeException e)
+		{
+			log.debug("Live-state push threw: {}", e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/flipsmart/api/dto/LiveStateSnapshot.java
+++ b/src/main/java/com/flipsmart/api/dto/LiveStateSnapshot.java
@@ -1,5 +1,6 @@
 package com.flipsmart.api.dto;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -64,7 +65,7 @@ public final class LiveStateSnapshot
 
 	public LiveStateSnapshot(List<SlotState> slots, Set<Integer> inventoryItemIds, Set<Integer> collectedItemIds)
 	{
-		this.slots = Collections.unmodifiableList(slots);
+		this.slots = Collections.unmodifiableList(new ArrayList<>(slots));
 		this.inventoryItemIds = Collections.unmodifiableSet(new LinkedHashSet<>(inventoryItemIds));
 		this.collectedItemIds = Collections.unmodifiableSet(new LinkedHashSet<>(collectedItemIds));
 	}

--- a/src/main/java/com/flipsmart/api/dto/LiveStateSnapshot.java
+++ b/src/main/java/com/flipsmart/api/dto/LiveStateSnapshot.java
@@ -1,0 +1,109 @@
+package com.flipsmart.api.dto;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/** Immutable snapshot of live player state pushed to the backend. */
+public final class LiveStateSnapshot
+{
+	public static final class SlotState
+	{
+		public final int slot;
+		public final int itemId;
+		public final String itemName;
+		public final boolean isBuy;
+		public final String state;
+		public final int totalQuantity;
+		public final int filledQuantity;
+		public final int price;
+
+		public SlotState(int slot, int itemId, String itemName, boolean isBuy, String state,
+			int totalQuantity, int filledQuantity, int price)
+		{
+			this.slot = slot;
+			this.itemId = itemId;
+			this.itemName = itemName;
+			this.isBuy = isBuy;
+			this.state = state;
+			this.totalQuantity = totalQuantity;
+			this.filledQuantity = filledQuantity;
+			this.price = price;
+		}
+
+		@Override
+		public boolean equals(Object o)
+		{
+			if (this == o)
+			{
+				return true;
+			}
+			if (!(o instanceof SlotState))
+			{
+				return false;
+			}
+			SlotState other = (SlotState) o;
+			return slot == other.slot && itemId == other.itemId && isBuy == other.isBuy
+				&& totalQuantity == other.totalQuantity && filledQuantity == other.filledQuantity
+				&& price == other.price && Objects.equals(itemName, other.itemName)
+				&& Objects.equals(state, other.state);
+		}
+
+		@Override
+		public int hashCode()
+		{
+			return Objects.hash(slot, itemId, itemName, isBuy, state, totalQuantity, filledQuantity, price);
+		}
+	}
+
+	private final List<SlotState> slots;
+	private final Set<Integer> inventoryItemIds;
+	private final Set<Integer> collectedItemIds;
+
+	public LiveStateSnapshot(List<SlotState> slots, Set<Integer> inventoryItemIds, Set<Integer> collectedItemIds)
+	{
+		this.slots = Collections.unmodifiableList(slots);
+		this.inventoryItemIds = Collections.unmodifiableSet(new LinkedHashSet<>(inventoryItemIds));
+		this.collectedItemIds = Collections.unmodifiableSet(new LinkedHashSet<>(collectedItemIds));
+	}
+
+	public List<SlotState> getSlots()
+	{
+		return slots;
+	}
+
+	public Set<Integer> getInventoryItemIds()
+	{
+		return inventoryItemIds;
+	}
+
+	public Set<Integer> getCollectedItemIds()
+	{
+		return collectedItemIds;
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o)
+		{
+			return true;
+		}
+		if (!(o instanceof LiveStateSnapshot))
+		{
+			return false;
+		}
+		LiveStateSnapshot other = (LiveStateSnapshot) o;
+		return slots.equals(other.slots)
+			&& inventoryItemIds.equals(other.inventoryItemIds)
+			&& collectedItemIds.equals(other.collectedItemIds);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(slots, inventoryItemIds, collectedItemIds);
+	}
+}

--- a/src/main/java/com/flipsmart/api/dto/LiveStateSnapshot.java
+++ b/src/main/java/com/flipsmart/api/dto/LiveStateSnapshot.java
@@ -46,10 +46,19 @@ public final class LiveStateSnapshot
 				return false;
 			}
 			SlotState other = (SlotState) o;
+			return sameNumericFields(other) && sameNamedFields(other);
+		}
+
+		private boolean sameNumericFields(SlotState other)
+		{
 			return slot == other.slot && itemId == other.itemId && isBuy == other.isBuy
 				&& totalQuantity == other.totalQuantity && filledQuantity == other.filledQuantity
-				&& price == other.price && Objects.equals(itemName, other.itemName)
-				&& Objects.equals(state, other.state);
+				&& price == other.price;
+		}
+
+		private boolean sameNamedFields(SlotState other)
+		{
+			return Objects.equals(itemName, other.itemName) && Objects.equals(state, other.state);
 		}
 
 		@Override

--- a/src/main/java/com/flipsmart/api/endpoints/LiveStateEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/LiveStateEndpoints.java
@@ -58,7 +58,10 @@ public class LiveStateEndpoints
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData -> Boolean.TRUE)
 			.exceptionally(e ->
 			{
-				log.debug("pushLiveStateAsync failed: {}", e.getMessage());
+				if (log.isDebugEnabled())
+				{
+					log.debug("pushLiveStateAsync failed: {}", e.getMessage());
+				}
 				return false;
 			});
 	}

--- a/src/main/java/com/flipsmart/api/endpoints/LiveStateEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/LiveStateEndpoints.java
@@ -1,0 +1,75 @@
+package com.flipsmart.api.endpoints;
+
+import com.flipsmart.api.ApiHttpTransport;
+import com.flipsmart.api.dto.LiveStateSnapshot;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+
+import java.util.concurrent.CompletableFuture;
+
+import static com.flipsmart.api.ApiHttpTransport.JSON;
+
+/**
+ * Live player-state push endpoint (lets the backend apply the same
+ * "still on the GE" predicate the plugin uses client-side).
+ */
+@Slf4j
+public class LiveStateEndpoints
+{
+	private final ApiHttpTransport transport;
+
+	public LiveStateEndpoints(ApiHttpTransport transport)
+	{
+		this.transport = transport;
+	}
+
+	public CompletableFuture<Boolean> pushLiveStateAsync(String rsn, String capturedAtIso, LiveStateSnapshot snapshot)
+	{
+		String url = String.format("%s/plugin/live-state", transport.getApiUrl());
+
+		JsonObject body = new JsonObject();
+		body.addProperty("rsn", rsn);
+		body.addProperty("captured_at", capturedAtIso);
+
+		JsonArray slots = new JsonArray();
+		for (LiveStateSnapshot.SlotState s : snapshot.getSlots())
+		{
+			JsonObject o = new JsonObject();
+			o.addProperty("slot", s.slot);
+			o.addProperty("item_id", s.itemId);
+			o.addProperty("item_name", s.itemName);
+			o.addProperty("is_buy", s.isBuy);
+			o.addProperty("state", s.state);
+			o.addProperty("total_quantity", s.totalQuantity);
+			o.addProperty("filled_quantity", s.filledQuantity);
+			o.addProperty("price", s.price);
+			slots.add(o);
+		}
+		body.add("slots", slots);
+		body.add("inventory_item_ids", toArray(snapshot.getInventoryItemIds()));
+		body.add("collected_item_ids", toArray(snapshot.getCollectedItemIds()));
+
+		RequestBody rb = RequestBody.create(JSON, body.toString());
+		Request.Builder requestBuilder = new Request.Builder().url(url).post(rb);
+
+		return transport.executeAuthenticatedAsync(requestBuilder, jsonData -> Boolean.TRUE)
+			.exceptionally(e ->
+			{
+				log.debug("pushLiveStateAsync failed: {}", e.getMessage());
+				return false;
+			});
+	}
+
+	private static JsonArray toArray(Iterable<Integer> ids)
+	{
+		JsonArray arr = new JsonArray();
+		for (Integer id : ids)
+		{
+			arr.add(id);
+		}
+		return arr;
+	}
+}

--- a/src/test/java/com/flipsmart/LiveStatePushServiceTest.java
+++ b/src/test/java/com/flipsmart/LiveStatePushServiceTest.java
@@ -1,0 +1,87 @@
+package com.flipsmart;
+
+import com.flipsmart.api.dto.LiveStateSnapshot;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+
+public class LiveStatePushServiceTest
+{
+	private FlipSmartApiClient apiClient;
+	private PlayerSession session;
+	private LiveStatePushService service;
+	private final AtomicInteger pushes = new AtomicInteger();
+
+	private static LiveStateSnapshot snapshot(int itemId)
+	{
+		return new LiveStateSnapshot(
+			Collections.singletonList(new LiveStateSnapshot.SlotState(
+				0, itemId, "Item", true, "BUYING", 5, 1, 100)),
+			Collections.emptySet(), Collections.emptySet());
+	}
+
+	@Before
+	public void setUp()
+	{
+		apiClient = Mockito.mock(FlipSmartApiClient.class);
+		session = Mockito.mock(PlayerSession.class);
+		Mockito.when(session.getRsnSafe()).thenReturn(Optional.of("dumbridge3"));
+		Mockito.when(apiClient.pushLiveStateAsync(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
+			.thenAnswer(inv ->
+			{
+				pushes.incrementAndGet();
+				return CompletableFuture.completedFuture(true);
+			});
+		service = new LiveStatePushService(apiClient, session);
+		pushes.set(0);
+	}
+
+	@Test
+	public void doesNotPushBeforeReady()
+	{
+		service.pushNow(snapshot(4151));
+		assertEquals(0, pushes.get());
+	}
+
+	@Test
+	public void pushesOnceReady()
+	{
+		service.markReady();
+		service.pushNow(snapshot(4151));
+		assertEquals(1, pushes.get());
+	}
+
+	@Test
+	public void suppressesIdenticalConsecutiveSnapshot()
+	{
+		service.markReady();
+		service.pushNow(snapshot(4151));
+		service.pushNow(snapshot(4151));
+		assertEquals(1, pushes.get());
+	}
+
+	@Test
+	public void pushesEmptySnapshotOnceReady()
+	{
+		service.markReady();
+		service.pushNow(new LiveStateSnapshot(
+			Collections.emptyList(), Collections.emptySet(), Collections.emptySet()));
+		assertEquals(1, pushes.get());
+	}
+
+	@Test
+	public void markNotReadyBlocksAgain()
+	{
+		service.markReady();
+		service.pushNow(snapshot(4151));
+		service.markNotReady();
+		service.pushNow(snapshot(555));
+		assertEquals(1, pushes.get());
+	}
+}

--- a/src/test/java/com/flipsmart/LiveStatePushServiceTest.java
+++ b/src/test/java/com/flipsmart/LiveStatePushServiceTest.java
@@ -19,7 +19,6 @@ public class LiveStatePushServiceTest
 	private static final long HEARTBEAT_STALE_AFTER_MS = 600_000L;
 
 	private FlipSmartApiClient apiClient;
-	private PlayerSession session;
 	private LiveStatePushService service;
 	private final AtomicInteger pushes = new AtomicInteger();
 	private final AtomicLong clockMillis = new AtomicLong(0L);
@@ -36,7 +35,7 @@ public class LiveStatePushServiceTest
 	public void setUp()
 	{
 		apiClient = Mockito.mock(FlipSmartApiClient.class);
-		session = Mockito.mock(PlayerSession.class);
+		PlayerSession session = Mockito.mock(PlayerSession.class);
 		Mockito.when(session.getRsnSafe()).thenReturn(Optional.of("dumbridge3"));
 		Mockito.when(apiClient.pushLiveStateAsync(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
 			.thenAnswer(inv ->

--- a/src/test/java/com/flipsmart/LiveStatePushServiceTest.java
+++ b/src/test/java/com/flipsmart/LiveStatePushServiceTest.java
@@ -84,4 +84,22 @@ public class LiveStatePushServiceTest
 		service.pushNow(snapshot(555));
 		assertEquals(1, pushes.get());
 	}
+
+	@Test
+	public void failedPushDoesNotSuppressRetry()
+	{
+		Mockito.doAnswer(inv ->
+			{
+				pushes.incrementAndGet();
+				CompletableFuture<Boolean> failed = new CompletableFuture<>();
+				failed.completeExceptionally(new RuntimeException("boom"));
+				return failed;
+			})
+			.when(apiClient)
+			.pushLiveStateAsync(Mockito.anyString(), Mockito.anyString(), Mockito.any());
+		service.markReady();
+		service.pushNow(snapshot(4151));
+		service.pushNow(snapshot(4151));
+		assertEquals(2, pushes.get());
+	}
 }

--- a/src/test/java/com/flipsmart/LiveStatePushServiceTest.java
+++ b/src/test/java/com/flipsmart/LiveStatePushServiceTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -15,10 +16,13 @@ import static org.junit.Assert.assertEquals;
 
 public class LiveStatePushServiceTest
 {
+	private static final long HEARTBEAT_STALE_AFTER_MS = 600_000L;
+
 	private FlipSmartApiClient apiClient;
 	private PlayerSession session;
 	private LiveStatePushService service;
 	private final AtomicInteger pushes = new AtomicInteger();
+	private final AtomicLong clockMillis = new AtomicLong(0L);
 
 	private static LiveStateSnapshot snapshot(int itemId)
 	{
@@ -40,7 +44,7 @@ public class LiveStatePushServiceTest
 				pushes.incrementAndGet();
 				return CompletableFuture.completedFuture(true);
 			});
-		service = new LiveStatePushService(apiClient, session);
+		service = new LiveStatePushService(apiClient, session, clockMillis::get);
 		pushes.set(0);
 	}
 
@@ -130,5 +134,77 @@ public class LiveStatePushServiceTest
 
 		service.pushNow(snapshot(4151));
 		assertEquals(3, pushes.get());
+	}
+
+	@Test
+	public void heartbeatPushesIdenticalContentWhenLastPushIsStale()
+	{
+		service.markReady();
+		service.pushNow(snapshot(4151));
+		assertEquals(1, pushes.get());
+
+		clockMillis.set(HEARTBEAT_STALE_AFTER_MS + 1);
+		service.heartbeatTick(() -> snapshot(4151));
+
+		assertEquals(2, pushes.get());
+	}
+
+	@Test
+	public void heartbeatDoesNotPushWhenLastPushIsRecent()
+	{
+		service.markReady();
+		service.pushNow(snapshot(4151));
+		assertEquals(1, pushes.get());
+
+		clockMillis.set(HEARTBEAT_STALE_AFTER_MS - 1);
+		service.heartbeatTick(() -> snapshot(4151));
+
+		assertEquals(1, pushes.get());
+	}
+
+	@Test
+	public void heartbeatDoesNotPushWhenNotReady()
+	{
+		clockMillis.set(HEARTBEAT_STALE_AFTER_MS + 1);
+		service.heartbeatTick(() -> snapshot(4151));
+
+		assertEquals(0, pushes.get());
+	}
+
+	@Test
+	public void heartbeatPushesEmptySnapshot()
+	{
+		service.markReady();
+
+		clockMillis.set(HEARTBEAT_STALE_AFTER_MS + 1);
+		service.heartbeatTick(() -> new LiveStateSnapshot(
+			Collections.emptyList(), Collections.emptySet(), Collections.emptySet()));
+
+		assertEquals(1, pushes.get());
+	}
+
+	@Test
+	public void failedPushDoesNotRefreshLastSuccessfulPushTime()
+	{
+		Mockito.doAnswer(inv ->
+			{
+				pushes.incrementAndGet();
+				CompletableFuture<Boolean> failed = new CompletableFuture<>();
+				failed.completeExceptionally(new RuntimeException("boom"));
+				return failed;
+			})
+			.when(apiClient)
+			.pushLiveStateAsync(Mockito.anyString(), Mockito.anyString(), Mockito.any());
+		service.markReady();
+		service.pushNow(snapshot(4151));
+		assertEquals(1, pushes.get());
+
+		// The prior push never succeeded, so the heartbeat should still see the
+		// last-successful-push time as unset and fire immediately, well before
+		// the staleness threshold would otherwise have elapsed.
+		clockMillis.set(1L);
+		service.heartbeatTick(() -> snapshot(4151));
+
+		assertEquals(2, pushes.get());
 	}
 }

--- a/src/test/java/com/flipsmart/LiveStatePushServiceTest.java
+++ b/src/test/java/com/flipsmart/LiveStatePushServiceTest.java
@@ -1,7 +1,9 @@
 package com.flipsmart;
 
 import com.flipsmart.api.dto.LiveStateSnapshot;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -101,5 +103,32 @@ public class LiveStatePushServiceTest
 		service.pushNow(snapshot(4151));
 		service.pushNow(snapshot(4151));
 		assertEquals(2, pushes.get());
+	}
+
+	@Test
+	public void outOfOrderCompletionDoesNotRevertToStaleSnapshot()
+	{
+		List<CompletableFuture<Boolean>> futures = new ArrayList<>();
+		Mockito.doAnswer(inv ->
+			{
+				pushes.incrementAndGet();
+				CompletableFuture<Boolean> future = new CompletableFuture<>();
+				futures.add(future);
+				return future;
+			})
+			.when(apiClient)
+			.pushLiveStateAsync(Mockito.anyString(), Mockito.anyString(), Mockito.any());
+		service.markReady();
+
+		service.pushNow(snapshot(4151));
+		service.pushNow(snapshot(555));
+
+		// Newer push (555) resolves first, older push (4151) resolves after it —
+		// the older completion must not overwrite the dedup baseline it lost the race to.
+		futures.get(1).complete(true);
+		futures.get(0).complete(true);
+
+		service.pushNow(snapshot(4151));
+		assertEquals(3, pushes.get());
 	}
 }

--- a/src/test/java/com/flipsmart/api/dto/LiveStateSnapshotEqualityTest.java
+++ b/src/test/java/com/flipsmart/api/dto/LiveStateSnapshotEqualityTest.java
@@ -1,8 +1,10 @@
 package com.flipsmart.api.dto;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -41,5 +43,18 @@ public class LiveStateSnapshotEqualityTest
 		LiveStateSnapshot b = snapshotWith(6);
 
 		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void slotsAreDefensivelyCopiedFromSourceList()
+	{
+		LiveStateSnapshot.SlotState slot = new LiveStateSnapshot.SlotState(
+			0, 4151, "Abyssal whip", true, "BUYING", 10, 5, 2_000_000);
+		List<LiveStateSnapshot.SlotState> source = new ArrayList<>(Collections.singletonList(slot));
+
+		LiveStateSnapshot snapshot = new LiveStateSnapshot(source, Collections.emptySet(), Collections.emptySet());
+		source.clear();
+
+		assertEquals(1, snapshot.getSlots().size());
 	}
 }

--- a/src/test/java/com/flipsmart/api/dto/LiveStateSnapshotEqualityTest.java
+++ b/src/test/java/com/flipsmart/api/dto/LiveStateSnapshotEqualityTest.java
@@ -1,0 +1,45 @@
+package com.flipsmart.api.dto;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Pins {@link LiveStateSnapshot}'s content-based equality: Task 9's push
+ * debouncer dedups consecutive snapshots by comparing them, so two captures
+ * with identical content must compare equal regardless of when each was built.
+ */
+public class LiveStateSnapshotEqualityTest
+{
+	private static LiveStateSnapshot snapshotWith(int filledQuantity)
+	{
+		LiveStateSnapshot.SlotState slot = new LiveStateSnapshot.SlotState(
+			0, 4151, "Abyssal whip", true, "BUYING", 10, filledQuantity, 2_000_000);
+		return new LiveStateSnapshot(
+			Collections.singletonList(slot),
+			new LinkedHashSet<>(Arrays.asList(4151)),
+			Collections.emptySet());
+	}
+
+	@Test
+	public void identicalContentIsEqualAndSameHashCode()
+	{
+		LiveStateSnapshot a = snapshotWith(5);
+		LiveStateSnapshot b = snapshotWith(5);
+
+		assertEquals(a, b);
+		assertEquals(a.hashCode(), b.hashCode());
+	}
+
+	@Test
+	public void differingSlotContentIsNotEqual()
+	{
+		LiveStateSnapshot a = snapshotWith(5);
+		LiveStateSnapshot b = snapshotWith(6);
+
+		assertNotEquals(a, b);
+	}
+}

--- a/src/test/java/com/flipsmart/domain/flip/ActiveFlipDisplayFilterIdempotenceTest.java
+++ b/src/test/java/com/flipsmart/domain/flip/ActiveFlipDisplayFilterIdempotenceTest.java
@@ -1,0 +1,45 @@
+package com.flipsmart.domain.flip;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ActiveFlipDisplayFilterIdempotenceTest
+{
+	private static ActiveFlip flip(int itemId)
+	{
+		ActiveFlip f = new ActiveFlip();
+		f.setItemId(itemId);
+		f.setItemName("Item " + itemId);
+		return f;
+	}
+
+	@Test
+	public void filteringAnAlreadyFilteredListChangesNothing()
+	{
+		List<ActiveFlip> backend = new ArrayList<>(Arrays.asList(flip(4151), flip(560), flip(2)));
+		Set<Integer> active = new HashSet<>(Arrays.asList(4151));
+		Set<Integer> inventory = new HashSet<>(Arrays.asList(560));
+
+		List<ActiveFlip> once = ActiveFlipDisplayFilter.retain(backend, active, inventory);
+		List<ActiveFlip> twice = ActiveFlipDisplayFilter.retain(once, active, inventory);
+
+		assertEquals(2, once.size());
+		assertEquals(once, twice);
+	}
+
+	@Test
+	public void serverFilteredEmptyListStaysEmpty()
+	{
+		List<ActiveFlip> serverFiltered = Collections.emptyList();
+		List<ActiveFlip> result = ActiveFlipDisplayFilter.retain(
+			serverFiltered, Collections.emptySet(), Collections.emptySet());
+		assertEquals(0, result.size());
+	}
+}


### PR DESCRIPTION
## ⚠️ Plugin-Hub Release Timing

**Do NOT bundle this into the in-review plugin-hub submission `plugin-hub#14277`.** That submission is already sized `size-l` and awaiting RuneLite Plugin Hub review — adding this work risks tipping it to `size-xl` and restarting the review clock. This PR's changes ride the *next* plugin-hub release after #14277 lands, not the current one.

## Summary

The web dashboard's Active Flips section was showing flips that had ended days ago, because the backend derived "active" purely from its transaction ledger while this plugin repaired the list client-side using live game state (`ActiveFlipDisplayFilter.retain`) that the server never saw — and cancellations were never reported to the server at all. This PR pushes that live GE/inventory state to the backend so it can apply the same "is this actually still open" predicate server-side.

## Changes

### ✨ New Features
- `LiveStateSnapshot` DTO — an absolute (not incremental) snapshot of open GE slots, inventory item ids, and items collected this session. Content-based equality, all collections defensively copied.
- `LiveStateEndpoints` / `FlipSmartApiClient#pushLiveStateAsync` — POSTs the snapshot to the backend's new `/plugin/live-state` endpoint.
- `LiveStatePushService` — 1.5s debounce, content-based dedup (skips redundant pushes), an explicit readiness gate, and a 60s-tick heartbeat that forces a push when the last successful push is over 10 minutes old.
- Lifecycle wiring in `FlipSmartPlugin` — pushes on GE offer changes and on inventory changes, a forced push once the post-login sync settles, and marks not-ready on logout.

### ♻️ Refactoring
- None — this is additive wiring around existing offer/inventory event handling.

## Design Notes

- **Absolute, not incremental payload.** A dropped push only costs freshness, never correctness — the next triggering event re-pushes the full current state. This is why there is deliberately no retry queue.
- **An empty snapshot is meaningful, not a no-op to skip.** It's how a player who cancels their last offer reports that fact to the server. `pushesEmptySnapshotOnceReady` is a test specifically written to fail if anyone "optimizes" this into skipping pushes when the snapshot is empty.
- **Placement of the offer-change push is load-bearing.** It fires after the post-login settle gate (before that, the client's GE state isn't trustworthy yet) and after `handleOfferChanged` runs (before that, the snapshot would describe state that is one event stale).
- **No regression to the plugin's own Active Trades tab (AC5).** The server now sends an already-filtered list, and the client filters again on top of that. `ActiveFlipDisplayFilterIdempotenceTest` demonstrates double-filtering is a no-op — it passed on first run with zero production code changes needed, which is itself the evidence of correctness.

## Testing

### Automated Tests
- Build: BUILD SUCCESSFUL
- Tests: 741 passing (already run and verified prior to this PR being opened)

### Manual Testing

This work has no automated in-game verification path — `qa-verifier` is Playwright/browser-only and cannot drive a live RuneLite client, so verification here is manual, by the user, in-game.

**Note:** steps 2-6 require the companion backend PR (Flip-Smart/flip-smart#1123) to be deployed first — this plugin PR alone won't produce visible dashboard changes until that ships.

- [ ] 1. Log in. Confirm no live-state push fires during the login burst, then confirm one fires roughly 15s after login (observable via `~/.runelite/logs/client.log`).
- [ ] 2. List a buy offer in the GE, confirm it appears on the web dashboard's Active Flips within ~32s.
- [ ] 3. Cancel that offer, confirm it disappears from the web dashboard within ~32s.
- [ ] 4. Let an offer complete, collect it, and sell, confirm it leaves Active Flips and lands correctly in Flip History.
- [ ] 5. Leave the client idle with unchanged GE offers for more than 10 minutes, confirm the dashboard's "as of" freshness label refreshes (this exercises the heartbeat).
- [ ] 6. Repeat steps 2-5 on a second RSN/account to confirm per-account state isolation.

## API Changes

No plugin-facing API changes. This PR consumes a new backend endpoint, `POST /plugin/live-state`, added in Flip-Smart/flip-smart#1123. Dashboard-visible behavior from this PR requires that backend PR to be deployed — this plugin PR alone is a no-op for end users until then.

## Deployment Notes

- No config or env var changes.
- No new dependencies.
- **Plugin-hub release timing (repeat of the callout above):** do NOT bundle into `plugin-hub#14277`. This rides the next plugin-hub release after that submission lands.
- Functionally inert on its own — requires Flip-Smart/flip-smart#1123 deployed to have any dashboard-visible effect.

## Checklist

- [x] Tests added/updated
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Manual in-game QA (blocked on backend PR #1123 deploy for steps 2-6)
- [ ] Reviewed by teammate

## Related Issues

Part of Flip-Smart/flip-smart#1113

## Related PRs

- Backend: Flip-Smart/flip-smart#1123
- Frontend: Flip-Smart/flip-smart-eng#275
- Metrics: Flip-Smart/flip-smart-metrics#15

### 🩺 Codacy Quality Gate — fixed in this PR
- `088cf70` Lizard_ccn-medium `LiveStatePushService.java:163` — extracted the `whenComplete` completion handling out of `doPush` into `handlePushOutcome`, dropping cyclomatic complexity from 11 to under the limit of 8
- `a217df0` Lizard_ccn-medium `LiveStateSnapshot.java:38` — split `SlotState::equals`'s 8-field comparison chain into `sameNumericFields`/`sameNamedFields` helpers
- `3d7dac7` PMD_GuardLogStatement `LiveStatePushService.java:120,198` — guarded the heartbeat and push catch-block debug logs with `isDebugEnabled()`
- `1934413` PMD_GuardLogStatement `LiveStateEndpoints.java:61` — guarded the `exceptionally()` debug log with `isDebugEnabled()`
- `c19ed8e` PMD_SingularField `LiveStatePushServiceTest.java:22` — `session` is only used inside `setUp()`; converted to a local variable

### 🩺 Codacy Quality Gate — dismissed via API (noise)
- PMD_AvoidInstantiatingObjectsInLoops `LiveStateEndpoints.java:40` — each GE slot needs its own distinct `JsonObject` in the request body; there's nothing to hoist out of the loop

### 🤖 Codacy AI Reviewer — fixed in this PR
- `088cf70` `LiveStatePushService.java:163` — `doPush` cyclomatic-complexity extraction (2 duplicate comments on this line)
- `a217df0` `LiveStateSnapshot.java:38` — resolved via helper-method extraction rather than adopting Lombok `@EqualsAndHashCode` (2 duplicate comments on this line)
- `c19ed8e` `LiveStatePushServiceTest.java:22` — `session` field converted to a local variable (2 duplicate comments on this line)

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `FlipSmartPlugin.java:1473` — `offerStore.liveOffers()` is `synchronized` and returns a fresh defensive copy; no `ConcurrentModificationException` is possible
- `LiveStatePushService.java:111` (HIGH) — all three inputs to `buildLiveStateSnapshot` are already safe for cross-thread reads by construction (synchronized+copy `OfferStore`, volatile snapshot-swap `inventoryFlipItemIds`, `ConcurrentHashMap`-backed `collectedItemIds`); the suggested `heartbeatRequested`/`onGameTick` redesign isn't needed

### 🤖 Codacy AI Reviewer — deferred (in-thread rationale)
- `FlipSmartPlugin.java:981` — the final shutdown-time push can be a no-op after a preceding logout (readiness gate) and races the async HTTP call against process exit in the still-logged-in case; real edge case, but bypassing the readiness gate and joining the future synchronously on teardown is a design change that deserves its own discussion rather than a fix bundled into this PR
