### PR TITLE
Fix manual sell price resolution and free-tier cap tracking

### DIFF
--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1115,7 +1115,7 @@ public class FlipFinderPanel extends PluginPanel
 	private void applyFilterSetting(String key, int value)
 	{
 		configManager.setConfiguration(CONFIG_GROUP, key, value);
-		populateRecommendations(new ArrayList<>(currentRecommendations));
+		repopulateRecommendationsGated();
 	}
 
 	/**
@@ -2369,6 +2369,21 @@ public class FlipFinderPanel extends PluginPanel
 		subscribeLabel.setText(SUBSCRIBE_MESSAGE);
 		subscribeLabel.setVisible(true);
 		refreshButton.setEnabled(true);
+	}
+
+	/**
+	 * Repaint the recommendation list through the free-tier slot gate. Repaints that bypass
+	 * this gate paint the full list back over the limit message once a free user is capped,
+	 * handing them recommendations they cannot act on. Caller must already be on the EDT.
+	 */
+	private void repopulateRecommendationsGated()
+	{
+		if (plugin.getSession() != null && plugin.isFlipFinderLimitReached())
+		{
+			showSlotLimitMessage();
+			return;
+		}
+		populateRecommendations(new ArrayList<>(currentRecommendations));
 	}
 
 	/**
@@ -4885,8 +4900,7 @@ public class FlipFinderPanel extends PluginPanel
 			}));
 
 			// Wire queue advanced callback to repaint panel highlight
-			service.setOnQueueAdvanced(() ->
-				populateRecommendations(new ArrayList<>(currentRecommendations)));
+			service.setOnQueueAdvanced(this::repopulateRecommendationsGated);
 
 			// Wire skip-exhausted callback to fetch fresh recommendations
 			service.setOnQueueExhausted(() -> refreshRecommendations(true));
@@ -4925,7 +4939,7 @@ public class FlipFinderPanel extends PluginPanel
 			autoRecommendStatusLabel.setVisible(false);
 
 			// Repaint recommendations to remove highlight
-			populateRecommendations(new ArrayList<>(currentRecommendations));
+			repopulateRecommendationsGated();
 
 			log.debug("Auto-recommend disabled");
 		}

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -444,7 +444,7 @@ public class FlipSmartPlugin extends Plugin
 	 * record with a fill, falling back to any buy record when nothing has filled yet.
 	 * Null when the store holds no buy record for the item.
 	 */
