### PR TITLE
feat: push the Active Flips projection so the website mirrors the plugin

### DIFF
--- a/src/main/java/com/flipsmart/ActiveFlipsSnapshotPushService.java
+++ b/src/main/java/com/flipsmart/ActiveFlipsSnapshotPushService.java
@@ -82,7 +82,10 @@ public class ActiveFlipsSnapshotPushService
 		}
 		catch (RejectedExecutionException e)
 		{
-			log.debug("active flips snapshot schedule rejected (shutting down): {}", e.getMessage());
+			if (log.isDebugEnabled())
+			{
+				log.debug("active flips snapshot schedule rejected (shutting down): {}", e.getMessage());
+			}
 		}
 	}
 
@@ -143,13 +146,19 @@ public class ActiveFlipsSnapshotPushService
 				})
 				.exceptionally(e ->
 				{
-					log.debug("active flips snapshot push failed: {}", e.getMessage());
+					if (log.isDebugEnabled())
+					{
+						log.debug("active flips snapshot push failed: {}", e.getMessage());
+					}
 					return null;
 				});
 		}
 		catch (RuntimeException e)
 		{
-			log.debug("active flips snapshot push threw: {}", e.getMessage());
+			if (log.isDebugEnabled())
+			{
+				log.debug("active flips snapshot push threw: {}", e.getMessage());
+			}
 		}
 	}
 }

--- a/src/main/java/com/flipsmart/ActiveFlipsSnapshotPushService.java
+++ b/src/main/java/com/flipsmart/ActiveFlipsSnapshotPushService.java
@@ -1,14 +1,15 @@
 package com.flipsmart;
 
 import com.flipsmart.domain.flip.ActiveFlip;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -30,7 +31,7 @@ public class ActiveFlipsSnapshotPushService
 
 	private final FlipSmartApiClient apiClient;
 	private final PlayerSession session;
-	private final ScheduledExecutorService scheduler;
+	private final ScheduledExecutorService scheduler; // NOPMD DoNotUseThreads - desktop plugin, not J2EE
 	private final AtomicReference<ScheduledFuture<?>> pending = new AtomicReference<>();
 	private final AtomicReference<String> lastDelivered = new AtomicReference<>();
 
@@ -41,7 +42,7 @@ public class ActiveFlipsSnapshotPushService
 		this.session = session;
 		this.scheduler = Executors.newSingleThreadScheduledExecutor(r ->
 		{
-			Thread t = new Thread(r, "flipsmart-active-flips-push");
+			Thread t = new Thread(r, "flipsmart-active-flips-push"); // NOPMD DoNotUseThreads
 			t.setDaemon(true);
 			return t;
 		});
@@ -62,26 +63,44 @@ public class ActiveFlipsSnapshotPushService
 			.collect(Collectors.joining(","));
 	}
 
-	public void scheduleSnapshotPush(List<ActiveFlip> flips)
+	/**
+	 * Schedule a debounced push. {@code flipsSupplier} is invoked at SEND time (after
+	 * the debounce), not now — so the payload and the {@code captured_at} timestamp
+	 * the endpoint stamps around it describe the same instant, instead of the payload
+	 * being up to {@link #DEBOUNCE_MS} stale relative to its own timestamp.
+	 */
+	public void scheduleSnapshotPush(Supplier<List<ActiveFlip>> flipsSupplier)
 	{
-		List<ActiveFlip> snapshot = new ArrayList<>(flips);
-		ScheduledFuture<?> previous = pending.getAndSet(
-			scheduler.schedule(() -> doPush(snapshot), DEBOUNCE_MS, TimeUnit.MILLISECONDS));
-		if (previous != null)
+		try
 		{
-			previous.cancel(false);
+			ScheduledFuture<?> previous = pending.getAndSet(
+				scheduler.schedule(() -> doPush(flipsSupplier), DEBOUNCE_MS, TimeUnit.MILLISECONDS));
+			if (previous != null)
+			{
+				previous.cancel(false);
+			}
+		}
+		catch (RejectedExecutionException e)
+		{
+			log.debug("active flips snapshot schedule rejected (shutting down): {}", e.getMessage());
 		}
 	}
 
-	public void pushNow(List<ActiveFlip> flips)
+	public void pushNow(Supplier<List<ActiveFlip>> flipsSupplier)
 	{
-		List<ActiveFlip> snapshot = new ArrayList<>(flips);
-		ScheduledFuture<?> previous = pending.getAndSet(null);
-		if (previous != null)
+		try
 		{
-			previous.cancel(false);
+			ScheduledFuture<?> previous = pending.getAndSet(null);
+			if (previous != null)
+			{
+				previous.cancel(false);
+			}
+			scheduler.execute(() -> doPush(flipsSupplier)); // NOPMD DoNotUseThreads
 		}
-		scheduler.execute(() -> doPush(snapshot));
+		catch (RejectedExecutionException e)
+		{
+			log.debug("active flips snapshot push rejected (shutting down): {}", e.getMessage());
+		}
 	}
 
 	/** Force the next push through even if the projection is unchanged (TTL refresh). */
@@ -97,13 +116,25 @@ public class ActiveFlipsSnapshotPushService
 		{
 			previous.cancel(false);
 		}
-		scheduler.shutdownNow();
+		scheduler.shutdownNow(); // NOPMD DoNotUseThreads
 	}
 
