### PR TITLE
fix(tracking): report fill deltas against high-water marks

### DIFF
--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -21,6 +21,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -62,6 +63,9 @@ public class OfflineSyncService
 
 	/** Hard ceiling on retained terminal records so the persisted blob stays bounded. */
 	static final int MAX_RETAINED_TERMINAL_RECORDS = 300;
+
+	/** Per-RSN key holding the high-water fill marks. */
+	private static final String WATERMARKS_KEY_PREFIX = "fillWatermarks_";
 	private final PlayerSession session;
 	private final ConfigManager configManager;
 	private final Gson gson;
@@ -231,6 +235,8 @@ public class OfflineSyncService
 		String offersKey = PERSISTED_OFFERS_KEY_PREFIX + rsn;
 		String collectedKey = COLLECTED_ITEMS_KEY_PREFIX + rsn;
 		String quantitiesKey = COLLECTED_QUANTITIES_KEY_PREFIX + rsn;
+
+		persistWatermarks(rsn);
 
 		List<OfferRecord> offersToSave = offerStore.export();
 		if (offersToSave.isEmpty())
@@ -402,6 +408,12 @@ public class OfflineSyncService
 			return;
 		}
 
+		// Raise the marks before the records land. Seeding from the records covers a client that
+		// has never persisted marks; merging the saved blob then adds anything the records no
+		// longer show. Both only ever raise, so a stale blob cannot rewind this session.
+		offerStore.watermarks().seedFrom(persistedRecords);
+		offerStore.watermarks().mergeFrom(loadPersistedWatermarks());
+
 		reconcilePersistedIntoStore(persistedRecords);
 		// Runs after reconciliation so cold-start seeding (when there is no persisted
 		// ledger at all) sees the just-reattached live buys, not a pre-reconcile snapshot.
@@ -465,6 +477,49 @@ public class OfflineSyncService
 			log.debug("Reconciled persisted offers into store: {} reattached, {} minted, {} offline-collected, {} terminal history retained (slots readable: {})",
 				plan.reattached.size(), plan.minted.size(), plan.offlineCollected.size(),
 				retainedHistory.size(), !liveSlots.isEmpty());
+		}
+	}
+
+	/**
+	 * Save the high-water fill marks. Written unconditionally: unlike the offer records, an empty
+	 * mark set carries no risk of wiping useful state, because a restore only ever raises marks.
+	 */
+	private void persistWatermarks(String rsn)
+	{
+		try
+		{
+			configManager.setConfiguration(CONFIG_GROUP, WATERMARKS_KEY_PREFIX + rsn,
+				gson.toJson(offerStore.watermarks().export()));
+		}
+		catch (Exception e)
+		{
+			log.error("Failed to persist fill watermarks for {}: {}", rsn, e.getMessage());
+		}
+	}
+
+	/** Saved high-water marks for the current RSN, or an empty map when none are stored. */
+	private Map<String, long[]> loadPersistedWatermarks()
+	{
+		String rsn = resolvePersistenceRsn();
+		if (rsn == null)
+		{
+			return Collections.emptyMap();
+		}
+		String json = configManager.getConfiguration(CONFIG_GROUP, WATERMARKS_KEY_PREFIX + rsn);
+		if (json == null || json.isEmpty())
+		{
+			return Collections.emptyMap();
+		}
+		try
+		{
+			Map<String, long[]> restored = gson.fromJson(json,
+				new com.google.gson.reflect.TypeToken<Map<String, long[]>>() { }.getType());
+			return restored == null ? Collections.emptyMap() : restored;
+		}
+		catch (Exception e)
+		{
+			log.error("Failed to read fill watermarks for {}: {}", rsn, e.getMessage());
+			return Collections.emptyMap();
 		}
 	}
 

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -493,7 +493,7 @@ public class OfflineSyncService
 		}
 		catch (Exception e)
 		{
-			log.error("Failed to persist fill watermarks for {}: {}", rsn, e.getMessage());
+			log.error("Failed to persist fill watermarks for {}", rsn, e);
 		}
 	}
 

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -513,7 +513,7 @@ public class OfflineSyncService
 		try
 		{
 			Map<String, long[]> restored = gson.fromJson(json,
-				new com.google.gson.reflect.TypeToken<Map<String, long[]>>() { }.getType());
+				new TypeToken<Map<String, long[]>>() { }.getType());
 			return restored == null ? Collections.emptyMap() : restored;
 		}
 		catch (Exception e)

--- a/src/main/java/com/flipsmart/trading/FillWatermarks.java
+++ b/src/main/java/com/flipsmart/trading/FillWatermarks.java
@@ -1,0 +1,107 @@
+package com.flipsmart.trading;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Highest cumulative fill ever observed for each order.
+ *
+ * <p>The Grand Exchange reports cumulative totals per slot, never increments, so what is new
+ * has to be derived by subtraction. Deriving it from whatever record happens to be in memory
+ * makes the result depend on that record surviving — and it does not always survive a hop, a
+ * reconcile, or a skipped persist. Holding the high-water mark here instead means a lost or
+ * rewound record cannot re-report fills that were already counted, and the first observation
+ * after a gap reports exactly the amount that filled during it.</p>
+ *
+ * <p>Marks only ever rise. Every path that brings marks in from elsewhere merges by maximum,
+ * so restoring an older snapshot can add knowledge but never remove it.</p>
+ */
+public final class FillWatermarks
+{
+	/** What one observation newly revealed. Zero on a replay or a stale snapshot. */
+	public static final class Delta
+	{
+		public final int quantity;
+		public final long spent;
+
+		Delta(int quantity, long spent)
+		{
+			this.quantity = quantity;
+			this.spent = spent;
+		}
+	}
+
+	private static final int FILLED = 0;
+	private static final int SPENT = 1;
+	private static final int FIRST_GENERATION = 1;
+
+	private final Map<String, long[]> marks = new HashMap<>();
+	private final Map<Integer, Integer> slotGeneration = new HashMap<>();
+
+	/** Record a cumulative observation and return only what it added. */
+	public synchronized Delta observe(OfferIdentity id, int cumulativeFilled, long cumulativeSpent)
+	{
+		String key = id.toString();
+		long[] mark = marks.get(key);
+		long priorFilled = mark == null ? 0L : mark[FILLED];
+		long priorSpent = mark == null ? 0L : mark[SPENT];
+
+		long raisedFilled = Math.max(priorFilled, cumulativeFilled);
+		long raisedSpent = Math.max(priorSpent, cumulativeSpent);
+		marks.put(key, new long[]{raisedFilled, raisedSpent});
+
+		return new Delta((int) (raisedFilled - priorFilled), raisedSpent - priorSpent);
+	}
+
+	/** The generation currently in force for {@code slot}. */
+	public synchronized int generationFor(int slot)
+	{
+		Integer generation = slotGeneration.get(slot);
+		return generation == null ? FIRST_GENERATION : generation;
+	}
+
+	/**
+	 * Called when a slot demonstrably turns over, so the order that follows starts from a zero
+	 * baseline rather than inheriting the finished order's progress.
+	 */
+	public synchronized void advanceGeneration(int slot)
+	{
+		slotGeneration.put(slot, generationFor(slot) + 1);
+	}
+
+	public synchronized Map<String, long[]> export()
+	{
+		return new HashMap<>(marks);
+	}
+
+	/**
+	 * Fold restored marks in, keeping the higher of each pair. Never replaces: a snapshot
+	 * written before the current session's fills would otherwise rewind them, and the next
+	 * observation would re-report fills already sent.
+	 */
+	public synchronized void mergeFrom(Map<String, long[]> restored)
+	{
+		if (restored == null)
+		{
+			return;
+		}
+		for (Map.Entry<String, long[]> entry : restored.entrySet())
+		{
+			long[] incoming = entry.getValue();
+			if (incoming == null || incoming.length < 2)
+			{
+				continue;
+			}
+			long[] current = marks.get(entry.getKey());
+			if (current == null)
+			{
+				marks.put(entry.getKey(), new long[]{incoming[FILLED], incoming[SPENT]});
+				continue;
+			}
+			marks.put(entry.getKey(), new long[]{
+				Math.max(current[FILLED], incoming[FILLED]),
+				Math.max(current[SPENT], incoming[SPENT])
+			});
+		}
+	}
+}

