### PR TITLE
fix(ge): decouple slot rendering from the durable store, and stop cancel prompts for cancelled offers

### DIFF
--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -2005,16 +2005,16 @@ public class AutoRecommendService
 		addToStaleQueue(offer);
 	}
 
-	/**
-	 * Add a tracked offer to the stale queue if not already present.
-	 * If the queue was empty, immediately shows the first prompt.
-	 */
 	/** Current stale-queue depth. */
 	int staleOfferCount()
 	{
 		return staleOffers.size();
 	}
 
+	/**
+	 * Add a tracked offer to the stale queue if not already present.
+	 * If the queue was empty, immediately shows the first prompt.
+	 */
 	void addToStaleQueue(OfferRecord offer)
 	{
 		if (offer.getState() == OfferState.CANCELLED_PARTIAL)

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -2009,8 +2009,22 @@ public class AutoRecommendService
 	 * Add a tracked offer to the stale queue if not already present.
 	 * If the queue was empty, immediately shows the first prompt.
 	 */
+	/** Current stale-queue depth. */
+	int staleOfferCount()
+	{
+		return staleOffers.size();
+	}
+
 	void addToStaleQueue(OfferRecord offer)
 	{
+		if (offer.getState() == OfferState.CANCELLED_PARTIAL)
+		{
+			// Cancelled but still occupying its slot until the player collects, so it reads as
+			// live. There is nothing left to cancel, and the resolver already produces the
+			// collect that is the only remaining action.
+			return;
+		}
+
 		if (skipCooldown.isCoolingDown(offer.getItemId()))
 		{
 			// Snoozed by a recent skip — don't re-prompt until the cooldown lifts.

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -720,7 +720,11 @@ public class FlipSmartPlugin extends Plugin
 		return calculateCompetitiveness(record.getItemId(), record.getPrice(), record.isBuy());
 	}
 
-	private OfferCompetitiveness calculateCompetitiveness(int itemId, int price, boolean isBuy)
+	/**
+	 * Competitiveness from the three facts a price check actually needs. The GE slot reports all
+	 * of them, so a render pass can decide a border without a tracked record existing.
+	 */
+	public OfferCompetitiveness calculateCompetitiveness(int itemId, int price, boolean isBuy)
 	{
 		// Try to get real-time wiki prices first
 		WikiPrice wikiPrice = apiClient.getWikiPrice(itemId);

--- a/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
+++ b/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
@@ -207,8 +207,10 @@ public class GeSlotWidgetDecorator
                 continue;
             }
 
+            // The record is needed for the timer only — the client cannot say when an offer was
+            // placed — so a missing one degrades to a bare label, not a bare slot.
             OfferRecord tracked = plugin.getOfferStore().bySlot(slot);
-            reconcileBorder(slotWidget, slot, tracked, bordersOn);
+            reconcileBorder(slotWidget, slot, offer, bordersOn);
             if (decorate)
             {
                 applyStateText(slot, slotWidget, offer, tracked, timersOn);
@@ -320,15 +322,19 @@ public class GeSlotWidgetDecorator
         }
     }
 
-    private void reconcileBorder(Widget slotWidget, int slot, OfferRecord tracked, boolean bordersOn)
+    void reconcileBorder(Widget slotWidget, int slot, GrandExchangeOffer offer, boolean bordersOn)
     {
         if (!bordersOn)
         {
             revertBorder(slot, slotWidget);
             return;
         }
-        java.util.Optional<SlotBorderTint> tint =
-            SlotBorderTint.forOffer(plugin.calculateCompetitiveness(tracked), config.colorblindMode());
+        // Tint from the live slot rather than the tracked record: the check needs only item,
+        // price and direction, so a gap in the store costs the timer but never the border.
+        java.util.Optional<SlotBorderTint> tint = SlotBorderTint.forOffer(
+            plugin.calculateCompetitiveness(
+                offer.getItemId(), offer.getPrice(), OfferSignal.isBuyState(offer.getState())),
+            config.colorblindMode());
         if (tint.isPresent())
         {
             applyBorder(slot, slotWidget, tint.get());

--- a/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
+++ b/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
@@ -2,7 +2,6 @@ package com.flipsmart;
 
 import com.flipsmart.domain.offer.OfferRecord;
 import com.flipsmart.domain.offer.OfferSignal;
-import com.flipsmart.trading.OfferEventMapper;
 import com.flipsmart.trading.OfferStore;
 import com.flipsmart.util.TimeUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -189,8 +188,6 @@ public class GeSlotWidgetDecorator
         {
             return;
         }
-        seedStoreFromLiveOffers(offers);
-
         for (int slot = 0; slot < Math.min(offers.length, GE_MAX_SLOTS); slot++)
         {
             Widget slotWidget = client.getWidget(GE_INTERFACE_GROUP, SLOT_CONTAINER_START + slot);
@@ -219,30 +216,6 @@ public class GeSlotWidgetDecorator
             {
                 revertStateText(slot, slotWidget);
             }
-        }
-    }
-
-    // Re-seed any live slot the store has lost track of, so borders/timers (which read
-    // bySlot) recover on the next render tick instead of waiting for the next fill event.
-    void seedStoreFromLiveOffers(GrandExchangeOffer[] offers)
-    {
-        OfferStore store = plugin.getOfferStore();
-        long now = System.currentTimeMillis();
-        for (int slot = 0; slot < Math.min(offers.length, GE_MAX_SLOTS); slot++)
-        {
-            GrandExchangeOffer offer = offers[slot];
-            if (offer == null || offer.getState() == GrandExchangeOfferState.EMPTY)
-            {
-                continue;
-            }
-            if (store.bySlot(slot) != null)
-            {
-                continue;
-            }
-            int itemId = offer.getItemId();
-            String itemName = itemManager != null ? itemManager.getItemComposition(itemId).getName() : "";
-            store.seedIfAbsent(OfferEventMapper.toSignal(slot, offer.getState(), itemId, itemName,
-                offer.getTotalQuantity(), offer.getPrice(), offer.getQuantitySold(), offer.getSpent()), now);
         }
     }
 

--- a/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
+++ b/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
@@ -11,7 +11,6 @@ import net.runelite.api.GrandExchangeOfferState;
 import net.runelite.api.SpritePixels;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetTextAlignment;
-import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.util.ImageUtil;
 
@@ -64,7 +63,6 @@ public class GeSlotWidgetDecorator
     private final FlipSmartConfig config;
     private final FlipSmartPlugin plugin;
     private final SpriteManager spriteManager;
-    private final ItemManager itemManager;
 
     // (vanillaSpriteId, tint) -> custom sprite id already registered in the override map
     private final Map<Long, Integer> registered = new HashMap<>();
@@ -81,13 +79,12 @@ public class GeSlotWidgetDecorator
 
     @Inject
     GeSlotWidgetDecorator(Client client, FlipSmartConfig config, FlipSmartPlugin plugin,
-        SpriteManager spriteManager, ItemManager itemManager)
+        SpriteManager spriteManager)
     {
         this.client = client;
         this.config = config;
         this.plugin = plugin;
         this.spriteManager = spriteManager;
-        this.itemManager = itemManager;
     }
 
     // Different border children can share a vanilla sprite id while needing different outline

--- a/src/main/java/com/flipsmart/trading/OfferStore.java
+++ b/src/main/java/com/flipsmart/trading/OfferStore.java
@@ -104,36 +104,6 @@ public final class OfferStore
         return t;
     }
 