-	private void doPush(List<ActiveFlip> flips)
+	/**
+	 * @param flipsSupplier evaluated here, at send time. May return {@code null} to
+	 *                      mean "skip this push" (e.g. an unobserved empty snapshot) —
+	 *                      distinct from an empty list, which is a real "no flips" and
+	 *                      is always delivered.
+	 */
+	private void doPush(Supplier<List<ActiveFlip>> flipsSupplier)
 	{
 		Optional<String> rsn = session.getRsnSafe();
 		if (!rsn.isPresent())
+		{
+			return;
+		}
+
+		List<ActiveFlip> flips = flipsSupplier.get();
+		if (flips == null)
 		{
 			return;
 		}

--- a/src/main/java/com/flipsmart/ActiveFlipsSnapshotPushService.java
+++ b/src/main/java/com/flipsmart/ActiveFlipsSnapshotPushService.java
@@ -51,11 +51,13 @@ public class ActiveFlipsSnapshotPushService
 	 * Identity of a projection for dedup purposes: which flips exist and on which
 	 * side, deliberately EXCLUDING fill progress. Fill ticks fire constantly; if
 	 * they counted as changes, one slowly-filling order would push dozens of times.
+	 * This is also exactly what the server consumes, so the payload's other fields
+	 * are only ever as fresh as the last identity change.
 	 */
 	private static String identity(List<ActiveFlip> flips)
 	{
 		return flips.stream()
-			.map(f -> f.getItemId() + ":" + f.getPhase() + ":" + f.getOrderQuantity())
+			.map(f -> f.getItemId() + ":" + f.getPhase())
 			.sorted()
 			.collect(Collectors.joining(","));
 	}

--- a/src/main/java/com/flipsmart/ActiveFlipsSnapshotPushService.java
+++ b/src/main/java/com/flipsmart/ActiveFlipsSnapshotPushService.java
@@ -1,0 +1,139 @@
+package com.flipsmart;
+
+import com.flipsmart.domain.flip.ActiveFlip;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Pushes the plugin's canonical Active Flips projection to the backend so the
+ * website mirrors the same list (Flip-Smart/flip-smart#1113).
+ *
+ * The projection itself is never recomputed here — this only serialises what the
+ * Active Flips tab already renders, which is what makes the two surfaces agree
+ * by construction.
+ */
+@Slf4j
+@Singleton
+public class ActiveFlipsSnapshotPushService
+{
+	private static final long DEBOUNCE_MS = 2_000L;
+
+	private final FlipSmartApiClient apiClient;
+	private final PlayerSession session;
+	private final ScheduledExecutorService scheduler;
+	private final AtomicReference<ScheduledFuture<?>> pending = new AtomicReference<>();
+	private final AtomicReference<String> lastDelivered = new AtomicReference<>();
+
+	@Inject
+	public ActiveFlipsSnapshotPushService(FlipSmartApiClient apiClient, PlayerSession session)
+	{
+		this.apiClient = apiClient;
+		this.session = session;
+		this.scheduler = Executors.newSingleThreadScheduledExecutor(r ->
+		{
+			Thread t = new Thread(r, "flipsmart-active-flips-push");
+			t.setDaemon(true);
+			return t;
+		});
+	}
+
+	/**
+	 * Identity of a projection for dedup purposes: which flips exist and on which
+	 * side, deliberately EXCLUDING fill progress. Fill ticks fire constantly; if
+	 * they counted as changes, one slowly-filling order would push dozens of times.
+	 */
+	private static String identity(List<ActiveFlip> flips)
+	{
+		return flips.stream()
+			.map(f -> f.getItemId() + ":" + f.getPhase() + ":" + f.getOrderQuantity())
+			.sorted()
+			.collect(Collectors.joining(","));
+	}
+
+	public void scheduleSnapshotPush(List<ActiveFlip> flips)
+	{
+		List<ActiveFlip> snapshot = new ArrayList<>(flips);
+		ScheduledFuture<?> previous = pending.getAndSet(
+			scheduler.schedule(() -> doPush(snapshot), DEBOUNCE_MS, TimeUnit.MILLISECONDS));
+		if (previous != null)
+		{
+			previous.cancel(false);
+		}
+	}
+
+	public void pushNow(List<ActiveFlip> flips)
+	{
+		List<ActiveFlip> snapshot = new ArrayList<>(flips);
+		ScheduledFuture<?> previous = pending.getAndSet(null);
+		if (previous != null)
+		{
+			previous.cancel(false);
+		}
+		scheduler.execute(() -> doPush(snapshot));
+	}
+
+	/** Force the next push through even if the projection is unchanged (TTL refresh). */
+	public void invalidateDedup()
+	{
+		lastDelivered.set(null);
+	}
+
+	public void shutdown()
+	{
+		ScheduledFuture<?> previous = pending.getAndSet(null);
+		if (previous != null)
+		{
+			previous.cancel(false);
+		}
+		scheduler.shutdownNow();
+	}
+
+	private void doPush(List<ActiveFlip> flips)
+	{
+		Optional<String> rsn = session.getRsnSafe();
+		if (!rsn.isPresent())
+		{
+			return;
+		}
+
+		String identity = identity(flips);
+		if (identity.equals(lastDelivered.get()))
+		{
+			return;
+		}
+
+		try
+		{
+			apiClient.pushActiveFlipsSnapshotAsync(rsn.get(), flips)
+				.thenAccept(ok ->
+				{
+					// Advance the baseline only on DELIVERY. Recording an attempt
+					// would let a dropped push suppress its own retry, silently
+					// breaking AC2 (a cancelled offer never leaving the dashboard).
+					if (Boolean.TRUE.equals(ok))
+					{
+						lastDelivered.set(identity);
+					}
+				})
+				.exceptionally(e ->
+				{
+					log.debug("active flips snapshot push failed: {}", e.getMessage());
+					return null;
+				});
+		}
+		catch (RuntimeException e)
+		{
+			log.debug("active flips snapshot push threw: {}", e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/flipsmart/ActiveFlipsSnapshotPushService.java
+++ b/src/main/java/com/flipsmart/ActiveFlipsSnapshotPushService.java
@@ -86,23 +86,6 @@ public class ActiveFlipsSnapshotPushService
 		}
 	}
 
-	public void pushNow(Supplier<List<ActiveFlip>> flipsSupplier)
-	{
-		try
-		{
-			ScheduledFuture<?> previous = pending.getAndSet(null);
-			if (previous != null)
-			{
-				previous.cancel(false);
-			}
-			scheduler.execute(() -> doPush(flipsSupplier)); // NOPMD DoNotUseThreads
-		}
-		catch (RejectedExecutionException e)
-		{
-			log.debug("active flips snapshot push rejected (shutting down): {}", e.getMessage());
-		}
-	}
-
 	/** Force the next push through even if the projection is unchanged (TTL refresh). */
 	public void invalidateDedup()
 	{

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -1,6 +1,7 @@
 package com.flipsmart;
 import com.flipsmart.api.ApiHttpTransport;
 import com.flipsmart.api.endpoints.ActiveFlipEndpoints;
+import com.flipsmart.api.endpoints.ActiveFlipsSnapshotEndpoints;
 import com.flipsmart.api.endpoints.BankSnapshotEndpoints;
 import com.flipsmart.api.endpoints.BlocklistEndpoints;
 import com.flipsmart.api.endpoints.FavoritesEndpoints;
@@ -76,6 +77,7 @@ public class FlipSmartApiClient
 	private final MotdEndpoints motd;
 	private final TradeStationEndpoints tradeStation;
 	private final FavoritesEndpoints favorites;
+	private final ActiveFlipsSnapshotEndpoints activeFlipsSnapshot;
 
 	@Inject
 	public FlipSmartApiClient(FlipSmartConfig config, Gson gson, OkHttpClient okHttpClient)
@@ -101,6 +103,7 @@ public class FlipSmartApiClient
 		this.motd = new MotdEndpoints(transport);
 		this.tradeStation = new TradeStationEndpoints(transport);
 		this.favorites = new FavoritesEndpoints(transport);
+		this.activeFlipsSnapshot = new ActiveFlipsSnapshotEndpoints(transport);
 	}
 
 	// ============================================================================
@@ -483,6 +486,15 @@ public class FlipSmartApiClient
 	public CompletableFuture<Boolean> pushTradeStationSlotsAsync(String rsn, java.util.List<Integer> itemIds)
 	{
 		return tradeStation.pushTradeStationSlotsAsync(rsn, itemIds);
+	}
+
+	// ============================================================================
+	// Active Flips snapshot mirror
+	// ============================================================================
+
+	public CompletableFuture<Boolean> pushActiveFlipsSnapshotAsync(String rsn, java.util.List<com.flipsmart.domain.flip.ActiveFlip> flips)
+	{
+		return activeFlipsSnapshot.pushActiveFlipsSnapshotAsync(rsn, flips);
 	}
 
 	// ============================================================================

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -246,6 +246,12 @@ public class FlipSmartPlugin extends Plugin
 	// client thread (e.g. the Swing EDT) where the live client inventory API cannot be.
 	private volatile java.util.Map<Integer, Integer> inventoryFlipItemCounts = java.util.Collections.emptyMap();
 
+	// True once the offer store has been seeded from real GE state (login burst or
+	// preloadPersistedOffers), set only on the client thread. Lets the snapshot-push
+	// executor (background thread) know whether emptiness is observed or just startup
+	// default, without itself calling the client-thread-only GE offers API.
+	private volatile boolean offerStoreSeeded = false;
+
 	// Track login to avoid recording existing offers as new transactions
 	private static final int GE_LOGIN_BURST_WINDOW = 3; // ticks
 
@@ -558,8 +564,13 @@ public class FlipSmartPlugin extends Plugin
 	 * Combines the sell-phase projection with live pending buy orders, marking the
 	 * latter {@code phase = "buy"} so the backend (and therefore the website) sees
 	 * live buy offers too. Returns {@code null} — meaning "skip this push" — when the
-	 * combined payload is empty AND the GE offers array hasn't been observed yet
-	 * (e.g. mid login-burst), so an unseeded client never erases a real dashboard.
+	 * combined payload is empty AND the offer store hasn't been seeded from real GE
+	 * state yet (e.g. plugin enabled mid-session with no persisted offers, before the
+	 * first live GE event), so an unseeded store never erases a real dashboard.
+	 *
+	 * <p>Runs on the snapshot-push executor, not the client thread, so this reads the
+	 * {@code offerStoreSeeded} field (set on the client thread) instead of calling the
+	 * client API directly.
 	 */
 	private java.util.List<ActiveFlip> buildActiveFlipsSnapshotPayload()
 	{
@@ -567,8 +578,7 @@ public class FlipSmartPlugin extends Plugin
 		java.util.List<PendingOrder> pendingBuys = getPendingBuyOrders();
 		java.util.List<ActiveFlip> payload = ActiveFlipsSnapshotPayload.combine(projection, pendingBuys);
 
-		boolean geOffersUnseeded = client.getGrandExchangeOffers() == null;
-		return ActiveFlipsSnapshotPayload.isUnobservedEmpty(payload, geOffersUnseeded) ? null : payload;
+		return ActiveFlipsSnapshotPayload.isUnobservedEmpty(payload, !offerStoreSeeded) ? null : payload;
 	}
 
 	public boolean isAutoRecommendActive()
@@ -1308,6 +1318,7 @@ public class FlipSmartPlugin extends Plugin
 		// This ensures createWithPreservedTimestamps() finds the existing offer
 		// with its original timestamp, giving us accurate timers from the start.
 		offlineSyncService.preloadPersistedOffers();
+		offerStoreSeeded = true;
 
 		restoreAutoRecommendState();
 		restoreExitTradesState();
@@ -1643,6 +1654,7 @@ public class FlipSmartPlugin extends Plugin
 				com.flipsmart.trading.OfferEventMapper.toSignal(
 					slot, state, itemId, itemName, totalQuantity, price, quantitySold, spent),
 				System.currentTimeMillis());
+			offerStoreSeeded = true;
 			pushActiveFlipsSnapshot();
 			return;
 		}

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -5,6 +5,7 @@ import com.flipsmart.domain.offer.OfferSignal;
 import com.flipsmart.api.dto.OfferAdviceResponse;
 import com.flipsmart.domain.flip.ActiveFlip;
 import com.flipsmart.domain.flip.ActiveFlipProjection;
+import com.flipsmart.domain.flip.ActiveFlipsSnapshotPayload;
 import com.flipsmart.domain.flip.AwaitingSaleLot;
 import com.flipsmart.domain.flip.AwaitingSaleLots;
 import com.flipsmart.domain.offer.PendingOrder;
@@ -545,18 +546,29 @@ public class FlipSmartPlugin extends Plugin
 	 * Serialise the current projection to the backend so the website mirrors the Active
 	 * Flips tab. Enrichment is intentionally empty: the server only needs which flips
 	 * exist, and an empty map avoids taking the panel's lock from the event thread.
+	 * Deferred to send time (inside the supplier) so the pushed payload and the
+	 * timestamp the endpoint stamps around it describe the same instant.
 	 */
-	private void pushActiveFlipsSnapshot(boolean immediate)
+	private void pushActiveFlipsSnapshot()
+	{
+		activeFlipsSnapshotPushService.scheduleSnapshotPush(this::buildActiveFlipsSnapshotPayload);
+	}
+
+	/**
+	 * Combines the sell-phase projection with live pending buy orders, marking the
+	 * latter {@code phase = "buy"} so the backend (and therefore the website) sees
+	 * live buy offers too. Returns {@code null} — meaning "skip this push" — when the
+	 * combined payload is empty AND the GE offers array hasn't been observed yet
+	 * (e.g. mid login-burst), so an unseeded client never erases a real dashboard.
+	 */
+	private java.util.List<ActiveFlip> buildActiveFlipsSnapshotPayload()
 	{
 		java.util.List<ActiveFlip> projection = getProjectedActiveFlips(java.util.Collections.emptyMap());
-		if (immediate)
-		{
-			activeFlipsSnapshotPushService.pushNow(projection);
-		}
-		else
-		{
-			activeFlipsSnapshotPushService.scheduleSnapshotPush(projection);
-		}
+		java.util.List<PendingOrder> pendingBuys = getPendingBuyOrders();
+		java.util.List<ActiveFlip> payload = ActiveFlipsSnapshotPayload.combine(projection, pendingBuys);
+
+		boolean geOffersUnseeded = client.getGrandExchangeOffers() == null;
+		return ActiveFlipsSnapshotPayload.isUnobservedEmpty(payload, geOffersUnseeded) ? null : payload;
 	}
 
 	public boolean isAutoRecommendActive()
@@ -887,7 +899,7 @@ public class FlipSmartPlugin extends Plugin
 			// refreshes the server-side TTL. Dedup means an idle account with an
 			// unchanged board sends nothing, so this costs no traffic when quiet.
 			activeFlipsSnapshotPushService.invalidateDedup();
-			pushActiveFlipsSnapshot(false);
+			pushActiveFlipsSnapshot();
 		});
 		exitTradesController = serviceWiring.initializeExitTradesController(this, flipAssistOverlay, geSlotOverlay, offerStore);
 		manualAdjustmentTracker = serviceWiring.initializeManualAdjustmentTracker(this, config, flipAssistOverlay,
@@ -1112,9 +1124,11 @@ public class FlipSmartPlugin extends Plugin
 		// Shut down the trade-station snapshot pusher's executor.
 		tradeStationSlotPushService.shutdown();
 
-		// Flush and stop the Active Flips snapshot pusher and its heartbeat.
-		activeFlipsSnapshotPushService.shutdown();
+		// Stop the heartbeat FIRST: it fires on its own Timer thread, so a tick landing
+		// after the executor below shuts down would throw RejectedExecutionException
+		// out of TimerTask.run() and kill the Timer thread.
 		scheduler.stopActiveFlipsSnapshotTimer();
+		activeFlipsSnapshotPushService.shutdown();
 	}
 
 	@Subscribe
