### PR TITLE
chore: reduce plugin token footprint below Plugin Hub review ceiling

### DIFF
--- a/src/main/java/com/flipsmart/ActiveFlipTracker.java
+++ b/src/main/java/com/flipsmart/ActiveFlipTracker.java
@@ -1,8 +1,16 @@
 package com.flipsmart;
-import com.flipsmart.domain.offer.OfferRecord;
-import com.flipsmart.domain.flip.ActiveFlip;
-import com.flipsmart.trading.OfferStore;
 
+import com.flipsmart.domain.flip.ActiveFlip;
+import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.trading.OfferStore;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.swing.SwingUtilities;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GrandExchangeOffer;
@@ -11,13 +19,6 @@ import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.game.ItemManager;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 /**
  * Tracks the lifecycle of active flips: mark sold, auto-close,
@@ -36,7 +37,9 @@ public class ActiveFlipTracker
 	private final ItemManager itemManager;
 	private final OfferStore offerStore;
 
+	@Setter
 	private Runnable onPanelRefreshNeeded;
+	@Setter
 	private Runnable onActiveFlipsRefreshNeeded;
 
 	@Inject
@@ -56,15 +59,6 @@ public class ActiveFlipTracker
 		this.offerStore = offerStore;
 	}
 
-	public void setOnPanelRefreshNeeded(Runnable callback)
-	{
-		this.onPanelRefreshNeeded = callback;
-	}
-
-	public void setOnActiveFlipsRefreshNeeded(Runnable callback)
-	{
-		this.onActiveFlipsRefreshNeeded = callback;
-	}
 
 	/**
 	 * Mark an item as sold - removes it from the collected tracking.
@@ -101,7 +95,7 @@ public class ActiveFlipTracker
 				log.debug("Dismissed active flip for item {}", itemId);
 				if (onPanelRefreshNeeded != null)
 				{
-					javax.swing.SwingUtilities.invokeLater(onPanelRefreshNeeded);
+					SwingUtilities.invokeLater(onPanelRefreshNeeded);
 				}
 			}
 		});
@@ -132,7 +126,7 @@ public class ActiveFlipTracker
 				log.debug("Successfully auto-closed active flip for item {} (no items remaining)", itemId);
 				if (onPanelRefreshNeeded != null)
 				{
-					javax.swing.SwingUtilities.invokeLater(onPanelRefreshNeeded);
+					SwingUtilities.invokeLater(onPanelRefreshNeeded);
 				}
 			}
 		});
@@ -205,7 +199,7 @@ public class ActiveFlipTracker
 	private Set<Integer> collectAllActiveItemIds()
 	{
 		Set<Integer> itemIds = new java.util.HashSet<>();
-		for (com.flipsmart.domain.offer.OfferRecord offer : offerStore.liveOffers())
+		for (OfferRecord offer : offerStore.liveOffers())
 		{
 			itemIds.add(offer.getItemId());
 		}
@@ -245,7 +239,7 @@ public class ActiveFlipTracker
 			log.debug("Stale flip cleanup completed successfully");
 			if (onActiveFlipsRefreshNeeded != null)
 			{
-				javax.swing.SwingUtilities.invokeLater(onActiveFlipsRefreshNeeded);
+				SwingUtilities.invokeLater(onActiveFlipsRefreshNeeded);
 			}
 		}
 	}

--- a/src/main/java/com/flipsmart/AutoRecommendService.java
+++ b/src/main/java/com/flipsmart/AutoRecommendService.java
@@ -1,37 +1,40 @@
 package com.flipsmart;
+
+import com.flipsmart.FlipAssistOverlay.FlipAssistStep;
 import com.flipsmart.api.dto.FlipAdjustmentRequest;
-import com.flipsmart.api.dto.WikiPrice;
 import com.flipsmart.api.dto.FlipAdjustmentResponse;
+import com.flipsmart.api.dto.WikiPrice;
+import com.flipsmart.domain.flip.FlipRecommendation;
 import com.flipsmart.domain.offer.OfferRecord;
 import com.flipsmart.domain.offer.OfferState;
-import com.flipsmart.domain.flip.FlipRecommendation;
 import com.flipsmart.recommend.ActionDecision;
 import com.flipsmart.recommend.ActionResolver;
-import com.flipsmart.recommend.AdjustmentService;
+import com.flipsmart.recommend.ActionStep;
 import com.flipsmart.recommend.AdjustmentService.SellAdjustmentState;
+import com.flipsmart.recommend.AdjustmentService;
 import com.flipsmart.recommend.CollectOrigin;
 import com.flipsmart.recommend.CollectedItem;
 import com.flipsmart.recommend.RecommendationQueue;
-import com.flipsmart.recommend.ActionStep;
 import com.flipsmart.recommend.ResolverInput;
 import com.flipsmart.recommend.SkipCooldownTracker;
 import com.flipsmart.recommend.StaleOfferQueue;
 import com.flipsmart.trading.OfferStore;
 import com.flipsmart.util.GpUtils;
-
-import com.flipsmart.FlipAssistOverlay.FlipAssistStep;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import java.util.function.IntFunction;
 import java.util.function.ObjIntConsumer;
+import javax.swing.SwingUtilities;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Manages the auto-recommend queue for cycling through flip recommendations.
@@ -113,7 +116,6 @@ public class AutoRecommendService
 	 */
 	private static final long PENDING_SELL_PRICE_GRACE_MS = 90_000L;
 
-
 	private final FlipSmartConfig config;
 	private final FlipSmartPlugin plugin;
 	private final OfferStore offerStore;
@@ -135,63 +137,76 @@ public class AutoRecommendService
 
 	private final List<Runnable> deferredActions = new ArrayList<>();
 
+	@Getter
 	private volatile boolean active;
 
 	// Callback to update Flip Assist overlay and panel
+	@Setter
 	private volatile Consumer<FocusedFlip> onFocusChanged;
 
 	// Callback to update status text in the panel
+	@Setter
 	private volatile Consumer<String> onStatusChanged;
 
 	// Callback when the queue advances (for panel highlight updates)
+	@Setter
 	private volatile Runnable onQueueAdvanced;
 
 	// Callback when skip exhausts the queue (to trigger a refresh)
+	@Setter
 	private volatile Runnable onQueueExhausted;
 
 	// Callback to update the Flip Assist overlay message (when no flip is focused)
 	// ObjIntConsumer<message, itemId> — itemId <= 0 means no icon
+	@Setter
 	private volatile ObjIntConsumer<String> onOverlayMessageChanged;
 
 	// Clears all transient slot highlights and lights the live slot for the given
 	// item. Used by both the stale re-sell prompt and the collect prompt so the
 	// bright box always tracks the currently-prompted item.
-	private volatile java.util.function.IntConsumer onHighlightItemSlot;
+	@Setter
+	private volatile IntConsumer onHighlightItemSlot;
 
 	// Clears all GE slot adjustment highlights when the stale-offer queue drains,
 	// so a slot highlight never lingers without a matching prompt.
+	@Setter
 	private volatile Runnable onClearAllHighlights;
 
 	// Sticky highlight callbacks (keyed by GE slot): keep a skipped-but-cooling action's
 	// orange box lit across focus changes, and drop it when the cooldown ends or the offer
 	// is acted on.
-	private volatile java.util.function.IntConsumer onStickyHighlight;
-	private volatile java.util.function.IntConsumer onClearStickyHighlight;
+	@Setter
+	private volatile IntConsumer onStickyHighlight;
+	@Setter
+	private volatile IntConsumer onClearStickyHighlight;
 
 	// Full highlight reset (transient + sticky) used when auto-mode stops.
+	@Setter
 	private volatile Runnable onResetAllHighlights;
 
 	// Items whose orange box is kept sticky because their action was skipped and is still
 	// cooling. Maps itemId -> the GE slot recorded at skip time, so the sticky box can be
 	// cleared by slot even after the offer has left the GE (the item lookup would then fail).
-	private final Map<Integer, Integer> stickyHighlightSlots = new java.util.concurrent.ConcurrentHashMap<>();
+	private final Map<Integer, Integer> stickyHighlightSlots = new ConcurrentHashMap<>();
 
 	// Items whose surfaced resell price is a margin-decay EXIT (#918 AC2) rather than a
 	// buy reprice, so the prompt reads "Cancel & re-sell" instead of "Adjust buy".
-	private final java.util.Set<Integer> advisorExitResellItems = java.util.concurrent.ConcurrentHashMap.newKeySet();
+	private final Set<Integer> advisorExitResellItems = ConcurrentHashMap.newKeySet();
 
 	// Items whose stale-queue prompt originates from the Active-mode advisor (SURFACE_PRICE
 	// reprices and margin-decay exits). These are backend-authoritative and must bypass the local
 	// wiki competitiveness prune that governs legacy stale-offer prompts — otherwise an advisor
 	// reprice/exit on an offer the local check still reads as "competitive" (green) is dropped
 	// before it can surface.
-	private final java.util.Set<Integer> advisorSurfacedItems = java.util.concurrent.ConcurrentHashMap.newKeySet();
+	private final Set<Integer> advisorSurfacedItems = ConcurrentHashMap.newKeySet();
 
 	// Provider for the panel's displayed (smart) sell price — preferred over session's stored price
+	@Setter
 	private volatile IntFunction<Integer> displayedSellPriceProvider;
 
 	// Last overlay message sent — readable by the overlay as a fallback when the
 	// async callback result gets lost due to race conditions
+	@Getter
 	private volatile String lastOverlayMessage;
 
 	// Currently-focused collected item sell prompt — used by skip() to remove stuck items
@@ -204,6 +219,7 @@ public class AutoRecommendService
 	// Fires on each applied decision so action alerts can notify. The notifier owns its own
 	// change detection: resolveAndApply re-applies unchanged decisions on every offer event,
 	// while the tick re-resolve only calls on change.
+	@Setter
 	private Consumer<ActionDecision> onActionAlert;
 
 	// Whether a FocusedFlip (buy/sell setup overlay) is currently shown. The game-tick
@@ -235,75 +251,15 @@ public class AutoRecommendService
 		this.offerStore = offerStore;
 	}
 
-	public void setOnFocusChanged(Consumer<FocusedFlip> callback)
-	{
-		this.onFocusChanged = callback;
-	}
 
-	public void setOnStatusChanged(Consumer<String> callback)
-	{
-		this.onStatusChanged = callback;
-	}
 
-	public void setOnActionAlert(Consumer<ActionDecision> callback)
-	{
-		this.onActionAlert = callback;
-	}
 
-	public void setOnQueueAdvanced(Runnable callback)
-	{
-		this.onQueueAdvanced = callback;
-	}
 
-	public void setOnQueueExhausted(Runnable callback)
-	{
-		this.onQueueExhausted = callback;
-	}
 
-	public void setOnOverlayMessageChanged(ObjIntConsumer<String> callback)
-	{
-		this.onOverlayMessageChanged = callback;
-	}
 
-	public void setOnHighlightItemSlot(java.util.function.IntConsumer callback)
-	{
-		this.onHighlightItemSlot = callback;
-	}
 
-	public void setOnClearAllHighlights(Runnable callback)
-	{
-		this.onClearAllHighlights = callback;
-	}
 
-	public void setOnStickyHighlight(java.util.function.IntConsumer callback)
-	{
-		this.onStickyHighlight = callback;
-	}
 
-	public void setOnClearStickyHighlight(java.util.function.IntConsumer callback)
-	{
-		this.onClearStickyHighlight = callback;
-	}
-
-	public void setOnResetAllHighlights(Runnable callback)
-	{
-		this.onResetAllHighlights = callback;
-	}
-
-	public void setDisplayedSellPriceProvider(IntFunction<Integer> provider)
-	{
-		this.displayedSellPriceProvider = provider;
-	}
-
-	public boolean isActive()
-	{
-		return active;
-	}
-
-	public String getLastOverlayMessage()
-	{
-		return lastOverlayMessage;
-	}
 
 	public long getLastQueueRefreshMillis()
 	{
@@ -1738,7 +1694,12 @@ public class AutoRecommendService
 	 * Displays one at a time with a counter (e.g., "1/3: Cancel Berserker necklace?").
 	 * When the queue is exhausted, falls through to normal focusNextAvailableAction.
 	 */
-	private void focusNextStaleOffer()
+	/**
+	 * Drop queue entries that no longer apply, then report whether any stale work remains.
+	 * Returning false means the queue drained and normal flow has already been resumed, so
+	 * the caller should simply return.
+	 */
+	private boolean pruneStaleQueue()
 	{
 		// Remove offers that are no longer relevant:
 		// - cancelled/collected (no longer in GE)
@@ -1758,6 +1719,15 @@ public class AutoRecommendService
 				onClearAllHighlights.run();
 			}
 			focusNextAvailableAction();
+			return false;
+		}
+		return true;
+	}
+
+	private void focusNextStaleOffer()
+	{
+		if (!pruneStaleQueue())
+		{
 			return;
 		}
 
@@ -1821,7 +1791,7 @@ public class AutoRecommendService
 		{
 			return;
 		}
-		java.util.function.IntConsumer cb = onHighlightItemSlot;
+		IntConsumer cb = onHighlightItemSlot;
 		if (cb != null)
 		{
 			cb.accept(itemId);
@@ -1877,20 +1847,8 @@ public class AutoRecommendService
 
 	private void focusStaleOfferForItem(int itemId)
 	{
-		PlayerSession session = plugin.getSession();
-		if (session != null)
+		if (!pruneStaleQueue())
 		{
-			List<OfferRecord> currentOffers = offerStore.liveOffers();
-			staleOffers.pruneIrrelevant(o -> staleOfferNoLongerRelevant(o, currentOffers));
-		}
-
-		if (staleOffers.isEmpty())
-		{
-			if (onClearAllHighlights != null)
-			{
-				onClearAllHighlights.run();
-			}
-			focusNextAvailableAction();
 			return;
 		}
 
@@ -1942,7 +1900,7 @@ public class AutoRecommendService
 			return;
 		}
 		stickyHighlightSlots.put(itemId, slot);
-		java.util.function.IntConsumer cb = onStickyHighlight;
+		IntConsumer cb = onStickyHighlight;
 		if (cb != null)
 		{
 			cb.accept(slot);
@@ -1955,7 +1913,7 @@ public class AutoRecommendService
 		Integer slot = stickyHighlightSlots.remove(itemId);
 		if (slot != null)
 		{
-			java.util.function.IntConsumer cb = onClearStickyHighlight;
+			IntConsumer cb = onClearStickyHighlight;
 			if (cb != null)
 			{
 				cb.accept(slot);
@@ -1976,7 +1934,7 @@ public class AutoRecommendService
 			return;
 		}
 		List<OfferRecord> live = offerStore.liveOffers();
-		for (Integer itemId : new java.util.ArrayList<>(stickyHighlightSlots.keySet()))
+		for (Integer itemId : new ArrayList<>(stickyHighlightSlots.keySet()))
 		{
 			boolean cooling = skipCooldown.isCoolingDown(itemId);
 			boolean stillLiveOffer = live.stream()
@@ -2055,11 +2013,22 @@ public class AutoRecommendService
 	 */
 	public synchronized void surfaceAdvisorResell(OfferRecord offer, int newPrice, Integer netProfitEstimate)
 	{
+		surfaceAdvisorPrompt(offer, newPrice, netProfitEstimate, false);
+	}
+
+	/**
+	 * Shared body of the two advisor sell prompts. The {@code exit} flag is what separates
+	 * them: an exit re-sell marks the item so the prompt reads "Cancel &amp; re-sell", and
+	 * deliberately skips the session recommended price so the listing takes the no-offset
+	 * path. The statement order here reproduces both original methods exactly.
+	 */
+	private void surfaceAdvisorPrompt(OfferRecord offer, int price, Integer netProfitEstimate, boolean exit)
+	{
 		if (offer == null)
 		{
 			return;
 		}
-		staleOffers.putResellPrice(offer.getItemId(), newPrice);
+		staleOffers.putResellPrice(offer.getItemId(), price);
 		if (netProfitEstimate != null)
 		{
 			staleOffers.putResellNet(offer.getItemId(), netProfitEstimate);
@@ -2068,12 +2037,19 @@ public class AutoRecommendService
 		{
 			staleOffers.removeResellNet(offer.getItemId());
 		}
-		PlayerSession sess = plugin.getSession();
-		if (sess != null)
+		if (!exit)
 		{
-			sess.setRecommendedPrice(offer.getItemId(), newPrice);
+			PlayerSession sess = plugin.getSession();
+			if (sess != null)
+			{
+				sess.setRecommendedPrice(offer.getItemId(), price);
+			}
+			advisorExitResellItems.remove(offer.getItemId());
 		}
-		advisorExitResellItems.remove(offer.getItemId());
+		else
+		{
+			advisorExitResellItems.add(offer.getItemId());
+		}
 		advisorSurfacedItems.add(offer.getItemId());
 		addToStaleQueue(offer);
 	}
@@ -2087,22 +2063,7 @@ public class AutoRecommendService
 	 */
 	public synchronized void surfaceAdvisorExitResell(OfferRecord offer, int resellPrice, Integer netProfitEstimate)
 	{
-		if (offer == null)
-		{
-			return;
-		}
-		staleOffers.putResellPrice(offer.getItemId(), resellPrice);
-		if (netProfitEstimate != null)
-		{
-			staleOffers.putResellNet(offer.getItemId(), netProfitEstimate);
-		}
-		else
-		{
-			staleOffers.removeResellNet(offer.getItemId());
-		}
-		advisorExitResellItems.add(offer.getItemId());
-		advisorSurfacedItems.add(offer.getItemId());
-		addToStaleQueue(offer);
+		surfaceAdvisorPrompt(offer, resellPrice, netProfitEstimate, true);
 	}
 
 	/**
@@ -2599,7 +2560,7 @@ public class AutoRecommendService
 				Runnable exhaustedCallback = onQueueExhausted;
 				if (exhaustedCallback != null)
 				{
-					javax.swing.SwingUtilities.invokeLater(exhaustedCallback);
+					SwingUtilities.invokeLater(exhaustedCallback);
 				}
 			}
 			return;
@@ -3110,7 +3071,7 @@ public class AutoRecommendService
 		Consumer<FocusedFlip> callback = onFocusChanged;
 		if (callback != null)
 		{
-			javax.swing.SwingUtilities.invokeLater(() -> callback.accept(focus));
+			SwingUtilities.invokeLater(() -> callback.accept(focus));
 		}
 	}
 
@@ -3162,7 +3123,7 @@ public class AutoRecommendService
 		Runnable callback = onQueueAdvanced;
 		if (callback != null)
 		{
-			javax.swing.SwingUtilities.invokeLater(callback);
+			SwingUtilities.invokeLater(callback);
 		}
 	}
 
@@ -3177,7 +3138,7 @@ public class AutoRecommendService
 		ObjIntConsumer<String> callback = onOverlayMessageChanged;
 		if (callback != null)
 		{
-			javax.swing.SwingUtilities.invokeLater(() -> callback.accept(message, itemId));
+			SwingUtilities.invokeLater(() -> callback.accept(message, itemId));
 		}
 	}
 
@@ -3187,7 +3148,7 @@ public class AutoRecommendService
 		Consumer<String> callback = onStatusChanged;
 		if (callback != null)
 		{
-			javax.swing.SwingUtilities.invokeLater(() -> callback.accept(status));
+			SwingUtilities.invokeLater(() -> callback.accept(status));
 		}
 	}
 

--- a/src/main/java/com/flipsmart/BankSnapshotService.java
+++ b/src/main/java/com/flipsmart/BankSnapshotService.java
@@ -24,7 +24,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Handles bank snapshot capture and submission to the API.

--- a/src/main/java/com/flipsmart/FlipAssistOverlay.java
+++ b/src/main/java/com/flipsmart/FlipAssistOverlay.java
@@ -1,8 +1,13 @@
 package com.flipsmart;
+
 import com.flipsmart.util.GeTax;
 import com.flipsmart.util.TimeUtils;
-
+import java.text.DecimalFormat;
+import java.util.List;
+import java.util.function.Consumer;
+import javax.inject.Inject;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.gameval.VarPlayerID;
@@ -15,10 +20,7 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.util.AsyncBufferedImage;
 
-import javax.inject.Inject;
 import java.awt.*;
-import java.text.DecimalFormat;
-import java.util.function.Consumer;
 
 /**
  * Flip Assist overlay - a unique step-by-step workflow guide.
@@ -149,12 +151,8 @@ public class FlipAssistOverlay extends Overlay
 	@Getter
 	private FlipAssistStep currentStep = FlipAssistStep.SELECT_ITEM;
 	private FlipAssistStep previousStep = FlipAssistStep.SELECT_ITEM;
+	@Setter
 	private Consumer<FlipAssistStep> onStepChanged;
-
-	public void setOnStepChanged(Consumer<FlipAssistStep> callback)
-	{
-		this.onStepChanged = callback;
-	}
 
 	@Inject
 	private FlipAssistOverlay(FlipSmartPlugin flipSmartPlugin, Client client, ClientThread clientThread, FlipSmartConfig config, ItemManager itemManager, TradeActivityLog tradeActivityLog, GEHistoryService geHistoryService)
@@ -401,10 +399,10 @@ public class FlipAssistOverlay extends Overlay
 		FontMetrics smallMetrics = graphics.getFontMetrics();
 		int textPadding = 10;
 		int maxTextWidth = HINT_PANEL_WIDTH - textPadding * 2;
-		java.util.List<String> wrappedLines = null;
+		List<String> wrappedLines = null;
 
 		// Activity log: shown in idle assist states (waiting/monitoring) (AC4)
-		java.util.List<TradeActivityLog.Entry> activityEntries =
+		List<TradeActivityLog.Entry> activityEntries =
 			isIdleAssistMessage(message) ? tradeActivityLog.snapshot() : java.util.Collections.emptyList();
 		int activityLogHeight = computeActivityLogHeight(activityEntries, smallMetrics);
 
@@ -412,7 +410,7 @@ public class FlipAssistOverlay extends Overlay
 		if (hasIcon)
 		{
 			int iconSpace = 20 + 6; // hintIconSize + gap
-			java.util.List<String> iconLines = wrapText(message, smallMetrics, maxTextWidth - iconSpace);
+			List<String> iconLines = wrapText(message, smallMetrics, maxTextWidth - iconSpace);
 			int lineHeight = smallMetrics.getHeight();
 			int textHeight = lineHeight * iconLines.size();
 			// Title (20px) + gap (12px) + max(icon height, text height) + bottom padding (8px)
@@ -476,7 +474,7 @@ public class FlipAssistOverlay extends Overlay
 
 			// Wrap message to fit alongside icon
 			int iconSpace = hintIconSize + 6;
-			java.util.List<String> iconLines = wrapText(message, smallMetrics, maxTextWidth - iconSpace);
+			List<String> iconLines = wrapText(message, smallMetrics, maxTextWidth - iconSpace);
 
 			int lineHeight = smallMetrics.getHeight();
 			int textBlockHeight = lineHeight * iconLines.size();
@@ -529,7 +527,7 @@ public class FlipAssistOverlay extends Overlay
 			|| message.startsWith(MONITORING_MESSAGE);
 	}
 
-	private int computeActivityLogHeight(java.util.List<TradeActivityLog.Entry> entries, FontMetrics fm)
+	private int computeActivityLogHeight(List<TradeActivityLog.Entry> entries, FontMetrics fm)
 	{
 		if (entries.isEmpty())
 		{
@@ -539,7 +537,7 @@ public class FlipAssistOverlay extends Overlay
 		return 4 + 1 + 4 + fm.getHeight() * entries.size() + 4;
 	}
 
-	private void renderActivityLog(Graphics2D graphics, java.util.List<TradeActivityLog.Entry> entries, int top, FontMetrics fm)
+	private void renderActivityLog(Graphics2D graphics, List<TradeActivityLog.Entry> entries, int top, FontMetrics fm)
 	{
 		int dividerY = top + 4;
 		graphics.setColor(COLOR_STEP_PENDING);
@@ -622,9 +620,9 @@ public class FlipAssistOverlay extends Overlay
 		return COLOR_TEXT;
 	}
 
-	private java.util.List<String> wrapText(String text, FontMetrics fm, int maxWidth)
+	private List<String> wrapText(String text, FontMetrics fm, int maxWidth)
 	{
-		java.util.List<String> lines = new java.util.ArrayList<>();
+		List<String> lines = new java.util.ArrayList<>();
 		for (String segment : text.split("\n"))
 		{
 			if (fm.stringWidth(segment) <= maxWidth)
@@ -639,7 +637,7 @@ public class FlipAssistOverlay extends Overlay
 		return lines;
 	}
 
-	private void wrapSegment(String segment, FontMetrics fm, int maxWidth, java.util.List<String> lines)
+	private void wrapSegment(String segment, FontMetrics fm, int maxWidth, List<String> lines)
 	{
 		StringBuilder currentLine = new StringBuilder();
 		for (String word : segment.split(" "))

--- a/src/main/java/com/flipsmart/FlipFinderPanel.java
+++ b/src/main/java/com/flipsmart/FlipFinderPanel.java
@@ -1,37 +1,56 @@
 package com.flipsmart;
-import com.flipsmart.domain.flip.CompletedFlip;
-import com.flipsmart.domain.flip.FlipRecommendation;
+
 import com.flipsmart.api.dto.ActiveFlipsResponse;
+import com.flipsmart.api.dto.BlocklistSummary;
 import com.flipsmart.api.dto.CompletedFlipsResponse;
 import com.flipsmart.api.dto.FavoriteItem;
-import com.flipsmart.api.dto.FavoritesResponse;
 import com.flipsmart.api.dto.FlipFinderResponse;
 import com.flipsmart.api.dto.FlipStatisticsResponse;
-import com.flipsmart.api.dto.PluginSyncResponse;
-import com.flipsmart.domain.flip.FlipAnalysis;
 import com.flipsmart.domain.flip.ActiveFlip;
-import com.flipsmart.api.dto.BlocklistSummary;
+import com.flipsmart.domain.flip.CompletedFlip;
+import com.flipsmart.domain.flip.FlipAnalysis;
+import com.flipsmart.domain.flip.FlipRecommendation;
 import com.flipsmart.domain.offer.OfferTransition;
 import com.flipsmart.domain.offer.PendingOrder;
 import com.flipsmart.exit.ExitTradesDialog;
 import com.flipsmart.recommend.SmartSellPricer;
+import com.flipsmart.session.OpenPositions;
+import com.flipsmart.session.SessionClock;
+import com.flipsmart.session.SessionStats;
+import com.flipsmart.session.SessionStatsView;
 import com.flipsmart.trading.ActiveFlipCardMetrics;
 import com.flipsmart.trading.RealizedFlipProfit;
 import com.flipsmart.ui.panel.CardWidgets;
 import com.flipsmart.ui.panel.FavoritesSort;
 import com.flipsmart.ui.panel.ItemNameFit;
 import com.flipsmart.ui.panel.LoginPanel;
-import com.flipsmart.ui.panel.PanelFormat;
 import com.flipsmart.ui.panel.Paginator;
-import com.flipsmart.session.OpenPositions;
-import com.flipsmart.session.SessionClock;
-import com.flipsmart.session.SessionStats;
-import com.flipsmart.session.SessionStatsView;
-import com.flipsmart.util.BuyPriceLookup;
+import com.flipsmart.ui.panel.PanelFormat;
 import com.flipsmart.util.GeTax;
 import com.flipsmart.util.GpUtils;
 import com.flipsmart.util.TimeUtils;
-
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.swing.Timer;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
@@ -40,19 +59,8 @@ import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.util.AsyncBufferedImage;
 import net.runelite.client.util.LinkBrowser;
 
-import javax.swing.*;
-import javax.swing.border.EmptyBorder;
-import javax.swing.event.PopupMenuEvent;
-import javax.swing.event.PopupMenuListener;
 import java.awt.*;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ThreadLocalRandom;
+import javax.swing.*;
 
 @Slf4j
 public class FlipFinderPanel extends PluginPanel
@@ -186,7 +194,7 @@ public class FlipFinderPanel extends PluginPanel
 	private final JTabbedPane tabbedPane = new JTabbedPane();
 	private final SessionClock sessionClock = new SessionClock(System.currentTimeMillis());
 	private final SessionStatsView sessionStatsView = new SessionStatsView();
-	private javax.swing.Timer sessionStatsTimer;
+	private Timer sessionStatsTimer;
 	private SessionStats.ProfitBase sessionProfitBase = SessionStats.ProfitBase.EMPTY;
 	private final transient FlipSmartPlugin plugin;  // Reference to plugin to store recommended prices
 	
@@ -198,12 +206,12 @@ public class FlipFinderPanel extends PluginPanel
 
 	// Completed tab sort controls
 	private CompletedSort completedSort = CompletedSort.RECENCY;
-	private final java.util.Map<CompletedSort, JLabel> completedSortTabs = new java.util.EnumMap<>(CompletedSort.class);
+	private final Map<CompletedSort, JLabel> completedSortTabs = new java.util.EnumMap<>(CompletedSort.class);
 
 	// Favorites tab sort + pagination controls
 	private FavoritesSort favoritesSort = FavoritesSort.PROFIT;
 	private int favoritesPage = 0;
-	private final java.util.Map<FavoritesSort, JLabel> favoritesSortTabs = new java.util.EnumMap<>(FavoritesSort.class);
+	private final Map<FavoritesSort, JLabel> favoritesSortTabs = new java.util.EnumMap<>(FavoritesSort.class);
 	private JLabel favoritesPageLabel;
 	private JLabel favoritesPrevPageLabel;
 	private JLabel favoritesNextPageLabel;
@@ -230,21 +238,24 @@ public class FlipFinderPanel extends PluginPanel
 	private JLabel subscribeLabel;
 
 	// Callback for when authentication completes (to sync RSN)
+	@Setter
 	private transient Runnable onAuthSuccess;
 
 	// Flip Assist focus tracking
+	@Getter
 	private transient FocusedFlip currentFocus = null;
 	private transient JPanel currentFocusedPanel = null;
 	private transient int currentFocusedItemId = -1;
-	private transient java.util.function.Consumer<FocusedFlip> onFocusChanged;
+	@Setter
+	private transient Consumer<FocusedFlip> onFocusChanged;
 
 	/** Refresh closures for the cards currently on the Active Flips tab; rebuilt with the list. */
-	private final transient java.util.List<Runnable> activeFlipCardRefreshers = new java.util.ArrayList<>();
-	private transient javax.swing.Timer activeFlipsPriceTimer;
+	private final transient List<Runnable> activeFlipCardRefreshers = new ArrayList<>();
+	private transient Timer activeFlipsPriceTimer;
 
 	// Cache displayed sell prices to ensure focus uses same price as shown in UI
 	// Key: itemId, Value: calculated sell price shown in the active flip panel
-	private final java.util.Map<Integer, Integer> displayedSellPrices = new java.util.concurrent.ConcurrentHashMap<>();
+	private final Map<Integer, Integer> displayedSellPrices = new ConcurrentHashMap<>();
 
 	// Auto-recommend UI
 	private JToggleButton autoRecommendButton;
@@ -255,7 +266,7 @@ public class FlipFinderPanel extends PluginPanel
 	// The next-refresh deadline itself lives on the PluginScheduler (the single source
 	// of truth shared with the actual refresh trigger); this ticker only renders it.
 	private JLabel refreshCountdownLabel;
-	private transient javax.swing.Timer refreshCountdownTimer;
+	private transient Timer refreshCountdownTimer;
 
 	// Cashstack override indicator (AC3) — shows the active override or an error
 	private JLabel cashstackOverrideLabel;
@@ -267,7 +278,7 @@ public class FlipFinderPanel extends PluginPanel
 
 	// Favorited item ids, hydrated from the sync payload. Card rebuilds are full removeAll(),
 	// so star fill is read from here at build time rather than stored on the widget.
-	private final java.util.Set<Integer> favoriteItemIds = new java.util.concurrent.CopyOnWriteArraySet<>();
+	private final Set<Integer> favoriteItemIds = new java.util.concurrent.CopyOnWriteArraySet<>();
 
 	public FlipFinderPanel(FlipSmartConfig config, FlipSmartApiClient apiClient, ItemManager itemManager, FlipSmartPlugin plugin, ConfigManager configManager)
 	{
@@ -363,21 +374,18 @@ public class FlipFinderPanel extends PluginPanel
 		mainPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
 
 		// Header: brand title + website link stacked on the left, buttons on the right
-		JPanel headerPanel = new JPanel(new BorderLayout());
-		headerPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel headerPanel = CardWidgets.panel(new BorderLayout(), ColorScheme.DARKER_GRAY_COLOR);
 		headerPanel.setBorder(new EmptyBorder(10, 10, 10, 10));
 
 		JPanel titleBox = new JPanel();
 		titleBox.setLayout(new BoxLayout(titleBox, BoxLayout.Y_AXIS));
 		titleBox.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 
-		JLabel titleLabel = new JLabel("FlipSmart");
-		titleLabel.setForeground(Color.WHITE);
-		titleLabel.setFont(FONT_BOLD_16);
-		titleLabel.setAlignmentX(java.awt.Component.LEFT_ALIGNMENT);
+		JLabel titleLabel = CardWidgets.label("FlipSmart", Color.WHITE, FONT_BOLD_16);
+		titleLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
 		JLabel brandLink = buildWebsiteLink();
-		brandLink.setAlignmentX(java.awt.Component.LEFT_ALIGNMENT);
+		brandLink.setAlignmentX(Component.LEFT_ALIGNMENT);
 
 		titleBox.add(titleLabel);
 		titleBox.add(brandLink);
@@ -402,8 +410,7 @@ public class FlipFinderPanel extends PluginPanel
 		settingsButton.setToolTipText("Quick settings");
 		settingsButton.addActionListener(e -> showSettingsPopout(settingsButton));
 
-		JPanel headerButtons = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 0));
-		headerButtons.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel headerButtons = CardWidgets.panel(new FlowLayout(FlowLayout.RIGHT, 8, 0), ColorScheme.DARKER_GRAY_COLOR);
 		headerButtons.add(logoutButton);
 		headerButtons.add(refreshButton);
 		headerButtons.add(settingsButton);
@@ -412,8 +419,7 @@ public class FlipFinderPanel extends PluginPanel
 		headerPanel.add(headerButtons, BorderLayout.EAST);
 
 		// Low-emphasis refresh countdown, right-aligned beneath the header buttons
-		JPanel countdownRow = new JPanel(new FlowLayout(FlowLayout.RIGHT, 4, 0));
-		countdownRow.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel countdownRow = CardWidgets.panel(new FlowLayout(FlowLayout.RIGHT, 4, 0), ColorScheme.DARKER_GRAY_COLOR);
 		refreshCountdownLabel = new JLabel();
 		refreshCountdownLabel.setIcon(new ImageIcon(PanelFormat.drawClockIcon(COLOR_TEXT_DIM_GRAY)));
 		refreshCountdownLabel.setForeground(COLOR_TEXT_DIM_GRAY);
@@ -422,13 +428,10 @@ public class FlipFinderPanel extends PluginPanel
 		headerPanel.add(countdownRow, BorderLayout.SOUTH);
 
 		// Controls panel (flip style dropdown)
-		JPanel controlsPanel = new JPanel(new BorderLayout());
-		controlsPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel controlsPanel = CardWidgets.panel(new BorderLayout(), ColorScheme.DARKER_GRAY_COLOR);
 		controlsPanel.setBorder(new EmptyBorder(5, 10, 5, 10));
 
-		JLabel flipStyleLabel = new JLabel("Style: ");
-		flipStyleLabel.setForeground(Color.LIGHT_GRAY);
-		flipStyleLabel.setFont(FONT_PLAIN_12);
+		JLabel flipStyleLabel = CardWidgets.label("Style: ", Color.LIGHT_GRAY, FONT_PLAIN_12);
 
 		// Custom renderer for better appearance
 		flipStyleDropdown.setRenderer(new DefaultListCellRenderer() {
@@ -470,23 +473,19 @@ public class FlipFinderPanel extends PluginPanel
 			}
 		});
 
-		JLabel flipTimeframeLabel = new JLabel("Timeframe: ");
-		flipTimeframeLabel.setForeground(Color.LIGHT_GRAY);
-		flipTimeframeLabel.setFont(FONT_PLAIN_12);
+		JLabel flipTimeframeLabel = CardWidgets.label("Timeframe: ", Color.LIGHT_GRAY, FONT_PLAIN_12);
 
 		// Row 1: Style dropdown (left) + Auto button (right)
-		JPanel styleRow = new JPanel(new BorderLayout());
-		styleRow.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel styleRow = CardWidgets.panel(new BorderLayout(), ColorScheme.DARKER_GRAY_COLOR);
 
-		JPanel styleLeft = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 0));
-		styleLeft.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel styleLeft = CardWidgets.panel(new FlowLayout(FlowLayout.LEFT, 5, 0), ColorScheme.DARKER_GRAY_COLOR);
 		styleLeft.add(flipStyleLabel);
 		styleLeft.add(flipStyleDropdown);
 
 		// Auto-recommend toggle button
 		autoRecommendButton = new JToggleButton("Auto") {
 			@Override
-			protected void paintComponent(java.awt.Graphics g)
+			protected void paintComponent(Graphics g)
 			{
 				super.paintComponent(g);
 				if (isSelected())
@@ -542,24 +541,20 @@ public class FlipFinderPanel extends PluginPanel
 		});
 		skipButton.setVisible(false);
 
-		JPanel styleRight = new JPanel(new FlowLayout(FlowLayout.RIGHT, 5, 0));
-		styleRight.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel styleRight = CardWidgets.panel(new FlowLayout(FlowLayout.RIGHT, 5, 0), ColorScheme.DARKER_GRAY_COLOR);
 		styleRight.add(autoRecommendButton);
 
 		styleRow.add(styleLeft, BorderLayout.WEST);
 		styleRow.add(styleRight, BorderLayout.EAST);
 
 		// Row 2: Timeframe dropdown (left) + Skip button (right)
-		JPanel timeframeRow = new JPanel(new BorderLayout());
-		timeframeRow.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel timeframeRow = CardWidgets.panel(new BorderLayout(), ColorScheme.DARKER_GRAY_COLOR);
 
-		JPanel timeframeLeft = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 0));
-		timeframeLeft.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel timeframeLeft = CardWidgets.panel(new FlowLayout(FlowLayout.LEFT, 5, 0), ColorScheme.DARKER_GRAY_COLOR);
 		timeframeLeft.add(flipTimeframeLabel);
 		timeframeLeft.add(flipTimeframeDropdown);
 
