### PR TITLE
fix(tracking): scope cost basis to the open round-trip cycle

### DIFF
--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -437,6 +437,16 @@ public class FlipSmartPlugin extends Plugin
 	}
 
 	/**
+	 * Average buy price for the round trip currently open on {@code itemId}, or {@code null} when
+	 * no position is open. Scoped to the cycle, so it never reflects stock already sold.
+	 */
+	public Integer getCycleBasisForItem(int itemId)
+	{
+		return roundTripLedger == null
+			? null : roundTripLedger.currentBasis(getCurrentRsnSafe().orElse(null), itemId);
+	}
+
+	/**
 	 * Local OfferStore records for an item — the fallback source for the recorded
 	 * buy price when the backend-sourced active-flips snapshot is empty.
 	 */
@@ -2186,7 +2196,8 @@ public class FlipSmartPlugin extends Plugin
 		if (!offer.isBuy())
 		{
 			return BuyPriceLookup.findAverageBuyPriceWithFallback(
-				getCurrentActiveFlips(), offerStore.forItem(offer.getItemId()), offer.getItemId());
+				getCurrentActiveFlips(), getCycleBasisForItem(offer.getItemId()),
+				offerStore.forItem(offer.getItemId()), offer.getItemId());
 		}
 		if (offer.getFilledQuantity() > 0 && offer.getSpent() > 0)
 		{

--- a/src/main/java/com/flipsmart/GeOfferDescriptionService.java
+++ b/src/main/java/com/flipsmart/GeOfferDescriptionService.java
@@ -484,7 +484,8 @@ public class GeOfferDescriptionService
 	private String buildSellDescription(int itemId)
 	{
 		Integer recordedBuyPrice = BuyPriceLookup.findAverageBuyPriceWithFallback(
-			plugin.getCurrentActiveFlips(), plugin.getOfferRecordsForItem(itemId), itemId);
+			plugin.getCurrentActiveFlips(), plugin.getCycleBasisForItem(itemId),
+			plugin.getOfferRecordsForItem(itemId), itemId);
 		int sellPrice = Math.max(client.getVarbitValue(VarbitID.GE_NEWOFFER_PRICE), 0);
 		int quantity = Math.max(client.getVarbitValue(VarbitID.GE_NEWOFFER_QUANTITY), 0);
 		return GeOfferDescriptionFormatter.formatSellDescription(itemId, recordedBuyPrice, sellPrice, quantity);
@@ -493,7 +494,8 @@ public class GeOfferDescriptionService
 	private String buildSellDescriptionStatic(int itemId, int listedPrice, int totalQuantity)
 	{
 		Integer recordedBuyPrice = BuyPriceLookup.findAverageBuyPriceWithFallback(
-			plugin.getCurrentActiveFlips(), plugin.getOfferRecordsForItem(itemId), itemId);
+			plugin.getCurrentActiveFlips(), plugin.getCycleBasisForItem(itemId),
+			plugin.getOfferRecordsForItem(itemId), itemId);
 		return GeOfferDescriptionFormatter.formatSellDescription(
 			itemId, recordedBuyPrice, Math.max(listedPrice, 0), Math.max(totalQuantity, 0));
 	}

--- a/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
@@ -342,7 +342,8 @@ public class GrandExchangeSlotOverlay extends Overlay
 	private Integer getBuyPriceForItem(int itemId)
 	{
 		return BuyPriceLookup.findAverageBuyPriceWithFallback(
-			plugin.getCurrentActiveFlips(), plugin.getOfferRecordsForItem(itemId), itemId);
+			plugin.getCurrentActiveFlips(), plugin.getCycleBasisForItem(itemId),
+			plugin.getOfferRecordsForItem(itemId), itemId);
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -352,9 +352,31 @@ public class OfflineSyncService
 	 */
 	private void preloadLedgerState(String rsn)
 	{
+		if (importPersistedLedger(rsn))
+		{
+			return;
+		}
 		if (rsn == null || !roundTripLedger.isEmpty(rsn))
 		{
 			return;
+		}
+		roundTripLedger.seedColdStart(rsn, liveUnmatchedBuys());
+	}
+
+	/**
+	 * Restore a saved ledger, reporting whether anything was imported.
+	 *
+	 * <p>Separated from the cold-start seeding around it because the two want opposite orderings:
+	 * seeding reads live buys and so must follow the reconcile, while retention asks the ledger
+	 * which items still back an open position and so must precede it. An empty ledger at that
+	 * point reads every position as closed and ages out the very records the exemption exists to
+	 * keep.</p>
+	 */
+	private boolean importPersistedLedger(String rsn)
+	{
+		if (rsn == null || !roundTripLedger.isEmpty(rsn))
+		{
+			return false;
 		}
 		String json = configManager.getConfiguration(CONFIG_GROUP, ROUND_TRIP_LEDGER_KEY_PREFIX + rsn);
 		if (json != null && !json.isEmpty())
@@ -364,14 +386,14 @@ public class OfflineSyncService
 				Type type = new TypeToken<Map<Integer, RoundTripLedger.Entry>>(){}.getType();
 				Map<Integer, RoundTripLedger.Entry> entries = gson.fromJson(json, type);
 				roundTripLedger.importState(rsn, entries);
-				return;
+				return true;
 			}
 			catch (Exception e)
 			{
 				log.debug("Ignoring unreadable persisted round-trip ledger for {} ({})", rsn, e.getMessage());
 			}
 		}
-		roundTripLedger.seedColdStart(rsn, liveUnmatchedBuys());
+		return false;
 	}
 
 	/** Currently-live buy offers with at least one filled unit — a stale unmatched position. */
@@ -411,6 +433,11 @@ public class OfflineSyncService
 		// Raise the marks before the records land. Seeding from the records covers a client that
 		// has never persisted marks; merging the saved blob then adds anything the records no
 		// longer show. Both only ever raise, so a stale blob cannot rewind this session.