@@ -1629,7 +1643,7 @@ public class FlipSmartPlugin extends Plugin
 				com.flipsmart.trading.OfferEventMapper.toSignal(
 					slot, state, itemId, itemName, totalQuantity, price, quantitySold, spent),
 				System.currentTimeMillis());
-			pushActiveFlipsSnapshot(false);
+			pushActiveFlipsSnapshot();
 			return;
 		}
 
@@ -1644,7 +1658,7 @@ public class FlipSmartPlugin extends Plugin
 			.isBuy(OfferSignal.isBuyState(state))
 			.state(state)
 			.build());
-		pushActiveFlipsSnapshot(false);
+		pushActiveFlipsSnapshot();
 	}
 
 	@Subscribe
@@ -1876,9 +1890,16 @@ public class FlipSmartPlugin extends Plugin
 		// An inventory change adds or removes an awaiting-sale lot, so re-derive the
 		// Active Flips projection whenever the held-item composition changes. Coins are
 		// ignored: they move on every trade but never form an awaiting-sale card.
-		if (flipFinderPanel != null && heldItemsChanged(previousInventoryCounts, currentInventoryCounts))
+		if (heldItemsChanged(previousInventoryCounts, currentInventoryCounts))
 		{
-			flipFinderPanel.onInventoryChanged();
+			if (flipFinderPanel != null)
+			{
+				flipFinderPanel.onInventoryChanged();
+			}
+			// Collecting a bought lot changes the awaiting-sale set without any GE offer
+			// event, so push here too — otherwise the website can lag up to the 5-minute
+			// heartbeat before the collected item appears.
+			pushActiveFlipsSnapshot();
 		}
 
 		if (totalCash != session.getCurrentCashStack())

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -250,7 +250,7 @@ public class FlipSmartPlugin extends Plugin
 	// preloadPersistedOffers), set only on the client thread. Lets the snapshot-push
 	// executor (background thread) know whether emptiness is observed or just startup
 	// default, without itself calling the client-thread-only GE offers API.
-	private volatile boolean offerStoreSeeded = false;
+	private volatile boolean offerStoreSeeded;
 
 	// Track login to avoid recording existing offers as new transactions
 	private static final int GE_LOGIN_BURST_WINDOW = 3; // ticks

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -177,6 +177,9 @@ public class FlipSmartPlugin extends Plugin
 	private TradeStationSlotPushService tradeStationSlotPushService;
 
 	@Inject
+	private ActiveFlipsSnapshotPushService activeFlipsSnapshotPushService;
+
+	@Inject
 	private Gson gson;
 
 	// Flip Finder panel
@@ -538,6 +541,24 @@ public class FlipSmartPlugin extends Plugin
 			enrichmentByItemId == null ? java.util.Collections.emptyMap() : enrichmentByItemId);
 	}
 
+	/**
+	 * Serialise the current projection to the backend so the website mirrors the Active
+	 * Flips tab. Enrichment is intentionally empty: the server only needs which flips
+	 * exist, and an empty map avoids taking the panel's lock from the event thread.
+	 */
+	private void pushActiveFlipsSnapshot(boolean immediate)
+	{
+		java.util.List<ActiveFlip> projection = getProjectedActiveFlips(java.util.Collections.emptyMap());
+		if (immediate)
+		{
+			activeFlipsSnapshotPushService.pushNow(projection);
+		}
+		else
+		{
+			activeFlipsSnapshotPushService.scheduleSnapshotPush(projection);
+		}
+	}
+
 	public boolean isAutoRecommendActive()
 	{
 		return autoRecommendService != null && autoRecommendService.isActive();
@@ -860,6 +881,14 @@ public class FlipSmartPlugin extends Plugin
 		autoRecommendService = serviceWiring.initializeAutoRecommendService(this, config, flipAssistOverlay, geSlotOverlay, offerStore, notifier, clientUI);
 		activeOfferAdvisorService = serviceWiring.initializeActiveOfferAdvisor(this);
 		scheduler.startActiveOfferAdvisorTimer(session::isLoggedIntoRunescape, this::pollActiveOfferAdvisor);
+		scheduler.startActiveFlipsSnapshotTimer(session::isLoggedIntoRunescape, () ->
+		{
+			// Periodic safety net: repairs drift from any dropped event push and
+			// refreshes the server-side TTL. Dedup means an idle account with an
+			// unchanged board sends nothing, so this costs no traffic when quiet.
+			activeFlipsSnapshotPushService.invalidateDedup();
+			pushActiveFlipsSnapshot(false);
+		});
 		exitTradesController = serviceWiring.initializeExitTradesController(this, flipAssistOverlay, geSlotOverlay, offerStore);
 		manualAdjustmentTracker = serviceWiring.initializeManualAdjustmentTracker(this, config, flipAssistOverlay,
 			geSlotOverlay, inventoryHighlightOverlay, session, grandExchangeTracker, activeOfferAdvisorService, offerStore);
@@ -1082,6 +1111,10 @@ public class FlipSmartPlugin extends Plugin
 
 		// Shut down the trade-station snapshot pusher's executor.
 		tradeStationSlotPushService.shutdown();
+
+		// Flush and stop the Active Flips snapshot pusher and its heartbeat.
+		activeFlipsSnapshotPushService.shutdown();
+		scheduler.stopActiveFlipsSnapshotTimer();
 	}
 
 	@Subscribe
