### PR TITLE
test: characterize panel formatting and card-widget layers ahead of UI restructuring

### DIFF
--- a/src/test/java/com/flipsmart/ui/panel/CardWidgetsCharacterizationTest.java
+++ b/src/test/java/com/flipsmart/ui/panel/CardWidgetsCharacterizationTest.java
@@ -1,0 +1,158 @@
+package com.flipsmart.ui.panel;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Cursor;
+import java.awt.Font;
+import java.awt.Insets;
+import javax.swing.BoxLayout;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Characterization tests for the shared card-construction helpers.
+ *
+ * <p>Every card in the panel is assembled from these, so their properties are the visual
+ * contract the whole UI inherits. The values below were captured from the real methods
+ * and pin CURRENT behaviour -- opacity, cursor, border insets and spacing structure are
+ * exactly the things a table-driven rewrite is most likely to change by accident while
+ * still looking roughly right in a screenshot.
+ *
+ * <p>These assert component PROPERTIES, never rendering, so they hold whether or not the
+ * test JVM has a display.
+ */
+public class CardWidgetsCharacterizationTest
+{
+	private static final Color FG = new Color(12, 34, 56);
+	private static final Color BG = new Color(65, 43, 21);
+
+	// ------------------------------------------------------------------ labels
+
+	@Test
+	public void labelAppliesTextForegroundAndFontVerbatim()
+	{
+		Font font = new Font("Arial", Font.BOLD, 12);
+		JLabel label = CardWidgets.label("hi", FG, font);
+
+		assertEquals("hi", label.getText());
+		assertEquals(FG, label.getForeground());
+		assertEquals("Arial", label.getFont().getName());
+		assertEquals(Font.BOLD, label.getFont().getStyle());
+		assertEquals(12, label.getFont().getSize());
+	}
+
+	/**
+	 * Labels are transparent so the card's background shows through. Cards recolour on
+	 * hover and focus by setting the PARENT's background, which only works while the
+	 * labels stay non-opaque -- making one opaque would leave a visible block that does
+	 * not follow the hover state.
+	 */
+	@Test
+	public void labelIsNotOpaque()
+	{
+		assertFalse(CardWidgets.label("x", FG, new Font("Arial", Font.PLAIN, 10)).isOpaque());
+		assertFalse(CardWidgets.createStyledLabel("x", FG).isOpaque());
+	}
+
+	@Test
+	public void labelIsLeftAligned()
+	{
+		assertEquals(Component.LEFT_ALIGNMENT,
+			CardWidgets.label("x", FG, new Font("Arial", Font.PLAIN, 10)).getAlignmentX(), 0.0001);
+	}
+
+	/** createStyledLabel is the no-font overload: Arial plain 12. */
+	@Test
+	public void createStyledLabelDefaultsToArialPlainTwelve()
+	{
+		JLabel label = CardWidgets.createStyledLabel("st", FG);
+		assertEquals(FG, label.getForeground());
+		assertEquals("Arial", label.getFont().getName());
+		assertEquals(Font.PLAIN, label.getFont().getStyle());
+		assertEquals(12, label.getFont().getSize());
+	}
+
+	// ------------------------------------------------------------------ panels
+
+	/** Panels ARE opaque -- they are what actually paints the card background. */
+	@Test
+	public void panelIsOpaqueAndKeepsGivenLayoutAndBackground()
+	{
+		JPanel panel = CardWidgets.panel(new BorderLayout(), BG);
+		assertEquals(BG, panel.getBackground());
+		assertTrue(panel.getLayout() instanceof BorderLayout);
+		assertTrue(panel.isOpaque());
+	}
+
+	@Test
+	public void createDetailsPanelUsesBoxLayoutWithTopPaddingOnly()
+	{
+		JPanel details = CardWidgets.createDetailsPanel(BG);
+		assertEquals(BG, details.getBackground());
+		assertTrue(details.getLayout() instanceof BoxLayout);
+		assertEquals(new Insets(5, 0, 0, 0), details.getBorder().getBorderInsets(details));
+	}
+
+	@Test
+	public void createBaseItemPanelAppliesUniformEightPixelPaddingAndMaxHeight()
+	{
+		JPanel base = CardWidgets.createBaseItemPanel(BG, 90, true);
+		assertEquals(BG, base.getBackground());
+		assertTrue(base.getLayout() instanceof BorderLayout);
+		assertEquals(90, base.getMaximumSize().height);
+		assertEquals(new Insets(8, 8, 8, 8), base.getBorder().getBorderInsets(base));
+	}
+
+	/** The handCursor flag is the only difference between the two base-panel forms. */
+	@Test
+	public void createBaseItemPanelHandCursorFlagSelectsCursor()
+	{
+		assertEquals(Cursor.HAND_CURSOR, CardWidgets.createBaseItemPanel(BG, 90, true).getCursor().getType());
+		assertEquals(Cursor.DEFAULT_CURSOR, CardWidgets.createBaseItemPanel(BG, 90, false).getCursor().getType());
+	}
+
+	// ----------------------------------------------------------------- spacing
+
+	/**
+	 * Labels are interleaved with rigid-area fillers, so N labels yield 2N-1 children in
+	 * strict label/filler/label order. A rewrite that appends spacing after every label
+	 * instead of between them would add a trailing gap and shift every card's height.
+	 */
+	@Test
+	public void addLabelsWithSpacingInterleavesFillersBetweenLabelsOnly()
+	{
+		JPanel host = new JPanel();
+		CardWidgets.addLabelsWithSpacing(host, new JLabel("a"), new JLabel("b"), new JLabel("c"));
+
+		assertEquals(5, host.getComponentCount());
+		assertTrue(host.getComponent(0) instanceof JLabel);
+		assertFalse(host.getComponent(1) instanceof JLabel);
+		assertTrue(host.getComponent(2) instanceof JLabel);
+		assertFalse(host.getComponent(3) instanceof JLabel);
+		assertTrue(host.getComponent(4) instanceof JLabel);
+	}
+
+	@Test
+	public void addLabelsWithSpacingAddsNoFillerForASingleLabel()
+	{
+		JPanel host = new JPanel();
+		CardWidgets.addLabelsWithSpacing(host, new JLabel("only"));
+		assertEquals(1, host.getComponentCount());
+	}
+
+	@Test
+	public void setPanelBackgroundsAppliesToEveryPanelGiven()
+	{
+		JPanel a = new JPanel();
+		JPanel b = new JPanel();
+		CardWidgets.setPanelBackgrounds(BG, a, b);
+		assertEquals(BG, a.getBackground());
+		assertEquals(BG, b.getBackground());
+	}
+}