+		// Before the reconcile: retention asks the ledger which items still back an open position,
+		// and on a cold start that answer lives in config rather than memory. Cold-start seeding
+		// stays after the reconcile below, because it reads live buys from the reconciled store.
+		importPersistedLedger(resolvePersistenceRsn());
+
 		offerStore.watermarks().seedFrom(persistedRecords);
 		offerStore.watermarks().mergeFrom(loadPersistedWatermarks());
 

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -531,29 +531,39 @@ public class OfflineSyncService
 	List<OfferRecord> retainRecentTerminalHistory(List<OfferRecord> persisted, long now)
 	{
 		String rsn = resolvePersistenceRsn();
-		List<OfferRecord> terminal = new ArrayList<>();
+		// Held-position records are exempt from both caps below, not just the age window: sorting
+		// everything together and count-capping the merged list would still let a record backing an
+		// open position fall past the cutoff behind 300 more-recent, unrelated terminal records.
+		List<OfferRecord> heldPosition = new ArrayList<>();
+		List<OfferRecord> windowed = new ArrayList<>();
 		for (OfferRecord r : persisted)
 		{
 			if (r == null || !r.getState().isTerminal())
 			{
 				continue;
 			}
-			boolean withinWindow = now - r.getEffectiveLastActivityAtMillis() <= TERMINAL_HISTORY_RETENTION_MS;
-			// Age alone would drop the basis of a position the player is still holding, which is the
-			// original defect on a slower clock. An item with an open position still depends on its
-			// buy history however old that history is.
 			boolean backsOpenPosition = rsn != null && roundTripLedger.heldQuantity(rsn, r.getItemId()) > 0;
-			if (withinWindow || backsOpenPosition)
+			if (backsOpenPosition)
 			{
-				terminal.add(r);
+				heldPosition.add(r);
+				continue;
+			}
+			if (now - r.getEffectiveLastActivityAtMillis() <= TERMINAL_HISTORY_RETENTION_MS)
+			{
+				windowed.add(r);
 			}
 		}
+		if (windowed.size() > MAX_RETAINED_TERMINAL_RECORDS)
+		{
+			windowed.sort(java.util.Comparator
+				.comparingLong(OfferRecord::getEffectiveLastActivityAtMillis).reversed());
+			windowed = windowed.subList(0, MAX_RETAINED_TERMINAL_RECORDS);
+		}
+		List<OfferRecord> terminal = new ArrayList<>(heldPosition.size() + windowed.size());
+		terminal.addAll(heldPosition);
+		terminal.addAll(windowed);
 		terminal.sort(java.util.Comparator
 			.comparingLong(OfferRecord::getEffectiveLastActivityAtMillis).reversed());
-		if (terminal.size() > MAX_RETAINED_TERMINAL_RECORDS)
-		{
-			return new ArrayList<>(terminal.subList(0, MAX_RETAINED_TERMINAL_RECORDS));
-		}
 		return terminal;
 	}
 

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -528,13 +528,22 @@ public class OfflineSyncService
 	 * {@link #TERMINAL_HISTORY_RETENTION_MS} and {@link #MAX_RETAINED_TERMINAL_RECORDS}.
 	 * Non-terminal records are the reconciler's business and are never returned here.
 	 */
-	static List<OfferRecord> retainRecentTerminalHistory(List<OfferRecord> persisted, long now)
+	List<OfferRecord> retainRecentTerminalHistory(List<OfferRecord> persisted, long now)
 	{
+		String rsn = resolvePersistenceRsn();
 		List<OfferRecord> terminal = new ArrayList<>();
 		for (OfferRecord r : persisted)
 		{
-			if (r != null && r.getState().isTerminal()
-				&& now - r.getEffectiveLastActivityAtMillis() <= TERMINAL_HISTORY_RETENTION_MS)
+			if (r == null || !r.getState().isTerminal())
+			{
+				continue;
+			}
+			boolean withinWindow = now - r.getEffectiveLastActivityAtMillis() <= TERMINAL_HISTORY_RETENTION_MS;
+			// Age alone would drop the basis of a position the player is still holding, which is the
+			// original defect on a slower clock. An item with an open position still depends on its
+			// buy history however old that history is.
+			boolean backsOpenPosition = rsn != null && roundTripLedger.heldQuantity(rsn, r.getItemId()) > 0;
+			if (withinWindow || backsOpenPosition)
 			{
 				terminal.add(r);
 			}

--- a/src/main/java/com/flipsmart/trading/RoundTripLedger.java
+++ b/src/main/java/com/flipsmart/trading/RoundTripLedger.java
@@ -255,6 +255,22 @@ public final class RoundTripLedger
     }
 
     /**
+     * Quantity the player is currently observed to hold for (rsn, itemId). Zero when the position
+     * is closed or unknown. Lets callers ask whether anything still depends on an item's history.
+     */
+    public int heldQuantity(String rsn, int itemId)
+    {
+        if (rsn == null || rsn.isEmpty())
+        {
+            return 0;
+        }
+        synchronized (lock)
+        {
+            return entryFor(rsn, itemId).heldQuantity;
+        }
+    }
+
+    /**
      * Quantity-weighted average buy price for the OPEN cycle, or {@code null} when it has taken
      * no priced buys. Because a closed cycle's basis is cleared, this can never average across a
      * position the player has already liquidated.

--- a/src/main/java/com/flipsmart/trading/RoundTripLedger.java
+++ b/src/main/java/com/flipsmart/trading/RoundTripLedger.java
@@ -36,6 +36,14 @@ public final class RoundTripLedger
         public int cycleId;
 
         /**
+         * Buy-side quantity and outlay accumulated for the CURRENT cycle, zeroed when it closes.
+         * Scoping them to the cycle is what keeps a cost basis from averaging across positions the
+         * player has already fully liquidated.
+         */
+        public int boughtQuantity;
+        public long boughtSpent;
+
+        /**
          * Cumulative filled quantity already folded into {@code heldQuantity} for the offer currently
          * on each (slot, direction), keyed by {@code slot * 2 + (isBuy ? 1 : 0)}. PERSISTED: on relog
          * the login reconciliation re-feeds an open offer's full current cumulative, and matching it
@@ -76,10 +84,18 @@ public final class RoundTripLedger
         public final Integer roundTripId;
         public final boolean duplicateSuppressed;
 
-        public FillResult(Integer roundTripId, boolean duplicateSuppressed)
+        /**
+         * Quantity actually folded into held, which is not always what the caller passed — a
+         * slot-keyed fill rebaselines against what that slot has already absorbed. Cost basis
+         * must follow this number, or the money would describe a different number of items.
+         */
+        public final int foldedQuantity;
+
+        public FillResult(Integer roundTripId, boolean duplicateSuppressed, int foldedQuantity)
         {
             this.roundTripId = roundTripId;
             this.duplicateSuppressed = duplicateSuppressed;
+            this.foldedQuantity = foldedQuantity;
         }
     }
 
@@ -135,7 +151,7 @@ public final class RoundTripLedger
         {
             if (rsn == null || rsn.isEmpty())
             {
-                return new FillResult(null, false);
+                return new FillResult(null, false, 0);
             }
             Entry e = entryFor(rsn, itemId);
 
@@ -145,7 +161,7 @@ public final class RoundTripLedger
             String fingerprint = slot == null ? null : slot + ":" + isBuy + ":" + cumulativeQuantity;
             if (fingerprint != null && fingerprint.equals(e.lastClosingFingerprint))
             {
-                return new FillResult(e.cycleId, true);
+                return new FillResult(e.cycleId, true, 0);
             }
 
             int effectiveDelta;
@@ -165,7 +181,7 @@ public final class RoundTripLedger
                 {
                     // Exactly the cumulative already folded in for this (slot, direction): a relog
                     // re-feed or a duplicate re-delivery. Fold nothing; tell the caller not to forward.
-                    return new FillResult(e.cycleId, true);
+                    return new FillResult(e.cycleId, true, 0);
                 }
                 // A lower cumulative means a fresh offer reused the slot (fills restart at 0), so its
                 // whole cumulative is new; a higher one is genuine incremental progress on this offer.
@@ -187,6 +203,10 @@ public final class RoundTripLedger
             if (closed)
             {
                 e.cycleId++;
+                // The position is gone, so its cost basis goes with it — otherwise the next cycle
+                // would inherit the average of stock that has already been sold.
+                e.boughtQuantity = 0;
+                e.boughtSpent = 0L;
                 e.lastClosingFingerprint = fingerprint;
             }
             else
@@ -205,7 +225,54 @@ public final class RoundTripLedger
                 e.absorbedBySlotDir.remove(slot * 2);
                 e.absorbedBySlotDir.remove(slot * 2 + 1);
             }
-            return new FillResult(roundTripId, false);
+            return new FillResult(roundTripId, false, effectiveDelta);
+        }
+    }
+
+    /**
+     * Fold a buy's quantity and outlay into the current cycle's cost basis.
+     *
+     * <p>Takes a per-item price rather than a total so the money always corresponds to the
+     * quantity actually folded in: {@link #recordFillGuarded} may rebaseline a fill's quantity
+     * against what a slot has already absorbed, and a separately-supplied total would then
+     * describe a different number of items than the one recorded.</p>
+     *
+     * <p>A non-positive price contributes nothing — a placement row carries no price, and folding
+     * it in would drag the average toward zero.</p>
+     */
+    public void recordBuyBasis(String rsn, int itemId, int quantity, int pricePerItem)
+    {
+        if (rsn == null || rsn.isEmpty() || quantity <= 0 || pricePerItem <= 0)
+        {
+            return;
+        }
+        synchronized (lock)
+        {
+            Entry e = entryFor(rsn, itemId);
+            e.boughtQuantity += quantity;
+            e.boughtSpent += (long) quantity * pricePerItem;
+        }
+    }
+
+    /**
+     * Quantity-weighted average buy price for the OPEN cycle, or {@code null} when it has taken
+     * no priced buys. Because a closed cycle's basis is cleared, this can never average across a
+     * position the player has already liquidated.
+     */
+    public Integer currentBasis(String rsn, int itemId)
+    {
+        if (rsn == null || rsn.isEmpty())
+        {
+            return null;
+        }
+        synchronized (lock)
+        {
+            Entry e = entryFor(rsn, itemId);
+            if (e.boughtQuantity <= 0)
+            {
+                return null;
+            }
+            return (int) Math.round(e.boughtSpent / (double) e.boughtQuantity);
         }
     }
 

