### PR TITLE
fix(tracking): keep collected buy history across a reconcile (#1121)

### DIFF
--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -52,6 +52,16 @@ public class OfflineSyncService
 
 	/** Persisted collected-item entries older than this are dropped on restore. */
 	static final long MAX_PERSISTED_COLLECTED_AGE_MS = 7L * 24 * 60 * 60 * 1000;
+
+	/**
+	 * Terminal (already-collected/cancelled) offer records this old are no longer carried across a
+	 * reconcile. They exist to keep the cost basis of a position the player still holds, so the
+	 * window only has to outlive a realistic buy-to-sell gap.
+	 */
+	static final long TERMINAL_HISTORY_RETENTION_MS = 24L * 60 * 60 * 1000;
+
+	/** Hard ceiling on retained terminal records so the persisted blob stays bounded. */
+	static final int MAX_RETAINED_TERMINAL_RECORDS = 300;
 	private final PlayerSession session;
 	private final ConfigManager configManager;
 	private final Gson gson;
@@ -440,13 +450,47 @@ public class OfflineSyncService
 				toImport.add(collected.withState(OfferState.COLLECTED, now));
 			}
 		}
+		// A collected buy is the cost basis for the sell that follows it. The reconcile plan
+		// carries only live and offline-collected records, so importing just those erased every
+		// already-collected buy on each LOGGED_IN — which fires on every world hop, not only
+		// login — leaving breakeven and profit unresolvable for the rest of the session. Carry
+		// the recent terminal history across, bounded by age and count so the persisted blob
+		// cannot grow without limit.
+		List<OfferRecord> retainedHistory = retainRecentTerminalHistory(persistedRecords, now);
+		toImport.addAll(retainedHistory);
 		offerStore.importRecords(toImport);
 
 		if (log.isDebugEnabled())
 		{
-			log.debug("Reconciled persisted offers into store: {} reattached, {} minted, {} offline-collected (slots readable: {})",
-				plan.reattached.size(), plan.minted.size(), plan.offlineCollected.size(), !liveSlots.isEmpty());
+			log.debug("Reconciled persisted offers into store: {} reattached, {} minted, {} offline-collected, {} terminal history retained (slots readable: {})",
+				plan.reattached.size(), plan.minted.size(), plan.offlineCollected.size(),
+				retainedHistory.size(), !liveSlots.isEmpty());
 		}
+	}
+
+	/**
+	 * The most recent already-terminal persisted records, newest first, capped by
+	 * {@link #TERMINAL_HISTORY_RETENTION_MS} and {@link #MAX_RETAINED_TERMINAL_RECORDS}.
+	 * Non-terminal records are the reconciler's business and are never returned here.
+	 */
+	static List<OfferRecord> retainRecentTerminalHistory(List<OfferRecord> persisted, long now)
+	{
+		List<OfferRecord> terminal = new ArrayList<>();
+		for (OfferRecord r : persisted)
+		{
+			if (r != null && r.getState().isTerminal()
+				&& now - r.getEffectiveLastActivityAtMillis() <= TERMINAL_HISTORY_RETENTION_MS)
+			{
+				terminal.add(r);
+			}
+		}
+		terminal.sort(java.util.Comparator
+			.comparingLong(OfferRecord::getEffectiveLastActivityAtMillis).reversed());
+		if (terminal.size() > MAX_RETAINED_TERMINAL_RECORDS)
+		{
+			return new ArrayList<>(terminal.subList(0, MAX_RETAINED_TERMINAL_RECORDS));
+		}
+		return terminal;
 	}
 
 	/** Reduce the live GE slots to {@link OfferSignal}s for reconciliation. */

--- a/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
+++ b/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
@@ -481,6 +481,92 @@ public class OfflineSyncPersistenceTest
 		assertEquals(1234, store.bySlot(0).getItemId());
 	}
 