@@ -1596,6 +1629,7 @@ public class FlipSmartPlugin extends Plugin
 				com.flipsmart.trading.OfferEventMapper.toSignal(
 					slot, state, itemId, itemName, totalQuantity, price, quantitySold, spent),
 				System.currentTimeMillis());
+			pushActiveFlipsSnapshot(false);
 			return;
 		}
 
@@ -1610,6 +1644,7 @@ public class FlipSmartPlugin extends Plugin
 			.isBuy(OfferSignal.isBuyState(state))
 			.state(state)
 			.build());
+		pushActiveFlipsSnapshot(false);
 	}
 
 	@Subscribe

--- a/src/main/java/com/flipsmart/api/endpoints/ActiveFlipsSnapshotEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/ActiveFlipsSnapshotEndpoints.java
@@ -1,0 +1,48 @@
+package com.flipsmart.api.endpoints;
+
+import com.flipsmart.api.ApiHttpTransport;
+import com.flipsmart.domain.flip.ActiveFlip;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import static com.flipsmart.api.ApiHttpTransport.JSON;
+
+@Slf4j
+public class ActiveFlipsSnapshotEndpoints
+{
+	private static final Gson GSON = new Gson();
+
+	private final ApiHttpTransport transport;
+
+	public ActiveFlipsSnapshotEndpoints(ApiHttpTransport transport)
+	{
+		this.transport = transport;
+	}
+
+	public CompletableFuture<Boolean> pushActiveFlipsSnapshotAsync(String rsn, List<ActiveFlip> flips)
+	{
+		String url = String.format("%s/plugin/active-flips-snapshot", transport.getApiUrl());
+
+		JsonObject body = new JsonObject();
+		body.addProperty("rsn", rsn);
+		body.addProperty("captured_at", Instant.now().toString());
+		// ActiveFlip carries @SerializedName on every field, so it serialises
+		// straight into the snake_case shape the backend expects.
+		body.add("flips", GSON.toJsonTree(flips));
+
+		RequestBody rb = RequestBody.create(JSON, body.toString());
+		Request.Builder requestBuilder = new Request.Builder().url(url).post(rb);
+
+		return transport.executeAuthenticatedAsync(requestBuilder, jsonData -> Boolean.TRUE)
+			.exceptionally(e ->
+			{
+				log.debug("pushActiveFlipsSnapshotAsync failed: {}", e.getMessage());
+				return false;
+			});
+	}
+}

--- a/src/main/java/com/flipsmart/api/endpoints/ActiveFlipsSnapshotEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/ActiveFlipsSnapshotEndpoints.java
@@ -15,13 +15,13 @@ import static com.flipsmart.api.ApiHttpTransport.JSON;
 @Slf4j
 public class ActiveFlipsSnapshotEndpoints
 {
-	private static final Gson GSON = new Gson();
-
 	private final ApiHttpTransport transport;
+	private final Gson gson;
 
 	public ActiveFlipsSnapshotEndpoints(ApiHttpTransport transport)
 	{
 		this.transport = transport;
+		this.gson = transport.getGson();
 	}
 
 	public CompletableFuture<Boolean> pushActiveFlipsSnapshotAsync(String rsn, List<ActiveFlip> flips)
@@ -33,7 +33,7 @@ public class ActiveFlipsSnapshotEndpoints
 		body.addProperty("captured_at", Instant.now().toString());
 		// ActiveFlip carries @SerializedName on every field, so it serialises
 		// straight into the snake_case shape the backend expects.
-		body.add("flips", GSON.toJsonTree(flips));
+		body.add("flips", gson.toJsonTree(flips));
 
 		RequestBody rb = RequestBody.create(JSON, body.toString());
 		Request.Builder requestBuilder = new Request.Builder().url(url).post(rb);
@@ -41,7 +41,10 @@ public class ActiveFlipsSnapshotEndpoints
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData -> Boolean.TRUE)
 			.exceptionally(e ->
 			{
-				log.debug("pushActiveFlipsSnapshotAsync failed: {}", e.getMessage());
+				if (log.isDebugEnabled())
+				{
+					log.debug("pushActiveFlipsSnapshotAsync failed: {}", e.getMessage());
+				}
 				return false;
 			});
 	}

--- a/src/main/java/com/flipsmart/domain/flip/ActiveFlipsSnapshotPayload.java
+++ b/src/main/java/com/flipsmart/domain/flip/ActiveFlipsSnapshotPayload.java
@@ -41,11 +41,14 @@ public final class ActiveFlipsSnapshotPayload
 
     /**
      * True when an empty payload should NOT be pushed because emptiness was defaulted
-     * rather than observed (the GE offers array not yet seeded), e.g. during the login
-     * burst. A non-empty payload is always safe to push.
+     * rather than observed — the offer store has not yet been seeded from real GE state
+     * (login burst or persisted-offer preload), e.g. the plugin was just enabled with no
+     * persisted offer blob while live offers still exist in-game. A genuinely empty
+     * payload from a seeded store is always safe to push (that's what clears a stale
+     * dashboard).
      */
-    public static boolean isUnobservedEmpty(List<ActiveFlip> payload, boolean geOffersUnseeded)
+    public static boolean isUnobservedEmpty(List<ActiveFlip> payload, boolean offerStoreUnseeded)
     {
-        return payload.isEmpty() && geOffersUnseeded;
+        return payload.isEmpty() && offerStoreUnseeded;
     }
 }

--- a/src/main/java/com/flipsmart/domain/flip/ActiveFlipsSnapshotPayload.java
+++ b/src/main/java/com/flipsmart/domain/flip/ActiveFlipsSnapshotPayload.java
@@ -1,0 +1,51 @@
+package com.flipsmart.domain.flip;
+
+import com.flipsmart.domain.offer.PendingOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Combines the canonical Active Flips projection (sell phase) with live pending buy
+ * orders into the single payload pushed to the backend. Pure merge of two existing
+ * outputs — never recomputes either one, so the canonical derivations stay untouched.
+ */
+public final class ActiveFlipsSnapshotPayload
+{
+    private ActiveFlipsSnapshotPayload() {}
+
+    public static List<ActiveFlip> combine(List<ActiveFlip> projectedActiveFlips,
+        List<PendingOrder> pendingBuyOrders)
+    {
+        List<ActiveFlip> payload = new ArrayList<>(projectedActiveFlips.size() + pendingBuyOrders.size());
+        payload.addAll(projectedActiveFlips);
+        for (PendingOrder order : pendingBuyOrders)
+        {
+            payload.add(toBuyPhaseFlip(order));
+        }
+        return payload;
+    }
+
+    private static ActiveFlip toBuyPhaseFlip(PendingOrder order)
+    {
+        ActiveFlip f = new ActiveFlip();
+        f.setItemId(order.itemId);
+        f.setItemName(order.itemName);
+        f.setTotalQuantity(order.quantity);
+        f.setOriginalQuantity(order.quantity);
+        f.setAverageBuyPrice(order.pricePerItem);
+        f.setTotalInvested((long) order.pricePerItem * order.quantityFilled);
+        f.setRecommendedSellPrice(order.recommendedSellPrice);
+        f.setPhase("buy");
+        return f;
+    }
+
+    /**
+     * True when an empty payload should NOT be pushed because emptiness was defaulted
+     * rather than observed (the GE offers array not yet seeded), e.g. during the login
+     * burst. A non-empty payload is always safe to push.
+     */
+    public static boolean isUnobservedEmpty(List<ActiveFlip> payload, boolean geOffersUnseeded)
+    {
+        return payload.isEmpty() && geOffersUnseeded;
+    }
+}

--- a/src/main/java/com/flipsmart/plugin/PluginScheduler.java
+++ b/src/main/java/com/flipsmart/plugin/PluginScheduler.java
@@ -27,6 +27,9 @@ public class PluginScheduler
 	public static final long ACTIVE_OFFER_ADVISOR_INTERVAL_MS = 30_000L;
 	public static final long ACTIVE_OFFER_ADVISOR_EVENT_DEBOUNCE_MS = 3_000L;
 