--- a/src/main/java/com/flipsmart/trading/RoundTripLedger.java
+++ b/src/main/java/com/flipsmart/trading/RoundTripLedger.java
@@ -333,6 +333,10 @@ public final class RoundTripLedger
             {
                 Entry source = entry.getValue();
                 Entry clone = new Entry(source.heldQuantity, source.cycleId);
+                // The open cycle's basis travels with the position it describes; a restored
+                // position without it falls back to averaging across already-closed flips.
+                clone.boughtQuantity = source.boughtQuantity;
+                clone.boughtSpent = source.boughtSpent;
                 if (source.absorbedBySlotDir != null)
                 {
                     clone.absorbedBySlotDir = new HashMap<>(source.absorbedBySlotDir);

--- a/src/main/java/com/flipsmart/trading/TransactionLogger.java
+++ b/src/main/java/com/flipsmart/trading/TransactionLogger.java
@@ -130,7 +130,14 @@ public final class TransactionLogger
             // so this fill's peeked id — and thus its dedup key — differs from the original's. The
             // ledger recognised it as a byte-identical re-delivery and mutated nothing; forwarding
             // it would stamp the backend with the next cycle's id, so drop it here.
+            // Basis is deliberately not folded either — a re-delivery buys nothing.
             return;
+        }
+        if (r.isBuy())
+        {
+            // Folded quantity, not the caller's: the ledger rebaselines a slot-keyed fill against
+            // what that slot already absorbed, and the basis has to describe the same items.
+            roundTripLedger.recordBuyBasis(rsn, r.getItemId(), fill.foldedQuantity, pricePerItem);
         }
         apiClient.recordTransactionAsync(baseBuilder(r, newlyFilled, pricePerItem, rsn, key).roundTripId(fill.roundTripId).build());
     }

--- a/src/main/java/com/flipsmart/trading/TransactionLogger.java
+++ b/src/main/java/com/flipsmart/trading/TransactionLogger.java
@@ -114,7 +114,9 @@ public final class TransactionLogger
         {
             return;
         }
-        int pricePerItem = newlyFilled > 0 ? (int) (newlySpent / newlyFilled) : 0;
+        // Rounded rather than truncated: this now also feeds recordBuyBasis below, and truncation
+        // biased every weighted-average basis down by up to 1gp/item.
+        int pricePerItem = newlyFilled > 0 ? (int) Math.round((double) newlySpent / newlyFilled) : 0;
         // The offer is done filling (so its slot's cumulative baseline may reset) once it is no longer
         // NEW or PARTIAL_FILL — i.e. FILLED, collected, or cancelled. A still-filling offer keeps its
         // baseline so a sibling slot of the same item is never double-counted on a mid-fill close.