--- a/src/main/java/com/flipsmart/trading/FillWatermarks.java
+++ b/src/main/java/com/flipsmart/trading/FillWatermarks.java
@@ -35,6 +35,14 @@ public final class FillWatermarks
 	private static final int SPENT = 1;
 	private static final int FIRST_GENERATION = 1;
 
+	/**
+	 * Prefix marking a persisted slot generation rather than a fill mark. Without carrying
+	 * generation across a restart, a slot restarts at the first generation while marks from the
+	 * previous session survive, so a new order matching a slot's earliest use would adopt that
+	 * finished order's mark and have its fills suppressed.
+	 */
+	private static final String GENERATION_KEY_PREFIX = "gen:";
+
 	private final Map<String, long[]> marks = new HashMap<>();
 	private final Map<Integer, Integer> slotGeneration = new HashMap<>();
 
@@ -71,7 +79,14 @@ public final class FillWatermarks
 
 	public synchronized Map<String, long[]> export()
 	{
-		return new HashMap<>(marks);
+		Map<String, long[]> out = new HashMap<>(marks);
+		// Generation rides along in the same map so there is only ever one thing to keep fresh.
+		// An identity key carries four colon-separated fields, so this prefix cannot collide.
+		for (Map.Entry<Integer, Integer> entry : slotGeneration.entrySet())
+		{
+			out.put(GENERATION_KEY_PREFIX + entry.getKey(), new long[]{entry.getValue(), 0L});
+		}
+		return out;
 	}
 
 	/**
@@ -118,6 +133,11 @@ public final class FillWatermarks
 			{
 				continue;
 			}
+			if (entry.getKey().startsWith(GENERATION_KEY_PREFIX))
+			{
+				restoreGeneration(entry.getKey(), incoming[FILLED]);
+				continue;
+			}
 			long[] current = marks.get(entry.getKey());
 			if (current == null)
 			{
@@ -128,6 +148,20 @@ public final class FillWatermarks
 				Math.max(current[FILLED], incoming[FILLED]),
 				Math.max(current[SPENT], incoming[SPENT])
 			});
+		}
+	}
+
+	/** Adopt a persisted slot generation, keeping the later one so a slot never rewinds. */
+	private void restoreGeneration(String key, long persisted)
+	{
+		try
+		{
+			int slot = Integer.parseInt(key.substring(GENERATION_KEY_PREFIX.length()));
+			slotGeneration.put(slot, Math.max(generationFor(slot), (int) persisted));
+		}
+		catch (NumberFormatException e)
+		{
+			// A malformed key is not worth failing a restore over; the slot keeps its default.
 		}
 	}
 }

--- a/src/main/java/com/flipsmart/trading/FillWatermarks.java
+++ b/src/main/java/com/flipsmart/trading/FillWatermarks.java
@@ -75,6 +75,32 @@ public final class FillWatermarks
 	}
 
 	/**
+	 * Raise marks to the progress already recorded on {@code records}.
+	 *
+	 * <p>Clients upgrading from a build without marks have none persisted, so the first
+	 * observation of an in-flight order would measure against zero and re-report the whole
+	 * cumulative. The records themselves already carry the correct totals, so seeding from them
+	 * starts the marks in the right place. Terminal records are skipped: they are finished, and
+	 * no further observation of them can arrive.</p>
+	 */
+	public synchronized void seedFrom(java.util.Collection<com.flipsmart.domain.offer.OfferRecord> records)
+	{
+		if (records == null)
+		{
+			return;
+		}
+		for (com.flipsmart.domain.offer.OfferRecord r : records)
+		{
+			if (r == null || r.getSlot() == null || r.getState().isTerminal())
+			{
+				continue;
+			}
+			observe(OfferIdentity.of(r.getSlot(), r.getItemId(), r.isBuy(), generationFor(r.getSlot())),
+				r.getFilledQuantity(), r.getSpent());
+		}
+	}
+
+	/**
 	 * Fold restored marks in, keeping the higher of each pair. Never replaces: a snapshot
 	 * written before the current session's fills would otherwise rewind them, and the next
 	 * observation would re-report fills already sent.

--- a/src/main/java/com/flipsmart/trading/OfferIdentity.java
+++ b/src/main/java/com/flipsmart/trading/OfferIdentity.java
@@ -1,0 +1,68 @@
+package com.flipsmart.trading;
+
+import lombok.Getter;
+
+/**
+ * Identity of one Grand Exchange order.
+ *
+ * <p>Deliberately excludes price, total quantity and fill count. Those drift while an order is
+ * live — a partial buy re-reads a different total, a relist changes price — and keying on them
+ * made a still-live order fail to match itself. Generation separates successive orders that
+ * reuse the same slot, so a new order never inherits the previous one's progress.</p>
+ */
+@Getter
+public final class OfferIdentity
+{
+	private final int slot;
+	private final int itemId;
+	private final boolean buy;
+	private final int generation;
+
+	private OfferIdentity(int slot, int itemId, boolean buy, int generation)
+	{
+		this.slot = slot;
+		this.itemId = itemId;
+		this.buy = buy;
+		this.generation = generation;
+	}
+
+	public static OfferIdentity of(int slot, int itemId, boolean buy, int generation)
+	{
+		return new OfferIdentity(slot, itemId, buy, generation);
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o)
+		{
+			return true;
+		}
+		if (!(o instanceof OfferIdentity))
+		{
+			return false;
+		}
+		OfferIdentity other = (OfferIdentity) o;
+		return slot == other.slot
+			&& itemId == other.itemId
+			&& buy == other.buy
+			&& generation == other.generation;
+	}
+
+	@Override
+	public int hashCode()
+	{
+		int result = slot;
+		result = 31 * result + itemId;
+		result = 31 * result + (buy ? 1 : 0);
+		result = 31 * result + generation;
+		return result;
+	}
+
+	/** Stable string form, used as the persisted watermark key. */
+	@Override
+	public String toString()
+	{
+		return slot + ":" + itemId + ":" + (buy ? "b" : "s") + ":" + generation;
+	}
+}

--- a/src/main/java/com/flipsmart/trading/OfferStore.java
+++ b/src/main/java/com/flipsmart/trading/OfferStore.java
@@ -28,12 +28,12 @@ public final class OfferStore
     private final Map<Integer, Long> slotToOfferId = new HashMap<>();   // 0..7 -> offerId (live only)
     private long nextOfferId = 1;
     private final List<Consumer<OfferEvent>> listeners = new ArrayList<>();
