### PR TITLE
fix(session): stop double-counting partial fills in Projected Profit

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -23,6 +23,7 @@ import com.flipsmart.ui.panel.ItemNameFit;
 import com.flipsmart.ui.panel.LoginPanel;
 import com.flipsmart.ui.panel.PanelFormat;
 import com.flipsmart.ui.panel.Paginator;
+import com.flipsmart.session.OpenPositions;
 import com.flipsmart.session.SessionClock;
 import com.flipsmart.session.SessionStats;
 import com.flipsmart.session.SessionStatsView;
@@ -1488,10 +1489,21 @@ public class FlipFinderPanel extends PluginPanel
 		return plugin.getProjectedActiveFlips(enrichment);
 	}
 
+	/**
+	 * Recompute the cached profit base and repaint. Self-guards onto the EDT: offer and
+	 * inventory events arrive on the client thread, and this both writes the cached base and
+	 * drives Swing labels through {@link #renderSessionStats()}.
+	 */
 	private void recomputeSessionProfitBase()
 	{
-		sessionProfitBase = SessionStats.computeBase(
-			currentCompletedFlips, projectedActiveFlips(), sessionClock.startMs());
+		if (!SwingUtilities.isEventDispatchThread())
+		{
+			SwingUtilities.invokeLater(this::recomputeSessionProfitBase);
+			return;
+		}
+		sessionProfitBase = SessionStats.computeBase(currentCompletedFlips,
+			OpenPositions.derive(projectedActiveFlips(), plugin::getLiveSellFilledQuantity),
+			sessionClock.startMs());
 		renderSessionStats();
 	}
 
@@ -1897,6 +1909,9 @@ public class FlipFinderPanel extends PluginPanel
 			return;
 		}
 		redisplayActiveFlipsLocally();
+		// A fill or lifecycle change moves the unsold quantity, which is derived locally — so
+		// recompute now rather than letting the session figures wait on the next API refresh.
+		recomputeSessionProfitBase();
 	}
 
 	/** Rebuild the Active Flips tab from the store projection — no list/aggregate API calls. */
@@ -1914,6 +1929,9 @@ public class FlipFinderPanel extends PluginPanel
 	public void onInventoryChanged()
 	{
 		renderActiveFlips();
+		// Held-item changes add or remove awaiting-sale lots, so the unrealised half of the
+		// session figures moves with them.
+		recomputeSessionProfitBase();
 	}
 
 	/** Update the 30-day profit summary label from a stats payload. Null-safe; hops to the EDT. */

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -518,6 +518,12 @@ public class FlipSmartPlugin extends Plugin
 	 * of its own. {@code enrichmentByItemId} layers in the last backend snapshot (recommended
 	 * sell price, P&L) without it ever being the source of truth for what's actually live.
 	 */