--- a/src/main/java/com/flipsmart/util/BuyPriceLookup.java
+++ b/src/main/java/com/flipsmart/util/BuyPriceLookup.java
@@ -40,24 +40,35 @@ public final class BuyPriceLookup
 	}
 
 	/**
-	 * Resolve the recorded average buy price from the active-flips snapshot, and
-	 * when that is absent, fall back to the local {@link OfferRecord} store
-	 * The active-flips list is backend-sourced and can be empty for
-	 * reasons unrelated to whether the player holds the item — a refresh race,
-	 * the free-tier slot trim, or a plain gap — and when it is, breakeven/margin/
-	 * profit rendered "?" despite the buy sitting in the OfferStore. The offer
-	 * records carry the same cost basis, so the derived stats stay populated.
+	 * Resolve the recorded average buy price, in descending order of authority.
 	 *
-	 * @return the average buy price, or {@code null} if neither source knows the
-	 *         item.
+	 * <p>The backend-sourced active-flips snapshot wins when present. It can be empty for reasons
+	 * unrelated to whether the player holds the item — a refresh race, the free-tier trim, or a
+	 * plain gap — and when it is, breakeven and profit used to render "?" despite the buy sitting
+	 * locally.</p>
+	 *
+	 * <p>{@code cycleBasis} is the ledger's average for the currently-open round trip. It comes
+	 * next because it is scoped to the position the player actually holds: a cycle closes when
+	 * holdings return to zero, taking its basis with it.</p>
+	 *
+	 * <p>The offer records are the last resort. They carry the same cost basis but the store
+	 * never evicts, so they outlive the flip they belong to and can average across positions
+	 * already sold — the reason the cycle basis is preferred over them rather than the other way
+	 * round. They still matter for a client whose ledger has not yet observed a fill.</p>
+	 *
+	 * @return the average buy price, or {@code null} if no source knows the item.
 	 */
 	public static Integer findAverageBuyPriceWithFallback(
-		List<ActiveFlip> activeFlips, List<OfferRecord> offerRecords, int itemId)
+		List<ActiveFlip> activeFlips, Integer cycleBasis, List<OfferRecord> offerRecords, int itemId)
 	{
 		Integer fromFlips = findAverageBuyPrice(activeFlips, itemId);
 		if (fromFlips != null)
 		{
 			return fromFlips;
+		}
+		if (cycleBasis != null && cycleBasis > 0)
+		{
+			return cycleBasis;
 		}
 		return averageBuyPriceFromOffers(offerRecords, itemId);
 	}

--- a/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
+++ b/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
@@ -583,6 +583,35 @@ public class OfflineSyncPersistenceTest
 		assertFalse("a liquidated position ages out as before", items.contains(444));
 	}
 
+	/**
+	 * The exemption is only as good as the ledger backing it. On a cold start the ledger lives in
+	 * config, not memory, so it has to be restored before retention asks it what is still held —
+	 * otherwise every held position reads as zero and its basis ages out exactly as before.
+	 */
+	@Test
+	public void terminalHistoryRetention_consultsAPersistedLedgerOnAColdStart()
+	{
+		when(session.getRsn()).thenReturn("Zezima");
+		long longAgo = System.currentTimeMillis()
+			- OfflineSyncService.TERMINAL_HISTORY_RETENTION_MS - 60_000L;
+
+		// An old, collected buy for an item the player still holds.
+		store.apply(sig(0, GrandExchangeOfferState.BUYING, 333, 0, 10), longAgo);
+		store.apply(sig(0, GrandExchangeOfferState.BOUGHT, 333, 10, 10), longAgo);
+		store.apply(sig(0, GrandExchangeOfferState.EMPTY, 333, 10, 10), longAgo);
+		service.persistOfferState();
+
+		// A cold start: the ledger is empty in memory and its state sits in config.
+		configStore.put("roundTripLedger_Zezima", "{\"333\":{\"heldQuantity\":10,\"cycleId\":1}}");
+		store.importRecords(Collections.emptyList());
+		when(client.getGrandExchangeOffers()).thenReturn(null);
+
+		service.preloadPersistedOffers();
+
+		assertFalse("the held position's basis must survive a cold start",
+			store.forItem(333).isEmpty());
+	}
+
 	@Test
 	public void terminalHistoryRetention_capsRecordCountKeepingNewest()
 	{

--- a/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
+++ b/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
@@ -46,6 +46,7 @@ public class OfflineSyncPersistenceTest
 	private OfferStore store;
 	private ActiveFlipTracker activeFlipTracker;
 	private OfflineSyncService service;
+	private com.flipsmart.trading.RoundTripLedger ledger;
 	private ItemManager itemManager;
 	private Map<String, String> configStore;
 
@@ -82,6 +83,7 @@ public class OfflineSyncPersistenceTest
 			return null;
 		}).when(clientThread).invokeLater(any(Runnable.class));
 
+		ledger = new com.flipsmart.trading.RoundTripLedger();
 		activeFlipTracker = mock(ActiveFlipTracker.class);
 		itemManager = mock(ItemManager.class);
 
@@ -95,7 +97,7 @@ public class OfflineSyncPersistenceTest
 			geHistoryService,
 			store,
 			itemManager,
-			new com.flipsmart.trading.RoundTripLedger());
+			ledger);
 	}
 
 	@Test
@@ -539,10 +541,46 @@ public class OfflineSyncPersistenceTest
 		store.apply(sig(1, GrandExchangeOfferState.EMPTY, 222, 10, 10), now - 1000L);
 
 		List<OfferRecord> retained =
-			OfflineSyncService.retainRecentTerminalHistory(store.export(), now);
+			service.retainRecentTerminalHistory(store.export(), now);
 
 		assertEquals("only the in-window terminal record is retained", 1, retained.size());
 		assertEquals(222, retained.get(0).getItemId());
+	}
+
+	/**
+	 * Age is the wrong sole criterion. A buy collected two days ago is still the cost basis for
+	 * stock the player is holding right now, and dropping it puts breakeven back to "?" — the same
+	 * defect the retention was added to fix, just on a slower clock.
+	 */
+	@Test
+	public void terminalHistoryRetention_keepsRecordsBackingAnOpenPosition()
+	{
+		when(session.getRsn()).thenReturn("Zezima");
+		long now = System.currentTimeMillis();
+		long longAgo = now - OfflineSyncService.TERMINAL_HISTORY_RETENTION_MS - 60_000L;
+
+		// Bought and collected well outside the window, but never sold: the position is still open.
+		store.apply(sig(0, GrandExchangeOfferState.BUYING, 333, 0, 10), longAgo);
+		store.apply(sig(0, GrandExchangeOfferState.BOUGHT, 333, 10, 10), longAgo);
+		store.apply(sig(0, GrandExchangeOfferState.EMPTY, 333, 10, 10), longAgo);
+		ledger.recordFill("Zezima", 333, true, 10);
+
+		// Equally old, but fully liquidated — nothing depends on it any more.
+		store.apply(sig(1, GrandExchangeOfferState.BUYING, 444, 0, 10), longAgo);
+		store.apply(sig(1, GrandExchangeOfferState.BOUGHT, 444, 10, 10), longAgo);
+		store.apply(sig(1, GrandExchangeOfferState.EMPTY, 444, 10, 10), longAgo);
+		ledger.recordFill("Zezima", 444, true, 10);
+		ledger.recordFill("Zezima", 444, false, 10);
+
+		List<OfferRecord> retained = service.retainRecentTerminalHistory(store.export(), now);
+
+		java.util.Set<Integer> items = new java.util.HashSet<>();
+		for (OfferRecord r : retained)
+		{
+			items.add(r.getItemId());
+		}
+		assertTrue("a held position keeps its basis however old", items.contains(333));
+		assertFalse("a liquidated position ages out as before", items.contains(444));
 	}
 
 	@Test
@@ -559,7 +597,7 @@ public class OfflineSyncPersistenceTest
 		}
 
 		List<OfferRecord> retained =