+	/** Active Flips snapshot heartbeat interval (5 minutes), deliberately not user-configurable */
+	public static final long ACTIVE_FLIPS_SNAPSHOT_INTERVAL_MS = 5 * 60 * 1000L;
+
 	/** Delay before syncing offline fills after login */
 	public static final int OFFLINE_SYNC_DELAY_MS = 2000;
 	/** Delay before refreshing panel after sync */
@@ -41,6 +44,7 @@ public class PluginScheduler
 	private Timer flipFinderRefreshTimer;
 	private Timer autoRecommendRefreshTimer;
 	private Timer activeOfferAdvisorTimer;
+	private Timer activeFlipsSnapshotTimer;
 
 	/**
 	 * Wall-clock instant at which the flip-finder auto-refresh timer will next fire.
@@ -201,6 +205,44 @@ public class PluginScheduler
 		{
 			activeOfferAdvisorTimer.cancel();
 			activeOfferAdvisorTimer = null;
+		}
+	}
+
+	/**
+	 * Start the Active Flips snapshot heartbeat (5-minute interval). Deliberately its
+	 * own timer rather than riding the user-configurable flip-finder refresh, which can
+	 * be set up to 60 minutes and would let a player leave the web dashboard that stale.
+	 *
+	 * @param loggedInCheck supplies whether the player is logged into RuneScape
+	 * @param body          the heartbeat body to run on each interval when logged in
+	 */
+	public void startActiveFlipsSnapshotTimer(BooleanSupplier loggedInCheck, Runnable body)
+	{
+		if (activeFlipsSnapshotTimer != null)
+		{
+			activeFlipsSnapshotTimer.cancel();
+		}
+
+		activeFlipsSnapshotTimer = new Timer("ActiveFlipsSnapshotTimer", true);
+		activeFlipsSnapshotTimer.scheduleAtFixedRate(new TimerTask()
+		{
+			@Override
+			public void run()
+			{
+				if (loggedInCheck.getAsBoolean())
+				{
+					body.run();
+				}
+			}
+		}, ACTIVE_FLIPS_SNAPSHOT_INTERVAL_MS, ACTIVE_FLIPS_SNAPSHOT_INTERVAL_MS);
+	}
+
+	public void stopActiveFlipsSnapshotTimer()
+	{
+		if (activeFlipsSnapshotTimer != null)
+		{
+			activeFlipsSnapshotTimer.cancel();
+			activeFlipsSnapshotTimer = null;
 		}
 	}
 