-    /**
-     * Seed a live offer into the store for {@code signal.slot}, but only when that slot is
-     * currently unmapped, and without notifying listeners. Lets a render pass repair a
-     * transient store gap in place rather than waiting for the next fill event. Returns
-     * true when a record was seeded.
-     */
-    public boolean seedIfAbsent(OfferSignal signal, long now)
-    {
-        synchronized (this)
-        {
-            if (slotToOfferId.containsKey(signal.slot))
-            {
-                return false;
-            }
-            OfferTransition t = OfferStateMachine.decide(null, signal, nextOfferId, now);
-            if (t.record == null)
-            {
-                return false;
-            }
-            nextOfferId = Math.max(nextOfferId, t.record.getOfferId() + 1);
-            byOfferId.put(t.record.getOfferId(), t.record);
-            if (t.record.getSlot() != null)
-            {
-                slotToOfferId.put(signal.slot, t.record.getOfferId());
-            }
-            fillWatermarks.seedFrom(Collections.singletonList(t.record));
-            return true;
-        }
-    }
-
     /** Live offer currently occupying {@code slot} (0–7), or {@code null} if the slot is empty. */
     public synchronized OfferRecord bySlot(int slot)
     {

--- a/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
+++ b/src/test/java/com/flipsmart/AutoRecommendDispatchTest.java
@@ -234,6 +234,24 @@ public class AutoRecommendDispatchTest {
         assertEquals(101, capturedId.get());
     }
 
+    /**
+     * A partially-filled buy that was cancelled stays in its slot until the player collects, so it
+     * still reads as live. Prompting to cancel it again is impossible to act on — the collect the
+     * resolver already produces is the only thing left to do.
+     */
+    @Test
+    public void cancelledPartialOfferIsNeverStaleQueued() {
+        OfferRecord cancelledAwaitingCollect = OfferRecord
+            .newOffer(12, 0, 22983, "Hydra leather", true, 3, 13883988, 0L)
+            .withFill(1, 13883988L, OfferState.CANCELLED_PARTIAL, 1L);
+        offerStore.importRecords(Arrays.asList(cancelledAwaitingCollect));
+
+        service.addToStaleQueue(cancelledAwaitingCollect);
+
+        assertEquals("an already-cancelled offer must not queue a cancel prompt",
+            0, service.staleOfferCount());
+    }
+
     @Test
     public void cancelHighlightReAssertsEveryResolveAndApplyCycle() {
         when(plugin.getFilledGESlotCount()).thenReturn(8);

--- a/src/test/java/com/flipsmart/GeSlotWidgetDecoratorTest.java
+++ b/src/test/java/com/flipsmart/GeSlotWidgetDecoratorTest.java
@@ -4,14 +4,11 @@ import com.flipsmart.trading.OfferStore;
 import net.runelite.api.Client;
 import net.runelite.api.GrandExchangeOffer;
 import net.runelite.api.GrandExchangeOfferState;
-import net.runelite.api.ItemComposition;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.api.widgets.Widget;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -47,32 +44,4 @@ public class GeSlotWidgetDecoratorTest
         verify(plugin).calculateCompetitiveness(4444, 100, true);
     }
 
-    @Test
-    public void seedStoreFromLiveOffers_seedsUnmappedLiveSlot()
-    {
-        OfferStore store = new OfferStore();
-        FlipSmartPlugin plugin = mock(FlipSmartPlugin.class);
-        when(plugin.getOfferStore()).thenReturn(store);
-
-        ItemManager itemManager = mock(ItemManager.class);
-        ItemComposition comp = mock(ItemComposition.class);
-        when(comp.getName()).thenReturn("Raw shark");
-        when(itemManager.getItemComposition(anyInt())).thenReturn(comp);
-
-        GeSlotWidgetDecorator decorator = new GeSlotWidgetDecorator(
-            mock(Client.class), mock(FlipSmartConfig.class), plugin, mock(SpriteManager.class), itemManager);
-
-        GrandExchangeOffer offer = mock(GrandExchangeOffer.class);
-        when(offer.getState()).thenReturn(GrandExchangeOfferState.BUYING);
-        when(offer.getItemId()).thenReturn(383);
-        when(offer.getTotalQuantity()).thenReturn(10);
-        when(offer.getPrice()).thenReturn(1000);
-        when(offer.getQuantitySold()).thenReturn(0);
-        when(offer.getSpent()).thenReturn(0);
-
-        decorator.seedStoreFromLiveOffers(new GrandExchangeOffer[]{ offer });
-
-        assertNotNull("slot 0 must be seeded from the live offer", store.bySlot(0));
-        assertEquals(383, store.bySlot(0).getItemId());
-    }
 }