-			OfflineSyncService.retainRecentTerminalHistory(store.export(), now);
+			service.retainRecentTerminalHistory(store.export(), now);
 
 		assertEquals("retained set is capped", OfflineSyncService.MAX_RETAINED_TERMINAL_RECORDS,
 			retained.size());

--- a/src/test/java/com/flipsmart/TransactionLoggerTest.java
+++ b/src/test/java/com/flipsmart/TransactionLoggerTest.java
@@ -49,6 +49,28 @@ public class TransactionLoggerTest
         return new TransactionLogger(apiClient, session, supplier, roundTripLedger);
     }
 
+    /**
+     * End-to-end: a buy filling through the store must leave the open cycle's cost basis
+     * populated. Observed in game with the basis empty across every ledger entry while cycle
+     * ids and held quantities tracked correctly.
+     */
+    @Test
+    public void buyFillThroughTheStore_populatesTheCycleBasis()
+    {
+        OfferStore store = new OfferStore();
+        TransactionLogger logger = newLogger(RSN);
+        store.addListener(logger::onOfferEvent);
+
+        store.apply(OfferEventMapper.toSignal(0, GrandExchangeOfferState.BUYING, 571,
+            "Water orb", 10, 1736, 0, 0L), 1700000000000L);
+        store.apply(OfferEventMapper.toSignal(0, GrandExchangeOfferState.BOUGHT, 571,
+            "Water orb", 10, 1736, 10, 17360L), 1700000001000L);
+
+        assertEquals("held quantity tracks the buy", 10, roundTripLedger.heldQuantity(RSN, 571));
+        assertEquals("the open cycle knows what it paid",
+            Integer.valueOf(1736), roundTripLedger.currentBasis(RSN, 571));
+    }
+
     private TransactionRequest capture()
     {
         ArgumentCaptor<TransactionRequest> cap = ArgumentCaptor.forClass(TransactionRequest.class);

--- a/src/test/java/com/flipsmart/trading/RoundTripLedgerTest.java
+++ b/src/test/java/com/flipsmart/trading/RoundTripLedgerTest.java
@@ -30,6 +30,55 @@ public class RoundTripLedgerTest
     }
 
     @Test
+    public void basis_isWeightedAcrossTheOpenCycle()
+    {
+        ledger.recordBuyBasis(RSN, ITEM, 10, 100);
+        ledger.recordBuyBasis(RSN, ITEM, 10, 140);
+
+        assertEquals(Integer.valueOf(120), ledger.currentBasis(RSN, ITEM));
+    }
+
+    @Test
+    public void basis_isAbsentBeforeAnyBuy()
+    {
+        assertNull("an untouched item has no basis", ledger.currentBasis(RSN, ITEM));
+    }
+
+    @Test
+    public void basis_resetsWhenTheCycleCloses()
+    {
+        ledger.recordBuyBasis(RSN, ITEM, 10, 100);
+        ledger.recordFill(RSN, ITEM, true, 10);
+        ledger.recordFill(RSN, ITEM, false, 10);   // fully liquidated: cycle closes
+
+        assertNull("a closed cycle carries no basis", ledger.currentBasis(RSN, ITEM));
+
+        ledger.recordBuyBasis(RSN, ITEM, 5, 200);
+        assertEquals("the next cycle starts clean",
+            Integer.valueOf(200), ledger.currentBasis(RSN, ITEM));
+    }
+
+    @Test
+    public void basis_survivesAPartialLiquidation()
+    {
+        ledger.recordBuyBasis(RSN, ITEM, 10, 100);
+        ledger.recordFill(RSN, ITEM, true, 10);
+        ledger.recordFill(RSN, ITEM, false, 3);    // holdings still 7, cycle stays open
+
+        assertEquals("a partial sell does not disturb the buy-side basis",
+            Integer.valueOf(100), ledger.currentBasis(RSN, ITEM));
+    }
+
+    @Test
+    public void basis_ignoresAZeroPrice()
+    {
+        // A placement row carries no price; folding it in would drag the average toward zero.
+        ledger.recordBuyBasis(RSN, ITEM, 10, 0);
+
+        assertNull("a priceless fill contributes no basis", ledger.currentBasis(RSN, ITEM));
+    }
+
+    @Test
     public void cleanTwoCycleSequence_producesTwoDistinctIds()
     {
         int buyLow = ledger.recordFill(RSN, ITEM, true, 10);

--- a/src/test/java/com/flipsmart/trading/RoundTripLedgerTest.java
+++ b/src/test/java/com/flipsmart/trading/RoundTripLedgerTest.java
@@ -39,6 +39,22 @@ public class RoundTripLedgerTest
     }
 
     @Test
+    public void basis_survivesAnExportImportRoundTrip()
+    {
+        // Persistence is the only thing that carries a position across a restart, and a position
+        // whose basis does not come with it silently falls back to averaging across closed flips.
+        ledger.recordFill(RSN, ITEM, true, 10);
+        ledger.recordBuyBasis(RSN, ITEM, 10, 1736);
+
+        RoundTripLedger restored = new RoundTripLedger();
+        restored.importState(RSN, ledger.export(RSN));
+
+        assertEquals("held quantity survives", 10, restored.heldQuantity(RSN, ITEM));
+        assertEquals("so must the basis it depends on",
+            Integer.valueOf(1736), restored.currentBasis(RSN, ITEM));
+    }
+
+    @Test
     public void basis_isAbsentBeforeAnyBuy()
     {
         assertNull("an untouched item has no basis", ledger.currentBasis(RSN, ITEM));

--- a/src/test/java/com/flipsmart/trading/SessionCorpusHarness.java
+++ b/src/test/java/com/flipsmart/trading/SessionCorpusHarness.java
@@ -110,34 +110,66 @@ final class SessionCorpusHarness
 		ItemManager itemManager = mock(ItemManager.class);
 		when(itemManager.getItemComposition(anyInt())).thenReturn(anyComposition);
 
-		OfflineSyncService service = new OfflineSyncService(
-			session,
-			configManager,
-			new Gson(),
-			client,
-			clientThread,
-			mock(ActiveFlipTracker.class),
-			mock(GEHistoryService.class),
-			store,
-			itemManager,
-			new RoundTripLedger());
+		// Everything above survives a restart because it stands in for the client and its config
+		// file. Everything below is process state, rebuilt from the config blob alone when the
+		// timeline restarts.
+		Session live = new Session();
+		live.rebuild(session, configManager, client, clientThread, itemManager, fills);
 
 		for (JsonElement element : fixture.getAsJsonArray("timeline"))
 		{
-			applyEvent(element.getAsJsonObject(), base, store, service, client);
+			applyEvent(element.getAsJsonObject(), base, live, client,
+				session, configManager, clientThread, itemManager, fills);
 		}
-		return new Result(store, fills);
+		return new Result(live.store, fills);
 	}
 