-	private AwaitingSaleLots.BuyBasis buyBasisForItem(int itemId)
+	public AwaitingSaleLots.BuyBasis buyBasisForItem(int itemId)
 	{
 		java.util.List<com.flipsmart.domain.offer.OfferRecord> buys = new java.util.ArrayList<>();
 		for (com.flipsmart.domain.offer.OfferRecord r : offerStore.forItem(itemId))

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -4,6 +4,7 @@ import com.flipsmart.api.dto.SellPriceCheckRequest;
 import com.flipsmart.domain.offer.OfferSignal;
 import com.flipsmart.api.dto.OfferAdviceResponse;
 import com.flipsmart.domain.flip.ActiveFlip;
+import com.flipsmart.domain.flip.ActiveFlipItemIds;
 import com.flipsmart.domain.flip.ActiveFlipProjection;
 import com.flipsmart.domain.flip.ActiveFlipsSnapshotPayload;
 import com.flipsmart.domain.flip.AwaitingSaleLot;
@@ -245,6 +246,11 @@ public class FlipSmartPlugin extends Plugin
 	// inventoryFlipItemIds and published as one volatile swap. Safe to read off the
 	// client thread (e.g. the Swing EDT) where the live client inventory API cannot be.
 	private volatile java.util.Map<Integer, Integer> inventoryFlipItemCounts = java.util.Collections.emptyMap();
+
+	// False until an inventory container has actually been read. Distinguishes "holds
+	// nothing" from "not logged in", so a collected lot is only dropped as sold when the
+	// inventory genuinely says so.
+	private volatile boolean inventorySnapshotKnown;
 
 	// True once the offer store has been seeded from real GE state (login burst or
 	// preloadPersistedOffers), set only on the client thread. Lets the snapshot-push
@@ -822,17 +828,21 @@ public class FlipSmartPlugin extends Plugin
 	 * This includes:
 	 * 1. Items currently in GE buy slots (pending or filled)
 	 * 2. Items currently in GE sell slots (pending sale)
-	 * 3. Items collected from GE in this session (waiting to be sold)
+	 * 3. Items collected from GE and still held (waiting to be sold)
+	 *
+	 * <p>A collected lot the player no longer holds is a finished flip: the collected set is
+	 * restored from disk at login and never cleared while empty, so a sold item would
+	 * otherwise linger there forever and keep consuming a slot.</p>
 	 */
 	public java.util.Set<Integer> getActiveFlipItemIds()
 	{
-		java.util.Set<Integer> itemIds = new java.util.HashSet<>();
+		java.util.Set<Integer> liveOfferItemIds = new java.util.HashSet<>();
 		for (com.flipsmart.domain.offer.OfferRecord offer : offerStore.liveOffers())
 		{
-			itemIds.add(offer.getItemId());
+			liveOfferItemIds.add(offer.getItemId());
 		}
-		itemIds.addAll(session.getCollectedItemIds());
-		return itemIds;
+		return ActiveFlipItemIds.derive(liveOfferItemIds, session.getCollectedItemIds(),
+			inventoryFlipItemCounts, inventorySnapshotKnown);
 	}
 
 	/**
@@ -1880,6 +1890,7 @@ public class FlipSmartPlugin extends Plugin
 			session.setCashStack(0);
 			inventoryFlipItemIds = java.util.Collections.emptySet();
 			inventoryFlipItemCounts = java.util.Collections.emptyMap();
+			inventorySnapshotKnown = false;
 			return;
 		}
 
@@ -1904,6 +1915,7 @@ public class FlipSmartPlugin extends Plugin
 		java.util.Map<Integer, Integer> previousInventoryCounts = inventoryFlipItemCounts;
 		inventoryFlipItemIds = java.util.Collections.unmodifiableSet(currentInventoryIds);
 		inventoryFlipItemCounts = java.util.Collections.unmodifiableMap(currentInventoryCounts);
+		inventorySnapshotKnown = true;
 
 		// An inventory change adds or removes an awaiting-sale lot, so re-derive the
 		// Active Flips projection whenever the held-item composition changes. Coins are

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -2,8 +2,10 @@ package com.flipsmart;
 import com.flipsmart.domain.offer.OfferAction;
 import com.flipsmart.api.dto.ActiveFlipsResponse;
 import com.flipsmart.api.dto.OfferAdviceResponse;
+import com.flipsmart.domain.flip.AwaitingSaleLots;
 import com.flipsmart.domain.flip.FlipRecommendation;
 import com.flipsmart.domain.flip.ActiveFlip;
+import com.flipsmart.recommend.ManualSellFocus;
 import com.flipsmart.domain.offer.OfferRecord;
 import com.flipsmart.domain.offer.OfferSignal;
 import com.flipsmart.domain.offer.OfferTransition;
@@ -67,6 +69,9 @@ public class GrandExchangeTracker
 	private BiConsumer<Integer, Boolean> onOrderSubmitted;
 	private IntFunction<Integer> displayedSellPriceProvider;
 	private BiConsumer<Integer, Runnable> oneShotScheduler;
+	// Cost basis straight from the offer store, so a manual exit can be priced without
+	// the backend's slot-capped active-flips list.
+	private IntFunction<AwaitingSaleLots.BuyBasis> buyBasisProvider;
 
 	// Debounce: prevent duplicate autoFocusOnActiveFlip calls for the same item
 	private volatile int lastAutoFocusItemId;
@@ -195,6 +200,11 @@ public class GrandExchangeTracker
 	public void setOneShotScheduler(BiConsumer<Integer, Runnable> scheduler)
 	{
 		this.oneShotScheduler = scheduler;
+	}
+
+	public void setBuyBasisProvider(IntFunction<AwaitingSaleLots.BuyBasis> provider)
+	{
+		this.buyBasisProvider = provider;
 	}
 
 	// =====================
@@ -809,7 +819,20 @@ public class GrandExchangeTracker
 			return;
 		}
 
-		// Manual mode: the backend active-flip snapshot lags the
+		// Manual mode: price the exit from local state first, the way auto mode already
+		// does. The backend list this used to depend on is trimmed to the subscription's
+		// display slots, so a held position can be missing from it entirely and no price
+		// ever filled in.
+		if (tryLocalSellFocus(itemId))
+		{
+			clearPendingSellFocus();
+			// The focus no longer waits on this lookup, but it still carries the
+			// under-counted-quantity correction that used to ride along with it.
+			tryAsyncSellFocus(itemId, false);
+			return;
+		}
+
+		// Nothing local to price it with yet: the backend active-flip snapshot lags the
 		// just-opened sell screen, so a single one-shot lookup returned no match
 		// and the sell target silently never filled. Arm the same bounded tick-
 		// retry auto mode gets, re-issuing the backend lookup until it resolves.
@@ -820,12 +843,64 @@ public class GrandExchangeTracker
 	}
 
 	/**
+	 * Focus a manual sell using only local state. Returns false when the item cannot be
+	 * priced or sized locally, leaving the caller to fall back to the backend lookup.
+	 * Runs on the client thread — reads the inventory container.
+	 */
+	private boolean tryLocalSellFocus(int itemId)
+	{
+		// An item already listed keeps whatever focus that offer owns.
+		if (offerStore.hasActiveSellOfferForItem(itemId))
+		{
+			return false;
+		}
+
+		// Inventory is both the quantity and the proof the player holds the position.
+		int inventoryCount = activeFlipTracker.getInventoryCountForItem(itemId);
+		if (inventoryCount <= 0)
+		{
+			return false;
+		}
+
+		AwaitingSaleLots.BuyBasis basis = buyBasisProvider != null ? buyBasisProvider.apply(itemId) : null;
+		Integer sellPrice = ManualSellFocus.resolveSellPrice(
+			displayedSellPriceProvider != null ? displayedSellPriceProvider.apply(itemId) : null,
+			session != null ? session.getRecommendedPrice(itemId) : null,
+			basis != null ? basis.avgBuyPrice : 0);
+		if (sellPrice == null)
+		{
+			return false;
+		}
+
+		String itemName = basis != null && basis.itemName != null
+			? basis.itemName : ItemUtils.getItemName(itemManager, itemId);
+		FocusedFlip focus = FocusedFlip.forSell(itemId, itemName, sellPrice, inventoryCount,
+			config != null ? config.priceOffset() : 0);
+		if (onFocusChanged != null)
+		{
+			javax.swing.SwingUtilities.invokeLater(() -> onFocusChanged.accept(focus));
+		}
+		log.debug("Manual sell focus resolved locally: {} @ {} gp (qty: inv={})",
+			itemName, sellPrice, inventoryCount);
+		return true;
+	}
+
+	/**
 	 * Backend fallback: resolve the item's active flip via the API and focus the
 	 * sell from that. Used for items the local auto-recommend state cannot resolve
 	 * (e.g. not in the queue), and after the local tick-retry budget is exhausted.
 	 * Runs on the client thread (reads the inventory container).
 	 */
 	private void tryAsyncSellFocus(int itemId)
+	{
+		tryAsyncSellFocus(itemId, true);
+	}
+
+	/**
+	 * @param setFocus false when local state already focused the sell, leaving this lookup
+	 *                 to do nothing but reconcile an under-counted quantity with the backend.
+	 */
+	private void tryAsyncSellFocus(int itemId, boolean setFocus)
 	{
 		String rsn = getRsn().orElse(null);
 
@@ -834,7 +909,7 @@ public class GrandExchangeTracker
 		int inventoryCount = activeFlipTracker.getInventoryCountForItem(itemId);
 
 		apiClient.getActiveFlipsAsync(rsn).thenAccept(response ->
-			handleActiveFlipResponse(response, itemId, inventoryCount, rsn));
+			handleActiveFlipResponse(response, itemId, inventoryCount, rsn, setFocus));
 	}
 
 	/**
@@ -853,9 +928,17 @@ public class GrandExchangeTracker
 
 		if (pendingSellFocusManual)
 		{
-			// Manual retry: no local resolver, so re-issue the backend
-			// lookup each tick until it resolves (handleActiveFlipResponse clears
-			// pending on success) or the budget runs out.
+			// A collect lands in inventory a tick or two after the sell screen opens, so
+			// retry the local resolver before falling back to the backend lookup — the
+			// same reason auto mode re-runs its own resolver here.
+			if (tryLocalSellFocus(itemId))
+			{
+				clearPendingSellFocus();
+				tryAsyncSellFocus(itemId, false);
+				return;
+			}
+			// Still nothing local: re-issue the backend lookup each tick until it resolves
+			// (handleActiveFlipResponse clears pending on success) or the budget runs out.
 			pendingSellFocusTicksLeft--;
 			if (pendingSellFocusTicksLeft <= 0)
 			{
@@ -898,7 +981,7 @@ public class GrandExchangeTracker
 	}
 
 	private void handleActiveFlipResponse(
-		ActiveFlipsResponse response, int itemId, int inventoryCount, String rsn)
+		ActiveFlipsResponse response, int itemId, int inventoryCount, String rsn, boolean setFocus)
 	{
 		if (response == null || response.getActiveFlips() == null)
 		{
@@ -932,7 +1015,10 @@ public class GrandExchangeTracker
 			return;
 		}
 
-		setFocusForSell(matchingFlip, inventoryCount);
+		if (setFocus)
+		{
+			setFocusForSell(matchingFlip, inventoryCount);
+		}
 		// The flip resolved — stop any manual tick-retry re-issuing the lookup.
 		clearPendingSellFocus();
 

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -462,6 +462,9 @@ public class GrandExchangeTracker
 			log.debug("Sell offer for {} went empty with no items in inventory - dismissing active flip",
 				collectedOffer.getItemName());
 			activeFlipTracker.dismissFlip(collectedOffer.getItemId());
+			// A flip ending frees a slot, so the subscription gate has to be re-applied here
+			// too — otherwise the cap message outlives the cap until the next manual refresh.
+			fireActiveFlipsRefresh();
 		}
 	}
 

--- a/src/main/java/com/flipsmart/domain/flip/ActiveFlipItemIds.java
+++ b/src/main/java/com/flipsmart/domain/flip/ActiveFlipItemIds.java
@@ -1,0 +1,59 @@
+package com.flipsmart.domain.flip;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Items with a flip still in flight: anything on a GE slot, plus collected lots the player
+ * still holds.
+ *
+ * <p>The collected set is persisted per-RSN and restored at login, and it is never rewritten
+ * while empty (so a transient empty during a hop cannot wipe it). An item sold in a later
+ * session therefore lingers in that set indefinitely. Counting such an entry keeps a finished
+ * flip alive forever, which pins a free user at their slot cap through refreshes and relogs.
+ * Inventory is the proof a collected lot is still open.</p>
+ */
+public final class ActiveFlipItemIds
+{
+	private ActiveFlipItemIds()
+	{
+	}
+
+	/**
+	 * @param liveOfferItemIds items on a GE slot; always active, since a listed sell is out
+	 *                         of the inventory by definition
+	 * @param collectedItemIds bought-and-collected lots, possibly stale from a restore
+	 * @param inventoryCounts  canonical item id to held quantity
+	 * @param inventoryKnown   false when no inventory snapshot is readable (logged out), in
+	 *                         which case the collected set is trusted rather than discarded
+	 */
+	public static Set<Integer> derive(Set<Integer> liveOfferItemIds, Set<Integer> collectedItemIds,
+									  Map<Integer, Integer> inventoryCounts, boolean inventoryKnown)
+	{
+		Set<Integer> active = new HashSet<>();
+		if (liveOfferItemIds != null)
+		{
+			active.addAll(liveOfferItemIds);
+		}
+		if (collectedItemIds == null)
+		{
+			return active;
+		}
+		if (!inventoryKnown)
+		{
+			active.addAll(collectedItemIds);
+			return active;
+		}
+		Map<Integer, Integer> counts = inventoryCounts == null ? Collections.emptyMap() : inventoryCounts;
+		for (Integer itemId : collectedItemIds)
+		{
+			if (itemId != null && counts.getOrDefault(itemId, 0) > 0)
+			{
+				active.add(itemId);
+			}
+		}
+		return active;
+	}
+}