--- a/src/test/java/com/flipsmart/GeSlotWidgetDecoratorTest.java
+++ b/src/test/java/com/flipsmart/GeSlotWidgetDecoratorTest.java
@@ -7,16 +7,46 @@ import net.runelite.api.GrandExchangeOfferState;
 import net.runelite.api.ItemComposition;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
+import net.runelite.api.widgets.Widget;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class GeSlotWidgetDecoratorTest
 {
+    /**
+     * A competitive-price check needs only item, price and direction, all of which the client
+     * reports. Reading them from the tracked record made a transient store gap blank the border.
+     */
+    @Test
+    public void borderTint_comesFromTheLiveOffer_notTheTrackedRecord()
+    {
+        OfferStore store = new OfferStore();   // deliberately empty: the store has lost this slot
+        FlipSmartPlugin plugin = mock(FlipSmartPlugin.class);
+        when(plugin.getOfferStore()).thenReturn(store);
+        when(plugin.calculateCompetitiveness(anyInt(), anyInt(), anyBoolean()))
+            .thenReturn(FlipSmartPlugin.OfferCompetitiveness.UNKNOWN);
+
+        FlipSmartConfig config = mock(FlipSmartConfig.class);
+        GeSlotWidgetDecorator decorator = new GeSlotWidgetDecorator(
+            mock(Client.class), config, plugin, mock(SpriteManager.class), mock(ItemManager.class));
+
+        GrandExchangeOffer live = mock(GrandExchangeOffer.class);
+        when(live.getState()).thenReturn(GrandExchangeOfferState.BUYING);
+        when(live.getItemId()).thenReturn(4444);
+        when(live.getPrice()).thenReturn(100);
+
+        decorator.reconcileBorder(mock(Widget.class), 0, live, true);
+
+        verify(plugin).calculateCompetitiveness(4444, 100, true);
+    }
+
     @Test
     public void seedStoreFromLiveOffers_seedsUnmappedLiveSlot()
     {

--- a/src/test/java/com/flipsmart/GeSlotWidgetDecoratorTest.java
+++ b/src/test/java/com/flipsmart/GeSlotWidgetDecoratorTest.java
@@ -4,7 +4,6 @@ import com.flipsmart.trading.OfferStore;
 import net.runelite.api.Client;
 import net.runelite.api.GrandExchangeOffer;
 import net.runelite.api.GrandExchangeOfferState;
-import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.api.widgets.Widget;
 import org.junit.Test;
@@ -32,7 +31,7 @@ public class GeSlotWidgetDecoratorTest
 
         FlipSmartConfig config = mock(FlipSmartConfig.class);
         GeSlotWidgetDecorator decorator = new GeSlotWidgetDecorator(
-            mock(Client.class), config, plugin, mock(SpriteManager.class), mock(ItemManager.class));
+            mock(Client.class), config, plugin, mock(SpriteManager.class));
 
         GrandExchangeOffer live = mock(GrandExchangeOffer.class);
         when(live.getState()).thenReturn(GrandExchangeOfferState.BUYING);

--- a/src/test/java/com/flipsmart/OfferStoreTest.java
+++ b/src/test/java/com/flipsmart/OfferStoreTest.java
@@ -321,44 +321,4 @@ public class OfferStoreTest
             store.bySlot(2).getEffectiveLastActivityAtMillis());
     }
 