-    private final FillWatermarks watermarks = new FillWatermarks();
+    private final FillWatermarks fillWatermarks = new FillWatermarks();
 
     /** The high-water fill marks backing every reported delta. Persisted alongside the records. */
     public FillWatermarks watermarks()
     {
-        return watermarks;
+        return fillWatermarks;
     }
 
     /** Register a listener to receive an {@link OfferEvent} after each successful state change. */
@@ -85,12 +85,12 @@ public final class OfferStore
             // reconcile against a stale snapshot; the mark cannot. Direction comes from the
             // record because a collect arrives as EMPTY, which reads as neither buy nor sell.
             OfferIdentity identity = OfferIdentity.of(
-                signal.slot, t.record.getItemId(), t.record.isBuy(), watermarks.generationFor(signal.slot));
-            FillWatermarks.Delta delta = watermarks.observe(identity, signal.quantitySold, signal.spent);
+                signal.slot, t.record.getItemId(), t.record.isBuy(), fillWatermarks.generationFor(signal.slot));
+            FillWatermarks.Delta delta = fillWatermarks.observe(identity, signal.quantitySold, signal.spent);
 
             if (t.record.getState().isTerminal())
             {
-                watermarks.advanceGeneration(signal.slot);
+                fillWatermarks.advanceGeneration(signal.slot);
             }
 
             event = new OfferEvent(t.kind, t.record, delta.quantity, delta.spent);
@@ -129,7 +129,7 @@ public final class OfferStore
             {
                 slotToOfferId.put(signal.slot, t.record.getOfferId());
             }
-            watermarks.seedFrom(Collections.singletonList(t.record));
+            fillWatermarks.seedFrom(Collections.singletonList(t.record));
             return true;
         }
     }
@@ -190,7 +190,7 @@ public final class OfferStore
         // A record entering the store carries progress that has already been reported. Raising the
         // marks to match keeps the next observation measuring the increment rather than re-reporting
         // the whole cumulative.
-        watermarks.seedFrom(records);
+        fillWatermarks.seedFrom(records);
     }
 
     /**

--- a/src/main/java/com/flipsmart/trading/OfferStore.java
+++ b/src/main/java/com/flipsmart/trading/OfferStore.java
@@ -27,6 +27,13 @@ public final class OfferStore
     private final Map<Integer, Long> slotToOfferId = new HashMap<>();   // 0..7 -> offerId (live only)
     private long nextOfferId = 1;
     private final List<Consumer<OfferEvent>> listeners = new ArrayList<>();
+    private final FillWatermarks watermarks = new FillWatermarks();
+
+    /** The high-water fill marks backing every reported delta. Persisted alongside the records. */
+    public FillWatermarks watermarks()
+    {
+        return watermarks;
+    }
 
     /** Register a listener to receive an {@link OfferEvent} after each successful state change. */
     public synchronized void addListener(Consumer<OfferEvent> listener)
@@ -72,7 +79,20 @@ public final class OfferStore
                 slotToOfferId.put(signal.slot, t.record.getOfferId());
             }
 
-            event = new OfferEvent(t.kind, t.record, t.newlyFilledQuantity, t.newlySpent);
+            // What the signal newly revealed, measured against the highest cumulative ever seen
+            // for this order rather than against the record. The record can be rewound by a
+            // reconcile against a stale snapshot; the mark cannot. Direction comes from the
+            // record because a collect arrives as EMPTY, which reads as neither buy nor sell.
+            OfferIdentity identity = OfferIdentity.of(
+                signal.slot, t.record.getItemId(), t.record.isBuy(), watermarks.generationFor(signal.slot));
+            FillWatermarks.Delta delta = watermarks.observe(identity, signal.quantitySold, signal.spent);
+
+            if (t.record.getState().isTerminal())
+            {
+                watermarks.advanceGeneration(signal.slot);
+            }
+
+            event = new OfferEvent(t.kind, t.record, delta.quantity, delta.spent);
             snapshot = new ArrayList<>(listeners);
         }
 
@@ -108,6 +128,7 @@ public final class OfferStore
             {
                 slotToOfferId.put(signal.slot, t.record.getOfferId());
             }
+            watermarks.seedFrom(Collections.singletonList(t.record));
             return true;
         }
     }
@@ -165,6 +186,10 @@ public final class OfferStore
             maxId = Math.max(maxId, r.getOfferId());
         }
         nextOfferId = maxId + 1;