--- a/src/main/java/com/flipsmart/plugin/ServiceWiring.java
+++ b/src/main/java/com/flipsmart/plugin/ServiceWiring.java
@@ -215,6 +215,7 @@ public class ServiceWiring
 		grandExchangeTracker.setOnOrderSubmitted(plugin::handleOrderSubmittedForSourcing);
 		grandExchangeTracker.setDisplayedSellPriceProvider(itemId -> plugin.getFlipFinderPanel() != null ? plugin.getFlipFinderPanel().getDisplayedSellPrice(itemId) : null);
 		grandExchangeTracker.setOneShotScheduler(plugin::scheduleOneShot);
+		grandExchangeTracker.setBuyBasisProvider(plugin::buyBasisForItem);
 
 		geHistoryService.setOnBackfillComplete(() -> {
 			if (plugin.getFlipFinderPanel() != null)

--- a/src/main/java/com/flipsmart/recommend/ManualSellFocus.java
+++ b/src/main/java/com/flipsmart/recommend/ManualSellFocus.java
@@ -1,0 +1,42 @@
+package com.flipsmart.recommend;
+
+/**
+ * Sell pricing for a manual (Auto Mode off) exit, resolved entirely from local state.
+ *
+ * <p>The backend active-flips list is trimmed to the subscription's display slots, so a
+ * held position can be missing from it while the item sits in the player's inventory.
+ * A display cap must never stop someone selling what they already own, so the price is
+ * sourced locally: the panel's shown price, then the session's stored recommendation,
+ * then the offer store's buy basis.</p>
+ */
+public final class ManualSellFocus
+{
+	private ManualSellFocus()
+	{
+	}
+
+	/**
+	 * Best locally-known sell price, or null when nothing can price the exit.
+	 *
+	 * @param panelPrice              price the Active Flips card is showing, if any
+	 * @param sessionRecommendedPrice recommendation cached for this item, if any
+	 * @param averageBuyPrice         cost basis from the offer store; 0 when unknown
+	 */
+	public static Integer resolveSellPrice(Integer panelPrice, Integer sessionRecommendedPrice,
+										   int averageBuyPrice)
+	{
+		if (panelPrice != null && panelPrice > 0)
+		{
+			return panelPrice;
+		}
+		if (sessionRecommendedPrice != null && sessionRecommendedPrice > 0)
+		{
+			return sessionRecommendedPrice;
+		}
+		if (averageBuyPrice > 0)
+		{
+			return SmartSellPricer.calculateMinProfitableSellPrice(averageBuyPrice);
+		}
+		return null;
+	}
+}

--- a/src/test/java/com/flipsmart/ManualSellFocusLocalResolutionTest.java
+++ b/src/test/java/com/flipsmart/ManualSellFocusLocalResolutionTest.java
@@ -1,0 +1,167 @@
+package com.flipsmart;
+
+import com.flipsmart.api.dto.ActiveFlipsResponse;
+import com.flipsmart.domain.flip.AwaitingSaleLots;
+import com.flipsmart.recommend.SmartSellPricer;
+import com.flipsmart.trading.OfferStore;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import net.runelite.client.game.ItemManager;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Manual-mode (Auto Mode off) sell focus must resolve from local state.
+ *
+ * <p>Prod (#1133): the manual path resolved the sell price only from
+ * {@code GET /transactions/active-flips}, which the backend trims to the subscription's
+ * display slots — 2 on free tier, unlimited on premium. A free user's held position could
+ * be absent from that response, so {@code handleActiveFlipResponse} found no match, never
+ * reached {@code setFocusForSell}, and no price was populated at all. Auto Mode was
+ * unaffected because it resolves locally, which is why the bug looked free-and-manual only.
+ *
+ * <p>A display cap must never stop someone selling what they already own.</p>
+ */
+public class ManualSellFocusLocalResolutionTest
+{
+	private static final int ITEM_ID = 4151; // Abyssal whip
+	private static final String ITEM_NAME = "Abyssal whip";
+	private static final int AVG_BUY_PRICE = 1_000_000;
+	private static final int HELD_QUANTITY = 3;
+
+	private PlayerSession session;
+	private FlipSmartApiClient apiClient;
+	private ActiveFlipTracker activeFlipTracker;
+	private GrandExchangeTracker tracker;
+	private AtomicReference<FocusedFlip> focus;
+
+	@Before
+	public void setUp()
+	{
+		session = new PlayerSession();
+		session.setRsn("TestPlayer");
+
+		apiClient = mock(FlipSmartApiClient.class);
+		activeFlipTracker = mock(ActiveFlipTracker.class);
+		ItemManager itemManager = mock(ItemManager.class);
+
+		// The backend list is EMPTY throughout: this is the free-tier trim, where the
+		// held position never appears in the response the old path depended on.
+		when(apiClient.getActiveFlipsAsync(any()))
+			.thenReturn(CompletableFuture.completedFuture(new ActiveFlipsResponse()));
+		when(activeFlipTracker.getInventoryCountForItem(anyInt())).thenReturn(HELD_QUANTITY);
+
+		tracker = new GrandExchangeTracker(
+			session, apiClient, activeFlipTracker, itemManager, mock(TradeActivityLog.class));
+		tracker.setOfferStore(new OfferStore());
+
+		focus = new AtomicReference<>();
+		tracker.setOnFocusChanged(focus::set);
+
+		// Auto-recommend left unset => manual mode, the path under test.
+	}
+
+	/** onFocusChanged is dispatched to the EDT; drain it before asserting. */
+	private FocusedFlip awaitFocus() throws Exception
+	{
+		javax.swing.SwingUtilities.invokeAndWait(() ->
+		{
+		});
+		return focus.get();
+	}
+
+	@Test
+	public void pricesTheExitFromTheOfferStoreBasisWhenTheBackendListOmitsTheHolding() throws Exception
+	{
+		tracker.setBuyBasisProvider(
+			itemId -> new AwaitingSaleLots.BuyBasis(ITEM_NAME, AVG_BUY_PRICE, null));
+
+		tracker.autoFocusOnActiveFlip(ITEM_ID);
+
+		FocusedFlip focused = awaitFocus();
+		assertNotNull("free-tier holding must still be priced for sale", focused);
+		assertEquals(ITEM_ID, focused.getItemId());
+		assertEquals(HELD_QUANTITY, focused.getSellQuantity());
+		assertEquals(SmartSellPricer.calculateMinProfitableSellPrice(AVG_BUY_PRICE),
+			focused.getSellPrice());
+	}
+
+	@Test
+	public void anEmptyBackendListNeitherBlocksNorUndoesTheLocalFocus() throws Exception
+	{
+		// The lookup still fires — it carries the under-counted-quantity reconciliation —
+		// but a response that omits the holding must no longer decide whether a price shows.
+		tracker.setBuyBasisProvider(
+			itemId -> new AwaitingSaleLots.BuyBasis(ITEM_NAME, AVG_BUY_PRICE, null));
+
+		tracker.autoFocusOnActiveFlip(ITEM_ID);
+
+		verify(apiClient).getActiveFlipsAsync(any());
+		assertNotNull("empty backend response must not clear a locally-priced focus", awaitFocus());
+	}
+
+	@Test
+	public void prefersThePanelPriceOverTheDerivedBreakevenPrice() throws Exception
+	{
+		tracker.setBuyBasisProvider(
+			itemId -> new AwaitingSaleLots.BuyBasis(ITEM_NAME, AVG_BUY_PRICE, null));
+		tracker.setDisplayedSellPriceProvider(itemId -> 1_234_567);
+
+		tracker.autoFocusOnActiveFlip(ITEM_ID);
+
+		assertEquals(1_234_567, awaitFocus().getSellPrice());
+	}
+
+	@Test
+	public void stillFallsBackToTheBackendLookupWhenNothingLocalCanPriceTheExit() throws Exception
+	{
+		// No buy basis, no cached price: local resolution genuinely cannot price this,
+		// so the original backend path must remain in place.
+		tracker.setBuyBasisProvider(itemId -> null);
+
+		tracker.autoFocusOnActiveFlip(ITEM_ID);
+
+		verify(apiClient).getActiveFlipsAsync(any());
+		// Nothing priced it, and the stubbed backend list is empty, so no focus is invented.
+		assertNull(awaitFocus());
+	}
+
+	@Test
+	public void doesNotFocusAnItemThePlayerDoesNotHold() throws Exception
+	{
+		when(activeFlipTracker.getInventoryCountForItem(anyInt())).thenReturn(0);
+		tracker.setBuyBasisProvider(
+			itemId -> new AwaitingSaleLots.BuyBasis(ITEM_NAME, AVG_BUY_PRICE, null));
+
+		tracker.autoFocusOnActiveFlip(ITEM_ID);
+
+		// Falls through to the backend rather than inventing a quantity out of nothing.
+		verify(apiClient).getActiveFlipsAsync(any());
+		assertNull(awaitFocus());
+	}
+
+	@Test
+	public void derivedPriceClearsGeTaxSoTheExitIsNotAGuaranteedLoss() throws Exception
+	{
+		tracker.setBuyBasisProvider(
+			itemId -> new AwaitingSaleLots.BuyBasis(ITEM_NAME, AVG_BUY_PRICE, null));
+
+		tracker.autoFocusOnActiveFlip(ITEM_ID);
+
+		assertTrue("a locally-derived price must still beat breakeven after 2% tax",
+			awaitFocus().getSellPrice() * 0.98 > AVG_BUY_PRICE);
+	}
+}

--- a/src/test/java/com/flipsmart/ManualSellFocusLocalResolutionTest.java
+++ b/src/test/java/com/flipsmart/ManualSellFocusLocalResolutionTest.java
@@ -42,7 +42,6 @@ public class ManualSellFocusLocalResolutionTest
 	private static final int AVG_BUY_PRICE = 1_000_000;
 	private static final int HELD_QUANTITY = 3;
 
-	private PlayerSession session;
 	private FlipSmartApiClient apiClient;
 	private ActiveFlipTracker activeFlipTracker;
 	private GrandExchangeTracker tracker;
@@ -51,7 +50,7 @@ public class ManualSellFocusLocalResolutionTest
 	@Before
 	public void setUp()
 	{
-		session = new PlayerSession();
+		PlayerSession session = new PlayerSession();
 		session.setRsn("TestPlayer");
 
 		apiClient = mock(FlipSmartApiClient.class);

--- a/src/test/java/com/flipsmart/RecommendationRepaintGateTest.java
+++ b/src/test/java/com/flipsmart/RecommendationRepaintGateTest.java
@@ -1,0 +1,91 @@
+package com.flipsmart;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Every repaint of the recommendation list must pass the free-tier slot gate.
+ *
+ * <p>Prod (#1133 follow-up): a free user at their 2-item cap saw the upgrade message replaced
+ * by a full list of recommendation cards, because Auto's queue-advance callback repainted via
+ * {@code populateRecommendations} directly. This is the second time a repaint call site skipped
+ * the gate — the cogwheel "Update" path had the same hole earlier — so the invariant is pinned
+ * here rather than left to review.
+ *
+ * <p>The gate lives in {@code repopulateRecommendationsGated} and {@code reevaluateSlotLimitDisplay};
+ * {@code handleRecommendationsResponse} applies it inline around the fetch. Any NEW call site is a
+ * bypass until it routes through one of those. If you are here because this test failed, call
+ * {@code repopulateRecommendationsGated()} instead of {@code populateRecommendations(...)}.</p>
+ */
+public class RecommendationRepaintGateTest
+{
+	private static final Path PANEL_SOURCE =
+		Paths.get("src/main/java/com/flipsmart/FlipFinderPanel.java");
+
+	/** Methods allowed to call populateRecommendations, because each applies the gate itself. */
+	private static final List<String> GATED_CALLERS = Arrays.asList(
+		"handleRecommendationsResponse",
+		"repopulateRecommendationsGated",
+		"reevaluateSlotLimitDisplay");
+
+	// A method declaration at class-body indentation (exactly one tab), e.g. "\tprivate void foo(".
+	// Anchored on an access modifier so control flow ("\t\telse if (") can't pose as a declaration.
+	private static final Pattern METHOD_DECL = Pattern.compile(
+		"^\\t(?:public|private|protected)\\s+(?:static\\s+|final\\s+|synchronized\\s+)*"
+			+ "[\\w<>,\\[\\].?]+\\s+(\\w+)\\s*\\(");
+
+	@Test
+	public void everyRecommendationRepaintRoutesThroughTheSlotGate() throws IOException
+	{
+		assertTrue("FlipFinderPanel source not found — is the test running from the project root?",
+			Files.exists(PANEL_SOURCE));
+
+		List<String> lines = Files.readAllLines(PANEL_SOURCE, StandardCharsets.UTF_8);
+		List<String> ungated = new ArrayList<>();
+
+		for (int i = 0; i < lines.size(); i++)
+		{
+			String line = lines.get(i);
+			if (!line.contains("populateRecommendations(") || line.contains("private void populateRecommendations("))
+			{
+				continue;
+			}
+			String enclosing = enclosingMethod(lines, i);
+			if (!GATED_CALLERS.contains(enclosing))
+			{
+				ungated.add((i + 1) + ": in " + enclosing + " -> " + line.trim());
+			}
+		}
+
+		assertEquals("ungated populateRecommendations call site(s) — route through "
+			+ "repopulateRecommendationsGated() so a capped free user keeps the upgrade message: "
+			+ ungated, 0, ungated.size());
+	}
+
+	/** Name of the method containing {@code lineIndex}, or "<unknown>" when none is found. */
+	private static String enclosingMethod(List<String> lines, int lineIndex)
+	{
+		for (int i = lineIndex; i >= 0; i--)
+		{
+			Matcher m = METHOD_DECL.matcher(lines.get(i));
+			if (m.find())
+			{
+				return m.group(1);
+			}
+		}
+		return "<unknown>";
+	}
+}

--- a/src/test/java/com/flipsmart/domain/flip/ActiveFlipItemIdsTest.java
+++ b/src/test/java/com/flipsmart/domain/flip/ActiveFlipItemIdsTest.java
@@ -1,0 +1,104 @@
+package com.flipsmart.domain.flip;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Which items count as an in-flight flip.
+ *
+ * Prod (#1133 follow-up): the collected set is persisted per-RSN and restored at login, and its
+ * don't-destroy-on-empty guard means an entry can never be cleared from disk once written. An
+ * item sold in a later session therefore stayed in the restored collected set forever, kept
+ * counting toward the free-tier cap, and pinned the user at "capReached=true" through refreshes
+ * AND relogs — locking them out of recommendations entirely.
+ *
+ * Inventory is the proof a collected lot is still open. A collected item the player no longer
+ * holds, with no live offer, is a finished flip.
+ */
+public class ActiveFlipItemIdsTest
+{
+	private static final int HELD = 11128;      // Berserker necklace, still in inventory
+	private static final int SOLD = 6914;       // stale collected entry, already sold
+	private static final int ON_OFFER = 31722;  // Rubium splinters, live GE sell
+
+	private static Map<Integer, Integer> inventory(int... itemIds)
+	{
+		Map<Integer, Integer> counts = new HashMap<>();
+		for (int id : itemIds)
+		{
+			counts.put(id, 1);
+		}
+		return counts;
+	}
+
+	private static Set<Integer> ids(Integer... itemIds)
+	{
+		return new HashSet<>(Arrays.asList(itemIds));
+	}
+
+	@Test
+	public void dropsCollectedItemsThePlayerNoLongerHolds()
+	{
+		Set<Integer> active = ActiveFlipItemIds.derive(
+			ids(ON_OFFER), ids(HELD, SOLD), inventory(HELD), true);
+
+		assertEquals(ids(ON_OFFER, HELD), active);
+	}
+
+	@Test
+	public void keepsCollectedItemsStillInInventory()
+	{
+		Set<Integer> active = ActiveFlipItemIds.derive(
+			Collections.emptySet(), ids(HELD), inventory(HELD), true);
+
+		assertTrue(active.contains(HELD));
+	}
+
+	@Test
+	public void alwaysKeepsItemsWithALiveOfferEvenWhenNotInInventory()
+	{
+		// A listed sell is out of the inventory by definition — it must still count.
+		Set<Integer> active = ActiveFlipItemIds.derive(
+			ids(ON_OFFER), Collections.emptySet(), inventory(), true);
+
+		assertEquals(ids(ON_OFFER), active);
+	}
+
+	@Test
+	public void trustsTheCollectedSetWhenNoInventorySnapshotIsReadable()
+	{
+		// Logged out: the snapshot is empty because it is unknown, not because the player
+		// holds nothing. Dropping the set here would release the cap while logged out.
+		Set<Integer> active = ActiveFlipItemIds.derive(
+			Collections.emptySet(), ids(HELD, SOLD), inventory(), false);
+
+		assertEquals(ids(HELD, SOLD), active);
+	}
+
+	@Test
+	public void theStuckCapScenarioReleasesOnceTheSoldItemIsGone()
+	{
+		// Exactly the reported state: one live sell, plus a sold item lingering in the
+		// restored collected set. Only the live sell should count, so a 2-item cap frees up.
+		Set<Integer> active = ActiveFlipItemIds.derive(
+			ids(ON_OFFER), ids(HELD), inventory(), true);
+
+		assertEquals(ids(ON_OFFER), active);
+		assertEquals(1, active.size());
+	}
+
+	@Test
+	public void toleratesNullInputs()
+	{
+		assertEquals(Collections.emptySet(), ActiveFlipItemIds.derive(null, null, null, true));
+	}
+}

--- a/src/test/java/com/flipsmart/recommend/ManualSellFocusTest.java
+++ b/src/test/java/com/flipsmart/recommend/ManualSellFocusTest.java
@@ -1,0 +1,65 @@
+package com.flipsmart.recommend;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Manual-mode sell pricing must resolve from local state alone.
+ *
+ * Prod (#1133): with Auto Mode off, the sell focus was resolved only from the backend
+ * active-flips list, which is trimmed to the subscription's display slots (2 on free).
+ * A free user's held position could be absent from that list entirely, so clicking the
+ * item to sell it back populated no price at all. Selling what you already own must not
+ * depend on a display cap, so every price source used here is local.
+ */
+public class ManualSellFocusTest
+{
+	@Test
+	public void prefersThePanelDisplayedPrice()
+	{
+		assertEquals(Integer.valueOf(120), ManualSellFocus.resolveSellPrice(120, 110, 100));
+	}
+
+	@Test
+	public void fallsBackToTheSessionRecommendedPriceWhenThePanelHasNone()
+	{
+		assertEquals(Integer.valueOf(110), ManualSellFocus.resolveSellPrice(null, 110, 100));
+	}
+
+	@Test
+	public void fallsBackToMinProfitableWhenOnlyTheLocalBuyBasisIsKnown()
+	{
+		// The free-tier regression: no backend flip, no cached price — the buy basis in
+		// the offer store is enough to price the exit.
+		assertEquals(
+			Integer.valueOf(SmartSellPricer.calculateMinProfitableSellPrice(100)),
+			ManualSellFocus.resolveSellPrice(null, null, 100));
+	}
+
+	@Test
+	public void treatsNonPositivePricesAsAbsent()
+	{
+		assertEquals(Integer.valueOf(110), ManualSellFocus.resolveSellPrice(0, 110, 100));
+		assertEquals(
+			Integer.valueOf(SmartSellPricer.calculateMinProfitableSellPrice(100)),
+			ManualSellFocus.resolveSellPrice(-1, 0, 100));
+	}
+
+	@Test
+	public void unresolvableWithoutAnyPriceOrBuyBasis()
+	{
+		assertNull(ManualSellFocus.resolveSellPrice(null, null, 0));
+	}
+
+	@Test
+	public void neverPricesBelowBreakevenWhenFallingBackToBasis()
+	{
+		// A basis-derived price must clear the 2% GE tax, else the "fix" would hand the
+		// player a guaranteed loss instead of no price at all.
+		int basis = 1_000_000;
+		Integer resolved = ManualSellFocus.resolveSellPrice(null, null, basis);
+		assertEquals(true, resolved != null && resolved * 0.98 > basis);
+	}
+}


### PR DESCRIPTION
## Summary

Three related free-tier bugs in Flip Assist's manual-sell flow. The primary bug (#1133) is that manual sell price failed to populate when Auto Mode is off, because pricing depended entirely on a backend response the free tier trims to 2 slots. Two more bugs were found during QA of that fix and folded into this PR at the user's explicit request: a stale cap-exceeded message getting painted over, and a free-tier slot never releasing after a flip completes.

## Changes

### 🐛 Bug Fixes

**1. Manual sell price resolves from local state (`893471a`)**
With Auto Mode off, the sell focus resolved ONLY from `GET /transactions/active-flips`, which the backend trims to the subscription's display slots (2 on free, unlimited on premium). When a held item was trimmed out of that response, `GrandExchangeTracker.handleActiveFlipResponse` returned before ever reaching `setFocusForSell` — every price fallback lived inside that method, so the user got no price at all rather than a worse one. Auto Mode was unaffected because it already resolves locally, which is why the bug presented as free-tier-and-manual-only. Manual mode now prices the exit locally first (panel displayed price -> session cached recommendation -> offer-store buy basis), falling back to the backend lookup only when none of those can price it. New pure class `com.flipsmart.recommend.ManualSellFocus`. The backend lookup still fires afterwards in reconcile-only mode so the under-counted-quantity correction it carried is preserved.

**2. Cap message survives every repaint (`007e055`)**
At the free cap, recommendation cards were painted back over the upgrade message. The cap was computed correctly; three `populateRecommendations` call sites (Auto queue-advance, filter spinners, auto-disable) bypassed the free-tier gate. All now route through a new `repopulateRecommendationsGated()`. A regression test, `RecommendationRepaintGateTest`, now fails on any new ungated call site.

**3. Free-tier slot releases when a flip finishes (`4006b7e`)**
A sold item consumed a slot forever. The cap counts against the collected set, which is persisted per-RSN and never rewritten while empty — so a sold item lingered on disk, was restored every login, and pinned the user at the cap through refreshes AND relogs. Inventory is now the proof a collected lot is still open. Live offers always count (a listed sell is out of inventory by definition), and a new `inventorySnapshotKnown` flag distinguishes "holds nothing" from "not logged in" so the cap cannot release while logged out. Also fires the active-flips refresh when a sell empties out.

## Testing

### Automated Tests
- ✅ 777 tests passing via `./gradlew test`, +18 tests versus master
- ✅ `./gradlew build` clean
- New tests were proven load-bearing by reintroducing each bug and confirming the new test catches it

### Manual Testing
- [x] Cancelled a partially-filled buy (2 of 3 filled), collected it, clicked it in inventory to sell with Auto OFF. Observed log line: `Manual sell focus resolved locally: Rune pouch note @ 3583297 gp (qty: inv=2)`. Quantity correctly clamped to inventory; the 1gp priceOffset applied correctly.
- [x] Cap release verified: free-tier count went 2 -> 1 after a flip sold out.
- [ ] Same-item-across-two-GE-slots — not tested, deferred (uncommon pattern)

### Known Limitations (stating honestly, not overselling)
- Same-item-across-two-GE-slots was not tested; deferred by the user as an uncommon pattern.
- The original reporter's exact account state (>2 server-side active flips) was never directly confirmed; the mechanism is confirmed from code review + backend tests, and the new local path no longer consults the capped backend list at all for manual pricing.
- The stale collected entry still persists on disk (now simply uncounted rather than removed). Fixing the persistence guard itself risks reintroducing a transient-empty-wipe-on-hop bug it was designed to prevent — deliberately left alone in this PR.
- A related bug found during this QA pass — Auto Mode continuing to act while switched off — was filed separately as Flip-Smart/flip-smart#1139 and is explicitly NOT fixed in this PR.

## API Changes

N/A — plugin-only change, no backend endpoints added/modified/removed. The backend `/transactions/active-flips` lookup is still called, just repositioned to reconcile-only in manual mode; no contract change.

## Database Migrations

N/A.

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: None
- [ ] Requires database migration: No

This is a plugin-side fix; it ships to players via the next RuneLite Plugin Hub release (not an independent deploy).

## Checklist

- [x] Tests added/updated
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Source comments audited for issue-number refs and narrative bloat (none found)
- [ ] Reviewed by teammate

## Related Issues

Closes Flip-Smart/flip-smart#1133
Related to Flip-Smart/flip-smart#1139


### 🩺 Codacy Quality Gate — silenced via API (noise)
- `PMD_category_java_multithreading_UseConcurrentHashMap` `ActiveFlipItemIdsTest.java:35` — single-threaded test helper map, no concurrent access
- `PMD_category_java_design_NPathComplexity` `GrandExchangeTracker.java:853` (`tryLocalSellFocus`) — the local-first pricing method this PR adds; not refactoring immediately after landing the fix
- `Lizard_ccn-medium` `GrandExchangeTracker.java:853` (`tryLocalSellFocus`) — same method as above

### 🩺 Codacy Quality Gate — fixed in this PR
- `18ec893` `PMD_category_java_design_SingularField` `ManualSellFocusLocalResolutionTest.java:45` — `session` was only read in `setUp()`; converted to a local variable

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `FlipFinderPanel.java:4903` — `repopulateRecommendationsGated` callback is already EDT-dispatched by `AutoRecommendService#invokeQueueAdvancedCallback`
- `GrandExchangeTracker.java:1023` — `setFocusForSell` already dispatches internally via `SwingUtilities.invokeLater`
- `GrandExchangeTracker.java:467` — `fireActiveFlipsRefresh` already dispatches internally via `SwingUtilities.invokeLater`

### 🤖 Codacy AI Reviewer — deferred (in-thread rationale)
- `GrandExchangeTracker.java:986` (`handleActiveFlipResponse`) — refactor suggestion; method carries this PR's `setFocus` guard, out of scope to split now
- `GrandExchangeTracker.java:853` (`tryLocalSellFocus`) — extraction suggestion; this is the intentional local-first pricing method the PR adds

### 🤖 Codacy AI Reviewer — fixed in this PR
- `18ec893` `ManualSellFocusLocalResolutionTest.java:45` — same PMD SingularField finding as the quality-gate fix above