-    @Test
-    public void seedIfAbsent_mapsUnmappedSlot_andIsIdempotent()
-    {
-        OfferStore store = new OfferStore();
-
-        boolean first = store.seedIfAbsent(sig(0, GrandExchangeOfferState.BUYING, 1234, 0, 10), NOW);
-        assertTrue(first);
-        assertEquals(1234, store.bySlot(0).getItemId());
-
-        // Second call for the same, now-mapped slot is a no-op.
-        boolean second = store.seedIfAbsent(sig(0, GrandExchangeOfferState.BUYING, 1234, 0, 10), NOW);
-        assertFalse(second);
-    }
-
-    @Test
-    public void seedIfAbsent_doesNotNotifyListeners()
-    {
-        OfferStore store = new OfferStore();
-        java.util.concurrent.atomic.AtomicInteger notified = new java.util.concurrent.atomic.AtomicInteger();
-        store.addListener(e -> notified.incrementAndGet());
-
-        store.seedIfAbsent(sig(0, GrandExchangeOfferState.BUYING, 1234, 0, 10), NOW);
-
-        assertEquals(0, notified.get());
-    }
-
-    @Test
-    public void seedIfAbsent_doesNotSeedFromCancelledSlot()
-    {
-        // A cancelled-but-uncollected slot (CANCELLED_BUY still reported until GP is collected) must
-        // not be reseeded into a live phantom offer — that phantom would linger in liveOffers()
-        // forever and keep re-surfacing stale prompts.
-        OfferStore store = new OfferStore();
-
-        boolean seeded = store.seedIfAbsent(sig(4, GrandExchangeOfferState.CANCELLED_BUY, 1234, 0, 10), NOW);
-
-        assertFalse(seeded);
-        assertNull(store.bySlot(4));
-        assertTrue(store.liveOffers().isEmpty());
-    }
 }


### PR DESCRIPTION
Closes Flip-Smart/flip-smart#1139

## Why

Two problems that both showed up as "the plugin is telling me something wrong about a slot it has lost track of".