+        // A record entering the store carries progress that has already been reported. Raising the
+        // marks to match keeps the next observation measuring the increment rather than re-reporting
+        // the whole cumulative.
+        watermarks.seedFrom(records);
     }
 
     /**

--- a/src/main/java/com/flipsmart/trading/OfferStore.java
+++ b/src/main/java/com/flipsmart/trading/OfferStore.java
@@ -14,6 +14,7 @@ import java.util.function.Consumer;
 
 import javax.inject.Singleton;
 
+
 /**
  * Single source of truth for offer state. Keyed by a monotonic offerId; indexed by slot
  * (event resolution) and item (consumer queries). The sole writer of offer state.

--- a/src/test/java/com/flipsmart/trading/FillWatermarksTest.java
+++ b/src/test/java/com/flipsmart/trading/FillWatermarksTest.java
@@ -1,0 +1,28 @@
+package com.flipsmart.trading;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class FillWatermarksTest
+{
+	@Test
+	public void identity_isValueEqual_andSeparatesGenerations()
+	{
+		OfferIdentity a = OfferIdentity.of(0, 4444, true, 1);
+		OfferIdentity b = OfferIdentity.of(0, 4444, true, 1);
+		OfferIdentity nextGen = OfferIdentity.of(0, 4444, true, 2);
+
+		assertEquals(a, b);
+		assertEquals(a.hashCode(), b.hashCode());
+		assertNotEquals("a reused slot holds a different offer", a, nextGen);
+	}
+
+	@Test
+	public void identity_ignoresDirectionCollisions()
+	{
+		assertNotEquals("a buy and a sell of one item are different offers",
+			OfferIdentity.of(0, 4444, true, 1), OfferIdentity.of(0, 4444, false, 1));
+	}
+}

--- a/src/test/java/com/flipsmart/trading/FillWatermarksTest.java
+++ b/src/test/java/com/flipsmart/trading/FillWatermarksTest.java
@@ -2,6 +2,9 @@ package com.flipsmart.trading;
 
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -24,5 +27,83 @@ public class FillWatermarksTest
 	{
 		assertNotEquals("a buy and a sell of one item are different offers",
 			OfferIdentity.of(0, 4444, true, 1), OfferIdentity.of(0, 4444, false, 1));
+	}
+
+	@Test
+	public void observe_returnsOnlyTheIncrement()
+	{
+		FillWatermarks watermarks = new FillWatermarks();
+		OfferIdentity id = OfferIdentity.of(0, 7777, true, 1);
+
+		assertEquals(4, watermarks.observe(id, 4, 400L).quantity);
+		assertEquals(3, watermarks.observe(id, 7, 700L).quantity);
+		assertEquals(300L, watermarks.observe(id, 10, 1000L).spent);
+	}
+
+	@Test
+	public void observe_isIdempotentOnReplay()
+	{
+		FillWatermarks watermarks = new FillWatermarks();
+		OfferIdentity id = OfferIdentity.of(0, 7777, true, 1);
+		watermarks.observe(id, 7, 700L);
+
+		// A login burst re-feeds the same cumulative; it carries no new information.
+		assertEquals(0, watermarks.observe(id, 7, 700L).quantity);
+		assertEquals(0L, watermarks.observe(id, 7, 700L).spent);
+	}
+
+	@Test
+	public void observe_neverRegressesOnALowerCumulative()
+	{
+		FillWatermarks watermarks = new FillWatermarks();
+		OfferIdentity id = OfferIdentity.of(0, 7777, true, 1);
+		watermarks.observe(id, 7, 700L);
+
+		assertEquals("a stale lower snapshot reports no fill", 0, watermarks.observe(id, 4, 400L).quantity);
+		assertEquals("and does not lower the mark", 0, watermarks.observe(id, 7, 700L).quantity);
+	}
+
+	@Test
+	public void advanceGeneration_startsAFreshBaselineForAReusedSlot()
+	{
+		FillWatermarks watermarks = new FillWatermarks();
+		OfferIdentity first = OfferIdentity.of(0, 7777, true, watermarks.generationFor(0));
+		watermarks.observe(first, 10, 1000L);
+
+		watermarks.advanceGeneration(0);
+		OfferIdentity second = OfferIdentity.of(0, 7777, true, watermarks.generationFor(0));
+
+		assertNotEquals(first, second);
+		assertEquals("a new order in a reused slot counts from zero",
+			5, watermarks.observe(second, 5, 500L).quantity);
+	}
+
+	@Test
+	public void mergeFrom_neverLowersAWatermark()
+	{
+		FillWatermarks watermarks = new FillWatermarks();
+		OfferIdentity id = OfferIdentity.of(0, 7777, true, 1);
+		watermarks.observe(id, 4, 400L);
+
+		// A persisted snapshot written before that fill. Restoring it must not rewind progress,
+		// or the next observation re-reports fills already sent.
+		Map<String, long[]> stale = new HashMap<>();
+		stale.put(id.toString(), new long[]{0L, 0L});
+		watermarks.mergeFrom(stale);
+
+		assertEquals("a stale restore cannot rewind the mark", 0, watermarks.observe(id, 4, 400L).quantity);
+	}
+
+	@Test
+	public void mergeFrom_adoptsMarksTheSessionHasNotSeen()
+	{
+		FillWatermarks watermarks = new FillWatermarks();
+		OfferIdentity id = OfferIdentity.of(0, 7777, true, 1);
+
+		Map<String, long[]> restored = new HashMap<>();
+		restored.put(id.toString(), new long[]{6L, 600L});
+		watermarks.mergeFrom(restored);
+
+		assertEquals("progress from a previous session is adopted", 1, watermarks.observe(id, 7, 700L).quantity);
 	}
 }

--- a/src/test/java/com/flipsmart/trading/FillWatermarksTest.java
+++ b/src/test/java/com/flipsmart/trading/FillWatermarksTest.java
@@ -95,6 +95,37 @@ public class FillWatermarksTest
 	}
 
 	@Test
+	public void generation_survivesARestart_soAReusedSlotDoesNotInheritAFinishedMark()
+	{
+		FillWatermarks before = new FillWatermarks();
+		OfferIdentity finished = OfferIdentity.of(0, 7777, true, before.generationFor(0));
+		before.observe(finished, 10, 1000L);
+		before.advanceGeneration(0);
+
+		// A restart: only what export() carries survives.
+		FillWatermarks after = new FillWatermarks();
+		after.mergeFrom(before.export());
+
+		OfferIdentity next = OfferIdentity.of(0, 7777, true, after.generationFor(0));
+		assertNotEquals("a new order must not reuse a finished order's identity", finished, next);
+		assertEquals("its fills must still be reported", 5, after.observe(next, 5, 500L).quantity);
+	}
+
+	@Test
+	public void generation_neverRewindsOnAStaleRestore()
+	{
+		FillWatermarks watermarks = new FillWatermarks();
+		watermarks.advanceGeneration(0);
+		watermarks.advanceGeneration(0);
+		int current = watermarks.generationFor(0);
+
+		// A snapshot written two turnovers ago must not roll the slot backwards.
+		watermarks.mergeFrom(new FillWatermarks().export());
+
+		assertEquals("generation only ever moves forward", current, watermarks.generationFor(0));
+	}
+
+	@Test
 	public void mergeFrom_adoptsMarksTheSessionHasNotSeen()
 	{
 		FillWatermarks watermarks = new FillWatermarks();

--- a/src/test/java/com/flipsmart/trading/SessionCorpusHarness.java
+++ b/src/test/java/com/flipsmart/trading/SessionCorpusHarness.java
@@ -1,0 +1,204 @@
+package com.flipsmart.trading;
+
+import com.flipsmart.ActiveFlipTracker;
+import com.flipsmart.GEHistoryService;
+import com.flipsmart.OfflineSyncService;
+import com.flipsmart.PlayerSession;
+import com.flipsmart.domain.offer.OfferSignal;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.runelite.api.Client;
+import net.runelite.api.GrandExchangeOffer;
+import net.runelite.api.GrandExchangeOfferState;
+import net.runelite.api.ItemComposition;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.game.ItemManager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Replays a session-corpus timeline through the real {@link OfferStore} and
+ * {@link OfflineSyncService}. Unlike the fill-level golden corpus, a timeline can express the
+ * session lifecycle — world hops, relogs and offline gaps — which is where retention and
+ * fill-accounting defects actually surface.
+ */
+final class SessionCorpusHarness
+{
+	private static final String CONFIG_GROUP = "flipsmart";
+	private static final int GE_SLOT_COUNT = 8;
+
+	static final class Result
+	{
+		final OfferStore store;
+		final List<OfferEvent> reportedFills;
+
+		Result(OfferStore store, List<OfferEvent> reportedFills)
+		{
+			this.store = store;
+			this.reportedFills = reportedFills;
+		}
+	}
+
+	private SessionCorpusHarness()
+	{
+		// Test helper - prevent instantiation
+	}
+
+	static Result run(JsonObject fixture)
+	{
+		// The services age records against the wall clock, so timeline offsets anchor to it.
+		long base = System.currentTimeMillis();
+		String rsn = fixture.has("rsn") ? fixture.get("rsn").getAsString() : "TestPlayer";
+
+		OfferStore store = new OfferStore();
+		List<OfferEvent> fills = new ArrayList<>();
+		store.addListener(e ->
+		{
+			if (e.newlyFilledQuantity > 0)
+			{
+				fills.add(e);
+			}
+		});
+
+		PlayerSession session = mock(PlayerSession.class);
+		when(session.getRsn()).thenReturn(rsn);
+		when(session.getCollectedItemIds()).thenReturn(Collections.emptySet());
+
+		Map<String, String> configStore = new HashMap<>();
+		ConfigManager configManager = mock(ConfigManager.class);
+		doAnswer(inv ->
+		{
+			configStore.put(inv.getArgument(1), inv.getArgument(2));
+			return null;
+		}).when(configManager).setConfiguration(eq(CONFIG_GROUP), anyString(), any());
+		doAnswer(inv ->
+		{
+			configStore.remove(inv.<String>getArgument(1));
+			return null;
+		}).when(configManager).unsetConfiguration(eq(CONFIG_GROUP), anyString());
+		when(configManager.getConfiguration(eq(CONFIG_GROUP), anyString()))
+			.thenAnswer(inv -> configStore.get(inv.<String>getArgument(1)));
+
+		Client client = mock(Client.class);
+		ClientThread clientThread = mock(ClientThread.class);
+		doAnswer(inv ->
+		{
+			inv.<Runnable>getArgument(0).run();
+			return null;
+		}).when(clientThread).invokeLater(any(Runnable.class));
+
+		// Stubbed up front: building a mock inside a when(...) argument throws
+		// UnfinishedStubbingException.
+		ItemComposition anyComposition = mock(ItemComposition.class);
+		when(anyComposition.getName()).thenReturn("item");
+		ItemManager itemManager = mock(ItemManager.class);
+		when(itemManager.getItemComposition(anyInt())).thenReturn(anyComposition);
+
+		OfflineSyncService service = new OfflineSyncService(
+			session,
+			configManager,
+			new Gson(),
+			client,
+			clientThread,
+			mock(ActiveFlipTracker.class),
+			mock(GEHistoryService.class),
+			store,
+			itemManager,
+			new RoundTripLedger());
+
+		for (JsonElement element : fixture.getAsJsonArray("timeline"))
+		{
+			applyEvent(element.getAsJsonObject(), base, store, service, client);
+		}
+		return new Result(store, fills);
+	}
+
+	private static void applyEvent(JsonObject event, long base, OfferStore store,
+		OfflineSyncService service, Client client)
+	{
+		long at = base + event.get("at_seconds").getAsLong() * 1000L;
+		String type = event.get("type").getAsString();
+
+		if ("observe".equals(type))
+		{
+			store.apply(toSignal(event), at);
+			return;
+		}
+
+		// A hop and a relog both persist then preload; only a relog loses the in-memory store.
+		service.persistOfferState();
+		if ("relog".equals(type))
+		{
+			store.importRecords(Collections.emptyList());
+		}
+		// Built before the stubbing call: creating mocks inside a when(...) argument throws
+		// UnfinishedStubbingException.
+		GrandExchangeOffer[] snapshot = toSnapshot(event);
+		when(client.getGrandExchangeOffers()).thenReturn(snapshot);
+		service.preloadPersistedOffers();
+	}
+
+	private static OfferSignal toSignal(JsonObject e)
+	{
+		int itemId = e.get("item_id").getAsInt();
+		return new OfferSignal(
+			e.get("slot").getAsInt(),
+			GrandExchangeOfferState.valueOf(e.get("state").getAsString()),
+			itemId,
+			"i" + itemId,
+			e.get("total").getAsInt(),
+			e.get("price").getAsInt(),
+			e.get("sold").getAsInt(),
+			e.get("spent").getAsLong());
+	}
+
+	/**
+	 * The GE snapshot as the client would report it: {@code null} when it is not readable yet,
+	 * otherwise a full-length array whose unused slots read EMPTY.
+	 */
+	private static GrandExchangeOffer[] toSnapshot(JsonObject event)
+	{
+		if (event.has("ge_readable") && !event.get("ge_readable").getAsBoolean())
+		{
+			return null;
+		}
+
+		GrandExchangeOffer empty = mock(GrandExchangeOffer.class);
+		when(empty.getState()).thenReturn(GrandExchangeOfferState.EMPTY);
+		GrandExchangeOffer[] slots = new GrandExchangeOffer[GE_SLOT_COUNT];
+		Arrays.fill(slots, empty);
+
+		JsonArray live = event.has("live_slots")
+			? event.getAsJsonArray("live_slots") : new JsonArray();
+		for (JsonElement element : live)
+		{
+			JsonObject s = element.getAsJsonObject();
+			GrandExchangeOffer offer = mock(GrandExchangeOffer.class);
+			when(offer.getState())
+				.thenReturn(GrandExchangeOfferState.valueOf(s.get("state").getAsString()));
+			when(offer.getItemId()).thenReturn(s.get("item_id").getAsInt());
+			when(offer.getTotalQuantity()).thenReturn(s.get("total").getAsInt());
+			when(offer.getPrice()).thenReturn(s.get("price").getAsInt());
+			when(offer.getQuantitySold()).thenReturn(s.get("sold").getAsInt());
+			when(offer.getSpent()).thenReturn(s.get("spent").getAsInt());
+			slots[s.get("slot").getAsInt()] = offer;
+		}
+		return slots;
+	}
+}