--- a/src/test/java/com/flipsmart/ui/panel/CardWidgetsCharacterizationTest.java
+++ b/src/test/java/com/flipsmart/ui/panel/CardWidgetsCharacterizationTest.java
@@ -31,18 +31,19 @@ public class CardWidgetsCharacterizationTest
 {
 	private static final Color FG = new Color(12, 34, 56);
 	private static final Color BG = new Color(65, 43, 21);
+	private static final String ARIAL = "Arial";
 
 	// ------------------------------------------------------------------ labels
 
 	@Test
 	public void labelAppliesTextForegroundAndFontVerbatim()
 	{
-		Font font = new Font("Arial", Font.BOLD, 12);
+		Font font = new Font(ARIAL, Font.BOLD, 12);
 		JLabel label = CardWidgets.label("hi", FG, font);
 
 		assertEquals("hi", label.getText());
 		assertEquals(FG, label.getForeground());
-		assertEquals("Arial", label.getFont().getName());
+		assertEquals(ARIAL, label.getFont().getName());
 		assertEquals(Font.BOLD, label.getFont().getStyle());
 		assertEquals(12, label.getFont().getSize());
 	}
@@ -56,7 +57,7 @@ public class CardWidgetsCharacterizationTest
 	@Test
 	public void labelIsNotOpaque()
 	{
-		assertFalse(CardWidgets.label("x", FG, new Font("Arial", Font.PLAIN, 10)).isOpaque());
+		assertFalse(CardWidgets.label("x", FG, new Font(ARIAL, Font.PLAIN, 10)).isOpaque());
 		assertFalse(CardWidgets.createStyledLabel("x", FG).isOpaque());
 	}
 
@@ -64,7 +65,7 @@ public class CardWidgetsCharacterizationTest
 	public void labelIsLeftAligned()
 	{
 		assertEquals(Component.LEFT_ALIGNMENT,
-			CardWidgets.label("x", FG, new Font("Arial", Font.PLAIN, 10)).getAlignmentX(), 0.0001);
+			CardWidgets.label("x", FG, new Font(ARIAL, Font.PLAIN, 10)).getAlignmentX(), 0.0001);
 	}
 
 	/** createStyledLabel is the no-font overload: Arial plain 12. */
@@ -73,7 +74,7 @@ public class CardWidgetsCharacterizationTest
 	{
 		JLabel label = CardWidgets.createStyledLabel("st", FG);
 		assertEquals(FG, label.getForeground());
-		assertEquals("Arial", label.getFont().getName());
+		assertEquals(ARIAL, label.getFont().getName());
 		assertEquals(Font.PLAIN, label.getFont().getStyle());
 		assertEquals(12, label.getFont().getSize());
 	}