-		JPanel timeframeRight = new JPanel(new FlowLayout(FlowLayout.RIGHT, 5, 0));
-		timeframeRight.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel timeframeRight = CardWidgets.panel(new FlowLayout(FlowLayout.RIGHT, 5, 0), ColorScheme.DARKER_GRAY_COLOR);
 		timeframeRight.add(skipButton);
 
 		timeframeRow.add(timeframeLeft, BorderLayout.WEST);
@@ -575,8 +570,7 @@ public class FlipFinderPanel extends PluginPanel
 		controlsPanel.add(dropdownWrapper, BorderLayout.WEST);
 
 		// Status panel
-		JPanel statusPanel = new JPanel(new BorderLayout());
-		statusPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel statusPanel = CardWidgets.panel(new BorderLayout(), ColorScheme.DARKER_GRAY_COLOR);
 		statusPanel.setBorder(new EmptyBorder(5, 10, 5, 10));
 		statusLabel.setForeground(Color.LIGHT_GRAY);
 		statusLabel.setFont(FONT_PLAIN_12);
@@ -593,8 +587,7 @@ public class FlipFinderPanel extends PluginPanel
 		cashstackOverrideLabel = new JLabel();
 		cashstackOverrideLabel.setFont(FONT_PLAIN_12);
 		cashstackOverrideLabel.setVisible(false);
-		JPanel overridePanel = new JPanel(new BorderLayout());
-		overridePanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel overridePanel = CardWidgets.panel(new BorderLayout(), ColorScheme.DARKER_GRAY_COLOR);
 		overridePanel.setBorder(new EmptyBorder(0, 10, 5, 10));
 		overridePanel.add(cashstackOverrideLabel, BorderLayout.CENTER);
 
@@ -680,7 +673,7 @@ public class FlipFinderPanel extends PluginPanel
 			}
 			
 			@Override
-			protected void paintTabBackground(java.awt.Graphics g, int tabPlacement, int tabIndex,
+			protected void paintTabBackground(Graphics g, int tabPlacement, int tabIndex,
 											  int x, int y, int w, int h, boolean isSelected) {
 				// Paint background for tabs
 				g.setColor(isSelected ? ColorScheme.DARKER_GRAY_COLOR : ColorScheme.DARK_GRAY_COLOR);
@@ -688,7 +681,7 @@ public class FlipFinderPanel extends PluginPanel
 			}
 			
 			@Override
-			protected void paintTabBorder(java.awt.Graphics g, int tabPlacement, int tabIndex,
+			protected void paintTabBorder(Graphics g, int tabPlacement, int tabIndex,
 										  int x, int y, int w, int h, boolean isSelected) {
 				// Paint border/underline for selected tab
 				if (isSelected) {
@@ -698,15 +691,14 @@ public class FlipFinderPanel extends PluginPanel
 			}
 			
 			@Override
-			protected void paintContentBorder(java.awt.Graphics g, int tabPlacement, int selectedIndex) {
+			protected void paintContentBorder(Graphics g, int tabPlacement, int selectedIndex) {
 				// Don't paint content border
 			}
 		});
 		
 		// The Recommended tab swaps between the algorithm list and the favorites list via a
 		// centered toggle button, so the favorites view no longer needs its own tab.
-		JPanel toggleBar = new JPanel(new FlowLayout(FlowLayout.CENTER, 0, 4));
-		toggleBar.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel toggleBar = CardWidgets.panel(new FlowLayout(FlowLayout.CENTER, 0, 4), ColorScheme.DARKER_GRAY_COLOR);
 		favoritesToggleButton = new JButton("★ Favorites");
 		favoritesToggleButton.setFocusable(false);
 		favoritesToggleButton.setFont(FONT_PLAIN_11);
@@ -734,8 +726,7 @@ public class FlipFinderPanel extends PluginPanel
 		recommendedCardPanel.add(recommendedScrollPane, CARD_ALGORITHM);
 		recommendedCardPanel.add(favoritesScrollPane, CARD_FAVORITES);
 
-		JPanel recommendedTabPanel = new JPanel(new BorderLayout());
-		recommendedTabPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		JPanel recommendedTabPanel = CardWidgets.panel(new BorderLayout(), ColorScheme.DARK_GRAY_COLOR);
 		recommendedTabPanel.add(recommendedControls, BorderLayout.NORTH);
 		recommendedTabPanel.add(recommendedCardPanel, BorderLayout.CENTER);
 		recommendedTabPanel.add(buildFavoritesPaginationRow(), BorderLayout.SOUTH);
@@ -744,8 +735,7 @@ public class FlipFinderPanel extends PluginPanel
 		tabbedPane.addTab("Active Flips", activeFlipsScrollPane);
 
 		// Completed tab carries a secondary sort row (Profit / Recency) above its list
-		JPanel completedTabPanel = new JPanel(new BorderLayout());
-		completedTabPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		JPanel completedTabPanel = CardWidgets.panel(new BorderLayout(), ColorScheme.DARK_GRAY_COLOR);
 		completedTabPanel.add(buildCompletedSortRow(), BorderLayout.NORTH);
 		completedTabPanel.add(completedFlipsScrollPane, BorderLayout.CENTER);
 		tabbedPane.addTab("Completed", completedTabPanel);
@@ -816,9 +806,7 @@ public class FlipFinderPanel extends PluginPanel
 			}
 		});
 
-		JLabel websiteLink = new JLabel("Website");
-		websiteLink.setForeground(new Color(100, 180, 255));
-		websiteLink.setFont(new Font(FONT_ARIAL, Font.PLAIN, 14));
+		JLabel websiteLink = CardWidgets.label("Website", new Color(100, 180, 255), new Font(FONT_ARIAL, Font.PLAIN, 14));
 		websiteLink.setCursor(new Cursor(Cursor.HAND_CURSOR));
 		websiteLink.setToolTipText("Visit our website to view your flips and track your performance");
 		websiteLink.addMouseListener(new MouseAdapter()
@@ -830,9 +818,7 @@ public class FlipFinderPanel extends PluginPanel
 			}
 		});
 