--- a/src/test/java/com/flipsmart/trading/SessionCorpusHarness.java
+++ b/src/test/java/com/flipsmart/trading/SessionCorpusHarness.java
@@ -142,7 +142,12 @@ final class SessionCorpusHarness
 		}
 
 		// A hop and a relog both persist then preload; only a relog loses the in-memory store.
-		service.persistOfferState();
+		// "persist": false models the window where the RSN cannot be resolved and the newer
+		// store state never reaches disk, so the preload reattaches an older persisted record.
+		if (!event.has("persist") || event.get("persist").getAsBoolean())
+		{
+			service.persistOfferState();
+		}
 		if ("relog".equals(type))
 		{
 			store.importRecords(Collections.emptyList());

--- a/src/test/java/com/flipsmart/trading/SessionCorpusTest.java
+++ b/src/test/java/com/flipsmart/trading/SessionCorpusTest.java
@@ -1,0 +1,148 @@
+package com.flipsmart.trading;
+
+import com.flipsmart.util.BuyPriceLookup;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Session-corpus regression harness.
+ *
+ * <p>Replays each fixture's {@code timeline} — slot observations interleaved with hops and
+ * relogs — through the real offer store and offline-sync service, then asserts the fixture's
+ * {@code expect} block. Complements the fill-level golden corpus, which cannot express the
+ * session lifecycle.</p>
+ *
+ * <p>Adding a case is one file: drop the JSON into {@code src/test/resources/session_corpus/};
+ * it is auto-discovered.</p>
+ */
+@RunWith(Parameterized.class)
+public class SessionCorpusTest
+{
+	private static final Path FIXTURES_DIR = Paths.get("src", "test", "resources", "session_corpus");
+	private static final Gson GSON = new Gson();
+
+	private final String name;
+	private final JsonObject fixture;
+
+	public SessionCorpusTest(String name, JsonObject fixture)
+	{
+		this.name = name;
+		this.fixture = fixture;
+	}
+
+	@Parameterized.Parameters(name = "{0}")
+	public static List<Object[]> fixtures() throws IOException
+	{
+		List<Object[]> cases = new ArrayList<>();
+		try (DirectoryStream<Path> stream = Files.newDirectoryStream(FIXTURES_DIR, "*.json"))
+		{
+			for (Path path : stream)
+			{
+				try (Reader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8))
+				{
+					JsonObject obj = GSON.fromJson(reader, JsonObject.class);
+					String name = obj.has("name")
+						? obj.get("name").getAsString() : path.getFileName().toString();
+					cases.add(new Object[]{name, obj});
+				}
+			}
+		}
+		cases.sort((a, b) -> ((String) a[0]).compareTo((String) b[0]));
+		return cases;
+	}
+
+	@Test
+	public void corpusIsNonTrivial()
+	{
+		// Guards against a silently-empty resource dir masking a green run.
+		assertTrue("[" + name + "] fixture must carry a timeline", fixture.has("timeline"));
+	}
+
+	@Test
+	public void timelineMatchesExpectations()
+	{
+		Assume.assumeFalse("known failure pending absolute-merge",
+			fixture.has("known_failure") && fixture.get("known_failure").getAsBoolean());
+
+		SessionCorpusHarness.Result result = SessionCorpusHarness.run(fixture);
+		JsonObject expect = fixture.getAsJsonObject("expect");
+
+		assertBuyBasis(expect, result);
+		assertLiveSlots(expect, result);
+		assertReportedFills(expect, result);
+	}
+
+	private void assertBuyBasis(JsonObject expect, SessionCorpusHarness.Result result)
+	{
+		if (!expect.has("buy_basis"))
+		{
+			return;
+		}
+		for (Map.Entry<String, JsonElement> e : expect.getAsJsonObject("buy_basis").entrySet())
+		{
+			int itemId = Integer.parseInt(e.getKey());
+			Integer basis = BuyPriceLookup.findAverageBuyPriceWithFallback(
+				null, result.store.forItem(itemId), itemId);
+			assertEquals("[" + name + "] buy basis for item " + itemId,
+				Integer.valueOf(e.getValue().getAsInt()), basis);
+		}
+	}
+
+	private void assertLiveSlots(JsonObject expect, SessionCorpusHarness.Result result)
+	{
+		if (!expect.has("live_slot_items"))
+		{
+			return;
+		}
+		for (Map.Entry<String, JsonElement> e : expect.getAsJsonObject("live_slot_items").entrySet())
+		{
+			int slot = Integer.parseInt(e.getKey());
+			assertNotNull("[" + name + "] slot " + slot + " must hold a live record",
+				result.store.bySlot(slot));
+			assertEquals("[" + name + "] item in slot " + slot,
+				e.getValue().getAsInt(), result.store.bySlot(slot).getItemId());
+		}
+	}
+
+	private void assertReportedFills(JsonObject expect, SessionCorpusHarness.Result result)
+	{
+		if (!expect.has("reported_fills"))
+		{
+			return;
+		}
+		List<String> actual = new ArrayList<>();
+		for (OfferEvent event : result.reportedFills)
+		{
+			actual.add(event.record.getItemId() + ":" + event.record.isBuy()
+				+ ":" + event.newlyFilledQuantity);
+		}
+		List<String> wanted = new ArrayList<>();
+		for (JsonElement element : expect.getAsJsonArray("reported_fills"))
+		{
+			JsonObject f = element.getAsJsonObject();
+			wanted.add(f.get("item_id").getAsInt() + ":" + f.get("is_buy").getAsBoolean()
+				+ ":" + f.get("quantity").getAsInt());
+		}
+		assertEquals("[" + name + "] reported fills", wanted, actual);
+	}
+}