--- a/src/test/java/com/flipsmart/ActiveFlipsSnapshotPushServiceTest.java
+++ b/src/test/java/com/flipsmart/ActiveFlipsSnapshotPushServiceTest.java
@@ -42,17 +42,19 @@ public class ActiveFlipsSnapshotPushServiceTest
 	@Test
 	public void pushesTheProjection() throws Exception
 	{
-		service.pushNow(() -> List.of(flip(4151, 0)));
-		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(eq(RSN), any());
+		service.scheduleSnapshotPush(() -> List.of(flip(4151, 0)));
+		verify(apiClient, timeout(3000).times(1)).pushActiveFlipsSnapshotAsync(eq(RSN), any());
 	}
 
 	@Test
 	public void identicalProjectionIsNotPushedTwice() throws Exception
 	{
-		service.pushNow(() -> List.of(flip(4151, 0)));
-		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
-		service.pushNow(() -> List.of(flip(4151, 0)));
-		verify(apiClient, after(200).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
+		service.scheduleSnapshotPush(() -> List.of(flip(4151, 0)));
+		verify(apiClient, timeout(3000).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
+		service.scheduleSnapshotPush(() -> List.of(flip(4151, 0)));
+		// after() blocks the full window so this actually waits out the second
+		// debounced push instead of just sampling a moment right after scheduling.
+		verify(apiClient, after(2500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
 	@Test
@@ -60,29 +62,29 @@ public class ActiveFlipsSnapshotPushServiceTest
 	{
 		// Same set of flips, more filled. Fill ticks fire constantly; if they
 		// each pushed, an actively-filling order would spam the API.
-		service.pushNow(() -> List.of(flip(4151, 0)));
-		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
-		service.pushNow(() -> List.of(flip(4151, 70)));
-		verify(apiClient, after(200).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
+		service.scheduleSnapshotPush(() -> List.of(flip(4151, 0)));
+		verify(apiClient, timeout(3000).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
+		service.scheduleSnapshotPush(() -> List.of(flip(4151, 70)));
+		verify(apiClient, after(2500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
 	@Test
 	public void aNewItemTriggersAPush() throws Exception
 	{
-		service.pushNow(() -> List.of(flip(4151, 0)));
-		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
-		service.pushNow(() -> List.of(flip(4151, 0), flip(561, 0)));
-		verify(apiClient, timeout(500).times(2)).pushActiveFlipsSnapshotAsync(any(), any());
+		service.scheduleSnapshotPush(() -> List.of(flip(4151, 0)));
+		verify(apiClient, timeout(3000).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
+		service.scheduleSnapshotPush(() -> List.of(flip(4151, 0), flip(561, 0)));
+		verify(apiClient, timeout(3000).times(2)).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
 	@Test
 	public void emptyProjectionIsPushed() throws Exception
 	{
 		// "No active flips" must reach the server — it is what clears the dashboard.
-		service.pushNow(() -> List.of(flip(4151, 0)));
-		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
-		service.pushNow(List::of);
-		verify(apiClient, timeout(500).times(2)).pushActiveFlipsSnapshotAsync(any(), any());
+		service.scheduleSnapshotPush(() -> List.of(flip(4151, 0)));
+		verify(apiClient, timeout(3000).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
+		service.scheduleSnapshotPush(List::of);
+		verify(apiClient, timeout(3000).times(2)).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
 	@Test
@@ -92,21 +94,21 @@ public class ActiveFlipsSnapshotPushServiceTest
 		// suppressed the retry, and AC2 (cancel disappears) silently failed.
 		when(apiClient.pushActiveFlipsSnapshotAsync(any(), any()))
 			.thenReturn(CompletableFuture.completedFuture(false));
-		service.pushNow(() -> List.of(flip(4151, 0)));
-		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
+		service.scheduleSnapshotPush(() -> List.of(flip(4151, 0)));
+		verify(apiClient, timeout(3000).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
 
 		when(apiClient.pushActiveFlipsSnapshotAsync(any(), any()))
 			.thenReturn(CompletableFuture.completedFuture(true));
-		service.pushNow(() -> List.of(flip(4151, 0)));
-		verify(apiClient, timeout(500).times(2)).pushActiveFlipsSnapshotAsync(any(), any());
+		service.scheduleSnapshotPush(() -> List.of(flip(4151, 0)));
+		verify(apiClient, timeout(3000).times(2)).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
 	@Test
 	public void noRsnMeansNoPush() throws Exception
 	{
 		when(session.getRsnSafe()).thenReturn(Optional.empty());
-		service.pushNow(() -> List.of(flip(4151, 0)));
-		verify(apiClient, after(200).never()).pushActiveFlipsSnapshotAsync(any(), any());
+		service.scheduleSnapshotPush(() -> List.of(flip(4151, 0)));
+		verify(apiClient, after(2500).never()).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
 	@Test
@@ -131,7 +133,7 @@ public class ActiveFlipsSnapshotPushServiceTest
 	{
 		// A null result signals "emptiness wasn't observed" (e.g. login burst) —
 		// the service must not attempt a push at all, not even an empty one.
-		service.pushNow(() -> null);
-		verify(apiClient, after(200).never()).pushActiveFlipsSnapshotAsync(any(), any());
+		service.scheduleSnapshotPush(() -> null);
+		verify(apiClient, after(2500).never()).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 }

--- a/src/test/java/com/flipsmart/ActiveFlipsSnapshotPushServiceTest.java
+++ b/src/test/java/com/flipsmart/ActiveFlipsSnapshotPushServiceTest.java
@@ -43,18 +43,16 @@ public class ActiveFlipsSnapshotPushServiceTest
 	public void pushesTheProjection() throws Exception
 	{
 		service.pushNow(List.of(flip(4151, 0)));
-		Thread.sleep(50);
-		verify(apiClient, times(1)).pushActiveFlipsSnapshotAsync(eq(RSN), any());
+		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(eq(RSN), any());
 	}
 
 	@Test
 	public void identicalProjectionIsNotPushedTwice() throws Exception
 	{
 		service.pushNow(List.of(flip(4151, 0)));
-		Thread.sleep(50);
+		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
 		service.pushNow(List.of(flip(4151, 0)));
-		Thread.sleep(50);
-		verify(apiClient, times(1)).pushActiveFlipsSnapshotAsync(any(), any());
+		verify(apiClient, after(200).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
 	@Test
@@ -63,20 +61,18 @@ public class ActiveFlipsSnapshotPushServiceTest
 		// Same set of flips, more filled. Fill ticks fire constantly; if they
 		// each pushed, an actively-filling order would spam the API.
 		service.pushNow(List.of(flip(4151, 0)));
-		Thread.sleep(50);
+		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
 		service.pushNow(List.of(flip(4151, 70)));
-		Thread.sleep(50);
-		verify(apiClient, times(1)).pushActiveFlipsSnapshotAsync(any(), any());
+		verify(apiClient, after(200).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
 	@Test
 	public void aNewItemTriggersAPush() throws Exception
 	{
 		service.pushNow(List.of(flip(4151, 0)));
-		Thread.sleep(50);
+		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
 		service.pushNow(List.of(flip(4151, 0), flip(561, 0)));
-		Thread.sleep(50);
-		verify(apiClient, times(2)).pushActiveFlipsSnapshotAsync(any(), any());
+		verify(apiClient, timeout(500).times(2)).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
 	@Test
@@ -84,10 +80,9 @@ public class ActiveFlipsSnapshotPushServiceTest
 	{
 		// "No active flips" must reach the server — it is what clears the dashboard.
 		service.pushNow(List.of(flip(4151, 0)));
-		Thread.sleep(50);
+		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
 		service.pushNow(List.of());
-		Thread.sleep(50);
-		verify(apiClient, times(2)).pushActiveFlipsSnapshotAsync(any(), any());
+		verify(apiClient, timeout(500).times(2)).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
 	@Test
@@ -98,14 +93,12 @@ public class ActiveFlipsSnapshotPushServiceTest
 		when(apiClient.pushActiveFlipsSnapshotAsync(any(), any()))
 			.thenReturn(CompletableFuture.completedFuture(false));
 		service.pushNow(List.of(flip(4151, 0)));
-		Thread.sleep(50);
+		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
 
 		when(apiClient.pushActiveFlipsSnapshotAsync(any(), any()))
 			.thenReturn(CompletableFuture.completedFuture(true));
 		service.pushNow(List.of(flip(4151, 0)));
-		Thread.sleep(50);
-
-		verify(apiClient, times(2)).pushActiveFlipsSnapshotAsync(any(), any());
+		verify(apiClient, timeout(500).times(2)).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
 	@Test
@@ -113,7 +106,6 @@ public class ActiveFlipsSnapshotPushServiceTest
 	{
 		when(session.getRsnSafe()).thenReturn(Optional.empty());
 		service.pushNow(List.of(flip(4151, 0)));
-		Thread.sleep(50);
-		verify(apiClient, never()).pushActiveFlipsSnapshotAsync(any(), any());
+		verify(apiClient, after(200).never()).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 }

--- a/src/test/java/com/flipsmart/ActiveFlipsSnapshotPushServiceTest.java
+++ b/src/test/java/com/flipsmart/ActiveFlipsSnapshotPushServiceTest.java
@@ -42,16 +42,16 @@ public class ActiveFlipsSnapshotPushServiceTest
 	@Test
 	public void pushesTheProjection() throws Exception
 	{
-		service.pushNow(List.of(flip(4151, 0)));
+		service.pushNow(() -> List.of(flip(4151, 0)));
 		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(eq(RSN), any());
 	}
 
 	@Test
 	public void identicalProjectionIsNotPushedTwice() throws Exception
 	{
-		service.pushNow(List.of(flip(4151, 0)));
+		service.pushNow(() -> List.of(flip(4151, 0)));
 		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
-		service.pushNow(List.of(flip(4151, 0)));
+		service.pushNow(() -> List.of(flip(4151, 0)));
 		verify(apiClient, after(200).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
@@ -60,18 +60,18 @@ public class ActiveFlipsSnapshotPushServiceTest
 	{
 		// Same set of flips, more filled. Fill ticks fire constantly; if they
 		// each pushed, an actively-filling order would spam the API.
-		service.pushNow(List.of(flip(4151, 0)));
+		service.pushNow(() -> List.of(flip(4151, 0)));
 		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
-		service.pushNow(List.of(flip(4151, 70)));
+		service.pushNow(() -> List.of(flip(4151, 70)));
 		verify(apiClient, after(200).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
 	@Test
 	public void aNewItemTriggersAPush() throws Exception
 	{
-		service.pushNow(List.of(flip(4151, 0)));
+		service.pushNow(() -> List.of(flip(4151, 0)));
 		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
-		service.pushNow(List.of(flip(4151, 0), flip(561, 0)));
+		service.pushNow(() -> List.of(flip(4151, 0), flip(561, 0)));
 		verify(apiClient, timeout(500).times(2)).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
@@ -79,9 +79,9 @@ public class ActiveFlipsSnapshotPushServiceTest
 	public void emptyProjectionIsPushed() throws Exception
 	{
 		// "No active flips" must reach the server — it is what clears the dashboard.
-		service.pushNow(List.of(flip(4151, 0)));
+		service.pushNow(() -> List.of(flip(4151, 0)));
 		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
-		service.pushNow(List.of());
+		service.pushNow(List::of);
 		verify(apiClient, timeout(500).times(2)).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
@@ -92,12 +92,12 @@ public class ActiveFlipsSnapshotPushServiceTest
 		// suppressed the retry, and AC2 (cancel disappears) silently failed.
 		when(apiClient.pushActiveFlipsSnapshotAsync(any(), any()))
 			.thenReturn(CompletableFuture.completedFuture(false));
-		service.pushNow(List.of(flip(4151, 0)));
+		service.pushNow(() -> List.of(flip(4151, 0)));
 		verify(apiClient, timeout(500).times(1)).pushActiveFlipsSnapshotAsync(any(), any());
 
 		when(apiClient.pushActiveFlipsSnapshotAsync(any(), any()))
 			.thenReturn(CompletableFuture.completedFuture(true));
-		service.pushNow(List.of(flip(4151, 0)));
+		service.pushNow(() -> List.of(flip(4151, 0)));
 		verify(apiClient, timeout(500).times(2)).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 
@@ -105,7 +105,33 @@ public class ActiveFlipsSnapshotPushServiceTest
 	public void noRsnMeansNoPush() throws Exception
 	{
 		when(session.getRsnSafe()).thenReturn(Optional.empty());
-		service.pushNow(List.of(flip(4151, 0)));
+		service.pushNow(() -> List.of(flip(4151, 0)));
+		verify(apiClient, after(200).never()).pushActiveFlipsSnapshotAsync(any(), any());
+	}
+
+	@Test
+	public void supplierIsEvaluatedAtSendTimeNotScheduleTime() throws Exception
+	{
+		// Regression: captured_at is stamped when the endpoint is called, which is
+		// when the supplier runs here. If the caller captured the list up-front
+		// instead of deferring to the supplier, this test would observe the stale
+		// value instead of the one set right before firing.
+		java.util.concurrent.atomic.AtomicReference<List<ActiveFlip>> latest =
+			new java.util.concurrent.atomic.AtomicReference<>(List.of(flip(4151, 0)));
+
+		service.scheduleSnapshotPush(latest::get);
+		latest.set(List.of(flip(4151, 0), flip(561, 0)));
+
+		verify(apiClient, timeout(3000).times(1))
+			.pushActiveFlipsSnapshotAsync(eq(RSN), eq(latest.get()));
+	}
+
+	@Test
+	public void nullFromSupplierSkipsThePush() throws Exception
+	{
+		// A null result signals "emptiness wasn't observed" (e.g. login burst) —
+		// the service must not attempt a push at all, not even an empty one.
+		service.pushNow(() -> null);
 		verify(apiClient, after(200).never()).pushActiveFlipsSnapshotAsync(any(), any());
 	}
 }

--- a/src/test/java/com/flipsmart/ActiveFlipsSnapshotPushServiceTest.java
+++ b/src/test/java/com/flipsmart/ActiveFlipsSnapshotPushServiceTest.java
@@ -1,0 +1,119 @@
+package com.flipsmart;
+
+import com.flipsmart.domain.flip.ActiveFlip;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Before;
+import org.junit.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class ActiveFlipsSnapshotPushServiceTest
+{
+	private static final String RSN = "zezima";
+
+	private FlipSmartApiClient apiClient;
+	private PlayerSession session;
+	private ActiveFlipsSnapshotPushService service;
+
+	private static ActiveFlip flip(int itemId, int filledSoFar)
+	{
+		ActiveFlip f = new ActiveFlip();
+		f.setItemId(itemId);
+		f.setPhase("sell");
+		f.setOrderQuantity(100);
+		f.setTotalQuantity(filledSoFar);
+		return f;
+	}
+
+	@Before
+	public void setUp()
+	{
+		apiClient = mock(FlipSmartApiClient.class);
+		session = mock(PlayerSession.class);
+		when(session.getRsnSafe()).thenReturn(Optional.of(RSN));
+		when(apiClient.pushActiveFlipsSnapshotAsync(any(), any()))
+			.thenReturn(CompletableFuture.completedFuture(true));
+		service = new ActiveFlipsSnapshotPushService(apiClient, session);
+	}
+
+	@Test
+	public void pushesTheProjection() throws Exception
+	{
+		service.pushNow(List.of(flip(4151, 0)));
+		Thread.sleep(50);
+		verify(apiClient, times(1)).pushActiveFlipsSnapshotAsync(eq(RSN), any());
+	}
+
+	@Test
+	public void identicalProjectionIsNotPushedTwice() throws Exception
+	{
+		service.pushNow(List.of(flip(4151, 0)));
+		Thread.sleep(50);
+		service.pushNow(List.of(flip(4151, 0)));
+		Thread.sleep(50);
+		verify(apiClient, times(1)).pushActiveFlipsSnapshotAsync(any(), any());
+	}
+
+	@Test
+	public void fillProgressAloneDoesNotTriggerAPush() throws Exception
+	{
+		// Same set of flips, more filled. Fill ticks fire constantly; if they
+		// each pushed, an actively-filling order would spam the API.
+		service.pushNow(List.of(flip(4151, 0)));
+		Thread.sleep(50);
+		service.pushNow(List.of(flip(4151, 70)));
+		Thread.sleep(50);
+		verify(apiClient, times(1)).pushActiveFlipsSnapshotAsync(any(), any());
+	}
+
+	@Test
+	public void aNewItemTriggersAPush() throws Exception
+	{
+		service.pushNow(List.of(flip(4151, 0)));
+		Thread.sleep(50);
+		service.pushNow(List.of(flip(4151, 0), flip(561, 0)));
+		Thread.sleep(50);
+		verify(apiClient, times(2)).pushActiveFlipsSnapshotAsync(any(), any());
+	}
+
+	@Test
+	public void emptyProjectionIsPushed() throws Exception
+	{
+		// "No active flips" must reach the server — it is what clears the dashboard.
+		service.pushNow(List.of(flip(4151, 0)));
+		Thread.sleep(50);
+		service.pushNow(List.of());
+		Thread.sleep(50);
+		verify(apiClient, times(2)).pushActiveFlipsSnapshotAsync(any(), any());
+	}
+
+	@Test
+	public void failedPushDoesNotAdvanceTheDedupBaseline() throws Exception
+	{
+		// v1 bug: baseline recorded what was ATTEMPTED. A dropped push then
+		// suppressed the retry, and AC2 (cancel disappears) silently failed.
+		when(apiClient.pushActiveFlipsSnapshotAsync(any(), any()))
+			.thenReturn(CompletableFuture.completedFuture(false));
+		service.pushNow(List.of(flip(4151, 0)));
+		Thread.sleep(50);
+
+		when(apiClient.pushActiveFlipsSnapshotAsync(any(), any()))
+			.thenReturn(CompletableFuture.completedFuture(true));
+		service.pushNow(List.of(flip(4151, 0)));
+		Thread.sleep(50);
+
+		verify(apiClient, times(2)).pushActiveFlipsSnapshotAsync(any(), any());
+	}
+
+	@Test
+	public void noRsnMeansNoPush() throws Exception
+	{
+		when(session.getRsnSafe()).thenReturn(Optional.empty());
+		service.pushNow(List.of(flip(4151, 0)));
+		Thread.sleep(50);
+		verify(apiClient, never()).pushActiveFlipsSnapshotAsync(any(), any());
+	}
+}

--- a/src/test/java/com/flipsmart/domain/flip/ActiveFlipsSnapshotPayloadTest.java
+++ b/src/test/java/com/flipsmart/domain/flip/ActiveFlipsSnapshotPayloadTest.java
@@ -1,0 +1,73 @@
+package com.flipsmart.domain.flip;
+
+import com.flipsmart.domain.offer.PendingOrder;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class ActiveFlipsSnapshotPayloadTest
+{
+    private static ActiveFlip sellFlip(int itemId)
+    {
+        ActiveFlip f = new ActiveFlip();
+        f.setItemId(itemId);
+        f.setPhase("sell");
+        return f;
+    }
+
+    private static PendingOrder pendingBuy(int itemId, int quantity, int quantityFilled, int pricePerItem)
+    {
+        return new PendingOrder(itemId, "item" + itemId, quantity, quantityFilled, pricePerItem, null, 3);
+    }
+
+    @Test
+    public void pendingBuyOrderAppearsInPayloadWithBuyPhase()
+    {
+        List<ActiveFlip> out = ActiveFlipsSnapshotPayload.combine(
+            Collections.emptyList(), List.of(pendingBuy(42, 10, 0, 100)));
+
+        assertEquals(1, out.size());
+        assertEquals(42, out.get(0).getItemId());
+        assertEquals("buy", out.get(0).getPhase());
+    }
+
+    @Test
+    public void onlyPendingBuysStillProducesAPayload()
+    {
+        List<ActiveFlip> out = ActiveFlipsSnapshotPayload.combine(
+            Collections.emptyList(), List.of(pendingBuy(42, 10, 5, 100)));
+
+        assertEquals(1, out.size());
+        assertEquals(500L, out.get(0).getTotalInvested());
+    }
+
+    @Test
+    public void sameItemOnBuyAndSellBothAppear()
+    {
+        List<ActiveFlip> out = ActiveFlipsSnapshotPayload.combine(
+            List.of(sellFlip(42)), List.of(pendingBuy(42, 10, 0, 100)));
+
+        assertEquals(2, out.size());
+        assertTrue(out.stream().anyMatch(f -> f.getItemId() == 42 && "sell".equals(f.getPhase())));
+        assertTrue(out.stream().anyMatch(f -> f.getItemId() == 42 && "buy".equals(f.getPhase())));
+    }
+
+    @Test
+    public void emptyPayloadWithUnseededGeOffersIsSkipped()
+    {
+        assertTrue(ActiveFlipsSnapshotPayload.isUnobservedEmpty(Collections.emptyList(), true));
+    }
+
+    @Test
+    public void emptyPayloadWithSeededGeOffersIsNotSkipped()
+    {
+        assertFalse(ActiveFlipsSnapshotPayload.isUnobservedEmpty(Collections.emptyList(), false));
+    }
+
+    @Test
+    public void nonEmptyPayloadIsNeverSkippedEvenIfUnseeded()
+    {
+        assertFalse(ActiveFlipsSnapshotPayload.isUnobservedEmpty(List.of(sellFlip(42)), true));
+    }
+}

--- a/src/test/java/com/flipsmart/domain/flip/ActiveFlipsSnapshotPayloadTest.java
+++ b/src/test/java/com/flipsmart/domain/flip/ActiveFlipsSnapshotPayloadTest.java
@@ -54,13 +54,13 @@ public class ActiveFlipsSnapshotPayloadTest
     }
 
     @Test
-    public void emptyPayloadWithUnseededGeOffersIsSkipped()
+    public void emptyPayloadWithUnseededOfferStoreIsSkipped()
     {
         assertTrue(ActiveFlipsSnapshotPayload.isUnobservedEmpty(Collections.emptyList(), true));
     }
 
     @Test
-    public void emptyPayloadWithSeededGeOffersIsNotSkipped()
+    public void emptyPayloadWithSeededOfferStoreIsNotSkipped()
     {
         assertFalse(ActiveFlipsSnapshotPayload.isUnobservedEmpty(Collections.emptyList(), false));
     }

--- a/src/test/java/com/flipsmart/plugin/PluginSchedulerTest.java
+++ b/src/test/java/com/flipsmart/plugin/PluginSchedulerTest.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Regression coverage for issue #917: a manual refresh must reset BOTH the visual
@@ -93,16 +94,30 @@ public class PluginSchedulerTest
 	@Test
 	public void activeFlipsSnapshotTimerStartAndStopIsIdempotent()
 	{
-		scheduler.startActiveFlipsSnapshotTimer(() -> true, () -> { });
-		scheduler.startActiveFlipsSnapshotTimer(() -> true, () -> { });
-		scheduler.stopActiveFlipsSnapshotTimer();
-		scheduler.stopActiveFlipsSnapshotTimer();
+		try
+		{
+			scheduler.startActiveFlipsSnapshotTimer(() -> true, () -> { });
+			scheduler.startActiveFlipsSnapshotTimer(() -> true, () -> { });
+			scheduler.stopActiveFlipsSnapshotTimer();
+			scheduler.stopActiveFlipsSnapshotTimer();
+		}
+		catch (RuntimeException e)
+		{
+			fail("double start/stop must not throw: " + e.getMessage());
+		}
 	}
 
 	/** Stopping a timer that was never started must be a no-op, not a NullPointerException. */
 	@Test
 	public void stoppingActiveFlipsSnapshotTimerBeforeStartIsSafe()
 	{
-		scheduler.stopActiveFlipsSnapshotTimer();
+		try
+		{
+			scheduler.stopActiveFlipsSnapshotTimer();
+		}
+		catch (RuntimeException e)
+		{
+			fail("stopping before start must not throw: " + e.getMessage());
+		}
 	}
 }

--- a/src/test/java/com/flipsmart/plugin/PluginSchedulerTest.java
+++ b/src/test/java/com/flipsmart/plugin/PluginSchedulerTest.java
@@ -32,6 +32,7 @@ public class PluginSchedulerTest
 	public void tearDown()
 	{
 		scheduler.stopFlipFinderRefreshTimer();
+		scheduler.stopActiveFlipsSnapshotTimer();
 	}
 
 	/** AC5(b): starting the timer aligns the next refresh to a full interval from now. */
@@ -79,5 +80,29 @@ public class PluginSchedulerTest
 		scheduler.startFlipFinderRefreshTimer(0, () -> true, () -> { });
 
 		assertEquals(60_000L, scheduler.getNextFlipFinderRefreshAtMillis());
+	}
+
+	/** The Active Flips heartbeat is a fixed 5 minutes, independent of the flip-finder setting. */
+	@Test
+	public void activeFlipsSnapshotIntervalIsFiveMinutes()
+	{
+		assertEquals(5 * 60 * 1000L, PluginScheduler.ACTIVE_FLIPS_SNAPSHOT_INTERVAL_MS);
+	}
+
+	/** Starting the heartbeat twice must cancel the prior timer rather than leaking it. */
+	@Test
+	public void activeFlipsSnapshotTimerStartAndStopIsIdempotent()
+	{
+		scheduler.startActiveFlipsSnapshotTimer(() -> true, () -> { });
+		scheduler.startActiveFlipsSnapshotTimer(() -> true, () -> { });
+		scheduler.stopActiveFlipsSnapshotTimer();
+		scheduler.stopActiveFlipsSnapshotTimer();
+	}
+
+	/** Stopping a timer that was never started must be a no-op, not a NullPointerException. */
+	@Test
+	public void stoppingActiveFlipsSnapshotTimerBeforeStartIsSafe()
+	{
+		scheduler.stopActiveFlipsSnapshotTimer();
 	}
 }


### PR DESCRIPTION
## Summary

Companion to Flip-Smart/flip-smart#1132 for Flip-Smart/flip-smart#1113. The website's Active Flips list disagreed with the plugin's Active Flips tab, because the backend derived "active" from its transaction ledger while the plugin repairs that view using live game state the server never sees — open GE slots, inventory contents, items collected this session. Cancellations were never reported to the backend at all.

PR #216 made the plugin's Active Flips tab a stateless projection of `OfferStore` — one canonical in-plugin source of truth. This PR serialises that projection and pushes it, so the website can mirror the same list instead of deriving its own.

## Changes

### ✨ New Features
- New `ActiveFlipsSnapshotPushService` — debounced (~2s), deduped, daemon single-thread executor, `shutdown()` wired into the plugin lifecycle.
- New `ActiveFlipsSnapshotEndpoints` → `POST /plugin/active-flips-snapshot`, mirroring the structure of the existing `TradeStationEndpoints`.
- `ActiveFlipsSnapshotPayload.combine()` — a pure helper merging the sell-phase projection with pending buy orders (marked `phase="buy"`) at the push site.
- A dedicated fixed 5-minute heartbeat that refreshes the server-side TTL.
- Pushes on GE offer changes and on inventory composition changes.

### 🐛 Bug Fixes
- N/A — this PR is the plugin-side half of the fix; the underlying divergence itself was root-caused and fixed on the projection side in PR #216 (already on `master`, unreleased). This PR is purely additive (new push mechanism).

### ♻️ Refactoring
- `refactor: gate empty snapshot pushes on offer-store seeding` — an empty payload is only sent once the offer store has actually observed empty state (client-thread-set `offerStoreSeeded` flag), never defaulted-empty during the login burst, which would otherwise blank the website's list.

### 📝 Documentation
- None beyond the single intentional javadoc issue reference on `ActiveFlipsSnapshotPushService` (pre-existing on this branch, not new).

## Design notes worth reviewing

- **The canonical derivations are untouched.** `ActiveFlipProjection` and `AwaitingSaleLots` are byte-identical to `master`; `getProjectedActiveFlips` and `getPendingBuyOrders` are unchanged. This PR only serialises their output — which is what makes the two surfaces agree by construction rather than by two implementations happening to match.
- **The payload is both lists the tab renders.** The tab renders the sell-phase projection *and* `getPendingBuyOrders()`. An earlier iteration pushed only the first, which would have hidden every live buy offer from the website. Both are now included.
- **Pushes fire after the offer store is updated**, in both branches of the GE-offer handler (the login-burst path and the normal path). Pushing before the store update publishes pre-event state — a completing buy would announce itself as still partly filled and never correct.
- **Dedup identity excludes fill progress.** Fill events fire constantly; if they counted as changes, one slowly-filling order would push dozens of times. Identity is the set of flips and their side.
- **The dedup baseline only advances on a delivered push.** Recording an attempt would let a dropped push suppress its own retry, silently breaking the "a cancelled offer disappears" requirement.
- **An empty payload is only sent when emptiness is observed**, gated on a client-thread-set `offerStoreSeeded` flag — never defaulted-empty during the login burst, which would otherwise blank the website's list.
- No client API is touched from the executor thread (a `volatile boolean` is read instead), following the same discipline as `TradeStationSlotPushService`.

## Traffic

Measured during live in-game QA: one small POST per 5 minutes while idle, ~3/min during active trading, ~10/min at peak during heavy GE churn. No push at all when the projection is unchanged.

## Testing

### Automated Tests
- ✅ `./gradlew clean build` — BUILD SUCCESSFUL
- ✅ 750 tests, all passing
- ✅ New unit tests: `ActiveFlipsSnapshotPushServiceTest`, `ActiveFlipsSnapshotPayloadTest`, `PluginSchedulerTest` (heartbeat scheduling)

### Manual Testing (verified in live in-game QA)
- [x] New buy appears on the website within ~3s (including zero-fill pending buys)
- [x] Cancel disappears within ~3-4s
- [x] A completed sell is removed within ~2s
- [x] An awaiting-sale lot (bought, collected, held unlisted) is tracked on both surfaces — the case that required plugin changes at all, since the backend cannot observe inventory contents
- [x] Zero exceptions across ~45 minutes of continuous trading

## API Changes

**New Endpoints** (consumed on the backend side in Flip-Smart/flip-smart#1132):
- `POST /plugin/active-flips-snapshot` — pushes the plugin's current Active Flips projection (sell-phase + pending buys) so the website can mirror it.

**Modified Endpoints**: None.

**Breaking Changes**: None. Purely additive; older plugin builds simply never call the new endpoint, and the backend fails open per-RSN when no snapshot exists.

## Frontend Impact

None directly from this repo — the website-facing change is the backend endpoint added in Flip-Smart/flip-smart#1132, which this plugin PR pushes data into.

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: None
- [ ] Requires database migration: No (handled on the backend side in #1132, not this repo)

## Release

This rides the next plugin-hub submission, bundled with #216 (which is also unreleased on `master`). The website-side changes ship first and are safe to deploy ahead of this: the backend fails open per-RSN when no snapshot exists, so players on older plugin builds see exactly today's behaviour, never worse.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (design notes above; no additional narrative source comments added — this repo counts LOC for Plugin Hub review)
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [x] Canonical derivations (`ActiveFlipProjection`, `AwaitingSaleLots`) verified untouched
- [x] No `Thread.currentThread().interrupt()` introduced
- [ ] Reviewed by teammate

## Related Issues

Related to Flip-Smart/flip-smart#1113
Companion to Flip-Smart/flip-smart#1132 (carries the closing reference for #1113)