-	private static void applyEvent(JsonObject event, long base, OfferStore store,
-		OfflineSyncService service, Client client)
+	/**
+	 * The process-local half of the plugin: the offer store and the service that reconciles into
+	 * it. A restart replaces both, which is what distinguishes it from a relog — a relog keeps the
+	 * running instance and only loses the GE slots, so anything held outside the store (the fill
+	 * watermarks, for one) survives it.
+	 */
+	private static final class Session
+	{
+		private OfferStore store;
+		private OfflineSyncService service;
+
+		void rebuild(PlayerSession session, ConfigManager configManager, Client client,
+			ClientThread clientThread, ItemManager itemManager, List<OfferEvent> fills)
+		{
+			store = new OfferStore();
+			store.addListener(e ->
+			{
+				if (e.newlyFilledQuantity > 0)
+				{
+					fills.add(e);
+				}
+			});
+			service = new OfflineSyncService(
+				session,
+				configManager,
+				new Gson(),
+				client,
+				clientThread,
+				mock(ActiveFlipTracker.class),
+				mock(GEHistoryService.class),
+				store,
+				itemManager,
+				new RoundTripLedger());
+		}
+	}
+
+	private static void applyEvent(JsonObject event, long base, Session live, Client client,
+		PlayerSession session, ConfigManager configManager, ClientThread clientThread,
+		ItemManager itemManager, List<OfferEvent> fills)
 	{
 		long at = base + event.get("at_seconds").getAsLong() * 1000L;
 		String type = event.get("type").getAsString();
 
 		if ("observe".equals(type))
 		{
-			store.apply(toSignal(event), at);
+			live.store.apply(toSignal(event), at);
 			return;
 		}
 
@@ -146,17 +178,22 @@ final class SessionCorpusHarness
 		// store state never reaches disk, so the preload reattaches an older persisted record.
 		if (!event.has("persist") || event.get("persist").getAsBoolean())
 		{
-			service.persistOfferState();
+			live.service.persistOfferState();
 		}
 		if ("relog".equals(type))
 		{
-			store.importRecords(Collections.emptyList());
+			live.store.importRecords(Collections.emptyList());
+		}
+		if ("restart".equals(type))
+		{
+			// Nothing but the config blob crosses a process boundary.
+			live.rebuild(session, configManager, client, clientThread, itemManager, fills);
 		}
 		// Built before the stubbing call: creating mocks inside a when(...) argument throws
 		// UnfinishedStubbingException.
 		GrandExchangeOffer[] snapshot = toSnapshot(event);
 		when(client.getGrandExchangeOffers()).thenReturn(snapshot);
-		service.preloadPersistedOffers();
+		live.service.preloadPersistedOffers();
 	}
 
 	private static OfferSignal toSignal(JsonObject e)

--- a/src/test/java/com/flipsmart/trading/SessionCorpusHarness.java
+++ b/src/test/java/com/flipsmart/trading/SessionCorpusHarness.java
@@ -110,18 +110,44 @@ final class SessionCorpusHarness
 		ItemManager itemManager = mock(ItemManager.class);
 		when(itemManager.getItemComposition(anyInt())).thenReturn(anyComposition);
 
-		// Everything above survives a restart because it stands in for the client and its config
-		// file. Everything below is process state, rebuilt from the config blob alone when the
-		// timeline restarts.
+		// Everything in the environment survives a restart because it stands in for the client
+		// and its config file. The Session below is process state, rebuilt from the config blob
+		// alone when the timeline restarts.
+		Environment env = new Environment(session, configManager, client, clientThread,
+			itemManager, fills);
 		Session live = new Session();
-		live.rebuild(session, configManager, client, clientThread, itemManager, fills);
+		live.rebuild(env);
 
 		for (JsonElement element : fixture.getAsJsonArray("timeline"))
 		{
-			applyEvent(element.getAsJsonObject(), base, live, client,
-				session, configManager, clientThread, itemManager, fills);
+			applyEvent(element.getAsJsonObject(), base, live, env);
 		}
 		return new Result(live.store, fills);