--- a/src/test/resources/session_corpus/01-hop-preserves-collected-buy-basis.json
+++ b/src/test/resources/session_corpus/01-hop-preserves-collected-buy-basis.json
@@ -1,0 +1,22 @@
+{
+  "name": "hop-preserves-collected-buy-basis",
+  "description": "A collected buy is the cost basis for the sell that follows it. LOGGED_IN fires on every world hop, so a reconcile that drops terminal history erases breakeven and profit mid-session with no logout.",
+  "rsn": "TestPlayer",
+  "timeline": [
+    {"at_seconds": -300, "type": "observe", "slot": 0, "state": "BUYING",  "item_id": 4444, "total": 10, "price": 100, "sold": 0,  "spent": 0},
+    {"at_seconds": -200, "type": "observe", "slot": 0, "state": "BOUGHT",  "item_id": 4444, "total": 10, "price": 100, "sold": 10, "spent": 1000},
+    {"at_seconds": -100, "type": "observe", "slot": 0, "state": "EMPTY",   "item_id": 4444, "total": 10, "price": 100, "sold": 10, "spent": 1000},
+    {"at_seconds": -50,  "type": "observe", "slot": 1, "state": "SELLING", "item_id": 5555, "total": 10, "price": 300, "sold": 0,  "spent": 0},
+    {"at_seconds": 0,    "type": "hop", "ge_readable": true,
+      "live_slots": [
+        {"slot": 1, "state": "SELLING", "item_id": 5555, "total": 10, "price": 300, "sold": 0, "spent": 0}
+      ]}
+  ],
+  "expect": {
+    "buy_basis": {"4444": 100},
+    "live_slot_items": {"1": 5555},
+    "reported_fills": [
+      {"item_id": 4444, "is_buy": true, "quantity": 10}
+    ]
+  }
+}

--- a/src/test/resources/session_corpus/02-hop-unreadable-snapshot-preserves-live.json
+++ b/src/test/resources/session_corpus/02-hop-unreadable-snapshot-preserves-live.json
@@ -1,0 +1,15 @@
+{
+  "name": "hop-unreadable-snapshot-preserves-live",
+  "description": "At the LOGGED_IN tick after a world hop the GE array is typically present but every slot still reads EMPTY. A destructive import against that snapshot wipes live offers and nothing re-seeds the slot map until the next fill, so borders, timers and the active-flips panel all blank together.",
+  "rsn": "TestPlayer",
+  "timeline": [
+    {"at_seconds": -200, "type": "observe", "slot": 0, "state": "BUYING",  "item_id": 1234, "total": 10, "price": 100, "sold": 0, "spent": 0},
+    {"at_seconds": -150, "type": "observe", "slot": 3, "state": "SELLING", "item_id": 8888, "total": 20, "price": 500, "sold": 0, "spent": 0},
+    {"at_seconds": -100, "type": "hop", "ge_readable": true, "live_slots": []},
+    {"at_seconds": 0,    "type": "hop", "ge_readable": false}
+  ],
+  "expect": {
+    "live_slot_items": {"0": 1234, "3": 8888},
+    "reported_fills": []
+  }
+}

--- a/src/test/resources/session_corpus/03-relog-does-not-recount-offline-fill.json
+++ b/src/test/resources/session_corpus/03-relog-does-not-recount-offline-fill.json
@@ -1,0 +1,20 @@
+{
+  "name": "relog-does-not-recount-offline-fill",
+  "description": "A buy fills to 4/10, the player logs out, and 3 more fill while away. On relog the client reports the cumulative 7. Only the 3-unit offline delta is new information; reporting 7 re-counts the 4 already sent. The fill delta is computed against the in-memory record, so when a relog leaves no record the baseline reads 0 and the whole cumulative re-reports.",
+  "rsn": "TestPlayer",
+  "timeline": [
+    {"at_seconds": -600, "type": "observe", "slot": 0, "state": "BUYING", "item_id": 7777, "total": 10, "price": 100, "sold": 0, "spent": 0},
+    {"at_seconds": -500, "type": "observe", "slot": 0, "state": "BUYING", "item_id": 7777, "total": 10, "price": 100, "sold": 4, "spent": 400},
+    {"at_seconds": -100, "type": "relog", "ge_readable": true,
+      "live_slots": [
+        {"slot": 0, "state": "BUYING", "item_id": 7777, "total": 10, "price": 100, "sold": 7, "spent": 700}
+      ]},
+    {"at_seconds": 0, "type": "observe", "slot": 0, "state": "BUYING", "item_id": 7777, "total": 10, "price": 100, "sold": 7, "spent": 700}
+  ],
+  "expect": {
+    "reported_fills": [
+      {"item_id": 7777, "is_buy": true, "quantity": 4},
+      {"item_id": 7777, "is_buy": true, "quantity": 3}
+    ]
+  }
+}