--- a/src/test/java/com/flipsmart/ui/panel/PanelFormatCharacterizationTest.java
+++ b/src/test/java/com/flipsmart/ui/panel/PanelFormatCharacterizationTest.java
@@ -1,0 +1,216 @@
+package com.flipsmart.ui.panel;
+
+import java.awt.Color;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Characterization tests for the formatting layer every card renders through.
+ *
+ * <p>These pin CURRENT observable behaviour, not desired behaviour. Each value below was
+ * captured by running the real methods, so a refactor that changes any rendered string
+ * fails here loudly instead of silently altering what players see. Where current output
+ * looks odd, it is pinned as-is and called out in a comment rather than corrected --
+ * fixing behaviour inside a characterization suite would destroy the baseline it exists
+ * to protect.
+ */
+public class PanelFormatCharacterizationTest
+{
+	// ---------------------------------------------------------------- formatGP
+
+	@Test
+	public void formatGpLeavesValuesUnderOneThousandBare()
+	{
+		assertEquals("0", PanelFormat.formatGP(0));
+		assertEquals("1", PanelFormat.formatGP(1));
+		assertEquals("999", PanelFormat.formatGP(999));
+	}
+
+	@Test
+	public void formatGpAbbreviatesThousandsWithOneDecimal()
+	{
+		assertEquals("1.0K", PanelFormat.formatGP(1_000));
+		assertEquals("1.5K", PanelFormat.formatGP(1_500));
+		assertEquals("-1.5K", PanelFormat.formatGP(-1_500));
+	}
+
+	/**
+	 * Pinned oddity: the K band runs to 999,999 rather than rolling into M at 1,000K,
+	 * so a value one gp below a million renders as "1000.0K", not "1.0M". Players do
+	 * see this. Changing it is a product decision, not a refactor.
+	 */
+	@Test
+	public void formatGpRendersJustUnderOneMillionAsFourDigitK()
+	{
+		assertEquals("1000.0K", PanelFormat.formatGP(999_999));
+		assertEquals("1.0M", PanelFormat.formatGP(1_000_000));
+	}
+
+	/**
+	 * There is no B suffix -- ten billion renders as "10000.0M". Pinned so the absence
+	 * is a deliberate, visible fact rather than something a future reader assumes.
+	 */
+	@Test
+	public void formatGpHasNoBillionsSuffix()
+	{
+		assertEquals("10000.0M", PanelFormat.formatGP(10_000_000_000L));
+		assertEquals("-10000.0M", PanelFormat.formatGP(-10_000_000_000L));
+	}
+
+	/**
+	 * formatGP itself takes a long and handles values past Integer.MAX_VALUE correctly.
+	 * The saturation risk tracked by #961 lives at the CALL SITES that narrow to int
+	 * (see formatVolumeText and formatProfitCostText below), not in this method.
+	 */
+	@Test
+	public void formatGpHandlesValuesBeyondIntegerRange()
+	{
+		assertEquals("2147.5M", PanelFormat.formatGP(2_147_483_647L));
+		assertEquals("2147.5M", PanelFormat.formatGP(2_147_483_648L));
+	}
+
+	@Test
+	public void formatGpExactGroupsWithCommasAndKeepsSign()
+	{
+		assertEquals("0", PanelFormat.formatGPExact(0));
+		assertEquals("1,000", PanelFormat.formatGPExact(1_000));
+		assertEquals("-1,500", PanelFormat.formatGPExact(-1_500));
+		assertEquals("2,147,483,648", PanelFormat.formatGPExact(2_147_483_648L));
+	}
+
+	// ------------------------------------------------------------- risk colour
+
+	/**
+	 * Boundaries are inclusive upper bounds: <=20 green, <=40 yellow-green, <=60 yellow,
+	 * else red. Pinned at both sides of every boundary because an off-by-one here silently
+	 * recolours risk for a whole band of items.
+	 */
+	@Test
+	public void getRiskColorBandsAreInclusiveUpperBounds()
+	{
+		assertEquals(new Color(100, 255, 100), PanelFormat.getRiskColor(0));
+		assertEquals(new Color(100, 255, 100), PanelFormat.getRiskColor(20));
+		assertEquals(new Color(150, 255, 100), PanelFormat.getRiskColor(20.1));
+		assertEquals(new Color(150, 255, 100), PanelFormat.getRiskColor(40));
+		assertEquals(new Color(255, 255, 100), PanelFormat.getRiskColor(40.1));
+		assertEquals(new Color(255, 255, 100), PanelFormat.getRiskColor(60));
+		assertEquals(new Color(255, 100, 100), PanelFormat.getRiskColor(60.1));
+		assertEquals(new Color(255, 100, 100), PanelFormat.getRiskColor(100));
+	}
+
+	@Test
+	public void brightenColorClampsEachChannelAtMax()
+	{
+		assertEquals(new Color(110, 120, 130), PanelFormat.brightenColor(new Color(100, 110, 120), 10));
+		assertEquals(new Color(255, 255, 255), PanelFormat.brightenColor(new Color(250, 250, 250), 50));
+	}
+
+	// -------------------------------------------------------------- escapeHtml
+
+	@Test
+	public void escapeHtmlEscapesAmpersandAnglesAndQuote()
+	{
+		assertEquals("a&amp;b&lt;c&gt;d&quot;e", PanelFormat.escapeHtml("a&b<c>d\"e"));
+	}
+
+	@Test
+	public void escapeHtmlMapsNullToEmptyString()
+	{
+		assertEquals("", PanelFormat.escapeHtml(null));
+	}
+
+	/** Single quotes are deliberately NOT escaped; the HTML labels quote attributes with '. */
+	@Test
+	public void escapeHtmlLeavesSingleQuotesAlone()
+	{
+		assertEquals("it's", PanelFormat.escapeHtml("it's"));
+	}
+
+	// ------------------------------------------------------------- row strings
+
+	@Test
+	public void formatVolumeTextReportsNaForNonPositiveVolume()
+	{
+		assertEquals("Volume: N/A", PanelFormat.formatVolumeText(0));
+		assertEquals("Volume: N/A", PanelFormat.formatVolumeText(-5));
+	}
+
+	@Test
+	public void formatVolumeTextAbbreviatesAndSuffixesPerDay()
+	{
+		assertEquals("Volume: 1.5K/day", PanelFormat.formatVolumeText(1_500));
+	}
+
+	@Test
+	public void formatRiskTextFallsBackOnNullScoreAndNullRating()
+	{
+		assertEquals("Risk: N/A", PanelFormat.formatRiskText(null, "Low"));
+		assertEquals("Risk: 15 (Low)", PanelFormat.formatRiskText(15.0, "Low"));
+		assertEquals("Risk: 15 (Unknown)", PanelFormat.formatRiskText(15.0, null));
+	}
+
+	@Test
+	public void formatLiquidityTextFallsBackOnNullScore()
+	{
+		assertEquals("Liquidity: N/A", PanelFormat.formatLiquidityText(null, "High", 1.0));
+		assertEquals("Liquidity: 9 (High) | 2.0K/hr", PanelFormat.formatLiquidityText(9.0, "High", 2000.0));
+	}
+
+	/**
+	 * Pinned wart: a null volumePerHour still emits the " | " separator with nothing after
+	 * it, so the row ends in a dangling pipe. Cosmetic, and visible to players.
+	 */
+	@Test
+	public void formatLiquidityTextLeavesDanglingSeparatorWhenVolumeIsNull()
+	{
+		assertEquals("Liquidity: 9 (High) | ", PanelFormat.formatLiquidityText(9.0, "High", null));
+	}
+
+	/**
+	 * Profit switches representation at 1,000 by absolute value -- under it the exact
+	 * comma-grouped figure, at or over it the abbreviated one. Cost is always abbreviated.
+	 */
+	@Test
+	public void formatProfitCostTextSwitchesProfitFormatAtOneThousand()
+	{
+		assertEquals("Profit: 500 | Cost: 10.0K", PanelFormat.formatProfitCostText(500, 10_000));
+		assertEquals("Profit: 5.0K | Cost: 10.0K", PanelFormat.formatProfitCostText(5_000, 10_000));
+	}
+
+	/** The 1,000 threshold is on the absolute value, so large losses abbreviate too. */
+	@Test
+	public void formatProfitCostTextAbbreviatesLargeNegativeProfit()
+	{
+		assertEquals("Profit: -5.0K | Cost: 100", PanelFormat.formatProfitCostText(-5_000, 100));
+	}
+
+	// -------------------------------------------------------------- html rows
+
+	@Test
+	public void qtyHtmlWrapsInDimGrayFont()
+	{
+		assertEquals("<html><font color='#9aa0a8'>Qty: 3/10</font></html>", PanelFormat.qtyHtml(3, 10));
+	}
+
+	@Test
+	public void taxHtmlAbbreviatesAndWrapsInDimGrayFont()
+	{
+		assertEquals("<html><font color='#9aa0a8'>Tax: 1.2K</font></html>", PanelFormat.taxHtml(1234));
+	}
+
+	@Test
+	public void buySellHtmlRendersNaWhenSellPriceMissing()
+	{
+		assertEquals("<html>Buy: <b><font color='#6fb1ff'>100</font></b> | Sell: N/A</html>",
+			PanelFormat.buySellHtml(100, null));
+	}
+
+	@Test
+	public void buySellHtmlColoursBuyBlueAndSellOrange()
+	{
+		assertEquals("<html>Buy: <b><font color='#6fb1ff'>100</font></b> "
+				+ "| Sell: <b><font color='#ffab54'>200</font></b></html>",
+			PanelFormat.buySellHtml(100, 200));
+	}
+}