+	/** Quantity already sold on live sell offers for {@code itemId} (see OfferStore). */
+	public int getLiveSellFilledQuantity(int itemId)
+	{
+		return offerStore.liveSellFilledQuantity(itemId);
+	}
+
 	public List<ActiveFlip> getProjectedActiveFlips(Map<Integer, ActiveFlip> enrichmentByItemId)
 	{
 		java.util.List<com.flipsmart.domain.offer.OfferRecord> liveSellOffers = new java.util.ArrayList<>();

--- a/src/main/java/com/flipsmart/session/OpenPosition.java
+++ b/src/main/java/com/flipsmart/session/OpenPosition.java
@@ -1,0 +1,22 @@
+package com.flipsmart.session;
+
+/**
+ * An unsold position held during the session: the quantity still to be sold, plus the
+ * basis and target used to value it. Deliberately not an {@code ActiveFlip} — a flip's
+ * quantity is the offer's original size, which over-values a partially-filled sell.
+ */
+public final class OpenPosition
+{
+	public final int itemId;
+	public final int unsoldQuantity;
+	public final int averageBuyPrice;
+	public final Integer recommendedSellPrice;
+
+	public OpenPosition(int itemId, int unsoldQuantity, int averageBuyPrice, Integer recommendedSellPrice)
+	{
+		this.itemId = itemId;
+		this.unsoldQuantity = unsoldQuantity;
+		this.averageBuyPrice = averageBuyPrice;
+		this.recommendedSellPrice = recommendedSellPrice;
+	}
+}

--- a/src/main/java/com/flipsmart/session/OpenPositions.java
+++ b/src/main/java/com/flipsmart/session/OpenPositions.java
@@ -1,0 +1,45 @@
+package com.flipsmart.session;
+
+import com.flipsmart.domain.flip.ActiveFlip;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.IntUnaryOperator;
+
+/**
+ * Derives unsold positions from the Active Flips projection.
+ *
+ * A projected flip carries the sell offer's original quantity, so valuing it directly also
+ * values the units that have already sold — and those are simultaneously counted in realised
+ * profit, double-counting every partial fill in projected profit until the offer terminalizes.
+ * Subtracting the filled quantity values only what is genuinely still unsold. Awaiting-sale
+ * lots have no live sell offer, so their filled lookup is zero and their full quantity stands.
+ *
+ * Returns new instances; the projected flips are shared with the panel's cards and the
+ * backend snapshot and are never mutated here.
+ */
+public final class OpenPositions
+{
+	private OpenPositions()
+	{
+	}
+
+	public static List<OpenPosition> derive(List<ActiveFlip> projected,
+											IntUnaryOperator filledSellQuantityForItem)
+	{
+		if (projected == null || projected.isEmpty())
+		{
+			return Collections.emptyList();
+		}
+		List<OpenPosition> out = new ArrayList<>(projected.size());
+		for (ActiveFlip flip : projected)
+		{
+			int filled = Math.max(0, filledSellQuantityForItem.applyAsInt(flip.getItemId()));
+			int unsold = Math.max(0, flip.getTotalQuantity() - filled);
+			out.add(new OpenPosition(flip.getItemId(), unsold,
+				flip.getAverageBuyPrice(), flip.getRecommendedSellPrice()));
+		}
+		return out;
+	}
+}

--- a/src/main/java/com/flipsmart/session/OpenPositions.java
+++ b/src/main/java/com/flipsmart/session/OpenPositions.java
@@ -4,9 +4,9 @@ import com.flipsmart.domain.flip.ActiveFlip;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.IntUnaryOperator;
 
 /**
@@ -38,7 +38,7 @@ public final class OpenPositions
 		{
 			return Collections.emptyList();
 		}
-		Map<Integer, Integer> unclaimedFilledByItem = new ConcurrentHashMap<>();
+		Map<Integer, Integer> unclaimedFilledByItem = new HashMap<>();
 		List<OpenPosition> out = new ArrayList<>(projected.size());
 		for (ActiveFlip flip : projected)
 		{

--- a/src/main/java/com/flipsmart/session/OpenPositions.java
+++ b/src/main/java/com/flipsmart/session/OpenPositions.java
@@ -4,9 +4,9 @@ import com.flipsmart.domain.flip.ActiveFlip;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.IntUnaryOperator;
 
 /**
@@ -38,7 +38,7 @@ public final class OpenPositions
 		{
 			return Collections.emptyList();
 		}
-		Map<Integer, Integer> unclaimedFilledByItem = new HashMap<>();
+		Map<Integer, Integer> unclaimedFilledByItem = new ConcurrentHashMap<>();
 		List<OpenPosition> out = new ArrayList<>(projected.size());
 		for (ActiveFlip flip : projected)
 		{

--- a/src/main/java/com/flipsmart/session/OpenPositions.java
+++ b/src/main/java/com/flipsmart/session/OpenPositions.java
@@ -4,7 +4,9 @@ import com.flipsmart.domain.flip.ActiveFlip;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.IntUnaryOperator;
 
 /**
@@ -15,6 +17,10 @@ import java.util.function.IntUnaryOperator;
  * profit, double-counting every partial fill in projected profit until the offer terminalizes.
  * Subtracting the filled quantity values only what is genuinely still unsold. Awaiting-sale
  * lots have no live sell offer, so their filled lookup is zero and their full quantity stands.
+ *
+ * {@code filledSellQuantityForItem} sums fills across every live sell offer of an item, not per
+ * offer, so two simultaneous sell offers of the same item share one filled pool here — consumed
+ * flip-by-flip — instead of each flip subtracting the item's whole filled total independently.
  *
  * Returns new instances; the projected flips are shared with the panel's cards and the
  * backend snapshot and are never mutated here.
@@ -32,12 +38,17 @@ public final class OpenPositions
 		{
 			return Collections.emptyList();
 		}
+		Map<Integer, Integer> unclaimedFilledByItem = new HashMap<>();
 		List<OpenPosition> out = new ArrayList<>(projected.size());
 		for (ActiveFlip flip : projected)
 		{
-			int filled = Math.max(0, filledSellQuantityForItem.applyAsInt(flip.getItemId()));
-			int unsold = Math.max(0, flip.getTotalQuantity() - filled);
-			out.add(new OpenPosition(flip.getItemId(), unsold,
+			int itemId = flip.getItemId();
+			int unclaimed = unclaimedFilledByItem.computeIfAbsent(itemId,
+				id -> Math.max(0, filledSellQuantityForItem.applyAsInt(id)));
+			int claimed = Math.min(unclaimed, flip.getTotalQuantity());
+			unclaimedFilledByItem.put(itemId, unclaimed - claimed);
+			int unsold = flip.getTotalQuantity() - claimed;
+			out.add(new OpenPosition(itemId, unsold,
 				flip.getAverageBuyPrice(), flip.getRecommendedSellPrice()));
 		}
 		return out;

--- a/src/main/java/com/flipsmart/session/SessionStats.java
+++ b/src/main/java/com/flipsmart/session/SessionStats.java
@@ -25,10 +25,10 @@ public final class SessionStats
 	{
 	}
 
-	public static ProfitBase computeBase(List<CompletedFlip> completed, List<ActiveFlip> active,
+	public static ProfitBase computeBase(List<CompletedFlip> completed, List<OpenPosition> open,
 										 long sessionStartMs)
 	{
-		return new ProfitBase(realisedProfit(completed, sessionStartMs), unrealisedProfit(active));
+		return new ProfitBase(realisedProfit(completed, sessionStartMs), unrealisedProfit(open));
 	}
 
 	public static Snapshot snapshot(ProfitBase base, long activeMs)
@@ -38,10 +38,10 @@ public final class SessionStats
 			gpPerHour(base.realisedProfit, activeMs), gpPerHour(projected, activeMs));
 	}
 
-	public static Snapshot compute(List<CompletedFlip> completed, List<ActiveFlip> active,
+	public static Snapshot compute(List<CompletedFlip> completed, List<OpenPosition> open,
 								   long sessionStartMs, long activeMs)
 	{
-		return snapshot(computeBase(completed, active, sessionStartMs), activeMs);
+		return snapshot(computeBase(completed, open, sessionStartMs), activeMs);
 	}
 
 	static long realisedProfit(List<CompletedFlip> completed, long sessionStartMs)
@@ -57,20 +57,24 @@ public final class SessionStats
 		return sum;
 	}
 
-	static long unrealisedProfit(List<ActiveFlip> active)
+	/**
+	 * Value of the positions still held, at their recommended sell price net of tax. Only the
+	 * unsold quantity counts — units already sold belong to realised profit, so valuing them
+	 * here too would double-count them (see {@link OpenPositions}).
+	 */
+	static long unrealisedProfit(List<OpenPosition> open)
 	{
 		long sum = 0L;
-		for (ActiveFlip flip : active)
+		for (OpenPosition position : open)
 		{
-			Integer recommendedSell = flip.getRecommendedSellPrice();
-			int heldQty = flip.getTotalQuantity();
-			if (recommendedSell == null || heldQty <= 0)
+			Integer recommendedSell = position.recommendedSellPrice;
+			if (recommendedSell == null || position.unsoldQuantity <= 0)
 			{
 				continue;
 			}
-			long tax = GeTax.taxFor(flip.getItemId(), recommendedSell);
-			long perItem = (long) recommendedSell - flip.getAverageBuyPrice() - tax;
-			sum += perItem * heldQty;
+			long tax = GeTax.taxFor(position.itemId, recommendedSell);
+			long perItem = (long) recommendedSell - position.averageBuyPrice - tax;
+			sum += perItem * position.unsoldQuantity;
 		}
 		return sum;
 	}

--- a/src/main/java/com/flipsmart/trading/OfferStore.java
+++ b/src/main/java/com/flipsmart/trading/OfferStore.java
@@ -221,6 +221,24 @@ public final class OfferStore
     }
 
     /**
+     * Quantity already sold across live (non-terminal) sell offers for {@code itemId}.
+     * Lets a consumer value only the unsold remainder of a partially-filled sell; terminal
+     * records are excluded because their fills have left the open position entirely.
+     */
+    public synchronized int liveSellFilledQuantity(int itemId)
+    {
+        int sum = 0;
+        for (OfferRecord r : byOfferId.values())
+        {
+            if (r.getItemId() == itemId && !r.isBuy() && !r.getState().isTerminal())
+            {
+                sum += r.getFilledQuantity();
+            }
+        }
+        return sum;
+    }
+
+    /**
      * Replace the createdAt timestamp of the record with {@code offerId}, preserving
      * its slot index. No-op when the offerId is unknown. Used to backfill a missing
      * placement time from an authoritative external source (e.g. backend active flips).

--- a/src/main/java/com/flipsmart/trading/OfferStore.java
+++ b/src/main/java/com/flipsmart/trading/OfferStore.java
@@ -225,17 +225,20 @@ public final class OfferStore
      * Lets a consumer value only the unsold remainder of a partially-filled sell; terminal
      * records are excluded because their fills have left the open position entirely.
      */