+	}
+
+	/**
+	 * The client/config/item stand-ins a real restart would rebuild the process against. Grouped
+	 * so the harness can pass "what a restart reads" as a single unit.
+	 */
+	private static final class Environment
+	{
+		final PlayerSession session;
+		final ConfigManager configManager;
+		final Client client;
+		final ClientThread clientThread;
+		final ItemManager itemManager;
+		final List<OfferEvent> fills;
+
+		Environment(PlayerSession session, ConfigManager configManager, Client client,
+			ClientThread clientThread, ItemManager itemManager, List<OfferEvent> fills)
+		{
+			this.session = session;
+			this.configManager = configManager;
+			this.client = client;
+			this.clientThread = clientThread;
+			this.itemManager = itemManager;
+			this.fills = fills;
+		}
 	}
 
 	/**
@@ -135,34 +161,31 @@ final class SessionCorpusHarness
 		private OfferStore store;
 		private OfflineSyncService service;
 
-		void rebuild(PlayerSession session, ConfigManager configManager, Client client,
-			ClientThread clientThread, ItemManager itemManager, List<OfferEvent> fills)
+		void rebuild(Environment env)
 		{
 			store = new OfferStore();
 			store.addListener(e ->
 			{
 				if (e.newlyFilledQuantity > 0)
 				{
-					fills.add(e);
+					env.fills.add(e);
 				}
 			});
 			service = new OfflineSyncService(
-				session,
-				configManager,
+				env.session,
+				env.configManager,
 				new Gson(),
-				client,
-				clientThread,
+				env.client,
+				env.clientThread,
 				mock(ActiveFlipTracker.class),
 				mock(GEHistoryService.class),
 				store,
-				itemManager,
+				env.itemManager,
 				new RoundTripLedger());
 		}
 	}
 
-	private static void applyEvent(JsonObject event, long base, Session live, Client client,
-		PlayerSession session, ConfigManager configManager, ClientThread clientThread,
-		ItemManager itemManager, List<OfferEvent> fills)
+	private static void applyEvent(JsonObject event, long base, Session live, Environment env)
 	{
 		long at = base + event.get("at_seconds").getAsLong() * 1000L;
 		String type = event.get("type").getAsString();
@@ -187,12 +210,12 @@ final class SessionCorpusHarness
 		if ("restart".equals(type))
 		{
 			// Nothing but the config blob crosses a process boundary.
-			live.rebuild(session, configManager, client, clientThread, itemManager, fills);
+			live.rebuild(env);
 		}
 		// Built before the stubbing call: creating mocks inside a when(...) argument throws
 		// UnfinishedStubbingException.
 		GrandExchangeOffer[] snapshot = toSnapshot(event);
-		when(client.getGrandExchangeOffers()).thenReturn(snapshot);
+		when(env.client.getGrandExchangeOffers()).thenReturn(snapshot);
 		live.service.preloadPersistedOffers();
 	}
 

--- a/src/test/java/com/flipsmart/trading/SessionCorpusTest.java
+++ b/src/test/java/com/flipsmart/trading/SessionCorpusTest.java
@@ -101,8 +101,10 @@ public class SessionCorpusTest
 		for (Map.Entry<String, JsonElement> e : expect.getAsJsonObject("buy_basis").entrySet())
 		{
 			int itemId = Integer.parseInt(e.getKey());
+			// Null cycle basis: the harness drives the store directly, so no fills reach a ledger.
+			// This assertion is deliberately about what the offer records alone can resolve.
 			Integer basis = BuyPriceLookup.findAverageBuyPriceWithFallback(
-				null, result.store.forItem(itemId), itemId);
+				null, null, result.store.forItem(itemId), itemId);
 			assertEquals("[" + name + "] buy basis for item " + itemId,
 				Integer.valueOf(e.getValue().getAsInt()), basis);
 		}

--- a/src/test/java/com/flipsmart/util/BuyPriceLookupTest.java
+++ b/src/test/java/com/flipsmart/util/BuyPriceLookupTest.java
@@ -42,8 +42,45 @@ public class BuyPriceLookupTest
     {
         Integer p = BuyPriceLookup.findAverageBuyPriceWithFallback(
             Collections.singletonList(flip(536, 3284)),
+            null,
             Collections.singletonList(buy(536, 100, 100L * 9999)),
             536);
+        assertEquals(Integer.valueOf(3284), p);
+    }
+
+    /**
+     * #1091: the offer store never evicts, so its records outlive the flip they belong to.
+     * Averaging across them made breakeven describe stock the player had already sold. The
+     * ledger's basis is scoped to the open cycle, so it cannot.
+     */
+    @Test
+    public void cycleBasisOutranksRecordsFromAlreadyClosedFlips()
+    {
+        List<OfferRecord> staleRecords = asList(buy(536, 1000, 1000L * 9999), buy(536, 1000, 1000L * 8888));
+
+        Integer p = BuyPriceLookup.findAverageBuyPriceWithFallback(
+            Collections.emptyList(), 3284, staleRecords, 536);
+
+        assertEquals(Integer.valueOf(3284), p);
+    }
+
+    @Test
+    public void activeFlipStillOutranksTheCycleBasis()
+    {
+        Integer p = BuyPriceLookup.findAverageBuyPriceWithFallback(
+            Collections.singletonList(flip(536, 3284)), 9999, Collections.emptyList(), 536);
+
+        assertEquals("the backend snapshot stays authoritative", Integer.valueOf(3284), p);
+    }
+
+    @Test
+    public void recordsStillCoverAnItemTheLedgerHasNoBasisFor()
+    {
+        // A client whose ledger has not seen a fill for this item yet — e.g. the buy happened
+        // before this build shipped. The records remain the last resort.
+        Integer p = BuyPriceLookup.findAverageBuyPriceWithFallback(
+            Collections.emptyList(), null, Collections.singletonList(buy(536, 1000, 1000L * 3284)), 536);
+
         assertEquals(Integer.valueOf(3284), p);
     }
 
@@ -52,7 +89,7 @@ public class BuyPriceLookupTest
     {
         // (3000*3284 + 1000*3300) / 4000 = 3288
         List<OfferRecord> offers = asList(buy(536, 3000, 3000L * 3284), buy(536, 1000, 1000L * 3300));
-        Integer p = BuyPriceLookup.findAverageBuyPriceWithFallback(Collections.emptyList(), offers, 536);
+        Integer p = BuyPriceLookup.findAverageBuyPriceWithFallback(Collections.emptyList(), null, offers, 536);
         assertEquals(Integer.valueOf(3288), p);
     }
 
@@ -61,7 +98,7 @@ public class BuyPriceLookupTest
     {
         OfferRecord otherItem = buy(999, 500, 500L * 100);
         List<OfferRecord> offers = asList(buy(536, 1000, 1000L * 3284), otherItem);
-        Integer p = BuyPriceLookup.findAverageBuyPriceWithFallback(Collections.emptyList(), offers, 536);
+        Integer p = BuyPriceLookup.findAverageBuyPriceWithFallback(Collections.emptyList(), null, offers, 536);
         assertEquals(Integer.valueOf(3284), p);
     }
 
@@ -69,6 +106,6 @@ public class BuyPriceLookupTest
     public void neitherSourceHasItem_returnsNull()
     {
         assertNull(BuyPriceLookup.findAverageBuyPriceWithFallback(
-            Collections.emptyList(), Collections.emptyList(), 536));
+            Collections.emptyList(), null, Collections.emptyList(), 536));
     }
 }

--- a/src/test/resources/session_corpus/06-restart-preserves-generation.json
+++ b/src/test/resources/session_corpus/06-restart-preserves-generation.json
@@ -1,0 +1,21 @@
+{
+  "name": "restart-preserves-generation",
+  "description": "A restart keeps only the config blob, so slot generation has to come back from it. If it restarts at the first generation while the marks from the previous session survive, an order matching a slot's earliest prior use adopts that finished order's mark and its fills are silently suppressed — an under-report. Here slot 0 buys the same item twice with a collect and a restart in between; both fills must be reported.",
+  "rsn": "TestPlayer",
+  "timeline": [
+    {"at_seconds": -900, "type": "observe", "slot": 0, "state": "BUYING", "item_id": 4444, "total": 10, "price": 100, "sold": 0,  "spent": 0},
+    {"at_seconds": -800, "type": "observe", "slot": 0, "state": "BOUGHT", "item_id": 4444, "total": 10, "price": 100, "sold": 10, "spent": 1000},
+    {"at_seconds": -700, "type": "observe", "slot": 0, "state": "EMPTY",  "item_id": 4444, "total": 10, "price": 100, "sold": 10, "spent": 1000},
+
+    {"at_seconds": -600, "type": "restart", "ge_readable": true, "live_slots": []},
+
+    {"at_seconds": -500, "type": "observe", "slot": 0, "state": "BUYING", "item_id": 4444, "total": 5, "price": 120, "sold": 0, "spent": 0},
+    {"at_seconds": -400, "type": "observe", "slot": 0, "state": "BOUGHT", "item_id": 4444, "total": 5, "price": 120, "sold": 5, "spent": 600}
+  ],
+  "expect": {
+    "reported_fills": [
+      {"item_id": 4444, "is_buy": true, "quantity": 10},
+      {"item_id": 4444, "is_buy": true, "quantity": 5}
+    ]
+  }
+}