### PR DESCRIPTION
## Summary

Adds two new characterization test suites (33 new tests, total test count 794 → 827) as a safety net ahead of upcoming UI-restructuring tickets (#1179, #1191, #1192). No `src/main` code is touched — this is test-only, zero token-budget cost.

## Changes

### ✅ Tests
- `PanelFormatCharacterizationTest` — pins every string the cards render: GP abbreviation bands, risk-colour boundaries, HTML row markup, N/A fallbacks.
- `CardWidgetsCharacterizationTest` — pins the properties every card inherits: label transparency, panel opacity, border insets, hand-cursor flag, label/filler interleaving.

### ♻️ Refactoring
- None. This PR does not touch `src/main` — it is test-only.

### 🗄️ Database Changes
- N/A

### 📝 Documentation
- N/A

## Why This Matters

Only 8 of 118 test files touched `FlipFinderPanel`, and `CardWidgets` — the shared helper every card is built from — had zero coverage. #1179, #1191, and #1192 would each restructure UI with nothing to catch a behaviour change, and plugin QA is manual-only (no automated browser/UI testing exists for this repo).

## Method

Every asserted value was captured by running the real methods first, not assumed/guessed. Current behaviour is pinned as-is even where it looks wrong, with an inline comment explaining why — correcting behaviour inside a characterization suite would destroy the baseline it exists to protect. Three deliberately-pinned warts:

- `formatGP` renders 999,999 as `"1000.0K"` rather than rolling into M.
- `formatGP` has no B suffix, so ten billion reads `"10000.0M"`.
- `formatLiquidityText` emits a dangling `" | "` when volumePerHour is null.

Assertions are on component properties, never on rendering, so they don't depend on the test JVM having a display.

## Honest Coverage Gap

The parent ticket #1178 also listed card builders, session stats, tab state, settings popout, overlay row assembly, and focus management as candidates for characterization. **Those are NOT covered by this PR.** Card builders and focus management need full panel construction with heavy DI (plugin, config, apiClient, session). `GrandExchangeOverlay.renderFull`/`renderCompact` are private and take `Graphics2D` — they paint directly and cannot be characterized without first extracting a row spec. That extraction is exactly what issue #1192 does, so #1192 should add its own characterization as part of that work rather than this PR being blocked on it.

Net effect: #1179 and #1191 are protected by this PR; #1192 is not.

## Testing

### Automated Tests
- ✅ `./gradlew test` → 827 tests, 0 failures, 0 errors
- ✅ Plugin-hub token budget unchanged at 192,689 (test code is not counted by the plugin-hub reviewer's token ceiling)

### Manual Testing
No manual/in-game QA is needed — this PR adds only test code and changes no runtime behaviour. Verification is the test suite itself going green in CI (`./gradlew test`).

- [x] N/A — test-only change, no manual QA required

## API Changes

N/A — no `src/main` code changed, no API surface touched.

## Frontend Impact

N/A — plugin-only, test-only change.

## Database Migrations

N/A

## Deployment Notes

- [x] Environment variables added/changed: None
- [x] Dependencies added: None
- [x] Configuration changes: None
- [x] Requires database migration: No
- No runtime behaviour changes — nothing to deploy beyond the merge itself.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (this PR body documents the method and coverage gap)
- [x] Code follows style guidelines
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [x] Types are correct
- [ ] Reviewed by teammate

## Related Issues

Closes Flip-Smart/flip-smart#1178
Related to Flip-Smart/flip-smart#1171

## Screenshots

N/A — test-only change, no UI/rendering changes.


### 🩺 Codacy Quality Gate — fixed in this PR
- `48816f6` PMD_category_java_errorprone_AvoidDuplicateLiterals `src/test/java/com/flipsmart/ui/panel/CardWidgetsCharacterizationTest.java:40` — extracted the repeated `"Arial"` literal (5 occurrences) into a `private static final String ARIAL` constant.

### 🤖 Codacy AI Reviewer
- No open comments at head `48816f6`.