-    public synchronized int liveSellFilledQuantity(int itemId)
+    public int liveSellFilledQuantity(int itemId)
     {
-        int sum = 0;
-        for (OfferRecord r : byOfferId.values())
+        synchronized (this)
         {
-            if (r.getItemId() == itemId && !r.isBuy() && !r.getState().isTerminal())
+            int sum = 0;
+            for (OfferRecord r : byOfferId.values())
             {
-                sum += r.getFilledQuantity();
+                if (r.getItemId() == itemId && !r.isBuy() && !r.getState().isTerminal())
+                {
+                    sum += r.getFilledQuantity();
+                }
             }
+            return sum;
         }
-        return sum;
     }
 
     /**

--- a/src/test/java/com/flipsmart/session/OpenPositionsTest.java
+++ b/src/test/java/com/flipsmart/session/OpenPositionsTest.java
@@ -1,0 +1,99 @@
+package com.flipsmart.session;
+
+import static org.junit.Assert.assertEquals;
+
+import com.flipsmart.domain.flip.ActiveFlip;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+public class OpenPositionsTest
+{
+	private static ActiveFlip projected(int itemId, Integer recSell, int avgBuy, int qty)
+	{
+		ActiveFlip a = new ActiveFlip();
+		a.setItemId(itemId);
+		a.setRecommendedSellPrice(recSell);
+		a.setAverageBuyPrice(avgBuy);
+		a.setTotalQuantity(qty);
+		return a;
+	}
+
+	@Test
+	public void partiallyFilledSell_leavesOnlyTheUnsoldRemainder()
+	{
+		// The projection reports the sell offer's original quantity (1000). 400 have sold and
+		// are already counted in realised profit, so only 600 may be valued as unrealised —
+		// otherwise those 400 are counted twice in projected profit.
+		List<OpenPosition> open = OpenPositions.derive(
+			Collections.singletonList(projected(4151, 200, 100, 1000)), itemId -> 400);
+
+		assertEquals(1, open.size());
+		assertEquals(600, open.get(0).unsoldQuantity);
+	}
+
+	@Test
+	public void awaitingSaleLot_withNoLiveSell_keepsItsFullQuantity()
+	{
+		List<OpenPosition> open = OpenPositions.derive(
+			Collections.singletonList(projected(4151, 200, 100, 25)), itemId -> 0);
+
+		assertEquals(25, open.get(0).unsoldQuantity);
+	}
+
+	@Test
+	public void fullyFilledSell_leavesNothingUnsold()
+	{
+		List<OpenPosition> open = OpenPositions.derive(
+			Collections.singletonList(projected(4151, 200, 100, 500)), itemId -> 500);
+
+		assertEquals(0, open.get(0).unsoldQuantity);
+	}
+
+	@Test
+	public void filledExceedingProjectedQuantity_clampsAtZero()
+	{
+		// Consolidation or a re-list can report more filled than the projection's snapshot
+		// quantity; a negative remainder would credit phantom profit.
+		List<OpenPosition> open = OpenPositions.derive(
+			Collections.singletonList(projected(4151, 200, 100, 100)), itemId -> 250);
+
+		assertEquals(0, open.get(0).unsoldQuantity);
+	}
+
+	@Test
+	public void carriesPricingBasisThrough()
+	{
+		OpenPosition p = OpenPositions.derive(
+			Collections.singletonList(projected(4151, 200, 100, 10)), itemId -> 0).get(0);
+
+		assertEquals(4151, p.itemId);
+		assertEquals(Integer.valueOf(200), p.recommendedSellPrice);
+		assertEquals(100, p.averageBuyPrice);
+	}
+
+	@Test
+	public void filledQuantityIsLookedUpPerItem()
+	{
+		List<OpenPosition> open = OpenPositions.derive(
+			Arrays.asList(projected(4151, 200, 100, 1000), projected(561, 200, 100, 1000)),
+			itemId -> itemId == 4151 ? 900 : 0);
+
+		assertEquals(100, open.get(0).unsoldQuantity);
+		assertEquals(1000, open.get(1).unsoldQuantity);
+	}
+
+	@Test
+	public void doesNotMutateTheProjectedFlips()
+	{
+		// The same ActiveFlip instances render the Active Flips cards and feed the backend
+		// snapshot push — deriving positions must not rewrite their quantities.
+		ActiveFlip flip = projected(4151, 200, 100, 1000);
+
+		OpenPositions.derive(Collections.singletonList(flip), itemId -> 400);
+
+		assertEquals(1000, flip.getTotalQuantity());
+	}
+}

--- a/src/test/java/com/flipsmart/session/OpenPositionsTest.java
+++ b/src/test/java/com/flipsmart/session/OpenPositionsTest.java
@@ -86,6 +86,21 @@ public class OpenPositionsTest
 	}
 
 	@Test
+	public void multipleLiveSellOffersOfTheSameItem_shareOneFilledPoolInsteadOfDoubleSubtracting()
+	{
+		// Two GE slots both selling item 4151: slot A sold 100/500, slot B sold 200/500 — the
+		// item-level lookup reports the combined fill (300). Applying that whole total to each
+		// flip independently would compute 500-300=200 twice (400 total) instead of the true
+		// 700 remaining across both slots.
+		List<OpenPosition> open = OpenPositions.derive(
+			Arrays.asList(projected(4151, 200, 100, 500), projected(4151, 200, 100, 500)),
+			itemId -> 300);
+
+		int totalUnsold = open.get(0).unsoldQuantity + open.get(1).unsoldQuantity;
+		assertEquals(700, totalUnsold);
+	}
+
+	@Test
 	public void doesNotMutateTheProjectedFlips()
 	{
 		// The same ActiveFlip instances render the Active Flips cards and feed the backend

--- a/src/test/java/com/flipsmart/session/SessionStatsTest.java
+++ b/src/test/java/com/flipsmart/session/SessionStatsTest.java
@@ -3,7 +3,6 @@ package com.flipsmart.session;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import com.flipsmart.domain.flip.ActiveFlip;
 import com.flipsmart.domain.flip.CompletedFlip;
 
 import java.time.Instant;
@@ -24,14 +23,10 @@ public class SessionStatsTest
 		return f;
 	}
 
-	private static ActiveFlip active(int itemId, Integer recSell, int avgBuy, int qty)
+	/** An unsold position: {@code unsoldQty} is what is still to be sold, never the offer total. */
+	private static OpenPosition open(int itemId, Integer recSell, int avgBuy, int unsoldQty)
 	{
-		ActiveFlip a = new ActiveFlip();
-		a.setItemId(itemId);
-		a.setRecommendedSellPrice(recSell);
-		a.setAverageBuyPrice(avgBuy);
-		a.setTotalQuantity(qty);
-		return a;
+		return new OpenPosition(itemId, unsoldQty, avgBuy, recSell);
 	}
 
 	@Test