--- a/src/test/resources/session_corpus/README.md
+++ b/src/test/resources/session_corpus/README.md
@@ -40,7 +40,12 @@ small values fall outside every retention window and get silently dropped.
   `GrandExchangeOfferState` name), `item_id`, `total`, `price`, `sold`, `spent`.
   `sold` and `spent` are **cumulative**, exactly as the client reports them.
 - **`hop`** — persist, then preload against the given snapshot. The store is *not* cleared.
-- **`relog`** — the same, but the in-memory store is cleared first, simulating a fresh JVM.
+- **`relog`** — the same, but the in-memory store is cleared first. The running instance survives,
+  so anything held outside the store (the fill watermarks, for one) is retained.
+- **`restart`** — a process boundary. The store *and* the service are rebuilt from nothing, so the
+  config blob is the only thing that crosses. Use this, not `relog`, to test whether state actually
+  round-trips through persistence: a `relog` will happily pass on in-memory state that was never
+  written to disk.
 
 Both `hop` and `relog` take:
 - `ge_readable: false` — `getGrandExchangeOffers()` returns `null` (snapshot not loaded yet)


### PR DESCRIPTION
Closes Flip-Smart/flip-smart#1091

## Why

Cost basis came from the offer store, which never evicts. Its records outlive the flip they belong to, so a weighted average across them describes stock the player has already sold — breakeven and profit drifted on any item flipped more than once.

Retention made that worse in the other direction. It was purely by age, so a buy collected more than a day before its sell was dropped entirely and breakeven went back to `?` — the same defect the retention was added to fix, on a slower clock. Observed live during QA: of thirty retained records, **nineteen had already aged out**.

## What changed

**The ledger already knew when a position opens and closes — it just never tracked what the position cost.** `RoundTripLedger.Entry` carries a held quantity and a cycle id that advances on a zero-crossing, is persisted per RSN, and is already pinned by the shared golden corpus. Adding buy-side quantity and outlay to it, cleared when the cycle closes, gives an average buy price that **cannot** span a liquidated position.

Deliberately not a new store. A fourth durable structure alongside the offer store, the fill watermarks and the ledger would repeat the multi-writer problem this architecture set out to remove.

**Basis follows the quantity the ledger actually folded**, exposed as `FillResult.foldedQuantity`, not the quantity the caller passed. A slot-keyed fill rebaselines against what that slot already absorbed, so the two differ, and money attached to the wrong number of items skews the average quietly. A suppressed duplicate folds nothing and contributes nothing.

**`BuyPriceLookup` resolution order is now active flips → cycle basis → offer records.** The records stay as a last resort for a client whose ledger has not yet observed a fill.

**Retention gained a reachability exemption:** a terminal record survives if it is within the age window **or** its item still shows a held quantity.

## A deliberate deviation from the plan

The plan called for **deleting** the age and count caps in favour of pure reachability. That would have regressed the Active Flips cards: `buyBasisForItem` reads the offer records to supply cost basis to `AwaitingSaleLots` and `ActiveFlipProjection`, so dropping terminal records would zero them — the same defect fixed in `8d172c6` during the #1118 review. The caps are kept and reachability is layered on top, so a closed position ages out exactly as before and the persisted blob stays bounded.

## Corpus

Added a **`restart`** event type. A `relog` clears the offer store but keeps the running instance, so anything held outside it — the fill watermarks, for one — survives. Nothing in the corpus had ever crossed a process boundary, which is why a slot generation that was never persisted still looked correct under test.

Verified the new fixture has teeth: with generation persistence removed, the second buy of the same item in the same slot reports **nothing at all** rather than its five units — a silent under-report.

## Tests

`./gradlew test check` — **807 tests, 0 failures, 0 skipped.** The golden corpus stays green, which matters because it replays `Entry` directly and would catch a cycle-semantics regression.

`BuyPriceLookupTest` gained the cases for resolution order; the file previously had no coverage of the cycle-basis path because it did not exist.

## Manual test plan

1. Buy an item across two fills at different prices → the sell screen shows the **weighted** average.
2. Fully sell it, then buy again at a different price → breakeven reflects **only** the new cycle. On the current release this shows a figure blended with the sold stock.
3. Buy something, close RuneLite, rewind that record's `createdAtMillis`/`lastActivityAtMillis` by 25+ hours in `profiles2/<profile>.properties`, relaunch, open a sell → breakeven still resolves. Before this change it returns `?`.
4. Hop mid-flip → offer timers continue rather than resetting.

Step 3 is the long-hold case; rewinding the persisted timestamps avoids waiting a day for it.

### 🩺 Codacy Quality Gate — fixed in this PR
- `08e6cc7` `Lizard_parameter-count-medium` `src/test/java/com/flipsmart/trading/SessionCorpusHarness.java:163` — bundled the mock environment (session/configManager/client/clientThread/itemManager/fills) into an `Environment` holder, cutting `applyEvent` from 9 to 4 parameters.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `08e6cc7` `src/test/java/com/flipsmart/trading/SessionCorpusHarness.java:165` — same `applyEvent` parameter-count fix as the quality-gate issue above (inline threaded comment, replied + resolved).
- `a305bc8` `src/main/java/com/flipsmart/OfflineSyncService.java:553` (found only in the review body, not a threaded comment — no thread to reply/resolve) — `retainRecentTerminalHistory`'s count cap (`MAX_RETAINED_TERMINAL_RECORDS`) applied to the merged held-position + within-window list, so a record backing a still-held position could still fall past the 300-record cutoff behind more-recent, unrelated terminal records. Held-position records are now kept out of the count cap entirely, matching the age-window exemption already in place.
- `825664b` `src/main/java/com/flipsmart/trading/TransactionLogger.java:117` (found only in the review body, not a threaded comment — no thread to reply/resolve) — `pricePerItem` now also feeds `recordBuyBasis` (this PR's new cycle-basis call), not just transaction reporting, so its integer-division truncation was biasing every weighted-average cost basis down by up to 1gp/item. Changed to round instead of truncate; per-item pricing contract unchanged.


### 🔁 Codacy re-verification at `f6adcc3` (after `6f9609b`, `f6adcc3`)
- **Quality gate:** `gate_ok=true new=0` at head `f6adcc3` — the two new commits introduced no new quality-gate findings.
- **AI Reviewer:** 0 new inline comments. The single existing thread (`SessionCorpusHarness.java:165`, parameter-count) already had a reply and is resolved. The most recent posted review is stale — anchored to commit `1a882af`, several commits behind head — and its "outside of diff" findings are the same two already listed above under "fixed in this PR" (`a305bc8`, `825664b`); both were verified against current code and remain fixed. No fresh review was posted for `6f9609b`/`f6adcc3` after ~4 minutes of polling.
- **Tests:** `./gradlew test check` — **810 tests, 0 failures, 0 skipped**.