-		JLabel discordLink = new JLabel("Discord");
-		discordLink.setForeground(new Color(88, 101, 242));
-		discordLink.setFont(new Font(FONT_ARIAL, Font.PLAIN, 14));
+		JLabel discordLink = CardWidgets.label("Discord", new Color(88, 101, 242), new Font(FONT_ARIAL, Font.PLAIN, 14));
 		discordLink.setCursor(new Cursor(Cursor.HAND_CURSOR));
 		discordLink.setToolTipText("Join our Discord community");
 		discordLink.addMouseListener(new MouseAdapter()
@@ -870,13 +856,13 @@ public class FlipFinderPanel extends PluginPanel
 	private JSpinner minVolumeSpinner;
 
 	private void showItemContextMenu(int itemId, String itemName, JLabel starLabel,
-		java.awt.Component invoker, int x, int y)
+		Component invoker, int x, int y)
 	{
 		showItemContextMenu(itemId, itemName, starLabel, invoker, x, y, false, null);
 	}
 
 	private void showItemContextMenu(int itemId, String itemName, JLabel starLabel,
-		java.awt.Component invoker, int x, int y, boolean includeDismiss, Runnable onDismiss)
+		Component invoker, int x, int y, boolean includeDismiss, Runnable onDismiss)
 	{
 		JPopupMenu menu = new JPopupMenu();
 		menu.setBackground(ColorScheme.DARKER_GRAY_COLOR);
@@ -976,12 +962,9 @@ public class FlipFinderPanel extends PluginPanel
 
 	private JPanel buildMinProfitRow()
 	{
-		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
-		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel row = CardWidgets.panel(new FlowLayout(FlowLayout.LEFT, 6, 0), ColorScheme.DARKER_GRAY_COLOR);
 
-		JLabel label = new JLabel("Min Profit: ");
-		label.setForeground(Color.LIGHT_GRAY);
-		label.setFont(FONT_PLAIN_12);
+		JLabel label = CardWidgets.label("Min Profit: ", Color.LIGHT_GRAY, FONT_PLAIN_12);
 		label.setToolTipText(FILTER_TOOLTIP);
 
 		JSpinner spinner = new JSpinner(
@@ -1014,12 +997,9 @@ public class FlipFinderPanel extends PluginPanel
 
 	private JPanel buildMinVolumeRow()
 	{
-		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
-		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel row = CardWidgets.panel(new FlowLayout(FlowLayout.LEFT, 6, 0), ColorScheme.DARKER_GRAY_COLOR);
 
-		JLabel label = new JLabel("Min Volume: ");
-		label.setForeground(Color.LIGHT_GRAY);
-		label.setFont(FONT_PLAIN_12);
+		JLabel label = CardWidgets.label("Min Volume: ", Color.LIGHT_GRAY, FONT_PLAIN_12);
 		label.setToolTipText(FILTER_TOOLTIP);
 
 		JSpinner spinner = new JSpinner(
@@ -1037,8 +1017,7 @@ public class FlipFinderPanel extends PluginPanel
 
 	private JPanel buildUpdateButtonRow()
 	{
-		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
-		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel row = CardWidgets.panel(new FlowLayout(FlowLayout.LEFT, 6, 0), ColorScheme.DARKER_GRAY_COLOR);
 
 		JButton update = new JButton("Update");
 		update.setFont(FONT_PLAIN_12);
@@ -1059,8 +1038,7 @@ public class FlipFinderPanel extends PluginPanel
 
 	private JPanel buildExitTradesRow()
 	{
-		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
-		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel row = CardWidgets.panel(new FlowLayout(FlowLayout.LEFT, 6, 0), ColorScheme.DARKER_GRAY_COLOR);
 
 		boolean exitActive = plugin.getExitTradesController() != null
 			&& plugin.getExitTradesController().isActive();
@@ -1096,8 +1074,7 @@ public class FlipFinderPanel extends PluginPanel
 
 	private JPanel buildHideButtonsRow()
 	{
-		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
-		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel row = CardWidgets.panel(new FlowLayout(FlowLayout.LEFT, 6, 0), ColorScheme.DARKER_GRAY_COLOR);
 
 		JCheckBox hide = new JCheckBox("Hide FlipSmart Buttons");
 		hide.setBackground(ColorScheme.DARKER_GRAY_COLOR);
@@ -1461,7 +1438,7 @@ public class FlipFinderPanel extends PluginPanel
 	{
 		if (refreshCountdownTimer == null)
 		{
-			refreshCountdownTimer = new javax.swing.Timer(1000, e -> updateRefreshCountdownLabel());
+			refreshCountdownTimer = new Timer(1000, e -> updateRefreshCountdownLabel());
 			refreshCountdownTimer.start();
 		}
 		updateRefreshCountdownLabel();
@@ -1479,7 +1456,7 @@ public class FlipFinderPanel extends PluginPanel
 	 * consumers — render, session P&L, cross-thread overlay reads — go through here so
 	 * there is a single source of truth and no maintained cache.
 	 */
-	private java.util.List<ActiveFlip> projectedActiveFlips()
+	private List<ActiveFlip> projectedActiveFlips()
 	{
 		Map<Integer, ActiveFlip> enrichment;
 		synchronized (enrichmentByItemId)
@@ -1511,7 +1488,7 @@ public class FlipFinderPanel extends PluginPanel
 	{
 		if (sessionStatsTimer == null)
 		{
-			sessionStatsTimer = new javax.swing.Timer(1000, e ->
+			sessionStatsTimer = new Timer(1000, e ->
 			{
 				sessionClock.update(plugin.isLoggedIntoRunescape(), System.currentTimeMillis());
 				renderSessionStats();
@@ -1531,7 +1508,7 @@ public class FlipFinderPanel extends PluginPanel
 	{
 		if (activeFlipsPriceTimer == null)
 		{
-			activeFlipsPriceTimer = new javax.swing.Timer(ACTIVE_FLIPS_PRICE_REFRESH_MS,
+			activeFlipsPriceTimer = new Timer(ACTIVE_FLIPS_PRICE_REFRESH_MS,
 				e -> runActiveFlipsPriceRefresh());
 		}
 		if (!activeFlipsPriceTimer.isRunning())
@@ -1580,7 +1557,7 @@ public class FlipFinderPanel extends PluginPanel
 			return;
 		}
 		// Copy: a refresh repopulates cards, which can rebuild the list underneath us.
-		for (Runnable refresher : new java.util.ArrayList<>(activeFlipCardRefreshers))
+		for (Runnable refresher : new ArrayList<>(activeFlipCardRefreshers))
 		{
 			try
 			{
@@ -1845,7 +1822,7 @@ public class FlipFinderPanel extends PluginPanel
 	 * projected flip counts as active, plus the store-derived pending buys.
 	 * Only writes the header while the Active Flips tab is selected.
 	 */
-	private void updateActiveFlipsStatusLabel(java.util.List<ActiveFlip> active, java.util.List<PendingOrder> pending)
+	private void updateActiveFlipsStatusLabel(List<ActiveFlip> active, List<PendingOrder> pending)
 	{
 		if (tabbedPane.getSelectedIndex() != TAB_ACTIVE_FLIPS)
 		{
@@ -1874,8 +1851,8 @@ public class FlipFinderPanel extends PluginPanel
 			return;
 		}
 		final int scrollPos = getScrollPosition(activeFlipsScrollPane);
-		java.util.List<ActiveFlip> active = projectedActiveFlips();
-		java.util.List<PendingOrder> pending = plugin.getPendingBuyOrders();
+		List<ActiveFlip> active = projectedActiveFlips();
+		List<PendingOrder> pending = plugin.getPendingBuyOrders();
 		if (active.isEmpty() && pending.isEmpty())
 		{
 			showNoActiveFlips();
@@ -1891,7 +1868,7 @@ public class FlipFinderPanel extends PluginPanel
 	 * @param pendingOrders the list of pending orders (used to trigger refresh)
 	 */
 	@SuppressWarnings("unused")
-	public void updatePendingOrders(java.util.List<PendingOrder> pendingOrders)
+	public void updatePendingOrders(List<PendingOrder> pendingOrders)
 	{
 		redisplayActiveFlipsLocally();
 	}
@@ -2003,7 +1980,7 @@ public class FlipFinderPanel extends PluginPanel
 	/**
 	 * Populate the completed flips list
 	 */
-	private void populateCompletedFlips(java.util.List<CompletedFlip> flips)
+	private void populateCompletedFlips(List<CompletedFlip> flips)
 	{
 		completedFlipsListContainer.removeAll();
 
@@ -2021,22 +1998,22 @@ public class FlipFinderPanel extends PluginPanel
 	 * Return a copy of {@code flips} ordered by the active Completed-tab sort:
 	 * Profit (highest net profit first, AC7) or Recency (most recently sold first, AC8).
 	 */
-	private java.util.List<CompletedFlip> sortedCompletedFlips(java.util.List<CompletedFlip> flips)
+	private List<CompletedFlip> sortedCompletedFlips(List<CompletedFlip> flips)
 	{
-		java.util.List<CompletedFlip> sorted = new ArrayList<>(flips);
-		java.util.Comparator<CompletedFlip> comparator;
+		List<CompletedFlip> sorted = new ArrayList<>(flips);
+		Comparator<CompletedFlip> comparator;
 		if (completedSort == CompletedSort.PROFIT)
 		{
-			comparator = java.util.Comparator.comparingLong(CompletedFlip::getNetProfit).reversed();
+			comparator = Comparator.comparingLong(CompletedFlip::getNetProfit).reversed();
 		}
 		else
 		{
-			java.util.Map<CompletedFlip, Long> tsCache = new java.util.IdentityHashMap<>();
+			Map<CompletedFlip, Long> tsCache = new java.util.IdentityHashMap<>();
 			for (CompletedFlip f : sorted)
 			{
 				tsCache.put(f, TimeUtils.parseIsoToMillis(f.getSellTime()));
 			}
-			comparator = java.util.Comparator
+			comparator = Comparator
 				.comparingLong((CompletedFlip f) -> tsCache.get(f))
 				.thenComparingInt(CompletedFlip::getId)
 				.reversed();
@@ -2051,21 +2028,29 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private JPanel buildCompletedSortRow()
 	{
-		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 4));
-		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		return buildSortRow(CompletedSort.values(), sort -> sort.label,
+			this::selectCompletedSort, completedSortTabs, this::applyCompletedSortTabStyles);
+	}
+
+	/**
+	 * Shared "Sort: [tab][tab]..." row for the completed and favourites lists. Both
+	 * differ only in their enum, its label accessor, and what a click does.
+	 */
+	private <T extends Enum<T>> JPanel buildSortRow(T[] sorts, Function<T, String> label,
+		Consumer<T> onSelect, Map<T, JLabel> tabs, Runnable applyStyles)
+	{
+		JPanel row = CardWidgets.panel(new FlowLayout(FlowLayout.LEFT, 6, 4), ColorScheme.DARKER_GRAY_COLOR);
 		row.setBorder(new EmptyBorder(0, 4, 0, 0));
 
-		JLabel sortByLabel = new JLabel("Sort:");
-		sortByLabel.setForeground(COLOR_TEXT_DIM_GRAY);
-		sortByLabel.setFont(new Font(FONT_ARIAL, Font.ITALIC, 10));
+		JLabel sortByLabel = CardWidgets.label("Sort:", COLOR_TEXT_DIM_GRAY, new Font(FONT_ARIAL, Font.ITALIC, 10));
 		row.add(sortByLabel);
 
 		Font tabFont = new Font(FONT_ARIAL, Font.BOLD, 11);
 		EmptyBorder tabBorder = new EmptyBorder(2, 7, 2, 7);
 		Cursor handCursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR);
-		for (CompletedSort sort : CompletedSort.values())
+		for (T sort : sorts)
 		{
-			JLabel tab = new JLabel(sort.label);
+			JLabel tab = new JLabel(label.apply(sort));
 			tab.setFont(tabFont);
 			tab.setBorder(tabBorder);
 			tab.setCursor(handCursor);
@@ -2075,14 +2060,14 @@ public class FlipFinderPanel extends PluginPanel
 				@Override
 				public void mouseClicked(MouseEvent e)
 				{
-					selectCompletedSort(sort);
+					onSelect.accept(sort);
 				}
 			});
-			completedSortTabs.put(sort, tab);
+			tabs.put(sort, tab);
 			row.add(tab);
 		}
 
-		applyCompletedSortTabStyles();
+		applyStyles.run();
 		return row;
 	}
 
@@ -2105,7 +2090,7 @@ public class FlipFinderPanel extends PluginPanel
 	/** Highlight the active sort tab (orange) and dim the others. */
 	private void applyCompletedSortTabStyles()
 	{
-		for (java.util.Map.Entry<CompletedSort, JLabel> entry : completedSortTabs.entrySet())
+		for (Map.Entry<CompletedSort, JLabel> entry : completedSortTabs.entrySet())
 		{
 			boolean selected = entry.getKey() == completedSort;
 			JLabel tab = entry.getValue();
@@ -2138,7 +2123,7 @@ public class FlipFinderPanel extends PluginPanel
 	 * live SELL offer or an awaiting-sale inventory lot — so every projected flip renders
 	 * with no dedup against the pending rows.
 	 */
-	private void displayActiveFlipsAndPending(java.util.List<ActiveFlip> activeFlips, java.util.List<PendingOrder> pendingOrders)
+	private void displayActiveFlipsAndPending(List<ActiveFlip> activeFlips, List<PendingOrder> pendingOrders)
 	{
 		activeFlipsListContainer.removeAll();
 		activeFlipCardRefreshers.clear();
@@ -2468,15 +2453,11 @@ public class FlipFinderPanel extends PluginPanel
 		emptyPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 		emptyPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
 
-		JLabel titleLabel = new JLabel(title);
-		titleLabel.setForeground(Color.WHITE);
-		titleLabel.setFont(FONT_BOLD_16);
+		JLabel titleLabel = CardWidgets.label(title, Color.WHITE, FONT_BOLD_16);
 		titleLabel.setHorizontalAlignment(SwingConstants.CENTER);
 		titleLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
-		JLabel instructionLabel = new JLabel(instruction);
-		instructionLabel.setForeground(COLOR_TEXT_DIM_GRAY);
-		instructionLabel.setFont(FONT_PLAIN_12);
+		JLabel instructionLabel = CardWidgets.label(instruction, COLOR_TEXT_DIM_GRAY, FONT_PLAIN_12);
 		instructionLabel.setHorizontalAlignment(SwingConstants.CENTER);
 		instructionLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
@@ -2681,39 +2662,8 @@ public class FlipFinderPanel extends PluginPanel
 	 */
 	private JPanel buildFavoritesSortRow()
 	{
-		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 4));
-		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-		row.setBorder(new EmptyBorder(0, 4, 0, 0));
-
-		JLabel sortByLabel = new JLabel("Sort:");
-		sortByLabel.setForeground(COLOR_TEXT_DIM_GRAY);
-		sortByLabel.setFont(new Font(FONT_ARIAL, Font.ITALIC, 10));
-		row.add(sortByLabel);
-
-		Font tabFont = new Font(FONT_ARIAL, Font.BOLD, 11);
-		EmptyBorder tabBorder = new EmptyBorder(2, 7, 2, 7);
-		Cursor handCursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR);
-		for (FavoritesSort sort : FavoritesSort.values())
-		{
-			JLabel tab = new JLabel(sort.getLabel());
-			tab.setFont(tabFont);
-			tab.setBorder(tabBorder);
-			tab.setCursor(handCursor);
-			tab.setOpaque(true);
-			tab.addMouseListener(new MouseAdapter()
-			{
-				@Override
-				public void mouseClicked(MouseEvent e)
-				{
-					selectFavoritesSort(sort);
-				}
-			});
-			favoritesSortTabs.put(sort, tab);
-			row.add(tab);
-		}
-
-		applyFavoritesSortTabStyles();
-		return row;
+		return buildSortRow(FavoritesSort.values(), FavoritesSort::getLabel,
+			this::selectFavoritesSort, favoritesSortTabs, this::applyFavoritesSortTabStyles);
 	}
 
 	/** Persist the chosen sort, reset to page 0, restyle the tabs, and re-render the list. */
@@ -2733,7 +2683,7 @@ public class FlipFinderPanel extends PluginPanel
 	/** Highlight the active sort tab (orange) and dim the others. */
 	private void applyFavoritesSortTabStyles()
 	{
-		for (java.util.Map.Entry<FavoritesSort, JLabel> entry : favoritesSortTabs.entrySet())
+		for (Map.Entry<FavoritesSort, JLabel> entry : favoritesSortTabs.entrySet())
 		{
 			boolean selected = entry.getKey() == favoritesSort;
 			JLabel tab = entry.getValue();
@@ -2794,8 +2744,7 @@ public class FlipFinderPanel extends PluginPanel
 	/** Build the row holding the premium-gated "Flip only from favorites" checkbox. */
 	private JPanel buildFlipOnlyFavoritesRow()
 	{
-		JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
-		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel row = CardWidgets.panel(new FlowLayout(FlowLayout.LEFT, 6, 0), ColorScheme.DARKER_GRAY_COLOR);
 		row.setBorder(new EmptyBorder(0, 4, 4, 0));
 		row.add(buildFlipOnlyFavoritesCheck());
 		return row;
@@ -2964,9 +2913,7 @@ public class FlipFinderPanel extends PluginPanel
 
 		// Recommended Buy/Sell prices — buy blue, sell orange, bold (matches the Active-tab live-price row).
 		// White base foreground keeps the "Buy:"/"Sell:" label text (outside the coloured spans) legible.
-		JLabel priceLabel = new JLabel(PanelFormat.buySellHtml(displayBuyPrice, displaySellPrice));
-		priceLabel.setForeground(Color.WHITE);
-		priceLabel.setFont(FONT_PLAIN_12);
+		JLabel priceLabel = CardWidgets.label(PanelFormat.buySellHtml(displayBuyPrice, displaySellPrice), Color.WHITE, FONT_PLAIN_12);
 
 		// Quantity
 		JLabel quantityLabel = new JLabel(String.format("Qty: %d (Limit: %d)",
@@ -2981,19 +2928,13 @@ public class FlipFinderPanel extends PluginPanel
 		marginLabel.setFont(FONT_PLAIN_12);
 
 		// Potential profit and total cost
-		JLabel profitLabel = new JLabel(PanelFormat.formatProfitCostText(displayProfit, displayCost));
-		profitLabel.setForeground(new Color(255, 215, 0));
-		profitLabel.setFont(FONT_PLAIN_12);
+		JLabel profitLabel = CardWidgets.label(PanelFormat.formatProfitCostText(displayProfit, displayCost), new Color(255, 215, 0), FONT_PLAIN_12);
 
 		// Volume info
-		JLabel volumeLabel = new JLabel(PanelFormat.formatVolumeText(rec.getDailyVolume()));
-		volumeLabel.setForeground(Color.CYAN);
-		volumeLabel.setFont(FONT_PLAIN_12);
+		JLabel volumeLabel = CardWidgets.label(PanelFormat.formatVolumeText(rec.getDailyVolume()), Color.CYAN, FONT_PLAIN_12);
 
 		// Risk info
-		JLabel riskLabel = new JLabel(PanelFormat.formatRiskText(rec.getRiskScore(), rec.getRiskRating()));
-		riskLabel.setForeground(PanelFormat.getRiskColor(rec.getRiskScore()));
-		riskLabel.setFont(FONT_PLAIN_12);
+		JLabel riskLabel = CardWidgets.label(PanelFormat.formatRiskText(rec.getRiskScore(), rec.getRiskRating()), PanelFormat.getRiskColor(rec.getRiskScore()), FONT_PLAIN_12);
 
 		CardWidgets.addLabelsWithSpacing(detailsPanel, priceLabel, quantityLabel, marginLabel,
 			profitLabel, volumeLabel, riskLabel);
@@ -3083,9 +3024,7 @@ public class FlipFinderPanel extends PluginPanel
 			extraDetails.setBackground(panel.getBackground());
 			extraDetails.setBorder(new EmptyBorder(5, 0, 0, 0));
 
-			JLabel focusHint = new JLabel("Click to focus • Press hotkey to auto-fill GE");
-			focusHint.setForeground(COLOR_FOCUSED_BORDER);
-			focusHint.setFont(new Font(FONT_ARIAL, Font.ITALIC, 10));
+			JLabel focusHint = CardWidgets.label("Click to focus • Press hotkey to auto-fill GE", COLOR_FOCUSED_BORDER, new Font(FONT_ARIAL, Font.ITALIC, 10));
 
 			extraDetails.add(focusHint);
 			panel.add(extraDetails, BorderLayout.SOUTH);
@@ -3173,11 +3112,9 @@ public class FlipFinderPanel extends PluginPanel
 	private HeaderPanels createItemHeaderPanels(int itemId, String itemName, Color bgColor,
 		JLabel trailingIcon, JLabel cornerSubtitle)
 	{
-		JPanel topPanel = new JPanel(new BorderLayout(4, 0));
-		topPanel.setBackground(bgColor);
+		JPanel topPanel = CardWidgets.panel(new BorderLayout(4, 0), bgColor);
 
-		JPanel namePanel = new JPanel(new BorderLayout(5, 0));
-		namePanel.setBackground(bgColor);
+		JPanel namePanel = CardWidgets.panel(new BorderLayout(5, 0), bgColor);
 
 		AsyncBufferedImage itemImage = itemManager.getImage(itemId);
 		JLabel iconLabel = new JLabel();
@@ -3249,106 +3186,105 @@ public class FlipFinderPanel extends PluginPanel
 	 * Create a clickable chart icon label that opens the item's page on the website.
 	 * Uses a simple bar chart icon drawn with Java 2D graphics.
 	 */
-	private JLabel createChartIconLabel(int itemId)
+	/** Base for the small clickable card icons: image, tooltip, hand cursor, transparent. */
+	private static JLabel iconLabel(BufferedImage icon, String tooltip)
 	{
-		java.awt.image.BufferedImage chartIcon = PanelFormat.drawChartIcon(new Color(100, 180, 255), new Color(150, 150, 150));
+		JLabel label = new JLabel(new ImageIcon(icon));
+		label.setToolTipText(tooltip);
+		label.setCursor(new Cursor(Cursor.HAND_CURSOR));
+		label.setOpaque(false);
+		return label;
+	}
 
-		JLabel chartLabel = new JLabel(new ImageIcon(chartIcon));
-		chartLabel.setToolTipText("View price history on FlipSmart website");
-		chartLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		chartLabel.setBorder(BorderFactory.createEmptyBorder(0, 1, 0, 0));
-		chartLabel.setOpaque(false);
+	/** As {@link #iconLabel(BufferedImage, String)}, with {@code leftPad} px of left inset. */
+	private static JLabel iconLabel(BufferedImage icon, String tooltip, int leftPad)
+	{
+		JLabel label = iconLabel(icon, tooltip);
+		label.setBorder(BorderFactory.createEmptyBorder(0, leftPad, 0, 0));
+		return label;
+	}
 
-		// Add click listener to open website
-		chartLabel.addMouseListener(new MouseAdapter()
+	/** Show {@code hover} while the pointer is over an enabled {@code label}, else {@code base}. */
+	private static void hoverSwap(JLabel label, BufferedImage base, Supplier<BufferedImage> hover)
+	{
+		label.addMouseListener(new MouseAdapter()
 		{
-			@Override
-			public void mouseClicked(MouseEvent e)
-			{
-				// Prevent the click from propagating to the parent panel
-				e.consume();
-				LinkBrowser.browse(WEBSITE_ITEM_URL + itemId);
-			}
-
 			@Override
 			public void mouseEntered(MouseEvent e)
 			{
-				chartLabel.setIcon(new ImageIcon(PanelFormat.drawChartIcon(new Color(150, 220, 255), new Color(200, 200, 200))));
+				if (label.isEnabled())
+				{
+					label.setIcon(new ImageIcon(hover.get()));
+				}
 			}
 
 			@Override
 			public void mouseExited(MouseEvent e)
 			{
-				chartLabel.setIcon(new ImageIcon(chartIcon));
+				label.setIcon(new ImageIcon(base));
 			}
 		});
+	}
 
+	/** Click handler that stops the event reaching the card underneath. */
+	private static void onIconClick(JLabel label, Runnable action)
+	{
+		label.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(MouseEvent e)
+			{
+				e.consume();
+				action.run();
+			}
+		});
+	}
+
+	private JLabel createChartIconLabel(int itemId)
+	{
+		BufferedImage chartIcon = PanelFormat.drawChartIcon(new Color(100, 180, 255), new Color(150, 150, 150));
+		JLabel chartLabel = iconLabel(chartIcon, "View price history on FlipSmart website", 1);
+		hoverSwap(chartLabel, chartIcon,
+			() -> PanelFormat.drawChartIcon(new Color(150, 220, 255), new Color(200, 200, 200)));
+		onIconClick(chartLabel, () -> LinkBrowser.browse(WEBSITE_ITEM_URL + itemId));
 		return chartLabel;
 	}
 
 	private JLabel createRefreshIconLabel(Runnable onRefresh)
 	{
-		java.awt.image.BufferedImage refreshIcon = PanelFormat.drawRefreshIcon(new Color(120, 200, 255));
-
-		JLabel refreshLabel = new JLabel(new ImageIcon(refreshIcon));
-		refreshLabel.setToolTipText("Refresh latest prices.");
-		refreshLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		refreshLabel.setBorder(BorderFactory.createEmptyBorder(0, 1, 0, 0));
-		refreshLabel.setOpaque(false);
-
-		refreshLabel.addMouseListener(new MouseAdapter()
+		BufferedImage refreshIcon = PanelFormat.drawRefreshIcon(new Color(120, 200, 255));
+		JLabel refreshLabel = iconLabel(refreshIcon, "Refresh latest prices.", 1);
+		hoverSwap(refreshLabel, refreshIcon, () -> PanelFormat.drawRefreshIcon(new Color(170, 225, 255)));
+		onIconClick(refreshLabel, () ->
 		{
-			@Override
-			public void mouseClicked(MouseEvent e)
+			if (!refreshLabel.isEnabled())
 			{
-				e.consume();
-				if (!refreshLabel.isEnabled())
-				{
-					return;
-				}
-				refreshLabel.setEnabled(false);
-				refreshLabel.setCursor(Cursor.getDefaultCursor());
-				onRefresh.run();
-				restartActiveFlipsPriceTimer();
-				// Re-enable shortly after; the async re-populate updates the rows independently
-				javax.swing.Timer timer = new javax.swing.Timer(1200, ev ->
-				{
-					refreshLabel.setEnabled(true);
-					refreshLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
-				});
-				timer.setRepeats(false);
-				timer.start();
+				return;
 			}
-
-			@Override
-			public void mouseEntered(MouseEvent e)
+			refreshLabel.setEnabled(false);
+			refreshLabel.setCursor(Cursor.getDefaultCursor());
+			onRefresh.run();
+			restartActiveFlipsPriceTimer();
+			// Re-enable shortly after; the async re-populate updates the rows independently
+			Timer timer = new Timer(1200, ev ->
 			{
-				if (refreshLabel.isEnabled())
-				{
-					refreshLabel.setIcon(new ImageIcon(PanelFormat.drawRefreshIcon(new Color(170, 225, 255))));
-				}
-			}
-
-			@Override
-			public void mouseExited(MouseEvent e)
-			{
-				refreshLabel.setIcon(new ImageIcon(refreshIcon));
-			}
+				refreshLabel.setEnabled(true);
+				refreshLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+			});
+			timer.setRepeats(false);
+			timer.start();
 		});
 
 		return refreshLabel;
 	}
 
-	/**
-	 * Create a clickable block icon label that adds the item to a blocklist.
-	 * Uses a ban/circle-slash icon drawn with Java 2D graphics.
-	 */
-	public static boolean isFavorite(java.util.Set<Integer> favorites, int itemId)
+	/** Whether {@code itemId} is in the caller's favourites, null-safe on the set. */
+	public static boolean isFavorite(Set<Integer> favorites, int itemId)
 	{
 		return favorites != null && favorites.contains(itemId);
 	}
 
-	private void applyFavoriteItemIds(java.util.List<Integer> ids)
+	private void applyFavoriteItemIds(List<Integer> ids)
 	{
 		SwingUtilities.invokeLater(() ->
 		{
@@ -3363,20 +3299,9 @@ public class FlipFinderPanel extends PluginPanel
 	private JLabel createStarIconLabel(int itemId)
 	{
 		boolean filled = isFavorite(favoriteItemIds, itemId);
-		JLabel star = new JLabel(new ImageIcon(
-			PanelFormat.drawStarIcon(filled, filled ? STAR_ON_COLOR : STAR_OFF_COLOR)));
-		star.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		star.setToolTipText(filled ? "Remove from favorites" : "Add to favorites");
-		star.setOpaque(false);
-		star.addMouseListener(new MouseAdapter()
-		{
-			@Override
-			public void mouseClicked(MouseEvent e)
-			{
-				e.consume();
-				handleStarClick(itemId, star);
-			}
-		});
+		JLabel star = iconLabel(PanelFormat.drawStarIcon(filled, filled ? STAR_ON_COLOR : STAR_OFF_COLOR),
+			filled ? "Remove from favorites" : "Add to favorites");
+		onIconClick(star, () -> handleStarClick(itemId, star));
 		return star;
 	}
 
@@ -3440,36 +3365,10 @@ public class FlipFinderPanel extends PluginPanel
 
 	private JLabel createBlockIconLabel(int itemId, String itemName)
 	{
-		java.awt.image.BufferedImage blockIcon = PanelFormat.drawBlockIcon(new Color(180, 100, 100));
-
-		JLabel blockLabel = new JLabel(new ImageIcon(blockIcon));
-		blockLabel.setToolTipText("Block this item from recommendations");
-		blockLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		blockLabel.setBorder(BorderFactory.createEmptyBorder(0, 2, 0, 0));
-		blockLabel.setOpaque(false);
-
-		// Add click listener to block the item
-		blockLabel.addMouseListener(new MouseAdapter()
-		{
-			@Override
-			public void mouseClicked(MouseEvent e)
-			{
-				e.consume();
-				handleBlockItemClick(itemId, itemName);
-			}
-
-			@Override
-			public void mouseEntered(MouseEvent e)
-			{
-				blockLabel.setIcon(new ImageIcon(PanelFormat.drawBlockIcon(new Color(255, 100, 100))));
-			}
-
-			@Override
-			public void mouseExited(MouseEvent e)
-			{
-				blockLabel.setIcon(new ImageIcon(blockIcon));
-			}
-		});
+		BufferedImage blockIcon = PanelFormat.drawBlockIcon(new Color(180, 100, 100));
+		JLabel blockLabel = iconLabel(blockIcon, "Block this item from recommendations", 2);
+		hoverSwap(blockLabel, blockIcon, () -> PanelFormat.drawBlockIcon(new Color(255, 100, 100)));
+		onIconClick(blockLabel, () -> handleBlockItemClick(itemId, itemName));
 
 		return blockLabel;
 	}
@@ -3716,24 +3615,7 @@ public class FlipFinderPanel extends PluginPanel
 			clearFocus();
 		}
 	}
-	
-	/**
-	 * Set the callback for when the focused flip changes
-	 */
-	public void setOnFocusChanged(java.util.function.Consumer<FocusedFlip> callback)
-	{
-		this.onFocusChanged = callback;
-	}
 
-	/**
-	 * Set the callback for when authentication succeeds.
-	 * This allows the plugin to sync RSN after Discord login.
-	 */
-	public void setOnAuthSuccess(Runnable callback)
-	{
-		this.onAuthSuccess = callback;
-	}
-	
 	/**
 	 * Set a recommendation as the current focus for Flip Assist
 	 */
@@ -3973,13 +3855,6 @@ public class FlipFinderPanel extends PluginPanel
 		updateChildBackgrounds(panel, COLOR_AUTO_RECOMMEND_BG);
 	}
 	
-	/**
-	 * Get the current focused flip
-	 */
-	public FocusedFlip getCurrentFocus()
-	{
-		return currentFocus;
-	}
 	
 	/**
 	 * Get the displayed sell price for an item from the Active Flips panel.
@@ -4644,8 +4519,7 @@ public class FlipFinderPanel extends PluginPanel
 		final JLabel completedStarLabel = header.starLabel;
 
 		// Details section with profit/loss info - use GridBagLayout for tighter column spacing
-		JPanel detailsPanel = new JPanel(new GridBagLayout());
-		detailsPanel.setBackground(backgroundColor);
+		JPanel detailsPanel = CardWidgets.panel(new GridBagLayout(), backgroundColor);
 		detailsPanel.setBorder(new EmptyBorder(3, 0, 0, 0));
 		
 		GridBagConstraints gbc = new GridBagConstraints();
@@ -4653,22 +4527,14 @@ public class FlipFinderPanel extends PluginPanel
 		gbc.insets = new Insets(1, 0, 1, 15); // 15px gap between columns
 
 		// Row 1: Quantity and Buy Price
-		JLabel qtyLabel = new JLabel(String.format(FORMAT_QTY, flip.getQuantity()));
-		qtyLabel.setForeground(COLOR_TEXT_GRAY);
-		qtyLabel.setFont(FONT_PLAIN_12);
+		JLabel qtyLabel = CardWidgets.label(String.format(FORMAT_QTY, flip.getQuantity()), COLOR_TEXT_GRAY, FONT_PLAIN_12);
 
-		JLabel buyPriceLabel = new JLabel(String.format("Buy: %s", PanelFormat.formatGPExact(flip.getBuyPricePerItem())));
-		buyPriceLabel.setForeground(COLOR_BUY_RED);
-		buyPriceLabel.setFont(FONT_PLAIN_12);
+		JLabel buyPriceLabel = CardWidgets.label(String.format("Buy: %s", PanelFormat.formatGPExact(flip.getBuyPricePerItem())), COLOR_BUY_RED, FONT_PLAIN_12);
 
 		// Row 2: Invested and Sell Price
-		JLabel investedLabel = new JLabel(String.format("Cost: %s", PanelFormat.formatGP(flip.getBuyTotal())));
-		investedLabel.setForeground(COLOR_TEXT_GRAY);
-		investedLabel.setFont(FONT_PLAIN_12);
+		JLabel investedLabel = CardWidgets.label(String.format("Cost: %s", PanelFormat.formatGP(flip.getBuyTotal())), COLOR_TEXT_GRAY, FONT_PLAIN_12);
 
-		JLabel sellPriceLabel = new JLabel(String.format(FORMAT_SELL, PanelFormat.formatGPExact(flip.getSellPricePerItem())));
-		sellPriceLabel.setForeground(COLOR_SELL_GREEN);
-		sellPriceLabel.setFont(FONT_PLAIN_12);
+		JLabel sellPriceLabel = CardWidgets.label(String.format(FORMAT_SELL, PanelFormat.formatGPExact(flip.getSellPricePerItem())), COLOR_SELL_GREEN, FONT_PLAIN_12);
 
 		// Row 3: Net Profit and ROI
 		JLabel profitLabel = new JLabel(String.format("Profit: %s", PanelFormat.formatGP(flip.getNetProfit())));
@@ -4678,9 +4544,7 @@ public class FlipFinderPanel extends PluginPanel
 		profitLabel.setForeground(profitColor);
 		profitLabel.setFont(FONT_BOLD_12);
 
-		JLabel roiLabel = new JLabel(String.format(FORMAT_ROI, flip.getRoiPercent()));
-		roiLabel.setForeground(profitColor);
-		roiLabel.setFont(FONT_BOLD_12);
+		JLabel roiLabel = CardWidgets.label(String.format(FORMAT_ROI, flip.getRoiPercent()), profitColor, FONT_BOLD_12);
 
 		// Add labels with GridBagLayout - columns stay compact
 		gbc.gridx = 0; gbc.gridy = 0; detailsPanel.add(qtyLabel, gbc);
@@ -4742,14 +4606,10 @@ public class FlipFinderPanel extends PluginPanel
 						String.format("%dh %dm", hours, minutes) :
 						String.format("%dm", minutes);
 
-					JLabel durationLabel = new JLabel(String.format("Duration: %s", duration));
-					durationLabel.setForeground(COLOR_TEXT_DIM_GRAY);
-					durationLabel.setFont(FONT_PLAIN_12);
+					JLabel durationLabel = CardWidgets.label(String.format("Duration: %s", duration), COLOR_TEXT_DIM_GRAY, FONT_PLAIN_12);
 
 					// GE Tax
-					JLabel taxLabel = new JLabel(String.format("GE Tax: %s", PanelFormat.formatGP(flip.getGeTax())));
-					taxLabel.setForeground(COLOR_TEXT_DIM_GRAY);
-					taxLabel.setFont(FONT_PLAIN_12);
+					JLabel taxLabel = CardWidgets.label(String.format("GE Tax: %s", PanelFormat.formatGP(flip.getGeTax())), COLOR_TEXT_DIM_GRAY, FONT_PLAIN_12);
 
 					extraDetails.add(durationLabel);
 					extraDetails.add(Box.createRigidArea(new Dimension(0, 2)));

--- a/src/main/java/com/flipsmart/FlipSmartApiClient.java
+++ b/src/main/java/com/flipsmart/FlipSmartApiClient.java
@@ -1,5 +1,31 @@
 package com.flipsmart;
+
 import com.flipsmart.api.ApiHttpTransport;
+import com.flipsmart.api.dto.ActiveFlipsResponse;
+import com.flipsmart.api.dto.AuthResult;
+import com.flipsmart.api.dto.BankItem;
+import com.flipsmart.api.dto.BankItemId;
+import com.flipsmart.api.dto.BankSnapshotResult;
+import com.flipsmart.api.dto.BlocklistsResponse;
+import com.flipsmart.api.dto.CompletedFlipsResponse;
+import com.flipsmart.api.dto.DeviceAuthResponse;
+import com.flipsmart.api.dto.DeviceStatusResponse;
+import com.flipsmart.api.dto.DumpEvent;
+import com.flipsmart.api.dto.FavoritesResponse;
+import com.flipsmart.api.dto.FlipAdjustmentRequest;
+import com.flipsmart.api.dto.FlipAdjustmentResponse;
+import com.flipsmart.api.dto.FlipFinderResponse;
+import com.flipsmart.api.dto.FlipStatisticsResponse;
+import com.flipsmart.api.dto.HistoryBackfillEntry;
+import com.flipsmart.api.dto.MotdResponse;
+import com.flipsmart.api.dto.OfferAdviceBatchResponse;
+import com.flipsmart.api.dto.OfferAdviceRequest;
+import com.flipsmart.api.dto.PluginSyncResponse;
+import com.flipsmart.api.dto.SellPriceCheckRequest;
+import com.flipsmart.api.dto.SellPriceCheckResponse;
+import com.flipsmart.api.dto.TimeframeFlipFinderResponse;
+import com.flipsmart.api.dto.TransactionRequest;
+import com.flipsmart.api.dto.WikiPrice;
 import com.flipsmart.api.endpoints.ActiveFlipEndpoints;
 import com.flipsmart.api.endpoints.ActiveFlipsSnapshotEndpoints;
 import com.flipsmart.api.endpoints.BankSnapshotEndpoints;
@@ -12,45 +38,19 @@ import com.flipsmart.api.endpoints.OfferActionEndpoints;
 import com.flipsmart.api.endpoints.TradeStationEndpoints;
 import com.flipsmart.api.endpoints.TransactionEndpoints;
 import com.flipsmart.api.endpoints.WebhookEndpoints;
-import com.flipsmart.api.dto.ActiveFlipsResponse;
-import com.flipsmart.api.dto.CompletedFlipsResponse;
-import com.flipsmart.api.dto.FavoritesResponse;
-import com.flipsmart.api.dto.FlipAdjustmentResponse;
-import com.flipsmart.api.dto.OfferAdviceBatchResponse;
-import com.flipsmart.api.dto.BankSnapshotResult;
-import com.flipsmart.api.dto.TimeframeFlipFinderResponse;
-import com.flipsmart.api.dto.FlipFinderResponse;
-import com.flipsmart.api.dto.PluginSyncResponse;
-import com.flipsmart.api.dto.BlocklistsResponse;
 import com.flipsmart.domain.flip.FlipAnalysis;
-import com.flipsmart.api.dto.DumpEvent;
-import com.flipsmart.api.dto.FlipStatisticsResponse;
-import com.flipsmart.api.dto.OfferAdviceRequest;
-import com.flipsmart.api.dto.SellPriceCheckRequest;
-import com.flipsmart.api.dto.SellPriceCheckResponse;
-import com.flipsmart.api.dto.AuthResult;
-import com.flipsmart.api.dto.DeviceAuthResponse;
-import com.flipsmart.api.dto.DeviceStatusResponse;
-import com.flipsmart.api.dto.MotdResponse;
-import com.flipsmart.api.dto.TransactionRequest;
-import com.flipsmart.api.dto.HistoryBackfillEntry;
-import com.flipsmart.api.dto.BankItem;
-import com.flipsmart.api.dto.BankItemId;
-import com.flipsmart.api.dto.WikiPrice;
-import com.flipsmart.api.dto.FlipAdjustmentRequest;
-
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
 
 /**
  * Facade over the FlipSmart API. Delegates transport + auth/session to
@@ -288,7 +288,7 @@ public class FlipSmartApiClient
 		return transactions.recordTransactionAsync(itemId, itemName, transactionType, quantity, pricePerItem, rsn);
 	}
 
-	public CompletableFuture<Void> recordHistoryBackfillBatchAsync(String rsn, java.util.List<HistoryBackfillEntry> entries)
+	public CompletableFuture<Void> recordHistoryBackfillBatchAsync(String rsn, List<HistoryBackfillEntry> entries)
 	{
 		return transactions.recordHistoryBackfillBatchAsync(rsn, entries);
 	}
@@ -354,9 +354,9 @@ public class FlipSmartApiClient
 
 	public CompletableFuture<BankSnapshotResult> createBankSnapshotAsync(
 		String rsn,
-		java.util.List<BankItem> items,
-		java.util.List<BankItemId> inventoryItems,
-		java.util.List<BankItemId> gearItems,
+		List<BankItem> items,
+		List<BankItemId> inventoryItems,
+		List<BankItemId> gearItems,
 		long geOffersValue)
 	{
 		return bankSnapshots.createBankSnapshotAsync(rsn, items, inventoryItems, gearItems, geOffersValue);
@@ -431,7 +431,7 @@ public class FlipSmartApiClient
 	// Offer actions
 	// ============================================================================
 
-	public CompletableFuture<OfferAdviceBatchResponse> postOfferActionsBatchAsync(java.util.List<OfferAdviceRequest> reqs)
+	public CompletableFuture<OfferAdviceBatchResponse> postOfferActionsBatchAsync(List<OfferAdviceRequest> reqs)
 	{
 		return offerActions.postOfferActionsBatchAsync(reqs);
 	}
@@ -483,7 +483,7 @@ public class FlipSmartApiClient
 	// Trade Station
 	// ============================================================================
 
-	public CompletableFuture<Boolean> pushTradeStationSlotsAsync(String rsn, java.util.List<Integer> itemIds)
+	public CompletableFuture<Boolean> pushTradeStationSlotsAsync(String rsn, List<Integer> itemIds)
 	{
 		return tradeStation.pushTradeStationSlotsAsync(rsn, itemIds);
 	}
@@ -492,7 +492,7 @@ public class FlipSmartApiClient
 	// Active Flips snapshot mirror
 	// ============================================================================
 
-	public CompletableFuture<Boolean> pushActiveFlipsSnapshotAsync(String rsn, java.util.List<com.flipsmart.domain.flip.ActiveFlip> flips)
+	public CompletableFuture<Boolean> pushActiveFlipsSnapshotAsync(String rsn, List<com.flipsmart.domain.flip.ActiveFlip> flips)
 	{
 		return activeFlipsSnapshot.pushActiveFlipsSnapshotAsync(rsn, flips);
 	}
@@ -547,7 +547,7 @@ public class FlipSmartApiClient
 		return body;
 	}
 
-	public static JsonObject buildOfferActionsBody(java.util.List<OfferAdviceRequest> reqs)
+	public static JsonObject buildOfferActionsBody(List<OfferAdviceRequest> reqs)
 	{
 		JsonObject body = new JsonObject();
 		com.google.gson.JsonArray offers = new com.google.gson.JsonArray();

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -2474,6 +2474,15 @@ public class FlipSmartPlugin extends Plugin
 
 	private String getExitTradesStateKey()
 	{
+		return stateKeyFor(EXIT_TRADES_STATE_KEY_PREFIX);
+	}
+
+	/**
+	 * Per-RSN config key for {@code prefix}, falling back to the last known RSN and then
+	 * to a fixed placeholder, so state never leaks between accounts.
+	 */
+	private String stateKeyFor(String prefix)
+	{
 		String rsn = session.getRsn();
 		if (rsn == null || rsn.isEmpty())
 		{
@@ -2481,9 +2490,9 @@ public class FlipSmartPlugin extends Plugin
 		}
 		if (rsn == null || rsn.isEmpty())
 		{
-			return EXIT_TRADES_STATE_KEY_PREFIX + UNKNOWN_RSN_FALLBACK;
+			return prefix + UNKNOWN_RSN_FALLBACK;
 		}
-		return EXIT_TRADES_STATE_KEY_PREFIX + rsn;
+		return prefix + rsn;
 	}
 
 	private void persistExitTradesState()
@@ -2537,16 +2546,7 @@ public class FlipSmartPlugin extends Plugin
 
 	private String getAutoRecommendStateKey()
 	{
-		String rsn = session.getRsn();
-		if (rsn == null || rsn.isEmpty())
-		{
-			rsn = lastKnownRsn;
-		}
-		if (rsn == null || rsn.isEmpty())
-		{
-			return AUTO_RECOMMEND_STATE_KEY_PREFIX + UNKNOWN_RSN_FALLBACK;
-		}
-		return AUTO_RECOMMEND_STATE_KEY_PREFIX + rsn;
+		return stateKeyFor(AUTO_RECOMMEND_STATE_KEY_PREFIX);
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1,80 +1,88 @@
 package com.flipsmart;
-import com.flipsmart.api.dto.WikiPrice;
-import com.flipsmart.api.dto.SellPriceCheckRequest;
-import com.flipsmart.domain.offer.OfferSignal;
+
+import com.flipsmart.api.dto.OfferAdviceRequest;
 import com.flipsmart.api.dto.OfferAdviceResponse;
+import com.flipsmart.api.dto.OfferAdviceResult;
+import com.flipsmart.api.dto.SellPriceCheckRequest;
+import com.flipsmart.api.dto.WikiPrice;
 import com.flipsmart.domain.flip.ActiveFlip;
 import com.flipsmart.domain.flip.ActiveFlipItemIds;
 import com.flipsmart.domain.flip.ActiveFlipProjection;
 import com.flipsmart.domain.flip.ActiveFlipsSnapshotPayload;
 import com.flipsmart.domain.flip.AwaitingSaleLot;
 import com.flipsmart.domain.flip.AwaitingSaleLots;
+import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.domain.offer.OfferSignal;
+import com.flipsmart.domain.offer.OfferState;
 import com.flipsmart.domain.offer.PendingOrder;
-import com.flipsmart.api.dto.OfferAdviceResult;
-import com.flipsmart.api.dto.OfferAdviceRequest;
-import com.flipsmart.util.BuyPriceLookup;
-import com.flipsmart.util.ItemUtils;
-import com.flipsmart.util.TimeUtils;
-import com.flipsmart.util.GpUtils;
+import com.flipsmart.exit.ExitTradesController;
 import com.flipsmart.plugin.EventRouter;
 import com.flipsmart.plugin.PanelRefreshCoalescer;
 import com.flipsmart.plugin.PluginScheduler;
 import com.flipsmart.plugin.RsnSyncGate;
 import com.flipsmart.plugin.ServiceWiring;
-
+import com.flipsmart.trading.OfferStore;
+import com.flipsmart.util.BuyPriceLookup;
+import com.flipsmart.util.GpUtils;
+import com.flipsmart.util.ItemUtils;
+import com.flipsmart.util.TimeUtils;
 import com.google.gson.Gson;
 import com.google.inject.Provides;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.swing.SwingUtilities;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.GrandExchangeOffer;
 import net.runelite.api.GrandExchangeOfferState;
-import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.Player;
 import net.runelite.api.WorldType;
+import net.runelite.api.events.BeforeRender;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
-import net.runelite.api.events.WorldChanged;
 import net.runelite.api.events.GrandExchangeOfferChanged;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.ScriptCallbackEvent;
 import net.runelite.api.events.ScriptPostFired;
-import net.runelite.api.events.BeforeRender;
 import net.runelite.api.events.VarClientIntChanged;
 import net.runelite.api.events.VarClientStrChanged;
 import net.runelite.api.events.WidgetLoaded;
-import net.runelite.api.widgets.Widget;
+import net.runelite.api.events.WorldChanged;
 import net.runelite.api.gameval.InterfaceID;
-import net.runelite.api.gameval.VarbitID;
-import net.runelite.api.gameval.VarPlayerID;
+import net.runelite.api.widgets.Widget;
 import net.runelite.client.Notifier;
 import net.runelite.client.callback.ClientThread;
-import net.runelite.client.ui.ClientUI;
-import net.runelite.client.input.KeyManager;
-import net.runelite.client.input.MouseListener;
-import net.runelite.client.input.MouseManager;
-import net.runelite.client.config.ConfigManager;
-import net.runelite.client.events.ConfigChanged;
-import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.plugins.Plugin;
-import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.ui.overlay.OverlayManager;
-import net.runelite.api.ChatMessageType;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatMessageBuilder;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
-
-import javax.inject.Inject;
-import java.awt.Point;
-import java.awt.Rectangle;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.input.KeyManager;
+import net.runelite.client.input.MouseListener;
+import net.runelite.client.input.MouseManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.ClientUI;
+import net.runelite.client.ui.overlay.OverlayManager;
 
 @Slf4j
 @PluginDescriptor(
@@ -113,6 +121,7 @@ public class FlipSmartPlugin extends Plugin
 	private InventoryHighlightOverlay inventoryHighlightOverlay;
 
 	@Inject
+	@Getter
 	private FlipSmartApiClient apiClient;
 
 	@Inject
@@ -146,6 +155,7 @@ public class FlipSmartPlugin extends Plugin
 	private DumpAlertService dumpAlertService;
 
 	@Inject
+	@Getter
 	private MotdService motdService;
 
 	@Inject
@@ -161,7 +171,8 @@ public class FlipSmartPlugin extends Plugin
 	private GrandExchangeTracker grandExchangeTracker;
 
 	@Inject
-	private com.flipsmart.trading.OfferStore offerStore;
+	@Getter
+	private OfferStore offerStore;
 
 	@Inject
 	private com.flipsmart.trading.RoundTripLedger roundTripLedger;
@@ -185,6 +196,7 @@ public class FlipSmartPlugin extends Plugin
 	private Gson gson;
 
 	// Flip Finder panel
+	@Getter
 	private FlipFinderPanel flipFinderPanel;
 	private net.runelite.client.ui.NavigationButton flipFinderNavButton;
 
@@ -194,13 +206,14 @@ public class FlipSmartPlugin extends Plugin
 
 	// Exit Trades controller (guided mass sell/cancel)
 	@Getter
-	private com.flipsmart.exit.ExitTradesController exitTradesController;
+	private ExitTradesController exitTradesController;
 
 	// Manual flip adjustment tracker (API-based staleness detection)
 	private ManualAdjustmentTracker manualAdjustmentTracker;
 
 	// Centralized session state management (provided via @Provides @Singleton)
 	@Inject
+	@Getter
 	private PlayerSession session;
 
 	// Timer / one-shot ownership extracted into PluginScheduler
@@ -231,21 +244,24 @@ public class FlipSmartPlugin extends Plugin
 	private volatile boolean membersWorld = true;
 
 	// Cached account-type string — updated on the client thread, read from any thread.
+	@Getter
 	private volatile String accountType;
 
 	// Cached GE location flag — updated each game tick on the client thread.
+	@Getter
 	private volatile boolean atGrandExchange = false;
 
 	// Canonical item ids currently held in the inventory. Rebuilt on the client
 	// thread (inventory ItemContainerChanged) and published as one volatile swap to
 	// an immutable set, so the Swing EDT reader in the Active Flips filter always
 	// sees a complete snapshot, never a partially-rebuilt set.
-	private volatile java.util.Set<Integer> inventoryFlipItemIds = java.util.Collections.emptySet();
+	@Getter
+	private volatile Set<Integer> inventoryFlipItemIds = Collections.emptySet();
 
 	// Canonical item id -> inventory count, rebuilt on the client thread alongside
 	// inventoryFlipItemIds and published as one volatile swap. Safe to read off the
 	// client thread (e.g. the Swing EDT) where the live client inventory API cannot be.
-	private volatile java.util.Map<Integer, Integer> inventoryFlipItemCounts = java.util.Collections.emptyMap();
+	private volatile Map<Integer, Integer> inventoryFlipItemCounts = Collections.emptyMap();
 
 	// False until an inventory container has actually been read. Distinguishes "holds
 	// nothing" from "not logged in", so a collected lot is only dropped as sold when the
@@ -291,39 +307,7 @@ public class FlipSmartPlugin extends Plugin
 		UNKNOWN           // Gray ? - Wiki price unavailable
 	}
 
-	
-	/**
-	 * Get the centralized player session state.
-	 */
-	public PlayerSession getSession()
-	{
-		return session;
-	}
 
-	/**
-	 * Authoritative offer-state store (for overlay/panel reads).
-	 */
-	public com.flipsmart.trading.OfferStore getOfferStore()
-	{
-		return offerStore;
-	}
-
-	public FlipSmartApiClient getApiClient()
-	{
-		return apiClient;
-	}
-
-	/** Flip Finder panel (may be null until initialized / when disabled in config). */
-	public FlipFinderPanel getFlipFinderPanel()
-	{
-		return flipFinderPanel;
-	}
-
-	/** MOTD service (used by the event router on login). */
-	public MotdService getMotdService()
-	{
-		return motdService;
-	}
 
 	/**
 	 * Get current RSN (delegates to session for backwards compatibility).
@@ -372,10 +356,6 @@ public class FlipSmartPlugin extends Plugin
 		return membersWorld;
 	}
 
-	public boolean isAtGrandExchange()
-	{
-		return atGrandExchange;
-	}
 
 	/**
 	 * Refresh the cached members-world state from the Client API.
@@ -395,10 +375,6 @@ public class FlipSmartPlugin extends Plugin
 		accountType = AccountTypeMapper.toApiValue(client.getAccountType());
 	}
 
-	public String getAccountType()
-	{
-		return accountType;
-	}
 
 	public int getFlipSlotLimit()
 	{
@@ -450,7 +426,7 @@ public class FlipSmartPlugin extends Plugin
 	 * Local OfferStore records for an item — the fallback source for the recorded
 	 * buy price when the backend-sourced active-flips snapshot is empty.
 	 */
-	public java.util.List<com.flipsmart.domain.offer.OfferRecord> getOfferRecordsForItem(int itemId)
+	public List<OfferRecord> getOfferRecordsForItem(int itemId)
 	{
 		return offerStore.forItem(itemId);
 	}
@@ -462,16 +438,16 @@ public class FlipSmartPlugin extends Plugin
 	 */
 	public AwaitingSaleLots.BuyBasis buyBasisForItem(int itemId)
 	{
-		java.util.List<com.flipsmart.domain.offer.OfferRecord> buys = new java.util.ArrayList<>();
-		for (com.flipsmart.domain.offer.OfferRecord r : offerStore.forItem(itemId))
+		List<OfferRecord> buys = new ArrayList<>();
+		for (OfferRecord r : offerStore.forItem(itemId))
 		{
 			if (r.isBuy())
 			{
 				buys.add(r);
 			}
 		}
-		com.flipsmart.domain.offer.OfferRecord bestFilled = mostRecentFilledBuy(buys);
-		com.flipsmart.domain.offer.OfferRecord best = bestFilled != null ? bestFilled : mostRecentBuy(buys);
+		OfferRecord bestFilled = mostRecentFilledBuy(buys);
+		OfferRecord best = bestFilled != null ? bestFilled : mostRecentBuy(buys);
 		if (best == null)
 		{
 			return null;
@@ -480,11 +456,11 @@ public class FlipSmartPlugin extends Plugin
 	}
 
 	/** Most recently active buy record in {@code buys}, or {@code null} when the list is empty. */
-	private static com.flipsmart.domain.offer.OfferRecord mostRecentBuy(
-		java.util.List<com.flipsmart.domain.offer.OfferRecord> buys)
+	private static OfferRecord mostRecentBuy(
+		List<OfferRecord> buys)
 	{
-		com.flipsmart.domain.offer.OfferRecord best = null;
-		for (com.flipsmart.domain.offer.OfferRecord r : buys)
+		OfferRecord best = null;
+		for (OfferRecord r : buys)
 		{
 			if (best == null || r.getEffectiveLastActivityAtMillis() > best.getEffectiveLastActivityAtMillis())
 			{
@@ -495,11 +471,11 @@ public class FlipSmartPlugin extends Plugin
 	}
 
 	/** Most recently active buy record in {@code buys} that has at least one filled unit. */
-	private static com.flipsmart.domain.offer.OfferRecord mostRecentFilledBuy(
-		java.util.List<com.flipsmart.domain.offer.OfferRecord> buys)
+	private static OfferRecord mostRecentFilledBuy(
+		List<OfferRecord> buys)
 	{
-		com.flipsmart.domain.offer.OfferRecord best = null;
-		for (com.flipsmart.domain.offer.OfferRecord r : buys)
+		OfferRecord best = null;
+		for (OfferRecord r : buys)
 		{
 			if (r.getFilledQuantity() <= 0)
 			{
@@ -513,14 +489,14 @@ public class FlipSmartPlugin extends Plugin
 		return best;
 	}
 
-	private static int avgBuyPrice(com.flipsmart.domain.offer.OfferRecord best)
+	private static int avgBuyPrice(OfferRecord best)
 	{
 		return best.getSpent() > 0 && best.getFilledQuantity() > 0
 			? (int) (best.getSpent() / best.getFilledQuantity())
 			: best.getPrice();
 	}
 
-	private static String firstBuyTimeIso(com.flipsmart.domain.offer.OfferRecord best)
+	private static String firstBuyTimeIso(OfferRecord best)
 	{
 		long firstBuyMillis = best.getCreatedAtMillis() > 0
 			? best.getCreatedAtMillis()
@@ -542,9 +518,9 @@ public class FlipSmartPlugin extends Plugin
 
 	public List<ActiveFlip> getProjectedActiveFlips(Map<Integer, ActiveFlip> enrichmentByItemId)
 	{
-		java.util.List<com.flipsmart.domain.offer.OfferRecord> liveSellOffers = new java.util.ArrayList<>();
-		java.util.Set<Integer> liveSellItemIds = new java.util.HashSet<>();
-		for (com.flipsmart.domain.offer.OfferRecord r : offerStore.liveOffers())
+		List<OfferRecord> liveSellOffers = new ArrayList<>();
+		Set<Integer> liveSellItemIds = new HashSet<>();
+		for (OfferRecord r : offerStore.liveOffers())
 		{
 			if (!r.isBuy() && r.getSlot() != null)
 			{
@@ -553,7 +529,7 @@ public class FlipSmartPlugin extends Plugin
 			}
 		}
 
-		Map<Integer, Integer> inventoryCounts = new java.util.HashMap<>();
+		Map<Integer, Integer> inventoryCounts = new HashMap<>();
 		for (int itemId : getInventoryFlipItemIds())
 		{
 			int count = getInventoryCountSnapshot(itemId);
@@ -563,11 +539,11 @@ public class FlipSmartPlugin extends Plugin
 			}
 		}
 
-		java.util.List<AwaitingSaleLot> awaitingSaleLots =
+		List<AwaitingSaleLot> awaitingSaleLots =
 			AwaitingSaleLots.derive(inventoryCounts, this::buyBasisForItem, liveSellItemIds);
 
 		return ActiveFlipProjection.project(liveSellOffers, this::buyBasisForItem, awaitingSaleLots,
-			enrichmentByItemId == null ? java.util.Collections.emptyMap() : enrichmentByItemId);
+			enrichmentByItemId == null ? Collections.emptyMap() : enrichmentByItemId);
 	}
 
 	/**
@@ -594,11 +570,11 @@ public class FlipSmartPlugin extends Plugin
 	 * {@code offerStoreSeeded} field (set on the client thread) instead of calling the
 	 * client API directly.
 	 */
-	private java.util.List<ActiveFlip> buildActiveFlipsSnapshotPayload()
+	private List<ActiveFlip> buildActiveFlipsSnapshotPayload()
 	{
-		java.util.List<ActiveFlip> projection = getProjectedActiveFlips(java.util.Collections.emptyMap());
-		java.util.List<PendingOrder> pendingBuys = getPendingBuyOrders();
-		java.util.List<ActiveFlip> payload = ActiveFlipsSnapshotPayload.combine(projection, pendingBuys);
+		List<ActiveFlip> projection = getProjectedActiveFlips(Collections.emptyMap());
+		List<PendingOrder> pendingBuys = getPendingBuyOrders();
+		List<ActiveFlip> payload = ActiveFlipsSnapshotPayload.combine(projection, pendingBuys);
 
 		return ActiveFlipsSnapshotPayload.isUnobservedEmpty(payload, !offerStoreSeeded) ? null : payload;
 	}
@@ -721,7 +697,7 @@ public class FlipSmartPlugin extends Plugin
 	 *
 	 * This shows if your offer is "in the margin" and likely to fill.
 	 */
-	public OfferCompetitiveness calculateCompetitiveness(com.flipsmart.domain.offer.OfferRecord record)
+	public OfferCompetitiveness calculateCompetitiveness(OfferRecord record)
 	{
 		if (record == null)
 		{
@@ -793,11 +769,11 @@ public class FlipSmartPlugin extends Plugin
 	 * Get current buy orders in GE slots (pending or partially filled).
 	 * These are buy orders that haven't been fully collected yet.
 	 */
-	public java.util.List<PendingOrder> getPendingBuyOrders()
+	public List<PendingOrder> getPendingBuyOrders()
 	{
-		java.util.List<PendingOrder> pendingOrders = new java.util.ArrayList<>();
+		List<PendingOrder> pendingOrders = new ArrayList<>();
 
-		for (com.flipsmart.domain.offer.OfferRecord offer : offerStore.liveOffers())
+		for (OfferRecord offer : offerStore.liveOffers())
 		{
 			// Include all buy orders (pending or partially filled)
 			if (offer.isBuy() && offer.getSlot() != null)
@@ -824,10 +800,10 @@ public class FlipSmartPlugin extends Plugin
 	/**
 	 * Get the set of item IDs currently in GE buy slots.
 	 */
-	public java.util.Set<Integer> getCurrentGEBuyItemIds()
+	public Set<Integer> getCurrentGEBuyItemIds()
 	{
-		java.util.Set<Integer> itemIds = new java.util.HashSet<>();
-		for (com.flipsmart.domain.offer.OfferRecord offer : offerStore.liveOffers())
+		Set<Integer> itemIds = new HashSet<>();
+		for (OfferRecord offer : offerStore.liveOffers())
 		{
 			if (offer.isBuy())
 			{
@@ -848,10 +824,10 @@ public class FlipSmartPlugin extends Plugin
 	 * restored from disk at login and never cleared while empty, so a sold item would
 	 * otherwise linger there forever and keep consuming a slot.</p>
 	 */
-	public java.util.Set<Integer> getActiveFlipItemIds()
+	public Set<Integer> getActiveFlipItemIds()
 	{
-		java.util.Set<Integer> liveOfferItemIds = new java.util.HashSet<>();
-		for (com.flipsmart.domain.offer.OfferRecord offer : offerStore.liveOffers())
+		Set<Integer> liveOfferItemIds = new HashSet<>();
+		for (OfferRecord offer : offerStore.liveOffers())
 		{
 			liveOfferItemIds.add(offer.getItemId());
 		}
@@ -859,26 +835,15 @@ public class FlipSmartPlugin extends Plugin
 			inventoryFlipItemCounts, inventorySnapshotKnown);
 	}
 
-	/**
-	 * Canonical item ids currently held in the inventory, as a thread-safe snapshot
-	 * maintained on the client thread. Read from the Swing EDT by the Active Flips
-	 * display filter to keep collected-but-unsold flips visible across a client
-	 * restart (when session-only collected state is lost) without reading the game
-	 * client off-thread.
-	 */
-	public java.util.Set<Integer> getInventoryFlipItemIds()
-	{
-		return inventoryFlipItemIds;
-	}
 
 	/**
 	 * Get all active flip item IDs including items in inventory.
 	 * This is used for filtering active flips display to show items the player
 	 * actually has (in GE slots or inventory).
 	 */
-	public java.util.Set<Integer> getActiveFlipItemIdsWithInventory()
+	public Set<Integer> getActiveFlipItemIdsWithInventory()
 	{
-		java.util.Set<Integer> itemIds = getActiveFlipItemIds();
+		Set<Integer> itemIds = getActiveFlipItemIds();
 		
 		// Also include items currently in inventory
 		ItemContainer inventory = client.getItemContainer(INVENTORY_CONTAINER_ID);
@@ -967,7 +932,7 @@ public class FlipSmartPlugin extends Plugin
 	public void highlightSlotForItem(int itemId)
 	{
 		geSlotOverlay.clearAllAdjustmentHighlights();
-		for (com.flipsmart.domain.offer.OfferRecord offer : offerStore.liveOffers())
+		for (OfferRecord offer : offerStore.liveOffers())
 		{
 			if (offer.getItemId() == itemId && offer.getSlot() != null)
 			{
@@ -1022,7 +987,7 @@ public class FlipSmartPlugin extends Plugin
 			// from re-creating the sell overlay after a sell order was placed
 			if (flipFinderPanel != null)
 			{
-				javax.swing.SwingUtilities.invokeLater(() -> flipFinderPanel.clearFocus());
+				SwingUtilities.invokeLater(() -> flipFinderPanel.clearFocus());
 			}
 		}
 	}
@@ -1033,7 +998,7 @@ public class FlipSmartPlugin extends Plugin
 		updateInventoryHighlightForFocus(focus);
 		if (flipFinderPanel != null)
 		{
-			javax.swing.SwingUtilities.invokeLater(() -> flipFinderPanel.setExternalFocus(focus));
+			SwingUtilities.invokeLater(() -> flipFinderPanel.setExternalFocus(focus));
 		}
 	}
 
@@ -1072,7 +1037,7 @@ public class FlipSmartPlugin extends Plugin
 			updateInventoryHighlightForFocus(null);
 			if (flipFinderPanel != null)
 			{
-				javax.swing.SwingUtilities.invokeLater(() -> flipFinderPanel.clearFocus());
+				SwingUtilities.invokeLater(() -> flipFinderPanel.clearFocus());
 			}
 		}
 	}
@@ -1275,7 +1240,7 @@ public class FlipSmartPlugin extends Plugin
 
 		if (flipFinderPanel != null)
 		{
-			javax.swing.SwingUtilities.invokeLater(() -> flipFinderPanel.showLoggedOutOfGameState());
+			SwingUtilities.invokeLater(() -> flipFinderPanel.showLoggedOutOfGameState());
 		}
 	}
 
@@ -1330,7 +1295,7 @@ public class FlipSmartPlugin extends Plugin
 			log.debug("User premium status: {}", isPremium);
 			if (flipFinderPanel != null)
 			{
-				javax.swing.SwingUtilities.invokeLater(() -> flipFinderPanel.updatePremiumStatus());
+				SwingUtilities.invokeLater(() -> flipFinderPanel.updatePremiumStatus());
 			}
 
 			// Pull webhook config after auth is confirmed
@@ -1401,7 +1366,7 @@ public class FlipSmartPlugin extends Plugin
 	 */
 	private void backfillMissingTimestamps()
 	{
-		java.util.List<com.flipsmart.domain.offer.OfferRecord> tracked = offerStore.liveOffers();
+		List<OfferRecord> tracked = offerStore.liveOffers();
 		if (tracked.isEmpty())
 		{
 			return;
@@ -1416,14 +1381,14 @@ public class FlipSmartPlugin extends Plugin
 				return;
 			}
 
-			Map<Integer, ActiveFlip> flipsByItem = new java.util.HashMap<>();
+			Map<Integer, ActiveFlip> flipsByItem = new HashMap<>();
 			for (ActiveFlip flip : response.getActiveFlips())
 			{
 				flipsByItem.put(flip.getItemId(), flip);
 			}
 
 			int corrected = 0;
-			for (com.flipsmart.domain.offer.OfferRecord offer : offerStore.liveOffers())
+			for (OfferRecord offer : offerStore.liveOffers())
 			{
 				if (correctOfferTimestamp(offer, flipsByItem))
 				{
@@ -1448,7 +1413,7 @@ public class FlipSmartPlugin extends Plugin
 	 * local timestamps, since they're more accurate (set at offer placement time).
 	 * The backend's last_buy_time can be from older transactions for the same item.
 	 */
-	private boolean correctOfferTimestamp(com.flipsmart.domain.offer.OfferRecord offer, Map<Integer, ActiveFlip> flipsByItem)
+	private boolean correctOfferTimestamp(OfferRecord offer, Map<Integer, ActiveFlip> flipsByItem)
 	{
 		if (offer.getCreatedAtMillis() > 0)
 		{
@@ -1849,7 +1814,7 @@ public class FlipSmartPlugin extends Plugin
 		});
 
 		// Try to load custom icon from resources
-		java.awt.image.BufferedImage iconImage = null;
+		BufferedImage iconImage = null;
 		try
 		{
 			iconImage = net.runelite.client.util.ImageUtil.loadImageResource(getClass(), "/flip_finder_icon.png");
@@ -1880,10 +1845,10 @@ public class FlipSmartPlugin extends Plugin
 	/**
 	 * Create a default icon for the Flip Finder button
 	 */
-	private java.awt.image.BufferedImage createDefaultIcon()
+	private BufferedImage createDefaultIcon()
 	{
 		// Create a simple default icon
-		java.awt.image.BufferedImage image = new java.awt.image.BufferedImage(16, 16, java.awt.image.BufferedImage.TYPE_INT_ARGB);
+		BufferedImage image = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
 		java.awt.Graphics2D g = image.createGraphics();
 		g.setColor(java.awt.Color.ORANGE);
 		g.fillRect(2, 2, 12, 12);
@@ -1902,8 +1867,8 @@ public class FlipSmartPlugin extends Plugin
 		if (inventory == null)
 		{
 			session.setCashStack(0);
-			inventoryFlipItemIds = java.util.Collections.emptySet();
-			inventoryFlipItemCounts = java.util.Collections.emptyMap();
+			inventoryFlipItemIds = Collections.emptySet();
+			inventoryFlipItemCounts = Collections.emptyMap();
 			inventorySnapshotKnown = false;
 			return;
 		}
@@ -1911,8 +1876,8 @@ public class FlipSmartPlugin extends Plugin
 		int totalCash = 0;
 		Item[] items = inventory.getItems();
 
-		java.util.Set<Integer> currentInventoryIds = new java.util.HashSet<>();
-		java.util.Map<Integer, Integer> currentInventoryCounts = new java.util.HashMap<>();
+		Set<Integer> currentInventoryIds = new HashSet<>();
+		Map<Integer, Integer> currentInventoryCounts = new HashMap<>();
 		for (Item item : items)
 		{
 			if (item.getId() == COINS_ITEM_ID)
@@ -1926,9 +1891,9 @@ public class FlipSmartPlugin extends Plugin
 				currentInventoryCounts.merge(canonicalId, item.getQuantity(), Integer::sum);
 			}
 		}
-		java.util.Map<Integer, Integer> previousInventoryCounts = inventoryFlipItemCounts;
-		inventoryFlipItemIds = java.util.Collections.unmodifiableSet(currentInventoryIds);
-		inventoryFlipItemCounts = java.util.Collections.unmodifiableMap(currentInventoryCounts);
+		Map<Integer, Integer> previousInventoryCounts = inventoryFlipItemCounts;
+		inventoryFlipItemIds = Collections.unmodifiableSet(currentInventoryIds);
+		inventoryFlipItemCounts = Collections.unmodifiableMap(currentInventoryCounts);
 		inventorySnapshotKnown = true;
 
 		// An inventory change adds or removes an awaiting-sale lot, so re-derive the
@@ -1970,10 +1935,10 @@ public class FlipSmartPlugin extends Plugin
 	 * Awaiting-sale derivation ignores coins, so cash-only movement must not force
 	 * a projection re-render.
 	 */
-	private boolean heldItemsChanged(java.util.Map<Integer, Integer> before, java.util.Map<Integer, Integer> after)
+	private boolean heldItemsChanged(Map<Integer, Integer> before, Map<Integer, Integer> after)
 	{
-		java.util.Map<Integer, Integer> a = new java.util.HashMap<>(before);
-		java.util.Map<Integer, Integer> b = new java.util.HashMap<>(after);
+		Map<Integer, Integer> a = new HashMap<>(before);
+		Map<Integer, Integer> b = new HashMap<>(after);
 		a.remove(COINS_ITEM_ID);
 		b.remove(COINS_ITEM_ID);
 		return !a.equals(b);
@@ -2014,7 +1979,7 @@ public class FlipSmartPlugin extends Plugin
 	{
 		if (flipFinderPanel != null && config.showFlipFinder())
 		{
-			javax.swing.SwingUtilities.invokeLater(() ->
+			SwingUtilities.invokeLater(() ->
 			{
 				log.debug("Auto-refreshing flip finder");
 				session.setLastFlipFinderRefresh(System.currentTimeMillis());
@@ -2057,7 +2022,7 @@ public class FlipSmartPlugin extends Plugin
 		{
 			if (flipFinderPanel != null)
 			{
-				javax.swing.SwingUtilities.invokeLater(() ->
+				SwingUtilities.invokeLater(() ->
 				{
 					log.debug("Auto-recommend refresh cycle");
 					flipFinderPanel.refresh();
@@ -2107,11 +2072,11 @@ public class FlipSmartPlugin extends Plugin
 			return;
 		}
 		lastAdvisorPollMs = System.currentTimeMillis();
-		java.util.List<com.flipsmart.domain.offer.OfferRecord> liveOffers = offerStore.liveOffers();
-		java.util.Set<Integer> activeItemIds = new java.util.HashSet<>();
-		for (com.flipsmart.domain.offer.OfferRecord o : liveOffers)
+		List<OfferRecord> liveOffers = offerStore.liveOffers();
+		Set<Integer> activeItemIds = new HashSet<>();
+		for (OfferRecord o : liveOffers)
 		{
-			if (o.getState() != com.flipsmart.domain.offer.OfferState.FILLED)
+			if (o.getState() != OfferState.FILLED)
 			{
 				activeItemIds.add(o.getItemId());
 			}
@@ -2120,10 +2085,10 @@ public class FlipSmartPlugin extends Plugin
 		{
 			activeOfferAdvisorService.reconcile(activeItemIds);
 		}
-		java.util.List<OfferAdviceRequest> requests = new java.util.ArrayList<>();
-		for (com.flipsmart.domain.offer.OfferRecord offer : liveOffers)
+		List<OfferAdviceRequest> requests = new ArrayList<>();
+		for (OfferRecord offer : liveOffers)
 		{
-			if (offer.getState() == com.flipsmart.domain.offer.OfferState.FILLED)
+			if (offer.getState() == OfferState.FILLED)
 			{
 				continue;
 			}
@@ -2191,7 +2156,7 @@ public class FlipSmartPlugin extends Plugin
 	 * offer's own average fill (falling back to the listed price), which the
 	 * margin-decay exit (#918 AC2) needs.
 	 */
-	private Integer avgBuyPriceFor(com.flipsmart.domain.offer.OfferRecord offer)
+	private Integer avgBuyPriceFor(OfferRecord offer)
 	{
 		if (!offer.isBuy())
 		{
@@ -2225,7 +2190,7 @@ public class FlipSmartPlugin extends Plugin
 		sess.setRecommendedPrice(itemId, resp.getNewPrice());
 		if (autoRecommendService != null)
 		{
-			com.flipsmart.domain.offer.OfferRecord offer = findLiveOfferForItem(itemId);
+			OfferRecord offer = findLiveOfferForItem(itemId);
 			if (offer != null)
 			{
 				autoRecommendService.surfaceAdvisorResell(offer, resp.getNewPrice(), resp.getNetProfitEstimate());
@@ -2248,7 +2213,7 @@ public class FlipSmartPlugin extends Plugin
 	private int last12hRecalcItemId = -1;
 	private long last12hRecalcMs;
 
-	static boolean ladderOwnsSell(com.flipsmart.domain.offer.OfferRecord liveSell, long now)
+	static boolean ladderOwnsSell(OfferRecord liveSell, long now)
 	{
 		if (liveSell == null)
 		{
@@ -2258,12 +2223,12 @@ public class FlipSmartPlugin extends Plugin
 		return ageMinutes >= LADDER_HANDOFF_MINUTES;
 	}
 
-	private com.flipsmart.domain.offer.OfferRecord findLiveSellForItem(int itemId)
+	private OfferRecord findLiveSellForItem(int itemId)
 	{
-		for (com.flipsmart.domain.offer.OfferRecord o : offerStore.liveOffers())
+		for (OfferRecord o : offerStore.liveOffers())
 		{
 			if (o.getItemId() == itemId && !o.isBuy()
-				&& o.getState() != com.flipsmart.domain.offer.OfferState.FILLED)
+				&& o.getState() != OfferState.FILLED)
 			{
 				return o;
 			}
@@ -2377,11 +2342,11 @@ public class FlipSmartPlugin extends Plugin
 			.build());
 	}
 
-	private com.flipsmart.domain.offer.OfferRecord findLiveOfferForItem(int itemId)
+	private OfferRecord findLiveOfferForItem(int itemId)
 	{
-		for (com.flipsmart.domain.offer.OfferRecord o : offerStore.liveOffers())
+		for (OfferRecord o : offerStore.liveOffers())
 		{
-			if (o.getItemId() == itemId && o.getState() != com.flipsmart.domain.offer.OfferState.FILLED)
+			if (o.getItemId() == itemId && o.getState() != OfferState.FILLED)
 			{
 				return o;
 			}
@@ -2396,7 +2361,7 @@ public class FlipSmartPlugin extends Plugin
 			return;
 		}
 		int itemId = resp.getItemIdHint();
-		for (com.flipsmart.domain.offer.OfferRecord offer : offerStore.liveOffers())
+		for (OfferRecord offer : offerStore.liveOffers())
 		{
 			if (offer.getItemId() == itemId)
 			{
@@ -2431,8 +2396,8 @@ public class FlipSmartPlugin extends Plugin
 		{
 			return 0;
 		}
-		com.flipsmart.domain.offer.OfferRecord best = null;
-		for (com.flipsmart.domain.offer.OfferRecord r : offerStore.forItem(itemId))
+		OfferRecord best = null;
+		for (OfferRecord r : offerStore.forItem(itemId))
 		{
 			if (r.isBuy() && r.getFilledQuantity() > 0
 				&& (best == null
@@ -2527,7 +2492,7 @@ public class FlipSmartPlugin extends Plugin
 		{
 			return;
 		}
-		com.flipsmart.exit.ExitTradesController.PersistedState state =
+		ExitTradesController.PersistedState state =
 			exitTradesController.getStateForPersistence(System.currentTimeMillis());
 		if (state == null)
 		{
@@ -2552,8 +2517,8 @@ public class FlipSmartPlugin extends Plugin
 		}
 		try
 		{
-			com.flipsmart.exit.ExitTradesController.PersistedState state =
-				gson.fromJson(json, com.flipsmart.exit.ExitTradesController.PersistedState.class);
+			ExitTradesController.PersistedState state =
+				gson.fromJson(json, ExitTradesController.PersistedState.class);
 			if (exitTradesController.restoreState(state, System.currentTimeMillis(), EXIT_TRADES_MAX_AGE_MS))
 			{
 				exitTradesController.surfaceCurrent(); // re-prompt pending slots (AC9 immediate resell)
@@ -2656,7 +2621,7 @@ public class FlipSmartPlugin extends Plugin
 	private final MouseListener overlayMouseListener = new MouseListener()
 	{
 		@Override
-		public java.awt.event.MouseEvent mouseClicked(java.awt.event.MouseEvent e)
+		public MouseEvent mouseClicked(MouseEvent e)
 		{
 			// Get the overlay bounds
 			Rectangle overlayBounds = geOverlay.getBounds();
@@ -2683,37 +2648,37 @@ public class FlipSmartPlugin extends Plugin
 		}
 		
 		@Override
-		public java.awt.event.MouseEvent mousePressed(java.awt.event.MouseEvent e)
+		public MouseEvent mousePressed(MouseEvent e)
 		{
 			return e;
 		}
 		
 		@Override
-		public java.awt.event.MouseEvent mouseReleased(java.awt.event.MouseEvent e)
+		public MouseEvent mouseReleased(MouseEvent e)
 		{
 			return e;
 		}
 		
 		@Override
-		public java.awt.event.MouseEvent mouseEntered(java.awt.event.MouseEvent e)
+		public MouseEvent mouseEntered(MouseEvent e)
 		{
 			return e;
 		}
 		
 		@Override
-		public java.awt.event.MouseEvent mouseExited(java.awt.event.MouseEvent e)
+		public MouseEvent mouseExited(MouseEvent e)
 		{
 			return e;
 		}
 		
 		@Override
-		public java.awt.event.MouseEvent mouseDragged(java.awt.event.MouseEvent e)
+		public MouseEvent mouseDragged(MouseEvent e)
 		{
 			return e;
 		}
 		
 		@Override
-		public java.awt.event.MouseEvent mouseMoved(java.awt.event.MouseEvent e)
+		public MouseEvent mouseMoved(MouseEvent e)
 		{
 			return e;
 		}

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -1,8 +1,19 @@
 package com.flipsmart;
+
 import com.flipsmart.api.dto.HistoryBackfillEntry;
 import com.flipsmart.domain.offer.OfferRecord;
 import com.flipsmart.trading.OfferStore;
-
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
@@ -12,17 +23,6 @@ import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatMessageBuilder;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Reads the in-game GE History tab to recover actual fill prices for trades
@@ -65,6 +65,7 @@ public class GEHistoryService
 	private final AtomicInteger pendingHistoryReadTicks = new AtomicInteger(0);
 	private volatile boolean historyReadThisSession = false;
 	private volatile boolean chatPromptSent = false;
+	@Setter
 	private volatile Runnable onBackfillComplete;
 
 	// Monotonic game-tick counter and the tick of the most recent read, used to
@@ -204,16 +205,6 @@ public class GEHistoryService
 			.type(ChatMessageType.CONSOLE)
 			.runeLiteFormattedMessage(msg)
 			.build());
-	}
-
-	/**
-	 * Runs after a History-backfill batch lands on the API. Used by the
-	 * plugin to refresh Active Flips / Completed panels so backfilled trades
-	 * appear without the user having to manually reload.
-	 */
-	public void setOnBackfillComplete(Runnable callback)
-	{
-		this.onBackfillComplete = callback;
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/GeOfferDescriptionFormatter.java
+++ b/src/main/java/com/flipsmart/GeOfferDescriptionFormatter.java
@@ -1,6 +1,5 @@
 package com.flipsmart;
 import com.flipsmart.util.GeTax;
-import com.flipsmart.util.GpUtils;
 
 import java.util.Locale;
 

--- a/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
+++ b/src/main/java/com/flipsmart/GeSlotWidgetDecorator.java
@@ -2,13 +2,11 @@ package com.flipsmart;
 
 import com.flipsmart.domain.offer.OfferRecord;
 import com.flipsmart.domain.offer.OfferSignal;
-import com.flipsmart.trading.OfferStore;
 import com.flipsmart.util.TimeUtils;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GrandExchangeOffer;
 import net.runelite.api.GrandExchangeOfferState;
-import net.runelite.api.SpritePixels;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetTextAlignment;
 import net.runelite.client.game.SpriteManager;

--- a/src/main/java/com/flipsmart/GrandExchangeOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeOverlay.java
@@ -1,7 +1,11 @@
 package com.flipsmart;
+
 import com.flipsmart.domain.offer.OfferSignal;
 import com.flipsmart.util.ItemUtils;
-
+import java.awt.image.BufferedImage;
+import java.text.DecimalFormat;
+import javax.inject.Inject;
+import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.GrandExchangeOffer;
 import net.runelite.api.GrandExchangeOfferState;
@@ -16,10 +20,7 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.util.AsyncBufferedImage;
 
-import javax.inject.Inject;
 import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.text.DecimalFormat;
 
 import static net.runelite.api.MenuAction.RUNELITE_OVERLAY_CONFIG;
 import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
@@ -90,6 +91,7 @@ public class GrandExchangeOverlay extends Overlay
 	private final ItemManager itemManager;
 
 	private boolean isCollapsed = false;
+	@Getter
 	private Rectangle collapseButtonBounds = new Rectangle();
 
 	@Inject
@@ -598,8 +600,4 @@ public class GrandExchangeOverlay extends Overlay
 		return isCollapsed;
 	}
 	
-	public Rectangle getCollapseButtonBounds()
-	{
-		return collapseButtonBounds;
-	}
 }

--- a/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
+++ b/src/main/java/com/flipsmart/GrandExchangeSlotOverlay.java
@@ -1,10 +1,13 @@
 package com.flipsmart;
+
 import com.flipsmart.api.dto.WikiPrice;
 import com.flipsmart.domain.offer.OfferSignal;
 import com.flipsmart.util.BuyPriceLookup;
 import com.flipsmart.util.GeTax;
 import com.flipsmart.util.GpUtils;
-
+import java.text.NumberFormat;
+import java.util.List;
+import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GrandExchangeOffer;
@@ -15,9 +18,7 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 
-import javax.inject.Inject;
 import java.awt.*;
-import java.text.NumberFormat;
 
 /**
  * Overlay that draws timer and competitiveness indicators directly on the
@@ -375,7 +376,7 @@ public class GrandExchangeSlotOverlay extends Overlay
 		graphics.setFont(new Font("Arial", Font.PLAIN, 11));
 		FontMetrics fm = graphics.getFontMetrics();
 
-		java.util.List<String> lines = buildTooltipLines(wikiPrice, offerPrice, buyPrice, isBuy, offer.getTotalQuantity(), offer.getItemId());
+		List<String> lines = buildTooltipLines(wikiPrice, offerPrice, buyPrice, isBuy, offer.getTotalQuantity(), offer.getItemId());
 		Color yourPriceColor = determineYourPriceColor(wikiPrice, offerPrice, isBuy);
 
 		drawTooltipBackground(graphics, x, y, lines, fm);
@@ -395,10 +396,10 @@ public class GrandExchangeSlotOverlay extends Overlay
 	/**
 	 * Build tooltip text lines based on wiki price data
 	 */
-	private java.util.List<String> buildTooltipLines(WikiPrice wikiPrice, int offerPrice,
+	private List<String> buildTooltipLines(WikiPrice wikiPrice, int offerPrice,
 													  Integer buyPrice, boolean isBuy, int totalQuantity, int itemId)
 	{
-		java.util.List<String> lines = new java.util.ArrayList<>();
+		List<String> lines = new java.util.ArrayList<>();
 
 		addPriceLines(lines, wikiPrice);
 		lines.add("Your Price: " + NUMBER_FORMAT.format(offerPrice) + " gp");
@@ -411,7 +412,7 @@ public class GrandExchangeSlotOverlay extends Overlay
 		return lines;
 	}
 
-	private void addPriceLines(java.util.List<String> lines, WikiPrice wikiPrice)
+	private void addPriceLines(List<String> lines, WikiPrice wikiPrice)
 	{
 		if (wikiPrice == null || (wikiPrice.instaBuy <= 0 && wikiPrice.instaSell <= 0))
 		{
@@ -428,7 +429,7 @@ public class GrandExchangeSlotOverlay extends Overlay
 		}
 	}
 
-	private void addProfitLossLine(java.util.List<String> lines, int sellPrice, int buyPrice, int totalQuantity, int itemId)
+	private void addProfitLossLine(List<String> lines, int sellPrice, int buyPrice, int totalQuantity, int itemId)
 	{
 		// Honor the GE tax-exempt list and the <=50gp threshold (issue #685 Bugs 3 & 4).
 		// ROI uses netPnlPerItem so it automatically becomes pre-tax for exempt items
@@ -477,7 +478,7 @@ public class GrandExchangeSlotOverlay extends Overlay
 	 */
 	private static final int DIVIDER_HEIGHT = 6;
 
-	private void drawTooltipBackground(Graphics2D graphics, int x, int y, java.util.List<String> lines, FontMetrics fm)
+	private void drawTooltipBackground(Graphics2D graphics, int x, int y, List<String> lines, FontMetrics fm)
 	{
 		int lineHeight = fm.getHeight();
 		int padding = 5;
@@ -500,7 +501,7 @@ public class GrandExchangeSlotOverlay extends Overlay
 	/**
 	 * Draw tooltip text lines
 	 */
-	private void drawTooltipText(Graphics2D graphics, int x, int y, java.util.List<String> lines,
+	private void drawTooltipText(Graphics2D graphics, int x, int y, List<String> lines,
 								 Color yourPriceColor, FontMetrics fm)
 	{
 		int padding = 5;

--- a/src/main/java/com/flipsmart/GrandExchangeTracker.java
+++ b/src/main/java/com/flipsmart/GrandExchangeTracker.java
@@ -1,32 +1,34 @@
 package com.flipsmart;
-import com.flipsmart.domain.offer.OfferAction;
+
 import com.flipsmart.api.dto.ActiveFlipsResponse;
 import com.flipsmart.api.dto.OfferAdviceResponse;
+import com.flipsmart.domain.flip.ActiveFlip;
 import com.flipsmart.domain.flip.AwaitingSaleLots;
 import com.flipsmart.domain.flip.FlipRecommendation;
-import com.flipsmart.domain.flip.ActiveFlip;
-import com.flipsmart.recommend.ManualSellFocus;
+import com.flipsmart.domain.offer.OfferAction;
 import com.flipsmart.domain.offer.OfferRecord;
 import com.flipsmart.domain.offer.OfferSignal;
+import com.flipsmart.domain.offer.OfferState;
 import com.flipsmart.domain.offer.OfferTransition;
 import com.flipsmart.domain.offer.PendingOrder;
 import com.flipsmart.recommend.CollectOrigin;
+import com.flipsmart.recommend.ManualSellFocus;
 import com.flipsmart.trading.OfferEventMapper;
 import com.flipsmart.trading.OfferStore;
 import com.flipsmart.util.ItemUtils;
-
-import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.GrandExchangeOfferState;
-import net.runelite.client.game.ItemManager;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.swing.SwingUtilities;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.GrandExchangeOfferState;
+import net.runelite.client.game.ItemManager;
 
 /**
  * Handles GE offer state changes: cancelled, collected/empty, and active fills.
@@ -51,26 +53,41 @@ public class GrandExchangeTracker
 	private OfferStore offerStore = new OfferStore();
 
 	// Set after construction (created in plugin startUp)
+	@Setter
 	private AutoRecommendService autoRecommendService;
+	@Setter
 	private ManualAdjustmentTracker manualAdjustmentTracker;
+	@Setter
 	private ActiveOfferAdvisorService activeOfferAdvisorService;
+	@Setter
 	private java.util.function.BooleanSupplier adjustmentPromptsEnabled;
+	@Setter
 	private FlipSmartConfig config;
 
 	// Callbacks wired by the plugin
+	@Setter
 	private Supplier<Optional<String>> rsnSupplier;
+	@Setter
 	private Runnable onPanelRefresh;
+	@Setter
 	private Runnable onActiveFlipsRefresh;
+	@Setter
 	private Consumer<List<PendingOrder>> onPendingOrdersUpdate;
+	@Setter
 	private Consumer<FocusedFlip> onFocusChanged;
+	@Setter
 	private BiConsumer<Integer, Boolean> onFocusClear;
 	// Fires on every order submission (buy or sell), for BOTH manual and Auto, unlike
 	// onFocusClear which is skipped during Auto. Used to mark Flip Finder-sourced buys.
+	@Setter
 	private BiConsumer<Integer, Boolean> onOrderSubmitted;
+	@Setter
 	private IntFunction<Integer> displayedSellPriceProvider;
+	@Setter
 	private BiConsumer<Integer, Runnable> oneShotScheduler;
 	// Cost basis straight from the offer store, so a manual exit can be priced without
 	// the backend's slot-capped active-flips list.
+	@Setter
 	private IntFunction<AwaitingSaleLots.BuyBasis> buyBasisProvider;
 
 	// Debounce: prevent duplicate autoFocusOnActiveFlip calls for the same item
@@ -132,80 +149,15 @@ public class GrandExchangeTracker
 		}
 	}
 
-	public void setAutoRecommendService(AutoRecommendService service)
-	{
-		this.autoRecommendService = service;
-	}
 
-	public void setManualAdjustmentTracker(ManualAdjustmentTracker tracker)
-	{
-		this.manualAdjustmentTracker = tracker;
-	}
 
-	public void setActiveOfferAdvisorService(ActiveOfferAdvisorService service)
-	{
-		this.activeOfferAdvisorService = service;
-	}
 
-	public void setAdjustmentPromptsEnabled(java.util.function.BooleanSupplier supplier)
-	{
-		this.adjustmentPromptsEnabled = supplier;
-	}
 
-	public void setRsnSupplier(Supplier<Optional<String>> rsnSupplier)
-	{
-		this.rsnSupplier = rsnSupplier;
-	}
 
-	public void setConfig(FlipSmartConfig config)
-	{
-		this.config = config;
-	}
 
-	public void setOnPanelRefresh(Runnable callback)
-	{
-		this.onPanelRefresh = callback;
-	}
 
-	public void setOnActiveFlipsRefresh(Runnable callback)
-	{
-		this.onActiveFlipsRefresh = callback;
-	}
 
-	public void setOnPendingOrdersUpdate(Consumer<List<PendingOrder>> callback)
-	{
-		this.onPendingOrdersUpdate = callback;
-	}
 
-	public void setOnFocusChanged(Consumer<FocusedFlip> callback)
-	{
-		this.onFocusChanged = callback;
-	}
-
-	public void setOnFocusClear(BiConsumer<Integer, Boolean> callback)
-	{
-		this.onFocusClear = callback;
-	}
-
-	public void setOnOrderSubmitted(BiConsumer<Integer, Boolean> callback)
-	{
-		this.onOrderSubmitted = callback;
-	}
-
-	public void setDisplayedSellPriceProvider(IntFunction<Integer> provider)
-	{
-		this.displayedSellPriceProvider = provider;
-	}
-
-	public void setOneShotScheduler(BiConsumer<Integer, Runnable> scheduler)
-	{
-		this.oneShotScheduler = scheduler;
-	}
-
-	public void setBuyBasisProvider(IntFunction<AwaitingSaleLots.BuyBasis> provider)
-	{
-		this.buyBasisProvider = provider;
-	}
 
 	// =====================
 	// GE Offer Changed Handler
@@ -246,7 +198,7 @@ public class GrandExchangeTracker
 		// CANCELLED_PARTIAL, so a legitimate later cancel still proceeds.
 		OfferRecord previousOffer = offerStore.bySlot(ctx.slot);
 		if (previousOffer == null
-			|| previousOffer.getState() == com.flipsmart.domain.offer.OfferState.CANCELLED_PARTIAL)
+			|| previousOffer.getState() == OfferState.CANCELLED_PARTIAL)
 		{
 			log.debug("Ignoring duplicate cancellation event for slot {}", ctx.slot);
 			return;
@@ -296,7 +248,7 @@ public class GrandExchangeTracker
 		if ((partialBuyCancel || sellCancelWithRemaining) && slotFreedByApply)
 		{
 			OfferRecord promoted = previousOffer
-				.withFill(ctx.quantitySold, ctx.spent, com.flipsmart.domain.offer.OfferState.CANCELLED_PARTIAL,
+				.withFill(ctx.quantitySold, ctx.spent, OfferState.CANCELLED_PARTIAL,
 					System.currentTimeMillis());
 			offerStore.importRecords(replaceInStore(promoted));
 		}
@@ -315,9 +267,9 @@ public class GrandExchangeTracker
 		}
 	}
 
-	private java.util.List<OfferRecord> replaceInStore(OfferRecord replacement)
+	private List<OfferRecord> replaceInStore(OfferRecord replacement)
 	{
-		java.util.List<OfferRecord> records = new java.util.ArrayList<>(offerStore.allRecords());
+		List<OfferRecord> records = new java.util.ArrayList<>(offerStore.allRecords());
 		records.removeIf(r -> r.getOfferId() == replacement.getOfferId());
 		records.add(replacement);
 		return records;
@@ -881,7 +833,7 @@ public class GrandExchangeTracker
 			config != null ? config.priceOffset() : 0);
 		if (onFocusChanged != null)
 		{
-			javax.swing.SwingUtilities.invokeLater(() -> onFocusChanged.accept(focus));
+			SwingUtilities.invokeLater(() -> onFocusChanged.accept(focus));
 		}
 		log.debug("Manual sell focus resolved locally: {} @ {} gp (qty: inv={})",
 			itemName, sellPrice, inventoryCount);
@@ -1111,7 +1063,7 @@ public class GrandExchangeTracker
 
 		if (onFocusChanged != null)
 		{
-			javax.swing.SwingUtilities.invokeLater(() -> onFocusChanged.accept(focus));
+			SwingUtilities.invokeLater(() -> onFocusChanged.accept(focus));
 		}
 		log.debug("Auto-focused on active flip for sell: {} @ {} gp (qty: api={}, inv={}, using={})",
 			flip.getItemName(), sellPrice, apiQuantity, inventoryFallbackCount, sellQuantity);
@@ -1178,7 +1130,7 @@ public class GrandExchangeTracker
 	{
 		if (onActiveFlipsRefresh != null)
 		{
-			javax.swing.SwingUtilities.invokeLater(onActiveFlipsRefresh);
+			SwingUtilities.invokeLater(onActiveFlipsRefresh);
 		}
 	}
 
@@ -1187,7 +1139,7 @@ public class GrandExchangeTracker
 		if (onPanelRefresh != null && oneShotScheduler != null)
 		{
 			oneShotScheduler.accept(TRANSACTION_REFRESH_DELAY_MS, () ->
-				javax.swing.SwingUtilities.invokeLater(onPanelRefresh));
+				SwingUtilities.invokeLater(onPanelRefresh));
 		}
 	}
 
@@ -1195,7 +1147,7 @@ public class GrandExchangeTracker
 	{
 		if (onPendingOrdersUpdate != null && onActiveFlipsRefresh != null)
 		{
-			javax.swing.SwingUtilities.invokeLater(() -> {
+			SwingUtilities.invokeLater(() -> {
 				onPendingOrdersUpdate.accept(null);
 				onActiveFlipsRefresh.run();
 			});

--- a/src/main/java/com/flipsmart/InventoryHighlightOverlay.java
+++ b/src/main/java/com/flipsmart/InventoryHighlightOverlay.java
@@ -1,5 +1,11 @@
 package com.flipsmart;
 
+import java.awt.geom.Area;
+import java.awt.image.BufferedImage;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.widgets.Widget;
@@ -7,12 +13,7 @@ import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
 
-import javax.inject.Inject;
 import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 public class InventoryHighlightOverlay extends WidgetItemOverlay
@@ -86,14 +87,14 @@ public class InventoryHighlightOverlay extends WidgetItemOverlay
 		float pulseAlpha = (float) (0.5 + 0.5 * Math.sin(elapsed / 1500.0 * 2 * Math.PI));
 
 		Shape originalClip = graphics.getClip();
-		java.awt.geom.Area clipArea = new java.awt.geom.Area(new Rectangle(
+		Area clipArea = new Area(new Rectangle(
 			bounds.x - 10, bounds.y - 10,
 			bounds.width + 20, bounds.height + 20));
 		// Stacks render a quantity number in the top-left corner; crop it out so the
 		// glow doesn't obscure it. A single item shows no number, so highlight fully.
 		if (quantity > SINGLE_ITEM_QUANTITY)
 		{
-			clipArea.subtract(new java.awt.geom.Area(new Rectangle(
+			clipArea.subtract(new Area(new Rectangle(
 				bounds.x, bounds.y, bounds.width / 2, bounds.height / 3)));
 		}
 		graphics.setClip(clipArea);

--- a/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
+++ b/src/main/java/com/flipsmart/ManualAdjustmentTracker.java
@@ -1,20 +1,22 @@
 package com.flipsmart;
+
 import com.flipsmart.api.dto.FlipAdjustmentRequest;
 import com.flipsmart.api.dto.FlipAdjustmentResponse;
+import com.flipsmart.api.dto.FlipFinderResponse;
+import com.flipsmart.domain.flip.FlipRecommendation;
 import com.flipsmart.domain.offer.OfferRecord;
 import com.flipsmart.domain.offer.OfferState;
-import com.flipsmart.domain.flip.FlipRecommendation;
-import com.flipsmart.api.dto.FlipFinderResponse;
 import com.flipsmart.trading.OfferStore;
 import com.flipsmart.util.GpUtils;
-
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
+import java.util.function.IntConsumer;
 import java.util.function.ObjIntConsumer;
+import java.util.function.Supplier;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Tracks adjustment timers for manual (non-auto-recommend) flip offers.
@@ -63,31 +65,42 @@ public class ManualAdjustmentTracker
 	private final Map<Integer, OfferAdjustmentState> trackedOffers = new ConcurrentHashMap<>();
 
 	// Callback to show adjustment prompts in FlipAssistOverlay
+	@Setter
 	private volatile ObjIntConsumer<String> onAdjustmentPrompt;
 
 	// Callback to set a FocusedFlip for buy adjustments
+	@Setter
 	private volatile BiConsumer<FocusedFlip, String> onFocusFlip;
 
 	// Callback to highlight a GE slot for adjustment
+	@Setter
 	private volatile BiConsumer<Integer, Integer> onHighlightSlot;
 
 	// Callback to clear a GE slot highlight
-	private volatile java.util.function.IntConsumer onClearHighlight;
+	@Setter
+	private volatile IntConsumer onClearHighlight;
 
 	// Callback to highlight an inventory item for sell adjustments
-	private volatile java.util.function.IntConsumer onHighlightInventoryItem;
+	@Setter
+	private volatile IntConsumer onHighlightInventoryItem;
 
 	// Callback to clear an inventory item highlight
-	private volatile java.util.function.IntConsumer onClearInventoryItem;
+	@Setter
+	private volatile IntConsumer onClearInventoryItem;
 
 	// Callback to persist adjusted sell price to session
+	@Setter
 	private volatile BiConsumer<Integer, Integer> onSellPriceAdjusted;
 
 	// Suppliers for ditch logic — needed to fetch replacement recommendations
-	private volatile java.util.function.Supplier<Integer> cashStackSupplier;
-	private volatile java.util.function.Supplier<String> rsnSupplier;
-	private volatile java.util.function.Supplier<Integer> filledSlotsSupplier;
-	private volatile java.util.function.Supplier<Boolean> membersWorldSupplier;
+	@Setter
+	private volatile Supplier<Integer> cashStackSupplier;
+	@Setter
+	private volatile Supplier<String> rsnSupplier;
+	@Setter
+	private volatile Supplier<Integer> filledSlotsSupplier;
+	@Setter
+	private volatile Supplier<Boolean> membersWorldSupplier;
 
 	public ManualAdjustmentTracker(FlipSmartApiClient apiClient, FlipSmartConfig config, OfferStore offerStore)
 	{
@@ -96,60 +109,12 @@ public class ManualAdjustmentTracker
 		this.offerStore = offerStore;
 	}
 
-	public void setOnAdjustmentPrompt(ObjIntConsumer<String> callback)
-	{
-		this.onAdjustmentPrompt = callback;
-	}
 
-	public void setOnFocusFlip(BiConsumer<FocusedFlip, String> callback)
-	{
-		this.onFocusFlip = callback;
-	}
 
-	public void setOnHighlightSlot(BiConsumer<Integer, Integer> callback)
-	{
-		this.onHighlightSlot = callback;
-	}
 
-	public void setOnClearHighlight(java.util.function.IntConsumer callback)
-	{
-		this.onClearHighlight = callback;
-	}
 
-	public void setOnHighlightInventoryItem(java.util.function.IntConsumer callback)
-	{
-		this.onHighlightInventoryItem = callback;
-	}
 
-	public void setOnClearInventoryItem(java.util.function.IntConsumer callback)
-	{
-		this.onClearInventoryItem = callback;
-	}
 
-	public void setOnSellPriceAdjusted(BiConsumer<Integer, Integer> callback)
-	{
-		this.onSellPriceAdjusted = callback;
-	}
-
-	public void setCashStackSupplier(java.util.function.Supplier<Integer> supplier)
-	{
-		this.cashStackSupplier = supplier;
-	}
-
-	public void setRsnSupplier(java.util.function.Supplier<String> supplier)
-	{
-		this.rsnSupplier = supplier;
-	}
-
-	public void setFilledSlotsSupplier(java.util.function.Supplier<Integer> supplier)
-	{
-		this.filledSlotsSupplier = supplier;
-	}
-
-	public void setMembersWorldSupplier(java.util.function.Supplier<Boolean> supplier)
-	{
-		this.membersWorldSupplier = supplier;
-	}
 
 	/**
 	 * Schedule an adjustment timer for a manual buy offer.
@@ -215,7 +180,7 @@ public class ManualAdjustmentTracker
 		if (removed != null)
 		{
 			log.debug("Manual adjustment timer cleared for {} (slot {})", removed.itemName, geSlot);
-			java.util.function.IntConsumer cb = onClearHighlight;
+			IntConsumer cb = onClearHighlight;
 			if (cb != null)
 			{
 				cb.accept(geSlot);
@@ -234,7 +199,7 @@ public class ManualAdjustmentTracker
 	{
 		for (Map.Entry<Integer, OfferAdjustmentState> entry : trackedOffers.entrySet())
 		{
-			java.util.function.IntConsumer cb = onClearHighlight;
+			IntConsumer cb = onClearHighlight;
 			if (cb != null)
 			{
 				cb.accept(entry.getKey());
@@ -446,7 +411,7 @@ public class ManualAdjustmentTracker
 
 	private void notifyInventoryHighlight(int itemId)
 	{
-		java.util.function.IntConsumer cb = onHighlightInventoryItem;
+		IntConsumer cb = onHighlightInventoryItem;
 		if (cb != null)
 		{
 			cb.accept(itemId);
@@ -455,7 +420,7 @@ public class ManualAdjustmentTracker
 
 	private void notifyClearInventoryHighlight(int itemId)
 	{
-		java.util.function.IntConsumer cb = onClearInventoryItem;
+		IntConsumer cb = onClearInventoryItem;
 		if (cb != null)
 		{
 			cb.accept(itemId);

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -1,4 +1,5 @@
 package com.flipsmart;
+
 import com.flipsmart.domain.offer.OfferRecord;
 import com.flipsmart.domain.offer.OfferSignal;
 import com.flipsmart.domain.offer.OfferState;
@@ -6,19 +7,8 @@ import com.flipsmart.trading.OfferEventMapper;
 import com.flipsmart.trading.OfferReconciler;
 import com.flipsmart.trading.OfferStore;
 import com.flipsmart.trading.RoundTripLedger;
-
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Client;
-import net.runelite.api.GrandExchangeOffer;
-import net.runelite.api.GrandExchangeOfferState;
-import net.runelite.client.callback.ClientThread;
-import net.runelite.client.config.ConfigManager;
-import net.runelite.client.game.ItemManager;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,6 +17,16 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.GrandExchangeOffer;
+import net.runelite.api.GrandExchangeOfferState;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.game.ItemManager;
 
 /**
  * Handles offline fill detection, offer state persistence, and collected item tracking.
@@ -78,6 +78,7 @@ public class OfflineSyncService
 	private final RoundTripLedger roundTripLedger;
 
 	/** Callback invoked after sync is complete (for scheduling post-sync tasks) */
+	@Setter
 	private Runnable onSyncComplete;
 
 	@Inject
@@ -103,11 +104,6 @@ public class OfflineSyncService
 		this.offerStore = offerStore;
 		this.itemManager = itemManager;
 		this.roundTripLedger = roundTripLedger;
-	}
-
-	public void setOnSyncComplete(Runnable onSyncComplete)
-	{
-		this.onSyncComplete = onSyncComplete;
 	}
 
 	/**
@@ -172,8 +168,8 @@ public class OfflineSyncService
 			{
 				return new HashSet<>();
 			}
-			Type type = new TypeToken<java.util.List<Integer>>(){}.getType();
-			java.util.List<Integer> items = gson.fromJson(json, type);
+			Type type = new TypeToken<List<Integer>>(){}.getType();
+			List<Integer> items = gson.fromJson(json, type);
 			return items != null ? new HashSet<>(items) : new HashSet<>();
 		}
 		catch (Exception e)
@@ -274,7 +270,7 @@ public class OfflineSyncService
 		{
 			try
 			{
-				String json = gson.toJson(new java.util.ArrayList<>(session.getCollectedItemsForPersistence()));
+				String json = gson.toJson(new ArrayList<>(session.getCollectedItemsForPersistence()));
 				configManager.setConfiguration(CONFIG_GROUP, collectedKey, json);
 
 				Map<Integer, Integer> quantities = session.getCollectedQuantitiesForPersistence();
@@ -311,7 +307,7 @@ public class OfflineSyncService
 			try
 			{
 				configManager.setConfiguration(CONFIG_GROUP, FLIP_FINDER_SOURCED_KEY_PREFIX + rsn,
-					gson.toJson(new java.util.ArrayList<>(sourced)));
+					gson.toJson(new ArrayList<>(sourced)));
 			}
 			catch (Exception e)
 			{
@@ -922,8 +918,8 @@ public class OfflineSyncService
 				return new HashSet<>();
 			}
 
-			Type type = new TypeToken<java.util.List<Integer>>(){}.getType();
-			java.util.List<Integer> items = gson.fromJson(json, type);
+			Type type = new TypeToken<List<Integer>>(){}.getType();
+			List<Integer> items = gson.fromJson(json, type);
 			log.debug("Loaded {} persisted collected items for {}", items != null ? items.size() : 0, session.getRsn());
 			return items != null ? new HashSet<>(items) : new HashSet<>();
 		}

--- a/src/main/java/com/flipsmart/PlayerSession.java
+++ b/src/main/java/com/flipsmart/PlayerSession.java
@@ -1,8 +1,6 @@
 package com.flipsmart;
-import com.flipsmart.recommend.CollectOrigin;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 
+import com.flipsmart.recommend.CollectOrigin;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -10,6 +8,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Centralized state management for a player's flip session.
@@ -24,12 +25,15 @@ public class PlayerSession
 	// =====================
 
 	@Getter
+	@Setter
 	private volatile String rsn;
 
 	@Getter
+	@Setter
 	private volatile boolean loggedIntoRunescape;
 
 	@Getter
+	@Setter
 	private volatile int lastLoginTick;
 
 	// =====================
@@ -64,6 +68,7 @@ public class PlayerSession
 	// =====================
 
 	@Getter
+	@Setter
 	private volatile boolean offlineSyncCompleted;
 
 	// =====================
@@ -71,12 +76,15 @@ public class PlayerSession
 	// =====================
 
 	@Getter
+	@Setter
 	private volatile boolean bankSnapshotInProgress;
 
 	@Getter
+	@Setter
 	private volatile long lastBankSnapshotAttempt;
 
 	@Getter
+	@Setter
 	private volatile long lastFlipFinderRefresh;
 
 	// =====================
@@ -90,11 +98,6 @@ public class PlayerSession
 	// Session Identity Methods
 	// =====================
 
-	public void setRsn(String rsn)
-	{
-		this.rsn = rsn;
-	}
-
 	public Optional<String> getRsnSafe()
 	{
 		String currentRsn = this.rsn;
@@ -103,16 +106,6 @@ public class PlayerSession
 			return Optional.of(currentRsn);
 		}
 		return Optional.empty();
-	}
-
-	public void setLoggedIntoRunescape(boolean loggedIn)
-	{
-		this.loggedIntoRunescape = loggedIn;
-	}
-
-	public void setLastLoginTick(int tick)
-	{
-		this.lastLoginTick = tick;
 	}
 
 	// =====================
@@ -325,29 +318,12 @@ public class PlayerSession
 	// Sync Status Methods
 	// =====================
 
-	public void setOfflineSyncCompleted(boolean completed)
-	{
-		this.offlineSyncCompleted = completed;
-	}
-
 	// =====================
 	// Feature State Methods
 	// =====================
 
-	public void setBankSnapshotInProgress(boolean inProgress)
-	{
-		this.bankSnapshotInProgress = inProgress;
-	}
 
-	public void setLastBankSnapshotAttempt(long timestamp)
-	{
-		this.lastBankSnapshotAttempt = timestamp;
-	}
 
-	public void setLastFlipFinderRefresh(long timestamp)
-	{
-		this.lastFlipFinderRefresh = timestamp;
-	}
 
 	// =====================
 	// Lifecycle Methods

--- a/src/main/java/com/flipsmart/api/ApiHttpTransport.java
+++ b/src/main/java/com/flipsmart/api/ApiHttpTransport.java
@@ -3,26 +3,26 @@ package com.flipsmart.api;
 import com.flipsmart.FlipSmartConfig;
 import com.flipsmart.api.dto.AuthResult;
 import com.flipsmart.api.dto.DeviceAuthResponse;
-import com.flipsmart.api.dto.EntitlementsResponse;
 import com.flipsmart.api.dto.DeviceStatusResponse;
+import com.flipsmart.api.dto.EntitlementsResponse;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import lombok.extern.slf4j.Slf4j;
-import okhttp3.Call;
-import okhttp3.Callback;
-import okhttp3.MediaType;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 /**
  * Transport + auth/session core for the FlipSmart API.
@@ -47,7 +47,9 @@ public class ApiHttpTransport
 	private static final int HTTP_SERVER_ERROR_THRESHOLD = 500;
 	private static final int HTTP_TOO_MANY_REQUESTS = 429;
 
+	@Getter
 	private final OkHttpClient httpClient;
+	@Getter
 	private final Gson gson;
 	private final FlipSmartConfig config;
 	private final ApiBackoffGate backoffGate;
@@ -69,9 +71,11 @@ public class ApiHttpTransport
 	private final Object authLock = new Object();
 
 	// Callback when authentication permanently fails (both refresh token and password fail)
+	@Setter
 	private volatile Runnable onAuthFailure = null;
 
 	// Callback when refresh token changes (for persistence to config)
+	@Setter
 	private volatile Consumer<String> onRefreshTokenChanged = null;
 
 	// Coalesce concurrent authenticateAsync() calls into a single attempt
@@ -90,11 +94,6 @@ public class ApiHttpTransport
 		this.backoffGate = backoffGate;
 	}
 
-	public Gson getGson()
-	{
-		return gson;
-	}
-
 	/**
 	 * Deserialize a response body into a DTO using the transport's Gson. Centralizes
 	 * the {@code gson.fromJson(body, T.class)} boilerplate that each endpoint group
@@ -104,11 +103,6 @@ public class ApiHttpTransport
 	public <T> T parse(String body, Class<T> type)
 	{
 		return gson.fromJson(body, type);
-	}
-
-	public OkHttpClient getHttpClient()
-	{
-		return httpClient;
 	}
 
 	/**
@@ -559,14 +553,23 @@ public class ApiHttpTransport
 	 */
 	public AuthResult login(String email, String password)
 	{
+		return awaitAuth("Login", loginAsync(email, password));
+	}
+
+	/**
+	 * Block on an async auth call, turning any failure into a failed {@link AuthResult}.
+	 * {@code label} names the operation in both the log line and the returned message.
+	 */
+	private static AuthResult awaitAuth(String label, CompletableFuture<AuthResult> call)
+	{
 		try
 		{
-			return loginAsync(email, password).get();
+			return call.get();
 		}
 		catch (Exception e)
 		{
-			log.error("Login failed: {}", e.getMessage());
-			return new AuthResult(false, "Login failed: " + e.getMessage());
+			log.error("{} failed: {}", label, e.getMessage());
+			return new AuthResult(false, label + " failed: " + e.getMessage());
 		}
 	}
 
@@ -775,15 +778,7 @@ public class ApiHttpTransport
 	 */
 	public AuthResult signup(String email, String password)
 	{
-		try
-		{
-			return signupAsync(email, password).get();
-		}
-		catch (Exception e)
-		{
-			log.error("Signup failed: {}", e.getMessage());
-			return new AuthResult(false, "Signup failed: " + e.getMessage());
-		}
+		return awaitAuth("Signup", signupAsync(email, password));
 	}
 
 	/**
@@ -844,25 +839,6 @@ public class ApiHttpTransport
 		}
 	}
 
-	/**
-	 * Set callback for when authentication permanently fails.
-	 * This is called when both refresh token and password auth fail,
-	 * indicating the user needs to re-login manually.
-	 */
-	public void setOnAuthFailure(Runnable callback)
-	{
-		this.onAuthFailure = callback;
-	}
-
-	/**
-	 * Set callback for when the refresh token changes (rotation or new login).
-	 * This allows the caller to persist the new token to config immediately,
-	 * preventing token loss if the plugin is closed before the panel saves it.
-	 */
-	public void setOnRefreshTokenChanged(Consumer<String> callback)
-	{
-		this.onRefreshTokenChanged = callback;
-	}
 
 	/**
 	 * Notify that authentication has permanently failed

--- a/src/main/java/com/flipsmart/api/dto/BankSnapshotResult.java
+++ b/src/main/java/com/flipsmart/api/dto/BankSnapshotResult.java
@@ -1,5 +1,7 @@
 package com.flipsmart.api.dto;
 
+import lombok.Getter;
+
 /**
  * Outcome of a bank snapshot upload. The server answers HTTP 429 when a
  * snapshot was already taken inside its 24h window; that is an expected
@@ -8,7 +10,9 @@ package com.flipsmart.api.dto;
  */
 public final class BankSnapshotResult
 {
+	@Getter
 	private final BankSnapshotResponse response;
+	@Getter
 	private final boolean rateLimited;
 
 	private BankSnapshotResult(BankSnapshotResponse response, boolean rateLimited)
@@ -37,13 +41,4 @@ public final class BankSnapshotResult
 		return response != null;
 	}
 
-	public boolean isRateLimited()
-	{
-		return rateLimited;
-	}
-
-	public BankSnapshotResponse getResponse()
-	{
-		return response;
-	}
 }

--- a/src/main/java/com/flipsmart/api/dto/OfferAdviceResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/OfferAdviceResponse.java
@@ -1,8 +1,10 @@
 package com.flipsmart.api.dto;
-import com.flipsmart.domain.offer.OfferAction;
 
+import com.flipsmart.domain.offer.OfferAction;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 @Data
 public class OfferAdviceResponse
@@ -26,17 +28,9 @@ public class OfferAdviceResponse
 	@SerializedName("cumulative_margin_reduction_pct")
 	private double cumulativeMarginReductionPct;
 
+	@Getter @Setter
 	private transient Integer itemIdHint;
 
-	public Integer getItemIdHint()
-	{
-		return itemIdHint;
-	}
-
-	public void setItemIdHint(Integer itemIdHint)
-	{
-		this.itemIdHint = itemIdHint;
-	}
 
 	public OfferAction getActionEnum()
 	{

--- a/src/main/java/com/flipsmart/api/dto/TimeframeFlipFinderResponse.java
+++ b/src/main/java/com/flipsmart/api/dto/TimeframeFlipFinderResponse.java
@@ -1,13 +1,12 @@
 package com.flipsmart.api.dto;
-import com.flipsmart.domain.flip.FlipRecommendation;
 
+import com.flipsmart.domain.flip.FlipRecommendation;
 import com.google.gson.annotations.SerializedName;
+import java.util.List;
+import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-
-import java.util.List;
-import java.util.Map;
 
 @Data
 public class TimeframeFlipFinderResponse
@@ -160,7 +159,7 @@ public class TimeframeFlipFinderResponse
 
 		if (recommendations != null)
 		{
-			java.util.List<FlipRecommendation> converted = new java.util.ArrayList<>();
+			List<FlipRecommendation> converted = new java.util.ArrayList<>();
 			for (TimeframeRecommendation rec : recommendations)
 			{
 				converted.add(rec.toFlipRecommendation());

--- a/src/main/java/com/flipsmart/api/endpoints/ActiveFlipEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/ActiveFlipEndpoints.java
@@ -41,23 +41,34 @@ public class ActiveFlipEndpoints
 	 */
 	public CompletableFuture<ActiveFlipsResponse> getActiveFlipsAsync(String rsn)
 	{
-		String apiUrl = transport.getApiUrl();
-		String url;
+		return getScoped("/transactions/active-flips", "", rsn, ActiveFlipsResponse.class);
+	}
+
+	/**
+	 * GET {@code path}, optionally scoped to a single RSN, decoding the body into
+	 * {@code type}. {@code query} is the leading query string without the rsn pair
+	 * ("limit=50", or empty when the path takes no other parameters).
+	 */
+	private <T> CompletableFuture<T> getScoped(String path, String query, String rsn, Class<T> type)
+	{
+		StringBuilder url = new StringBuilder(transport.getApiUrl()).append(path);
+		String separator = "?";
+		if (!query.isEmpty())
+		{
+			url.append(separator).append(query);
+			separator = "&";
+		}
 		if (rsn != null && !rsn.isEmpty())
 		{
-			url = String.format("%s/transactions/active-flips?rsn=%s", apiUrl, urlEncode(rsn));
-		}
-		else
-		{
-			url = String.format("%s/transactions/active-flips", apiUrl);
+			url.append(separator).append("rsn=").append(urlEncode(rsn));
 		}
 
 		Request.Builder requestBuilder = new Request.Builder()
-			.url(url)
+			.url(url.toString())
 			.get();
 
 		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
-			gson.fromJson(jsonData, ActiveFlipsResponse.class));
+			gson.fromJson(jsonData, type));
 	}
 
 	/**
@@ -225,23 +236,7 @@ public class ActiveFlipEndpoints
 	 */
 	public CompletableFuture<CompletedFlipsResponse> getCompletedFlipsAsync(int limit, String rsn)
 	{
-		String apiUrl = transport.getApiUrl();
-		String url;
-		if (rsn != null && !rsn.isEmpty())
-		{
-			url = String.format("%s/flips/completed?limit=%d&rsn=%s", apiUrl, limit, urlEncode(rsn));
-		}
-		else
-		{
-			url = String.format("%s/flips/completed?limit=%d", apiUrl, limit);
-		}
-
-		Request.Builder requestBuilder = new Request.Builder()
-			.url(url)
-			.get();
-
-		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
-			gson.fromJson(jsonData, CompletedFlipsResponse.class));
+		return getScoped("/flips/completed", "limit=" + limit, rsn, CompletedFlipsResponse.class);
 	}
 
 	/**
@@ -257,22 +252,6 @@ public class ActiveFlipEndpoints
 	 */
 	public CompletableFuture<FlipStatisticsResponse> getFlipStatisticsAsync(int days, String rsn)
 	{
-		String apiUrl = transport.getApiUrl();
-		String url;
-		if (rsn != null && !rsn.isEmpty())
-		{
-			url = String.format("%s/flips/statistics?days=%d&rsn=%s", apiUrl, days, urlEncode(rsn));
-		}
-		else
-		{
-			url = String.format("%s/flips/statistics?days=%d", apiUrl, days);
-		}
-
-		Request.Builder requestBuilder = new Request.Builder()
-			.url(url)
-			.get();
-
-		return transport.executeAuthenticatedAsync(requestBuilder, jsonData ->
-			gson.fromJson(jsonData, FlipStatisticsResponse.class));
+		return getScoped("/flips/statistics", "days=" + days, rsn, FlipStatisticsResponse.class);
 	}
 }

--- a/src/main/java/com/flipsmart/api/endpoints/TradeStationEndpoints.java
+++ b/src/main/java/com/flipsmart/api/endpoints/TradeStationEndpoints.java
@@ -1,7 +1,6 @@
 package com.flipsmart.api.endpoints;
 
 import com.flipsmart.api.ApiHttpTransport;
-import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/flipsmart/domain/offer/OfferAction.java
+++ b/src/main/java/com/flipsmart/domain/offer/OfferAction.java
@@ -1,5 +1,7 @@
 package com.flipsmart.domain.offer;
 
+import lombok.Getter;
+
 public enum OfferAction
 {
 	WAIT("wait"),
@@ -10,16 +12,12 @@ public enum OfferAction
 	EXIT_AT_BREAKEVEN("exit_at_breakeven"),
 	EXIT_AT_LOSS("exit_at_loss");
 
+	@Getter
 	private final String wire;
 
 	OfferAction(String wire)
 	{
 		this.wire = wire;
-	}
-
-	public String getWire()
-	{
-		return wire;
 	}
 
 	public static OfferAction fromWire(String value)

--- a/src/main/java/com/flipsmart/exit/ExitSlotTarget.java
+++ b/src/main/java/com/flipsmart/exit/ExitSlotTarget.java
@@ -1,6 +1,7 @@
 package com.flipsmart.exit;
 
 import lombok.Getter;
+import lombok.Setter;
 
 /** One occupied GE slot the Exit Trades flow must unwind. Phase mutates as the player acts. */
 @Getter
@@ -11,7 +12,9 @@ public final class ExitSlotTarget
 	private final String itemName;
 	private final boolean buy;
 	private final int buyBasis;
+	@Setter
 	private ExitPhase phase;
+	@Setter
 	private int heldQuantity; // stock bought from a cancelled/filled buy, remembered across the collect lag
 
 	private ExitSlotTarget(int slot, int itemId, String itemName, boolean buy, int buyBasis, ExitPhase phase)
@@ -34,13 +37,4 @@ public final class ExitSlotTarget
 		return new ExitSlotTarget(slot, itemId, itemName, true, buyBasis, ExitPhase.PENDING_CANCEL);
 	}
 
-	public void setPhase(ExitPhase phase)
-	{
-		this.phase = phase;
-	}
-
-	public void setHeldQuantity(int heldQuantity)
-	{
-		this.heldQuantity = heldQuantity;
-	}
 }

--- a/src/main/java/com/flipsmart/exit/ExitTradesController.java
+++ b/src/main/java/com/flipsmart/exit/ExitTradesController.java
@@ -5,9 +5,6 @@ import com.flipsmart.api.dto.WikiPrice;
 import com.flipsmart.domain.offer.OfferRecord;
 import com.flipsmart.domain.offer.OfferState;
 import com.flipsmart.trading.OfferStore;
-
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -16,6 +13,9 @@ import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.function.IntFunction;
 import java.util.function.IntUnaryOperator;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Owns an in-progress Exit Trades run: a mode plus an ordered per-slot queue the player
@@ -27,20 +27,31 @@ public final class ExitTradesController
 	private static final int GE_SLOTS = 8;
 
 	private final OfferStore offerStore;
+	@Setter
 	private IntUnaryOperator buyBasisSupplier = itemId -> 0;
+	@Setter
 	private IntUnaryOperator backendSellPriceSupplier = itemId -> 0;
+	@Setter
 	private IntFunction<WikiPrice> wikiPriceSupplier = itemId -> null;
+	@Setter
 	private IntUnaryOperator inventoryQtySupplier = itemId -> 0;
+	@Setter
 	private Consumer<FocusedFlip> onFocusTarget = f -> { };
+	@Setter
 	private BiConsumer<String, Integer> onStatusMessage = (m, id) -> { };
+	@Setter
 	private IntConsumer onHighlightSlotForItem = itemId -> { };
+	@Setter
 	private Runnable onClearHighlights = () -> { };
+	@Setter
 	private Runnable onComplete = () -> { };
 
 	// active/mode are read across threads — the client thread (resolver, overlay focus), the Swing
 	// EDT (cog button, panel focus guard), and the render thread (isModifyingActiveOffer) — so the
 	// buy-suppression / ownsOverlay checks see a consistent value without a one-tick stale read.
+	@Getter
 	private volatile boolean active;
+	@Getter
 	private volatile ExitTradesMode mode;
 	private volatile boolean modifyingActiveOffer;
 	private final List<ExitSlotTarget> targets = new ArrayList<>();
@@ -50,51 +61,9 @@ public final class ExitTradesController
 		this.offerStore = offerStore;
 	}
 
-	public void setBuyBasisSupplier(IntUnaryOperator supplier)
-	{
-		this.buyBasisSupplier = supplier;
-	}
 
-	/** Backend-computed exit-at-breakeven sell price (source of truth); 0 when unknown. */
-	public void setBackendSellPriceSupplier(IntUnaryOperator supplier)
-	{
-		this.backendSellPriceSupplier = supplier;
-	}
 
-	public void setWikiPriceSupplier(IntFunction<WikiPrice> supplier)
-	{
-		this.wikiPriceSupplier = supplier;
-	}
 
-	public void setInventoryQtySupplier(IntUnaryOperator supplier)
-	{
-		this.inventoryQtySupplier = supplier;
-	}
-
-	public void setOnFocusTarget(Consumer<FocusedFlip> cb)
-	{
-		this.onFocusTarget = cb;
-	}
-
-	public void setOnStatusMessage(BiConsumer<String, Integer> cb)
-	{
-		this.onStatusMessage = cb;
-	}
-
-	public void setOnHighlightSlotForItem(IntConsumer cb)
-	{
-		this.onHighlightSlotForItem = cb;
-	}
-
-	public void setOnClearHighlights(Runnable cb)
-	{
-		this.onClearHighlights = cb;
-	}
-
-	public void setOnComplete(Runnable cb)
-	{
-		this.onComplete = cb;
-	}
 
 	public void start(ExitTradesMode mode)
 	{
@@ -125,10 +94,6 @@ public final class ExitTradesController
 		log.debug("Exit Trades started: mode={} occupiedSlots={}", mode, targets.size());
 	}
 
-	public boolean isActive()
-	{
-		return active;
-	}
 
 	/**
 	 * Whether the exit flow owns the trading overlay (queue-driven breakeven/instant). REGULAR mode
@@ -139,10 +104,6 @@ public final class ExitTradesController
 		return active && mode != ExitTradesMode.REGULAR;
 	}
 
-	public ExitTradesMode getMode()
-	{
-		return mode;
-	}
 
 	public List<ExitSlotTarget> getTargets()
 	{

--- a/src/main/java/com/flipsmart/exit/ExitTradesDialog.java
+++ b/src/main/java/com/flipsmart/exit/ExitTradesDialog.java
@@ -1,5 +1,6 @@
 package com.flipsmart.exit;
 
+import com.flipsmart.ui.panel.CardWidgets;
 import net.runelite.client.ui.ColorScheme;
 
 import javax.swing.BorderFactory;
@@ -42,8 +43,7 @@ public final class ExitTradesDialog
 		heading.setBorder(BorderFactory.createEmptyBorder(10, 12, 0, 12));
 		dialog.add(heading, BorderLayout.NORTH);
 
-		JPanel cards = new JPanel(new GridLayout(1, 3, 8, 0));
-		cards.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel cards = CardWidgets.panel(new GridLayout(1, 3, 8, 0), ColorScheme.DARKER_GRAY_COLOR);
 		cards.setBorder(BorderFactory.createEmptyBorder(8, 12, 12, 12));
 		cards.add(card("Regular Sell",
 			"Sell-only: stops suggesting new buys but keeps the normal sell flow and prices. Stays on until you switch back to Buy/Sell mode.",

--- a/src/main/java/com/flipsmart/plugin/PluginScheduler.java
+++ b/src/main/java/com/flipsmart/plugin/PluginScheduler.java
@@ -6,7 +6,7 @@ import java.util.TimerTask;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BooleanSupplier;
 import java.util.function.LongSupplier;
-
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -53,6 +53,7 @@ public class PluginScheduler
 	 * independent deadline, so a manual refresh (which restarts the timer) always
 	 * moves the countdown and the actual refresh together. 0 when the timer is stopped.
 	 */
+	@Getter
 	private volatile long nextFlipFinderRefreshAtMillis;
 
 	private final LongSupplier clock;
@@ -124,16 +125,6 @@ public class PluginScheduler
 			nextFlipFinderRefreshAtMillis = 0;
 			log.debug("Flip Finder auto-refresh stopped");
 		}
-	}
-
-	/**
-	 * Wall-clock instant of the next flip-finder auto-refresh, or 0 when the timer
-	 * is not running. The panel's countdown label reads this so the display and the
-	 * actual refresh trigger can never drift apart.
-	 */
-	public long getNextFlipFinderRefreshAtMillis()
-	{
-		return nextFlipFinderRefreshAtMillis;
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/plugin/ServiceWiring.java
+++ b/src/main/java/com/flipsmart/plugin/ServiceWiring.java
@@ -8,7 +8,6 @@ import com.flipsmart.FlipAssistOverlay;
 import com.flipsmart.FlipSmartConfig;
 import com.flipsmart.FlipSmartPlugin;
 import com.flipsmart.GEHistoryService;
-import com.flipsmart.GrandExchangeOverlay;
 import com.flipsmart.GrandExchangeSlotOverlay;
 import com.flipsmart.InventoryHighlightOverlay;
 import com.flipsmart.ManualAdjustmentTracker;

--- a/src/main/java/com/flipsmart/recommend/RecommendationQueue.java
+++ b/src/main/java/com/flipsmart/recommend/RecommendationQueue.java
@@ -1,7 +1,6 @@
 package com.flipsmart.recommend;
 
 import com.flipsmart.domain.flip.FlipRecommendation;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -10,6 +9,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.ToIntFunction;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Owns the auto-recommend buy queue: the ordered recommendation list, the
@@ -25,24 +26,17 @@ public final class RecommendationQueue
 	private final List<FlipRecommendation> recommendations = new ArrayList<>();
 	// Cached item names from recommendations - survives queue refreshes
 	private final Map<Integer, String> itemNames = new ConcurrentHashMap<>();
+	@Getter @Setter
 	private int currentIndex;
 
 	// Offer-screen lock. While set, the coordinator drops focus changes
 	// for any item other than this one. null = unlocked.
+	@Getter @Setter
 	private volatile Integer lockedItemId;
 
 	// Timestamp of last queue refresh for staleness checks
+	@Getter @Setter
 	private volatile long lastQueueRefreshMillis;
-
-	public int getCurrentIndex()
-	{
-		return currentIndex;
-	}
-
-	public void setCurrentIndex(int index)
-	{
-		this.currentIndex = index;
-	}
 
 	public int size()
 	{
@@ -182,29 +176,12 @@ public final class RecommendationQueue
 	// Offer-screen lock
 	// =====================
 
-	public Integer getLockedItemId()
-	{
-		return lockedItemId;
-	}
-
-	public void setLockedItemId(Integer itemId)
-	{
-		this.lockedItemId = itemId;
-	}
 
 	// =====================
 	// Refresh timestamp
 	// =====================
 
-	public long getLastQueueRefreshMillis()
-	{
-		return lastQueueRefreshMillis;
-	}
 
-	public void setLastQueueRefreshMillis(long millis)
-	{
-		this.lastQueueRefreshMillis = millis;
-	}
 
 	// =====================
 	// Cursor advancement

--- a/src/main/java/com/flipsmart/session/SessionStats.java
+++ b/src/main/java/com/flipsmart/session/SessionStats.java
@@ -1,6 +1,5 @@
 package com.flipsmart.session;
 
-import com.flipsmart.domain.flip.ActiveFlip;
 import com.flipsmart.domain.flip.CompletedFlip;
 import com.flipsmart.util.GeTax;
 import com.flipsmart.util.GpUtils;

--- a/src/main/java/com/flipsmart/session/SessionStatsView.java
+++ b/src/main/java/com/flipsmart/session/SessionStatsView.java
@@ -1,21 +1,22 @@
 package com.flipsmart.session;
 
-import net.runelite.client.ui.ColorScheme;
-
-import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.SwingConstants;
+import com.flipsmart.ui.panel.CardWidgets;
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.function.Consumer;
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.client.ui.ColorScheme;
 
 /**
  * The session-performance block above the panel tabs: session profit, session
@@ -38,6 +39,7 @@ public final class SessionStatsView
 	// triangle glyphs; Arial (as the rest of the panel uses) renders them.
 	private static final Font ARROW_FONT = new Font("Arial", Font.PLAIN, 11);
 
+	@Getter
 	private final JPanel component = new JPanel();
 	private final JPanel body = new JPanel();
 	private final JLabel toggleArrow = new JLabel(ARROW_EXPANDED, SwingConstants.RIGHT);
@@ -46,7 +48,9 @@ public final class SessionStatsView
 	private final JLabel realisedRateValue = new JLabel();
 	private final JLabel projectedRateValue = new JLabel();
 
+	@Getter
 	private boolean collapsed;
+	@Setter
 	private Consumer<Boolean> toggleListener;
 
 	public SessionStatsView()
@@ -68,8 +72,7 @@ public final class SessionStatsView
 
 	private JPanel buildHeader()
 	{
-		JPanel header = new JPanel(new BorderLayout());
-		header.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel header = CardWidgets.panel(new BorderLayout(), ColorScheme.DARKER_GRAY_COLOR);
 		header.setMaximumSize(new Dimension(Integer.MAX_VALUE, ROW_HEIGHT));
 		header.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 
@@ -94,8 +97,7 @@ public final class SessionStatsView
 
 	private JPanel buildRow(String label, JLabel valueLabel)
 	{
-		JPanel row = new JPanel(new BorderLayout());
-		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JPanel row = CardWidgets.panel(new BorderLayout(), ColorScheme.DARKER_GRAY_COLOR);
 		row.setMaximumSize(new Dimension(Integer.MAX_VALUE, ROW_HEIGHT));
 		JLabel name = new JLabel(label);
 		name.setForeground(Color.LIGHT_GRAY);
@@ -105,21 +107,7 @@ public final class SessionStatsView
 		return row;
 	}
 
-	public Component getComponent()
-	{
-		return component;
-	}
 
-	public boolean isCollapsed()
-	{
-		return collapsed;
-	}
-
-	/** Notified with the new collapsed state whenever the user clicks the header. */
-	public void setToggleListener(Consumer<Boolean> listener)
-	{
-		this.toggleListener = listener;
-	}
 
 	/** Apply a collapsed state (e.g. restoring a persisted preference) without notifying the listener. */
 	public void setCollapsed(boolean value)

--- a/src/main/java/com/flipsmart/trading/FillWatermarks.java
+++ b/src/main/java/com/flipsmart/trading/FillWatermarks.java
@@ -1,5 +1,6 @@
 package com.flipsmart.trading;
 
+import com.flipsmart.domain.offer.OfferRecord;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -98,13 +99,13 @@ public final class FillWatermarks
 	 * starts the marks in the right place. Terminal records are skipped: they are finished, and
 	 * no further observation of them can arrive.</p>
 	 */
-	public synchronized void seedFrom(java.util.Collection<com.flipsmart.domain.offer.OfferRecord> records)
+	public synchronized void seedFrom(java.util.Collection<OfferRecord> records)
 	{
 		if (records == null)
 		{
 			return;
 		}
-		for (com.flipsmart.domain.offer.OfferRecord r : records)
+		for (OfferRecord r : records)
 		{
 			if (r == null || r.getSlot() == null || r.getState().isTerminal())
 			{

--- a/src/main/java/com/flipsmart/trading/TransactionLogger.java
+++ b/src/main/java/com/flipsmart/trading/TransactionLogger.java
@@ -3,15 +3,16 @@ package com.flipsmart.trading;
 import com.flipsmart.FlipSmartApiClient;
 import com.flipsmart.PlayerSession;
 import com.flipsmart.api.dto.TransactionRequest;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import com.flipsmart.domain.offer.OfferRecord;
+import com.flipsmart.domain.offer.OfferState;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * Single recording point for GE transactions, driven by OfferEvents from OfferStore.
@@ -89,7 +90,7 @@ public final class TransactionLogger
         }
     }
 
-    private void recordPlacement(com.flipsmart.domain.offer.OfferRecord r)
+    private void recordPlacement(OfferRecord r)
     {
         String rsn = rsnSupplier.get().orElse(null);
         String key = idempotencyKey(rsn, r, Type.PLACE);
@@ -103,7 +104,7 @@ public final class TransactionLogger
         apiClient.recordTransactionAsync(baseBuilder(r, 0, r.getPrice(), rsn, key).roundTripId(roundTripId).build());
     }
 
-    private void recordFill(com.flipsmart.domain.offer.OfferRecord r, int newlyFilled, long newlySpent)
+    private void recordFill(OfferRecord r, int newlyFilled, long newlySpent)
     {
         String rsn = rsnSupplier.get().orElse(null);
         String key = idempotencyKey(rsn, r, Type.FILL);
@@ -120,9 +121,9 @@ public final class TransactionLogger
         // The offer is done filling (so its slot's cumulative baseline may reset) once it is no longer
         // NEW or PARTIAL_FILL — i.e. FILLED, collected, or cancelled. A still-filling offer keeps its
         // baseline so a sibling slot of the same item is never double-counted on a mid-fill close.
-        com.flipsmart.domain.offer.OfferState state = r.getState();
-        boolean offerComplete = state != com.flipsmart.domain.offer.OfferState.NEW
-            && state != com.flipsmart.domain.offer.OfferState.PARTIAL_FILL;
+        OfferState state = r.getState();
+        boolean offerComplete = state != OfferState.NEW
+            && state != OfferState.PARTIAL_FILL;
         RoundTripLedger.FillResult fill = roundTripLedger.recordFillGuarded(
             rsn, r.getItemId(), r.getSlot(), r.isBuy(), newlyFilled, r.getFilledQuantity(), offerComplete);
         if (fill.duplicateSuppressed)
@@ -171,14 +172,14 @@ public final class TransactionLogger
      * only for client-side send suppression; the sent idempotency key is unchanged.
      */
     static String normalizedDedupKey(String rsn, Integer roundTripId,
-                                     com.flipsmart.domain.offer.OfferRecord r, Type type)
+                                     OfferRecord r, Type type)
     {
         long cumulative = type == Type.PLACE ? 0 : r.getFilledQuantity();
         return rsn + ":" + r.getItemId() + ":" + r.isBuy() + ":" + r.getSlot()
             + ":" + roundTripId + ":" + type + ":" + cumulative;
     }
 
-    private TransactionRequest.Builder baseBuilder(com.flipsmart.domain.offer.OfferRecord r,
+    private TransactionRequest.Builder baseBuilder(OfferRecord r,
                                                     int qty, int price, String rsn, String key)
     {
         Integer recPrice = r.isBuy() ? session.getRecommendedPrice(r.getItemId()) : null;
@@ -197,7 +198,7 @@ public final class TransactionLogger
      * Format: {@code rsn:offerId:createdAtMillis:TYPE:cumulative}
      * where cumulative=0 for PLACE, filledQuantity for FILL.
      */
-    public static String idempotencyKey(String rsn, com.flipsmart.domain.offer.OfferRecord r, Type type)
+    public static String idempotencyKey(String rsn, OfferRecord r, Type type)
     {
         long cumulative = type == Type.PLACE ? 0 : r.getFilledQuantity();
         return rsn + ":" + r.getOfferId() + ":" + r.getCreatedAtMillis() + ":" + type + ":" + cumulative;

--- a/src/main/java/com/flipsmart/ui/panel/CardWidgets.java
+++ b/src/main/java/com/flipsmart/ui/panel/CardWidgets.java
@@ -6,6 +6,7 @@ import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Font;
+import java.awt.LayoutManager;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
@@ -33,11 +34,30 @@ public final class CardWidgets
 	 */
 	public static JLabel createStyledLabel(String text, Color foreground)
 	{
-		JLabel label = new JLabel(text);
-		label.setForeground(foreground);
-		label.setFont(FONT_PLAIN_12);
+		JLabel label = label(text, foreground, FONT_PLAIN_12);
 		label.setAlignmentX(Component.LEFT_ALIGNMENT);
 		return label;
+	}
+
+	/**
+	 * A label with its foreground and font applied. Unlike
+	 * {@link #createStyledLabel(String, Color)} this sets no alignment, so it suits
+	 * the plain construct-then-style idiom rather than the detail rows.
+	 */
+	public static JLabel label(String text, Color foreground, Font font)
+	{
+		JLabel label = new JLabel(text);
+		label.setForeground(foreground);
+		label.setFont(font);
+		return label;
+	}
+
+	/** A panel with its layout manager and background applied. */
+	public static JPanel panel(LayoutManager layout, Color background)
+	{
+		JPanel panel = new JPanel(layout);
+		panel.setBackground(background);
+		return panel;
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/ui/panel/FavoritesSort.java
+++ b/src/main/java/com/flipsmart/ui/panel/FavoritesSort.java
@@ -2,6 +2,7 @@ package com.flipsmart.ui.panel;
 
 import com.flipsmart.api.dto.FavoriteItem;
 import java.util.Comparator;
+import lombok.Getter;
 
 public enum FavoritesSort
 {
@@ -10,6 +11,7 @@ public enum FavoritesSort
 	ALPHABETICAL("A-Z", Comparator.comparing(
 		f -> f.getItemName() == null ? "" : f.getItemName(), String.CASE_INSENSITIVE_ORDER));
 
+	@Getter
 	private final String label;
 	private final Comparator<FavoriteItem> itemComparator;
 
@@ -17,11 +19,6 @@ public enum FavoritesSort
 	{
 		this.label = label;
 		this.itemComparator = itemComparator;
-	}
-
-	public String getLabel()
-	{
-		return label;
 	}
 
 	public Comparator<FavoriteItem> comparator()

--- a/src/main/java/com/flipsmart/ui/panel/LoginPanel.java
+++ b/src/main/java/com/flipsmart/ui/panel/LoginPanel.java
@@ -1,5 +1,6 @@
 package com.flipsmart.ui.panel;
 
+import com.flipsmart.ui.panel.CardWidgets;
 import com.flipsmart.FlipSmartApiClient;
 import com.flipsmart.FlipSmartConfig;
 import com.flipsmart.api.dto.AuthResult;
@@ -155,21 +156,15 @@ public class LoginPanel
 		contentPanel.setBorder(BorderFactory.createEmptyBorder(40, 20, 40, 20));
 
 		// Title
-		JLabel titleLabel = new JLabel("FlipSmart");
-		titleLabel.setForeground(Color.WHITE);
-		titleLabel.setFont(new Font(FONT_ARIAL, Font.BOLD, 24));
+		JLabel titleLabel = CardWidgets.label("FlipSmart", Color.WHITE, new Font(FONT_ARIAL, Font.BOLD, 24));
 		titleLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
 		// Subtitle
-		JLabel subtitleLabel = new JLabel("Sign in to start flipping");
-		subtitleLabel.setForeground(Color.LIGHT_GRAY);
-		subtitleLabel.setFont(new Font(FONT_ARIAL, Font.PLAIN, 14));
+		JLabel subtitleLabel = CardWidgets.label("Sign in to start flipping", Color.LIGHT_GRAY, new Font(FONT_ARIAL, Font.PLAIN, 14));
 		subtitleLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
 		// Email field
-		JLabel emailLabel = new JLabel("Email");
-		emailLabel.setForeground(Color.LIGHT_GRAY);
-		emailLabel.setFont(FONT_PLAIN_12);
+		JLabel emailLabel = CardWidgets.label("Email", Color.LIGHT_GRAY, FONT_PLAIN_12);
 		emailLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
 		emailField = new JTextField(20);
@@ -183,9 +178,7 @@ public class LoginPanel
 		));
 
 		// Password field
-		JLabel passwordLabel = new JLabel("Password");
-		passwordLabel.setForeground(Color.LIGHT_GRAY);
-		passwordLabel.setFont(FONT_PLAIN_12);
+		JLabel passwordLabel = CardWidgets.label("Password", Color.LIGHT_GRAY, FONT_PLAIN_12);
 		passwordLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
 		passwordField = new JPasswordField(20);
@@ -205,8 +198,7 @@ public class LoginPanel
 		loginStatusLabel.setForeground(Color.LIGHT_GRAY);
 
 		// Buttons panel for Login/Sign Up
-		JPanel buttonsPanel = new JPanel(new GridLayout(1, 2, 10, 0));
-		buttonsPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		JPanel buttonsPanel = CardWidgets.panel(new GridLayout(1, 2, 10, 0), ColorScheme.DARK_GRAY_COLOR);
 		buttonsPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 35));
 
 		// Sign Up button
@@ -234,8 +226,7 @@ public class LoginPanel
 		buttonsPanel.add(loginButton);
 
 		// Divider
-		JPanel dividerPanel = new JPanel(new BorderLayout());
-		dividerPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		JPanel dividerPanel = CardWidgets.panel(new BorderLayout(), ColorScheme.DARK_GRAY_COLOR);
 		dividerPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 20));
 
 		JLabel orLabel = new JLabel("OR", SwingConstants.CENTER);


### PR DESCRIPTION
## Summary

The RuneLite Plugin Hub's AI review bot refuses to run when a plugin's source exceeds 200,000 tokens. It reported 200,915 tokens for `master`, blocking any further Plugin Hub submission for this plugin. The bot counts non-comment code under `src/main/java` only — `src/test` and comments are excluded from its count, so nothing in this PR trades away test coverage or documentation to hit the number.

A local estimator script (`flip-smart-claude/scripts/plugin-token-budget.py`, in a sibling repo, not part of this PR) reproduces the bot's count to within 0.04% (it estimated 200,998 vs the bot's actual 200,915), so every change in this PR was measured against that estimator rather than guessed at.

Result: estimated token count went from 200,998 to 197,453 (-3,545 tokens). All changes are behavior-preserving refactors — no functional/behavioral changes. 810 tests pass, 0 failures, 0 skipped.

## Changes

### ♻️ Refactoring

1. 97 trivial getter/setter accessors replaced with Lombok `@Getter`/`@Setter` annotations (~2,260 tokens saved). Only conversions Lombok reproduces exactly were taken — e.g. `setCashStack` (backed by a differently-named field `currentCashStack`) and an `isX()` accessor on a boxed `Boolean` were both deliberately left alone because Lombok's generated method name/signature wouldn't match the existing call sites.
2. 271 inline fully-qualified class names replaced with import statements (~730 tokens saved). This was selective: an import line costs `len(fqn) + 9` characters, so a single-use FQN is a net token loss and was intentionally left inline rather than "improved."
3. 61 construct-then-style Swing UI call sites folded into two new shared factory methods, `CardWidgets.label` and `CardWidgets.panel` (~440 tokens saved).
4. The four card icon builder methods deduplicated to share three common helpers: `iconLabel`, `hoverSwap`, `onIconClick` (~390 tokens saved).
5. Method-level deduplication across six call sites: `buildSortRow` (replaces both `buildCompletedSortRow` and `buildFavoritesSortRow`), `surfaceAdvisorPrompt`, `pruneStaleQueue`, `awaitAuth`, `getScoped`, `stateKeyFor` (~570 tokens saved).
6. 15 unused imports removed, plus one javadoc comment that was misfiled/misplaced.

### Notes / Why not X

- **Splitting large files into smaller ones does NOT help this token budget** and would actually make it worse — every new file requires its own package declaration and its own import block, both of which cost tokens. Only deletion and deduplication reduce the count; file-splitting was considered and rejected for this reason.
- **A follow-up PR will stack on top of this branch** with more aggressive reductions (removing unused feature plumbing). This PR is the conservative, purely-mechanical first pass.

## Testing

### Automated Tests
- ✅ `./gradlew test` — 810 tests, 0 failures, 0 skipped.
- ✅ `./gradlew compileJava` — clean, no warnings introduced.

### Manual Testing
- Not applicable — this is a non-behavioral refactor (getter/setter extraction, import consolidation, method dedup). No functional or user-facing behavior changed, so no manual/QA testing checklist applies.

## Database Migrations

N/A — no database involved in this repo.

## Deployment Notes

- [ ] Environment variables added/changed: None
- [ ] Dependencies added: None
- [ ] Configuration changes: None
- [ ] Requires database migration: No

## Checklist

- [x] Tests added/updated (existing coverage validated unchanged; no new coverage needed for a behavior-preserving refactor)
- [x] Documentation updated (N/A)
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by teammate

## Related Issues

Closes Flip-Smart/flip-smart#1169

### 🩺 Codacy Quality Gate — dismissed via API (noise)
- `PMD_category_java_multithreading_UseConcurrentHashMap` (×5) `FlipSmartPlugin.java:532,1384,1880,1940,1941` — flagged on plain method-local `HashMap`s that never escape the enclosing method/lambda and are never shared across threads; PMD's rule doesn't distinguish local scratch maps from shared state.
- `PMD_category_java_bestpractices_GuardLogStatement` `ApiHttpTransport.java:571` — flagged on an SLF4J parameterized `log.error("{} failed: {}", label, e.getMessage())`; the `{}` placeholders already defer formatting cost, and `error` level is effectively always enabled, so a level guard adds nothing.

### 🩺 Codacy Quality Gate — deferred to follow-up
- `PMD_category_java_multithreading_AvoidSynchronizedAtMethodLevel` `FillWatermarks.java:102` — legitimate style suggestion (block-level over method-level `synchronized`), but the loop body already needs the lock for its full duration (it calls `observe()`, which mutates shared state), so scope can't actually shrink, and wrapping it in an explicit `synchronized (this) { }` block only adds code for a stylistic gain — against this PR's sole purpose of cutting token count. Deferred as a normal follow-up if the concern is durable; the other 5 methods on this class stay method-level-synchronized for consistency. **Gate remains red on this one issue.**

### 🤖 Codacy AI Reviewer — deferred (in-thread rationale)
- `ApiHttpTransport.java:571` — suggested splitting `awaitAuth`'s catch into `InterruptedException`/`ExecutionException` and calling `Thread.currentThread().interrupt()`. Rejected: that call would interrupt a thread this code doesn't own (violates this repo's Plugin Hub thread-ownership rule), and the extra catch blocks add code against this PR's token-reduction goal for marginal diagnostic gain — `awaitAuth` already turns every failure into a reported `AuthResult`.
- `FillWatermarks.java:102` — same block-level-synchronization suggestion as the quality-gate issue above; same rationale, deferred for the same reason.