@@ -53,20 +48,20 @@ public class SessionStatsTest
 	}
 
 	@Test
-	public void unrealisedProfitValuesHeldQtyAtRecommendedSellMinusTax()
+	public void unrealisedProfitValuesUnsoldQtyAtRecommendedSellMinusTax()
 	{
 		// (200 - 100 - 4 tax) * 10 = 960
 		long unrealised = SessionStats.unrealisedProfit(
-			Collections.singletonList(active(4151, 200, 100, 10)));
+			Collections.singletonList(open(4151, 200, 100, 10)));
 		assertEquals(960L, unrealised);
 	}
 
 	@Test
-	public void unrealisedProfitSkipsNullTargetAndEmptyQty()
+	public void unrealisedProfitSkipsNullTargetAndFullySoldPositions()
 	{
 		long unrealised = SessionStats.unrealisedProfit(Arrays.asList(
-			active(4151, null, 100, 10),
-			active(4151, 200, 100, 0)));
+			open(4151, null, 100, 10),
+			open(4151, 200, 100, 0)));
 		assertEquals(0L, unrealised);
 	}
 
@@ -87,7 +82,7 @@ public class SessionStatsTest
 	{
 		SessionStats.Snapshot snap = SessionStats.compute(
 			Collections.singletonList(completed("2026-07-22T13:00:00Z", 1000)),
-			Collections.singletonList(active(4151, 200, 100, 10)),
+			Collections.singletonList(open(4151, 200, 100, 10)),
 			SESSION_START, 3_600_000L);
 		assertEquals(1000L, snap.realisedProfit);
 		assertEquals(1960L, snap.projectedProfit);   // 1000 + 960
@@ -100,7 +95,7 @@ public class SessionStatsTest
 	{
 		SessionStats.ProfitBase base = SessionStats.computeBase(
 			Collections.singletonList(completed("2026-07-22T13:00:00Z", 1000)),
-			Collections.singletonList(active(4151, 200, 100, 10)),
+			Collections.singletonList(open(4151, 200, 100, 10)),
 			SESSION_START);
 		assertEquals(1000L, base.realisedProfit);
 		assertEquals(960L, base.unrealisedProfit);


### PR DESCRIPTION
## Summary

This started as "Total Profit / Realised GP never update in Session Stats" but in-game diagnosis (2026-07-29, temporary instrumented build, live GE session with ~15 completed flips) changed the picture. AC1/AC2 (the static-value claim) are **not reproducible** on current `master` — realised profit tracked every sell within 3-6 seconds. What actually is broken (AC3/AC5) is that partial fills were double-counted between the realised and unrealised halves of Projected Profit, producing the "lurching" values the ticket reported. This PR fixes that double-count only.

## Changes

### 🐛 Bug Fixes

- **Projected Profit double-counted partial fills (AC3/AC5 — real bug, fixed).** `ActiveFlipProjection` sets a projected flip's `totalQuantity` from the sell offer's *original* size, and `SessionStats.unrealisedProfit` valued that whole quantity — so units already sold were valued as unrealised while the backend's completed-flips feed counted the same units in realised. Evidence from the live session: across ~12,000+ units sold between 23:24:23–23:26:24, `unrealised` held at exactly `625,220` through every fill while realised moved 7 times — it only changed when an offer entered/left the projection (`625,220 → 564,306` on a SELL COMPLETED, then `→ 669,908` on a new listing). That is why Projected Profit lurched instead of tracking results.
  - New `OpenPosition` / `OpenPositions.derive(...)` subtract the filled quantity of live sell offers (new `OfferStore.liveSellFilledQuantity(itemId)`) so only the genuinely unsold remainder is valued. `SessionStats` now values `OpenPosition`s instead of the raw projected flip quantity. Lots awaiting sale (no live sell offer yet) still have their full quantity valued, unchanged.
  - Projected flips are copied, never mutated — the same instances still drive the Active Flips cards and the backend snapshot push.
  - Also recompute the profit base on local offer/inventory events (not just on the API-driven panel refresh), so the locally-derived unrealised half tracks fills immediately instead of waiting on the next refresh. Self-guarded onto the EDT, since those events arrive on the client thread.

### 🔍 Investigated and ruled out (AC1/AC2 — not reproducible, no code change)

- **ISO sell-time parse failure** — ruled out. Observed `sellTime=2026-07-30T03:24:23.655959+00:00` parsed to a valid epoch (`1785381863655`) with `passesWindow=true`. Java's `Instant.parse` accepts the backend's `+00:00` / microsecond format fine.
- **Session-window filter mis-firing** — ruled out. An apparent `inSessionWindow=0` at login was correct: the newest flip had sold 33s before the session start, so excluding it was the right behavior, not a bug.
- The existing update path — `applyFillSideEffects → schedulePanelRefresh → PanelRefreshCoalescer → panel.refresh() → recomputeSessionProfitBase` — works as designed. Realised profit updated on every sell in the live session: `0 → 52,787 → -473,122 → -461,552 → -459,152 → -452,812 → -446,264 → -444,217`.

### Deliberately NOT changed (flagging for reviewer judgement)

- The per-second decline of the GP/hour rows is `profit × 3.6M ÷ activeMs` — mathematically correct for a rate metric (earning nothing for a minute *should* lower GP/hour). The reported "starts high and steadily decreases" behavior was driven by the inflated numerator described above, which this fix addresses. Redesigning the rate metric itself (e.g. how unrealised gains should be annualised over the session) is a product decision, not folded into this fix.
- AC4 (session timer) is untouched and was never implicated.

### Known minor follow-up (not fixed here, no separate ticket filed)

`recomputeSessionProfitBase` now re-derives the projection on offer/inventory events, which already trigger a re-render elsewhere on that same event — slightly redundant work on a path that also repaints Swing. Not worth a dedicated ticket; mentioning for visibility.

## Testing

### Automated Tests

- ✅ `./gradlew test shadowJar` — 757 tests, 0 failures, BUILD SUCCESSFUL
- ✅ New unit coverage: `session/OpenPositionsTest.java` (new), `session/SessionStatsTest.java` (updated)
- Note: this repo's `build.gradle` has no local checkstyle task — Codacy is the lint/quality gate here, not a missing local step.

### Manual Testing (in-game, RuneLite client — required, cannot be automated)

Playwright / `qa-verifier` **cannot** exercise this: it requires a live in-game RuneLite Java client at the Grand Exchange, not a browser, so this PR intentionally does **not** get the qa-verifier follow-up step. The checklist below is for a human reviewer/author to run manually:

- [ ] Log in at the GE with Session Stats expanded. Note "Profit this session".
- [ ] Place a sell offer with a large quantity; let it fill partially. Projected/profit figures must move with each fill and must NOT count the unsold remainder as already earned.
- [ ] Let the offer complete. Confirm no sudden jump/lurch in Projected Profit as the offer terminalizes (this was the double-count clearing in the old build).
- [ ] Buy an item and leave it in inventory (awaiting sale) — its full quantity should still be valued as unrealised.
- [ ] Complete 2-3 flips consecutively; confirm Total Profit / Realised stay consistent with each other and with Flip History.
- [ ] Confirm Session duration still ticks normally.

## Deployment Notes

- No environment variables, dependencies, or configuration changes.
- No backend/API changes — plugin-only fix.
- Pending the usual plugin-hub release cycle once merged; this PR does not touch the plugin-hub pin.

## Checklist

- [x] Tests added/updated (`OpenPositionsTest`, `SessionStatsTest`)
- [x] Local build green (757 tests, 0 failures)
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left (temporary instrumented-build logging used only for live diagnosis, not included in this diff)
- [x] Source-comment LOC-budget scan run — no issue-ref or narration comments found in the diff
- [ ] Reviewed by teammate
- [ ] Manual in-game QA (see checklist above)

## Related Issues

Closes Flip-Smart/flip-smart#1124


### 🩺 Codacy Quality Gate — fixed in this PR
- `67bf84c` PMD_category_java_multithreading_AvoidSynchronizedAtMethodLevel `src/main/java/com/flipsmart/trading/OfferStore.java:228` — new `liveSellFilledQuantity` method converted from method-level `synchronized` to a `synchronized (this)` block, matching the style already used by `apply()` in the same class; no behavior change.
- `50e0dc9` (real bug, same-item multi-slot double subtraction) `src/main/java/com/flipsmart/session/OpenPositions.java` — `derive()` now tracks one unclaimed-filled pool per item, consumed flip-by-flip, instead of subtracting the item's whole aggregate filled quantity from every flip of that item independently. Fixes a case where two live sell offers of the same item (different GE slots) would have their unsold quantity double-subtracted. New test: `multipleLiveSellOffersOfTheSameItem_shareOneFilledPoolInsteadOfDoubleSubtracting`.

### 🩺 Codacy Quality Gate — dismissed via API (noise)
- PMD_category_java_multithreading_UseConcurrentHashMap `src/main/java/com/flipsmart/session/OpenPositions.java:41` — `unclaimedFilledByItem` is method-local to `derive()`: created, populated, and discarded within a single call, never stored in a field or published across threads. No concurrent access is possible, so `HashMap` is correct; dismissed as a false positive rather than paying `ConcurrentHashMap` overhead on a hot path (runs on every offer/inventory event) for zero safety benefit.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `50e0dc9` `src/main/java/com/flipsmart/session/OpenPositions.java:38` (HIGH risk) — same same-item multi-slot double-subtraction bug flagged independently by the AI reviewer; fixed together with the quality-gate item above.
- `67bf84c` `src/main/java/com/flipsmart/trading/OfferStore.java:228` (MEDIUM risk) — same finding as the quality-gate PMD item above (method-level synchronization); fixed once, both channels replied.