--- a/src/test/resources/session_corpus/04-stale-persistence-recounts-fills.json
+++ b/src/test/resources/session_corpus/04-stale-persistence-recounts-fills.json
@@ -1,8 +1,6 @@
 {
   "name": "stale-persistence-recounts-fills",
   "description": "A buy is persisted at 0 filled, then fills to 4 in session. The next persist is skipped (the RSN is unresolvable during the logout window), so the preload reattaches the stale 0-filled record and the running total resets. The following observation of cumulative 4 then re-reports fills already sent, because the delta is computed against whatever record is in the store rather than against the highest cumulative ever seen.",
-  "known_failure": true,
-  "measured_today": ["7777:true:4", "7777:true:4"],
   "rsn": "TestPlayer",
   "timeline": [
     {"at_seconds": -600, "type": "observe", "slot": 0, "state": "BUYING", "item_id": 7777, "total": 10, "price": 100, "sold": 0, "spent": 0},

--- a/src/test/resources/session_corpus/04-stale-persistence-recounts-fills.json
+++ b/src/test/resources/session_corpus/04-stale-persistence-recounts-fills.json
@@ -1,0 +1,25 @@
+{
+  "name": "stale-persistence-recounts-fills",
+  "description": "A buy is persisted at 0 filled, then fills to 4 in session. The next persist is skipped (the RSN is unresolvable during the logout window), so the preload reattaches the stale 0-filled record and the running total resets. The following observation of cumulative 4 then re-reports fills already sent, because the delta is computed against whatever record is in the store rather than against the highest cumulative ever seen.",
+  "known_failure": true,
+  "measured_today": ["7777:true:4", "7777:true:4"],
+  "rsn": "TestPlayer",
+  "timeline": [
+    {"at_seconds": -600, "type": "observe", "slot": 0, "state": "BUYING", "item_id": 7777, "total": 10, "price": 100, "sold": 0, "spent": 0},
+    {"at_seconds": -500, "type": "hop", "persist": true, "ge_readable": true,
+      "live_slots": [
+        {"slot": 0, "state": "BUYING", "item_id": 7777, "total": 10, "price": 100, "sold": 0, "spent": 0}
+      ]},
+    {"at_seconds": -400, "type": "observe", "slot": 0, "state": "BUYING", "item_id": 7777, "total": 10, "price": 100, "sold": 4, "spent": 400},
+    {"at_seconds": -100, "type": "hop", "persist": false, "ge_readable": true,
+      "live_slots": [
+        {"slot": 0, "state": "BUYING", "item_id": 7777, "total": 10, "price": 100, "sold": 4, "spent": 400}
+      ]},
+    {"at_seconds": 0, "type": "observe", "slot": 0, "state": "BUYING", "item_id": 7777, "total": 10, "price": 100, "sold": 4, "spent": 400}
+  ],
+  "expect": {
+    "reported_fills": [
+      {"item_id": 7777, "is_buy": true, "quantity": 4}
+    ]
+  }
+}

--- a/src/test/resources/session_corpus/README.md
+++ b/src/test/resources/session_corpus/README.md
@@ -1,0 +1,66 @@
+# Session-corpus fixtures (plugin-owned)
+
+These fixtures replay a **session timeline** — GE slot observations interleaved with world hops
+and relogs — through the real `OfferStore` and `OfflineSyncService`, and assert what the store
+retained and what fills were reported downstream.
+
+## How this differs from `golden_corpus/`
+
+| | `golden_corpus/` | `session_corpus/` (here) |
+|---|---|---|
+| Ownership | **Shared with the backend**, kept byte-identical | Plugin-only |
+| Event unit | Already-reduced fills | Raw slot observations + lifecycle events |
+| Replayed through | `RoundTripLedger` | `OfferStore` + `OfflineSyncService` |
+| Can express a hop / relog / offline gap | No | Yes |
+
+Do **not** move cases between the two directories. The golden corpus is kept identical with the
+backend's copies, so plugin-only lifecycle events cannot go there. Retention and fill-accounting
+defects live in the session lifecycle, which is why they need their own corpus.
+
+## Fixture schema
+
+```jsonc
+{
+  "name": "kebab-case-name",          // test display name
+  "description": "why this case exists",
+  "rsn": "TestPlayer",                 // optional, defaults to TestPlayer
+  "known_failure": true,               // optional; skips assertions, for a pinned defect
+  "timeline": [ /* events, applied in order */ ],
+  "expect": { /* all keys optional */ }
+}
+```
+
+### Timeline events
+
+`at_seconds` is relative to a wall-clock base captured when the fixture runs. It must be
+relative: the services age records against `System.currentTimeMillis()`, so absolute
+small values fall outside every retention window and get silently dropped.
+
+- **`observe`** — one `GrandExchangeOfferChanged`. Fields: `slot`, `state` (a
+  `GrandExchangeOfferState` name), `item_id`, `total`, `price`, `sold`, `spent`.
+  `sold` and `spent` are **cumulative**, exactly as the client reports them.
+- **`hop`** — persist, then preload against the given snapshot. The store is *not* cleared.
+- **`relog`** — the same, but the in-memory store is cleared first, simulating a fresh JVM.
+
+Both `hop` and `relog` take:
+- `ge_readable: false` — `getGrandExchangeOffers()` returns `null` (snapshot not loaded yet)
+- `live_slots: []` with `ge_readable: true` — a non-null array where every slot reads `EMPTY`
+
+Those two are **different states** and must be tested separately: a world hop presents as
+non-null-all-EMPTY at the `LOGGED_IN` tick, not as null.
+
+### Expectations
+
+- **`buy_basis`** — `{itemId: expectedAverageBuyPrice}` via `BuyPriceLookup`. Asserts the cost
+  basis a sell screen would render.
+- **`live_slot_items`** — `{slot: itemId}` still live in the store.
+- **`reported_fills`** — every `OfferEvent` carrying a fill, in order, as
+  `{item_id, is_buy, quantity}`. **This is the over/under-count assertion.**
+
+## Writing a fixture: three traps
+
+1. **A collect only terminalizes a filled offer.** `BUYING → EMPTY` is silently rejected and the
+   record stays `NEW`. Write `BUYING → BOUGHT → EMPTY`.
+2. **Anchor times to the wall clock** via `at_seconds` (see above).
+3. **`sold`/`spent` are cumulative, not per-event increments.** A partial fill of 4 then 3 more
+   is `sold: 4` followed by `sold: 7`.


### PR DESCRIPTION
Stacked on #220 — review that first. Base retargets to `master` automatically when #220 merges.

## Why

Fill deltas reported to the backend were computed as `signal.quantitySold - base.getFilledQuantity()`, where `base` is the record in the `OfferStore`. That makes the result depend on the record surviving, and it doesn't always: any path that skips a persist lets the reconcile reattach a **stale** record, silently resetting the running total so the next observation re-reports fills already sent.

Measured, not theorised: 4 units reported twice — a 100% over-count on that position.

## What changed

**Session corpus** (`src/test/resources/session_corpus/`) — a plugin-owned fixture set replaying slot observations interleaved with hops and relogs through the real `OfferStore` and `OfflineSyncService`. The existing `golden_corpus/` is kept byte-identical with the backend and its events are already-reduced fills, so it cannot express a snapshot, a hop, or an offline gap — which is why it caught neither the offer-store wipe nor the collected-basis drop. The two corpora are deliberately separate; see the README.

**`FillWatermarks` + `OfferIdentity`** — the highest cumulative ever observed per order, keyed by `(slot, itemId, buy, generation)`. Deltas measure against the mark, not the record. Marks only ever rise, so a stale restore can add knowledge but never remove it. Identity excludes price, total and fill count because those legitimately drift while an order is live.

Three properties that are load-bearing and each cost a bug to find:

1. **Restore merges by max, never replaces.** A `clear() + putAll()` restore reproduces the exact bug being fixed.
2. **Identity direction comes from the record, not the signal.** A collect arrives as `EMPTY`, which `OfferSignal.isBuy()` reads as a *sell* — keying on the signal splits one order across two identities and fabricates a fill on every collect.
3. **Every entry point raises the marks** (`apply`, `importRecords`, `seedIfAbsent`). Wiring only `apply` made two existing tests fail *worse than baseline*, reporting full cumulative instead of a delta, because the other two install records without passing through it.

**Upgrade path.** Clients upgrading have no saved marks, so the first observation of an in-flight order would measure against zero and re-report its whole cumulative. Marks are seeded from the persisted `OfferRecord`s, which already carry correct totals.

## Tests

`./gradlew test check` — **798 tests, 0 failures, 0 skipped.**

## In-game QA (dumbridge3, real client, temporary instrumentation since reverted)

| Scenario | Result |
|---|---|
| Upgrade path — existing persisted state, no saved marks | ✅ Seeded from records; no mass over-count |
| Offline gap across a full logout/login | ✅ Exact: 11000−7817=3183, 798−45=753 |
| Breakeven/profit on the sell screen after a relog reconcile | ✅ Real numbers, no `?` |
| Collects and cancels | ✅ Every one reported `delta=0` — no double-counting |
| Slot reuse | ✅ Generation advanced across 4 turnovers; reused slots never inherited a finished order's mark |

The relog case is the important one: the reconcile logged `30 terminal history retained`, so the cost basis went **through** the destructive import path and the sell screen still resolved it afterwards.

## Known gaps

- **Strict same-item, same-direction slot rebuy is untested.** Every observed reuse also flipped direction (`b:1` → `s:2`), so identity differed on two axes at once. Generation demonstrably advances, but that specific isolation wasn't exercised.
- **The GE slot-hover `Profit:` line wasn't visually confirmed** in this pass. It reads the same `BuyPriceLookup` path as the offer screen, which was confirmed.

## Related

Does not close an issue. Relevant to #1091 (basis averaging across closed cycles — a cycle-scoped fold in a later stage closes it), #1116 (overlapping buy/sell is a cycle-identity problem), and #1097 (this is plausibly the mechanism behind that residual drift, so it likely is **not** obsolete).

### 🩺 Codacy Quality Gate — fixed in this PR
- `3f43711` `PMD_AvoidFieldNameMatchingMethodName` `src/main/java/com/flipsmart/trading/OfferStore.java:31` — renamed the field to `fillWatermarks`; the public `watermarks()` accessor keeps its name
- `2422b7d` (real defect, not a gate finding) `FillWatermarks.slotGeneration` is now persisted alongside the fill marks under a reserved `"gen:"` key in the same `Map<String, long[]>`, restored with `Math.max` so a slot generation never rewinds — closes the deferred item below

### 🩺 Codacy Quality Gate — dismissed via API (noise)
- `PMD_AvoidSynchronizedAtMethodLevel` ×6 `FillWatermarks.java` (`observe`, `generationFor`, `advanceGeneration`, `export`, `seedFrom`, `mergeFrom`) — method-level `synchronized` on this class is deliberate; every mutable field is only ever touched from inside these monitors
- `PMD_UseConcurrentHashMap` ×7 (`FillWatermarks.java:38,39`, `OfflineSyncService.java:515`, `SessionCorpusHarness.java:83`, `FillWatermarksTest.java:90,103`) — the two production sites are already fully guarded by the class's own synchronized methods (a concurrent map adds nothing there); the rest are method-local test variables never shared across threads
- `PMD_AvoidInstantiatingObjectsInLoops` ×2 `FillWatermarks.java:124,127` — `mergeFrom` genuinely needs one new `long[]` per restored entry; there is no shared instance to hoist
- `PMD_GuardLogStatement` ×2 `OfflineSyncService.java:496,521` — both are parameterized SLF4J `log.error` calls (already lazy); a level guard adds no value on error-level logging
- `PMD_ReturnEmptyCollectionRatherThanNull` `SessionCorpusHarness.java:184` — the `null` return simulates the client API's actual behavior when the GE snapshot isn't readable yet (see fixture `02-hop-unreadable-snapshot-preserves-live.json`); returning an empty array would erase that test case
- `Lizard_nloc-medium` `SessionCorpusHarness.java:63` — test-harness mock-setup method; expected shape for this kind of fixture, not production complexity
- `PMD_UseConcurrentHashMap` `FillWatermarks.java:82` (new in `2422b7d`) — `export()`'s local `out` copy is built and returned entirely inside a `synchronized` method; no concurrent access reaches it before or after the lock
- `PMD_AvoidInstantiatingObjectsInLoops` `FillWatermarks.java:87` (new in `2422b7d`) — one `long[]` per generation entry when folding `slotGeneration` into the exported map; same shape as the `mergeFrom` dismissal above, and the `long[]` pairing is the established Gson serialization contract
- `PMD_EmptyCatchBlock` `FillWatermarks.java:162` (new in `2422b7d`) — `restoreGeneration`'s `catch (NumberFormatException e)` deliberately swallows a malformed key rather than failing the whole restore; already carries an explanatory comment, PMD's default rule config just doesn't recognize commented blocks as intentional

### 🤖 Codacy AI Reviewer — fixed in this PR
- `3f43711` `OfferStore.java:31` — renamed the `watermarks` field to `fillWatermarks` to stop it shadowing the `watermarks()` accessor
- `929d9b5` `OfflineSyncService.java:496` — pass the caught exception to `log.error` instead of manually stringifying `e.getMessage()`, so SLF4J captures the stack trace
- `e418065` `OfflineSyncService.java:516` — use the already-imported `TypeToken` instead of the fully-qualified name
- `2422b7d` `FillWatermarks.java:39` — persisted `slotGeneration` (see Quality Gate entry above), closing the item previously tracked below as deferred

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `SessionCorpusHarness.java:184` — the `null` return is intentional test data (see Quality Gate dismissal above), not an oversight
- `SessionCorpusHarness.java:153` — a relog doesn't recreate the plugin's Guice singletons in production, so keeping the same `OfferStore` instance across a simulated relog is accurate, not a test gap
- `FillWatermarks.java:39` (partial) — the ConcurrentHashMap / block-level-synchronization portion of this comment is rejected as intentional (see Quality Gate dismissals); only the persistence gap (now fixed in `2422b7d`) was accepted as legitimate