**Rendering depended on the durable store.** `GeSlotWidgetDecorator` read the tracked `OfferRecord` to decide a slot's border tint. When the store transiently lost a slot, the border reverted along with the timer — so a store gap cost the whole decoration. To paper over that, the render pass seeded the store whenever it found a live slot with no record. That self-heal is what minted phantom live offers from cancelled-but-uncollected slots, which could never be terminalized.

**The stale-offer sweep prompted cancels for already-cancelled offers.** A partially-filled buy that is cancelled keeps its slot until the player collects, so it still reads as live and got queued for a "Consider cancelling" prompt that cannot be acted on.

## What changed

**Border tint derives from the live offer.** A competitive-price check needs only item, price and direction — all reported by the client. `FlipSmartPlugin` already had a private overload taking exactly those three primitives; it is now public and the decorator calls it directly. The record is still read, but only for the timer, which genuinely needs durable timestamps the client cannot supply.

The result is a deliberate asymmetry: a store gap now costs the **timer** but never the **border or label**.

**Deleted `seedStoreFromLiveOffers`**, and with it `OfferStore.seedIfAbsent`, which had no other caller. Rendering no longer writes to the source of truth. The phantom guard itself is untouched — it lives where it belongs, on the state machine's null-current branch (`OfferStateMachineTest:160-166`).

**Guarded the stale queue** against `CANCELLED_PARTIAL` at `addToStaleQueue`, covering all seven call sites in one place. The resolver was already producing the correct `COLLECT`; this stops it being displaced.

No `SlotView` abstraction was needed — investigation showed the seam already existed.

## Tests

`./gradlew test check` — **796 tests, 0 failures, 0 skipped.** Net 125 lines deleted across the render change.

## In-game QA (dumbridge3, Auto mode ON)

| Check | Result |
|---|---|
| Borders and timers survive a world hop | ✅ both present |
| Hover `Profit:` line on a live sell | ✅ |
| Zero-fill and partial-fill cancels | ✅ correct quantity synced (`x1`, not the `x3` offer size) |
| Phantom minted offer | ✅ none |
| Same-item, same-slot rebuy reports its fill | ✅ `Fill side-effects: BUY Hydra leather x1` |
| "Consider cancelling" for a cancelled offer | ✅ reproduced before the fix, gone after |

The #1139 repro is worth recording: cancel a partially-filled buy, leave it uncollected, wait ~10 minutes. The resolver emits `S1/COLLECT` correctly the whole time, then the stale queue overrides it and the status flips to `Auto: Consider cancelling:` every 30 seconds.

## Deliberately not in scope

**This does not close #1070.** That ticket's stated cause is borders re-evaluating on a backend price re-check, which is a different vector entirely. This removes the store-gap flash only; the price-recheck flash needs its own fix, most likely a sticky last-known tint that only transitions forward.

### 🩺 Codacy Quality Gate
No new static-analysis issues (`gate_ok=true`, `new=0`) at every checked head — Pass B was a no-op.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `405c5c0` `AutoRecommendService.java:2016` — moved `staleOfferCount()` ahead of `addToStaleQueue()` so the pre-existing Javadoc stays attached to the method it documents (nitpick, in-thread).
- `4f4a4b2` `GeSlotWidgetDecorator.java` (review-body finding, no inline thread) — removed the now-unused `itemManager` field/constructor param/import; its only caller, `seedStoreFromLiveOffers`, was already deleted by this PR. Updated `GeSlotWidgetDecoratorTest` to match the trimmed constructor.

### 🤖 Codacy AI Reviewer — false positives (in-thread rationale)
- `GeSlotWidgetDecorator.java:210` (HIGH RISK, in-thread) — claimed NPE risk in `stateTextFor` on `tracked.getCompletedAtMillis()`. The line immediately above already short-circuits on `tracked == null`, and `stateTextFor` is unmodified by this PR (only `reconcileBorder` changed).
- `AutoRecommendService.addToStaleQueue` (review-body summary text, no inline thread) — claimed the fix "fails to exclude generic terminal CANCELLED states." There is no generic `CANCELLED` state; `OfferState` has only `CANCELLED_EMPTY` (terminal, already excluded from `OfferStore.liveOffers()` via `isTerminal()` before any scan loop reaches `addToStaleQueue`) and `CANCELLED_PARTIAL` (the one this PR guards, since it is non-terminal and still occupies its slot). No gap exists.