+	/**
+	 * A collected buy is the cost basis for the sell that follows it, so breakeven and profit go
+	 * unresolvable if a reconcile drops it. LOGGED_IN fires on every world hop, so this ran
+	 * mid-session with no logout, and the following persist wrote the loss through to disk.
+	 */
+	@Test
+	public void preload_withReadableGeSnapshot_preservesCollectedBuyHistory()
+	{
+		when(session.getRsn()).thenReturn("Zezima");
+
+		// Wall-clock relative: the service reconciles against System.currentTimeMillis().
+		long now = System.currentTimeMillis();
+
+		// Earlier this session: bought 10 of item 4444 and collected them (terminal history).
+		store.apply(sig(0, GrandExchangeOfferState.BUYING, 4444, 0, 10), now - 300_000L);
+		store.apply(sig(0, GrandExchangeOfferState.BOUGHT, 4444, 10, 10), now - 200_000L);
+		store.apply(sig(0, GrandExchangeOfferState.EMPTY, 4444, 10, 10), now - 100_000L);
+		// A live sell for a different item occupies slot 1.
+		store.apply(sig(1, GrandExchangeOfferState.SELLING, 5555, 0, 10), now - 50_000L);
+		service.persistOfferState();
+
+		assertFalse("sanity: collected buy present before preload", store.forItem(4444).isEmpty());
+
+		// World hop where the GE snapshot IS readable: slot 1 still holds the live sell.
+		ItemComposition comp5555 = itemComp("i5555");
+		when(itemManager.getItemComposition(5555)).thenReturn(comp5555);
+		GrandExchangeOffer liveSell = geOffer(5555, GrandExchangeOfferState.SELLING, 10, 100);
+		when(client.getGrandExchangeOffers()).thenReturn(new GrandExchangeOffer[]{null, liveSell});
+
+		service.preloadPersistedOffers();
+
+		boolean survivedInStore = !store.forItem(4444).isEmpty();
+
+		// The next persist writes the store back over the saved blob, so if the record was
+		// dropped in memory it is also gone from disk — a relog cannot bring it back.
+		store.apply(sig(2, GrandExchangeOfferState.BUYING, 6666, 0, 5), 5000L);
+		service.persistOfferState();
+		boolean survivedInPersistence = configStore.get("persistedOffers_Zezima") != null
+			&& configStore.get("persistedOffers_Zezima").contains("4444");
+
+		assertTrue("collected buy history must survive a readable-snapshot preload", survivedInStore);
+		assertTrue("collected buy history must survive the following persist", survivedInPersistence);
+	}
+
+	@Test
+	public void terminalHistoryRetention_dropsRecordsOlderThanTheWindow()
+	{
+		long now = 10_000_000_000L;
+		// A collect only terminalizes a filled offer, so each record runs BUYING -> BOUGHT -> EMPTY.
+		store.apply(sig(0, GrandExchangeOfferState.BUYING, 111, 0, 10), now);
+		store.apply(sig(0, GrandExchangeOfferState.BOUGHT, 111, 10, 10), now);
+		store.apply(sig(0, GrandExchangeOfferState.EMPTY, 111, 10, 10),
+			now - OfflineSyncService.TERMINAL_HISTORY_RETENTION_MS - 1);
+		store.apply(sig(1, GrandExchangeOfferState.BUYING, 222, 0, 10), now);
+		store.apply(sig(1, GrandExchangeOfferState.BOUGHT, 222, 10, 10), now);
+		store.apply(sig(1, GrandExchangeOfferState.EMPTY, 222, 10, 10), now - 1000L);
+
+		List<OfferRecord> retained =
+			OfflineSyncService.retainRecentTerminalHistory(store.export(), now);
+
+		assertEquals("only the in-window terminal record is retained", 1, retained.size());
+		assertEquals(222, retained.get(0).getItemId());
+	}
+
+	@Test
+	public void terminalHistoryRetention_capsRecordCountKeepingNewest()
+	{
+		long now = 10_000_000_000L;
+		for (int i = 0; i < OfflineSyncService.MAX_RETAINED_TERMINAL_RECORDS + 25; i++)
+		{
+			int itemId = 1000 + i;
+			store.apply(sig(0, GrandExchangeOfferState.BUYING, itemId, 0, 1), now);
+			store.apply(sig(0, GrandExchangeOfferState.BOUGHT, itemId, 1, 1), now);
+			// Newer index == more recent activity.
+			store.apply(sig(0, GrandExchangeOfferState.EMPTY, itemId, 1, 1), now - 100_000L + i);
+		}
+
+		List<OfferRecord> retained =
+			OfflineSyncService.retainRecentTerminalHistory(store.export(), now);
+
+		assertEquals("retained set is capped", OfflineSyncService.MAX_RETAINED_TERMINAL_RECORDS,
+			retained.size());
+		assertEquals("newest record is kept", 1000 + OfflineSyncService.MAX_RETAINED_TERMINAL_RECORDS + 24,
+			retained.get(0).getItemId());
+	}
+
 	@Test
 	public void relog_restoresOfferAge_forStillLiveOffer()
 	{


### PR DESCRIPTION
Closes Flip-Smart/flip-smart#1121

## Summary

Breakeven and profit intermittently rendered `?` on the GE sell screen, and the profit line silently vanished from the slot-hover tooltip, mid-session with no logout. The ticket suspected trades being dropped from tracking. They aren't — the **cost basis** is dropped. The sell offer tracks correctly; the collected buy that gives it a breakeven is erased.

## Root cause

`OfferReconciler.reconcile()` deliberately skips terminal records — they land in no bucket. `OfflineSyncService.reconcilePersistedIntoStore()` then calls `offerStore.importRecords(reattached + offlineCollected)`, and `importRecords` clears the map first. Every collected buy record is destroyed.

That path runs from `preloadPersistedOffers()` on each `LOGGED_IN`, which fires on **every world hop**, not only at login — hence "mid-session, no log-off." The next `persistOfferState()` then writes the pruned store back over the saved blob, so the loss reaches disk and a relog does not recover it.

The offer-store guard added for the previous incident does not cover this: it only early-returns when the GE snapshot is *unreadable*. A hop where the GE array loads normally proceeds straight to the destructive import.

## Fix

`retainRecentTerminalHistory()` carries recent terminal records across the reconcile, bounded by `TERMINAL_HISTORY_RETENTION_MS` (24h) and `MAX_RETAINED_TERMINAL_RECORDS` (300, newest first).

**Both caps are load-bearing.** There is no other retention or pruning for offer records anywhere in the plugin — the terminal drop was the only thing bounding the persisted blob. Preserving history without caps would regrow it, which is the blob-growth regression guarded against previously.

## Trade-off, stated explicitly

This slightly widens the known cross-cycle averaging issue in `BuyPriceLookup` (tracked separately). Closed-cycle buy records were previously being wiped by accident on every hop, which partially masked it; they are now deliberately retained for up to 24h. A stale basis is strictly better than no basis, and the caps bound the exposure. The real fix is scoping basis to the open cycle, which is planned separately.

## Tests

`./gradlew test check` — **780 tests, 0 failures.**

Three new tests in `OfflineSyncPersistenceTest`:

- `preload_withReadableGeSnapshot_preservesCollectedBuyHistory` — the regression. Asserts survival in the store **and** in persistence, because the follow-up persist was writing the loss through to disk.
- `terminalHistoryRetention_dropsRecordsOlderThanTheWindow`
- `terminalHistoryRetention_capsRecordCountKeepingNewest`

## Manual test plan

1. Buy an item and collect it, so the buy record goes terminal.
2. **World hop** (do not log out). This is the trigger — a hop where the GE interface loads normally.
3. Open a sell offer for that item. Expect `Breakeven: <n> gp` and `Your profit: <n> gp` — not `?`.
4. Hover the live sell offer on the main GE screen. Expect the `Profit:` line present in the tooltip.
5. Repeat across several hops and with multiple concurrent flips.
6. Relog and confirm breakeven still resolves (the persisted blob should retain the buy).

Note the two surfaces fail differently, which is useful when reading QA screenshots: the offer screen renders a literal `?`, while the hover tooltip **omits the profit line entirely**, so it reads as "no data exists" rather than "we lost it."

### 🩺 Codacy Quality Gate — passing
Green at HEAD `d6b4374d25` (0 new issues). No inline review comments were posted on this PR.

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `OfflineSyncService.java:437` — AI Reviewer suggested `toImport.addAll(plan.minted)` to include newly-discovered live offers in the preload import. This is wrong on two counts: (1) `plan.minted` is `List<OfferSignal>` while `toImport` is `List<OfferRecord>` — the suggested line does not compile, `OfferSignal` is not an `OfferRecord`; (2) the javadoc directly above this method (lines 414-418) already documents that minted live slots are *intentionally* left for the normal GE event burst to mint, not the preload path — importing raw `OfferSignal`s here would create incomplete stub records ahead of the proper event-driven creation path. No thread exists for this comment (Codacy anchored it "outside the diff," which GitHub does not support as a real review comment/thread — confirmed via the GraphQL `reviewThreads` query returning zero nodes), so this rationale is recorded here instead of in-thread.

