### PR TITLE
fix(offline-sync): derive collected items and stop dropping offline fills

### DIFF
--- a/src/main/java/com/flipsmart/FlipSmartPlugin.java
+++ b/src/main/java/com/flipsmart/FlipSmartPlugin.java
@@ -1243,9 +1243,10 @@ public class FlipSmartPlugin extends Plugin
 			webhookSyncService.pullFromBackend();
 		});
 
-		// Restore collected items from config (items bought but not yet sold)
-		// Must be after syncRSN() so we have the correct RSN for the config key
-		offlineSyncService.restoreCollectedItems();
+		// Collected items are no longer restored here: they are derived from the persisted offer
+		// records and live inventory, rebuilt by the offline sync scheduled below. That sync runs
+		// on a delay precisely because the inventory container is not reliably loaded on the first
+		// LOGGED_IN tick, which is what a restore at this point would have had to read.
 
 		// Restore the Flip Finder-sourced set so the free-tier cap survives a restart.
 		offlineSyncService.restoreFlipFinderSourcedItems();

--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -143,11 +143,8 @@ public class GEHistoryService
 
 	private void readHistoryNow()
 	{
-		// historyReadThisSession alone gates hasUnverifiedOfflineFills() and
-		// further registerOfflineFill calls; pendingOfflineFillItemIds is
-		// allowed to stay populated until reset() so future reads (e.g. user
-		// reopens History) can still see what we'd registered.
-		historyReadThisSession = true;
+		// Throttle the next re-scan regardless of outcome, so an unreadable tab
+		// cannot spin the proactive path every tick.
 		lastReadTick = tickCount;
 
 		Widget listWidget = client.getWidget(InterfaceID.GE_HISTORY, GE_HISTORY_LIST_CHILD);
@@ -161,6 +158,13 @@ public class GEHistoryService
 		{
 			return;
 		}
+
+		// Latch only once rows were actually recovered. Latching on entry — before the
+		// widget and row checks below — meant a WidgetLoaded whose clientscripts had not
+		// populated the list yet (or a tab closed within the two-tick defer) still counted
+		// as "History has been read", after which registerOfflineFill silently discards
+		// every subsequent offline fill for the rest of the session.
+		historyReadThisSession = true;
 
 		log.debug("Read {} GE history entries", entries.size());
 		backfillOfflineFills(entries);

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -694,8 +694,17 @@ public class OfflineSyncService
 			int inventory = inventoryCountOrZero(entry.getKey());
 			if (inventory > 0)
 			{
-				session.addCollectedItem(entry.getKey(), Math.min(inventory, entry.getValue()));
+				int quantity = Math.min(inventory, entry.getValue());
+				session.addCollectedItem(entry.getKey(), quantity);
 				rebuilt++;
+				// Per-item, because the aggregate count alone cannot show whether the inventory cap
+				// actually applied — the whole point of deriving the quantity rather than replaying
+				// the figure recorded at collect time.
+				if (log.isDebugEnabled())
+				{
+					log.debug("Rebuilt collected item {} qty={} (inventory={}, persistedFilled={}) for {}",
+						entry.getKey(), quantity, inventory, entry.getValue(), session.getRsn());
+				}
 			}
 		}
 		if (rebuilt > 0 && log.isDebugEnabled())

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -686,7 +686,7 @@ public class OfflineSyncService
 				rebuilt++;
 			}
 		}
-		if (rebuilt > 0)
+		if (rebuilt > 0 && log.isDebugEnabled())
 		{
 			log.debug("Rebuilt {} collected item(s) for {} from persisted offers", rebuilt, session.getRsn());
 		}

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -684,22 +684,9 @@ public class OfflineSyncService
 	 */
 	private void rebuildCollectedItems(List<OfferRecord> persistedRecords, List<OfferRecord> reattached)
 	{
-		Set<Long> stillInSlot = new HashSet<>();
-		for (OfferRecord r : reattached)
-		{
-			stillInSlot.add(r.getOfferId());
-		}
-		List<OfferRecord> collectedOnly = new ArrayList<>(persistedRecords.size());
-		for (OfferRecord r : persistedRecords)
-		{
-			if (r != null && !stillInSlot.contains(r.getOfferId()))
-			{
-				collectedOnly.add(r);
-			}
-		}
-
 		int rebuilt = 0;
-		for (Map.Entry<Integer, Integer> entry : filledBuyQuantitiesByItem(collectedOnly).entrySet())
+		for (Map.Entry<Integer, Integer> entry
+			: filledBuyQuantitiesByItem(excludingReattached(persistedRecords, reattached)).entrySet())
 		{
 			int inventory = inventoryCountOrZero(entry.getKey());
 			if (inventory > 0)
@@ -721,6 +708,28 @@ public class OfflineSyncService
 		{
 			log.debug("Rebuilt {} collected item(s) for {} from persisted offers", rebuilt, session.getRsn());
 		}
+	}
+
+	/**
+	 * {@code records} minus the ones that reattached to a live GE slot. Those offers still occupy
+	 * their slot, so their fills are in the Exchange rather than the player's inventory.
+	 */
+	private static List<OfferRecord> excludingReattached(List<OfferRecord> records, List<OfferRecord> reattached)
+	{
+		Set<Long> stillInSlot = new HashSet<>();
+		for (OfferRecord r : reattached)
+		{
+			stillInSlot.add(r.getOfferId());
+		}
+		List<OfferRecord> out = new ArrayList<>(records.size());
+		for (OfferRecord r : records)
+		{
+			if (r != null && !stillInSlot.contains(r.getOfferId()))
+			{
+				out.add(r);
+			}
+		}
+		return out;
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -667,17 +667,8 @@ public class OfflineSyncService
 	 */
 	private void rebuildCollectedItems(List<OfferRecord> persistedRecords)
 	{
-		Map<Integer, Integer> filledByItem = new HashMap<>();
-		for (OfferRecord r : persistedRecords)
-		{
-			if (r != null && r.isBuy() && r.getFilledQuantity() > 0)
-			{
-				filledByItem.merge(r.getItemId(), r.getFilledQuantity(), Integer::sum);
-			}
-		}
-
 		int rebuilt = 0;
-		for (Map.Entry<Integer, Integer> entry : filledByItem.entrySet())
+		for (Map.Entry<Integer, Integer> entry : filledBuyQuantitiesByItem(persistedRecords).entrySet())
 		{
 			int inventory = inventoryCountOrZero(entry.getKey());
 			if (inventory > 0)
@@ -690,6 +681,24 @@ public class OfflineSyncService
 		{
 			log.debug("Rebuilt {} collected item(s) for {} from persisted offers", rebuilt, session.getRsn());
 		}
+	}
+
+	/**
+	 * Total quantity actually bought per item across {@code records}. Summed rather than replaced:
+	 * a position built up over several offers of the same item is one holding, and taking only the
+	 * last record's fill would under-report it.
+	 */
+	private static Map<Integer, Integer> filledBuyQuantitiesByItem(List<OfferRecord> records)
+	{
+		Map<Integer, Integer> filledByItem = new HashMap<>();
+		for (OfferRecord r : records)
+		{
+			if (r != null && r.isBuy() && r.getFilledQuantity() > 0)
+			{
+				filledByItem.merge(r.getItemId(), r.getFilledQuantity(), Integer::sum);
+			}
+		}
+		return filledByItem;
 	}
 
 	/** Remove the config keys the collected set used to be stored in. Idempotent. */

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -575,7 +575,9 @@ public class OfflineSyncService
 		// Rebuild the collected set before anything reads it. Driven by the whole persisted blob
 		// rather than plan.offlineCollected, so a position the player has held across several
 		// sessions — whose record long ago stopped being "recently vanished" — is still recovered.
-		rebuildCollectedItems(persistedRecords);
+		// Records that reattached are excluded: their fills are still sitting in the GE slot, not in
+		// the player's inventory, so they have not been collected yet.
+		rebuildCollectedItems(persistedRecords, plan.reattached);
 
 		// Each offline-collected record represents an offer whose slot is now gone on login, and
 		// the reconciler has already dropped anything older than the freshness cutoff. This is the
@@ -661,14 +663,33 @@ public class OfflineSyncService
 	 * partly sold or used offline land at its true remainder instead of the figure recorded when it
 	 * was first collected.</p>
 	 *
+	 * <p>Records in {@code reattached} are skipped: those offers still occupy a GE slot, so their
+	 * fills are in the Exchange rather than the inventory and have not been collected. Without that
+	 * exclusion a live partial-fill would contribute to the collected set whenever the player
+	 * happened to hold units of the same item, stranding a phantom sell prompt.</p>
+	 *
 	 * <p>Adds only: a collect observed live earlier in this session keeps its entry, and
 	 * {@link #pruneStaleCollectedItems} drops whatever has no backing. Must run on the client
 	 * thread — it reads inventory.</p>
 	 */
-	private void rebuildCollectedItems(List<OfferRecord> persistedRecords)
+	private void rebuildCollectedItems(List<OfferRecord> persistedRecords, List<OfferRecord> reattached)
 	{
+		Set<Long> stillInSlot = new HashSet<>();
+		for (OfferRecord r : reattached)
+		{
+			stillInSlot.add(r.getOfferId());
+		}
+		List<OfferRecord> collectedOnly = new ArrayList<>(persistedRecords.size());
+		for (OfferRecord r : persistedRecords)
+		{
+			if (r != null && !stillInSlot.contains(r.getOfferId()))
+			{
+				collectedOnly.add(r);
+			}
+		}
+
 		int rebuilt = 0;
-		for (Map.Entry<Integer, Integer> entry : filledBuyQuantitiesByItem(persistedRecords).entrySet())
+		for (Map.Entry<Integer, Integer> entry : filledBuyQuantitiesByItem(collectedOnly).entrySet())
 		{
 			int inventory = inventoryCountOrZero(entry.getKey());
 			if (inventory > 0)

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -386,6 +386,16 @@ public class OfflineSyncService
 				toImport.add(collected.withState(OfferState.COLLECTED, now));
 			}
 		}
+		else
+		{
+			// Deferring classification means carrying the records, not discarding them. They are
+			// non-terminal, so retainRecentTerminalHistory below will not pick them up, and
+			// importRecords replaces the store wholesale — leaving them out drops them, and the
+			// persist that follows writes the truncated set back over the saved blob. That erased
+			// the cost basis of a position the player still holds, and with the collected set now
+			// derived from these records rather than stored separately, it erased the position too.
+			toImport.addAll(plan.offlineCollected);
+		}
 		// A collected buy is the cost basis for the sell that follows it. The reconcile plan
 		// carries only live and offline-collected records, so importing just those erased every
 		// already-collected buy on each LOGGED_IN — which fires on every world hop, not only

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -41,18 +41,20 @@ public class OfflineSyncService
 	private static final String UNKNOWN_RSN_FALLBACK = "unknown";
 	private static final String PERSISTED_OFFERS_KEY_PREFIX = "persistedOffers_";
 	private static final String PERSISTED_OFFERS_FALLBACK_KEY = "persistedOffers_lastSession";
-	private static final String COLLECTED_ITEMS_KEY_PREFIX = "collectedItems_";
 	private static final String FLIP_FINDER_SOURCED_KEY_PREFIX = "flipFinderSourced_";
-	private static final String COLLECTED_QUANTITIES_KEY_PREFIX = "collectedQuantities_";
-	private static final String COLLECTED_ITEMS_SAVED_AT_KEY_PREFIX = "collectedItemsSavedAt_";
 	private static final String ROUND_TRIP_LEDGER_KEY_PREFIX = "roundTripLedger_";
 	private static final String LAST_KNOWN_RSN_KEY = "lastKnownRsn";
 	// Wall-clock of the last completed offline sync, per RSN. A persisted offer is only a genuine
 	// offline fill if it was active since this marker; older leftovers are already-known history.
 	private static final String OFFLINE_SYNC_MARKER_KEY_PREFIX = "offlineSyncAt_";
 
-	/** Persisted collected-item entries older than this are dropped on restore. */
-	static final long MAX_PERSISTED_COLLECTED_AGE_MS = 7L * 24 * 60 * 60 * 1000;
+	/**
+	 * Config keys that held the collected set before it became derived state. Unset on the first
+	 * sync of each session so upgrading clients do not leave orphaned blobs behind.
+	 */
+	private static final String[] LEGACY_COLLECTED_KEY_PREFIXES = {
+		"collectedItems_", "collectedQuantities_", "collectedItemsSavedAt_"
+	};
 
 	/**
 	 * Terminal (already-collected/cancelled) offer records this old are no longer carried across a
@@ -107,40 +109,6 @@ public class OfflineSyncService
 	}
 
 	/**
-	 * Restore collected item IDs from persisted config.
-	 * These are items that were bought but not yet sold when the player logged out.
-	 * Entries older than {@link #MAX_PERSISTED_COLLECTED_AGE_MS} are dropped.
-	 */
-	public void restoreCollectedItems()
-	{
-		String key = getCollectedItemsKey();
-		log.debug("Attempting to restore collected items for RSN: {} (key: {})", session.getRsn(), key);
-
-		if (isPersistedCollectedTooOld())
-		{
-			log.debug("Persisted collected items for {} are stale - clearing", session.getRsn());
-			clearPersistedCollectedItems();
-			session.clearCollectedItems();
-			return;
-		}
-
-		Set<Integer> persisted = loadPersistedCollectedItems();
-		if (!persisted.isEmpty())
-		{
-			Map<Integer, Integer> quantities = loadPersistedCollectedQuantities();
-			session.restoreCollectedItems(persisted, quantities);
-			log.debug("Restored {} collected items from previous session: {} (with {} quantities)",
-				persisted.size(), persisted, quantities.size());
-		}
-		else
-		{
-			log.debug("No collected items found in config for RSN: {}", session.getRsn());
-			session.clearCollectedItems();
-		}
-
-	}
-
-	/**
 	 * Restore the Flip Finder-sourced set for the current RSN on login, so the free-tier cap
 	 * counts flips that were in progress before a client restart. Stale entries (items no
 	 * longer an active flip) are pruned by {@code retainAndCountFlipFinderActive} on the first
@@ -179,42 +147,6 @@ public class OfflineSyncService
 		}
 	}
 
-	/** Missing timestamps (legacy data) are treated as stale. */
-	private boolean isPersistedCollectedTooOld()
-	{
-		String savedAtKey = getCollectedItemsSavedAtKey();
-		String collectedKey = getCollectedItemsKey();
-
-		String collectedJson = configManager.getConfiguration(CONFIG_GROUP, collectedKey);
-		if (collectedJson == null || collectedJson.isEmpty())
-		{
-			return false;
-		}
-
-		String savedAtStr = configManager.getConfiguration(CONFIG_GROUP, savedAtKey);
-		if (savedAtStr == null || savedAtStr.isEmpty())
-		{
-			return true;
-		}
-
-		try
-		{
-			long savedAt = Long.parseLong(savedAtStr);
-			return System.currentTimeMillis() - savedAt > MAX_PERSISTED_COLLECTED_AGE_MS;
-		}
-		catch (NumberFormatException e)
-		{
-			return true;
-		}
-	}
-
-	private void clearPersistedCollectedItems()
-	{
-		configManager.unsetConfiguration(CONFIG_GROUP, getCollectedItemsKey());
-		configManager.unsetConfiguration(CONFIG_GROUP, getCollectedQuantitiesKey());
-		configManager.unsetConfiguration(CONFIG_GROUP, getCollectedItemsSavedAtKey());
-	}
-
 	/**
 	 * Persist the current GE offer state to config for offline tracking.
 	 * Called when the player logs out or plugin shuts down.
@@ -229,8 +161,6 @@ public class OfflineSyncService
 		}
 
 		String offersKey = PERSISTED_OFFERS_KEY_PREFIX + rsn;
-		String collectedKey = COLLECTED_ITEMS_KEY_PREFIX + rsn;
-		String quantitiesKey = COLLECTED_QUANTITIES_KEY_PREFIX + rsn;
 
 		persistWatermarks(rsn);
 
@@ -258,41 +188,12 @@ public class OfflineSyncService
 			}
 		}
 
-		// Persist collected item IDs (items bought but not yet sold)
-		String savedAtKey = COLLECTED_ITEMS_SAVED_AT_KEY_PREFIX + rsn;
-		if (session.getCollectedItemIds().isEmpty())
-		{
-			// Same don't-destroy-on-empty treatment as the offers branch: a transient
-			// empty collected set during the logout/hop window must not wipe saved data.
-			log.debug("Collected set empty — preserving existing persisted collected items for {}", rsn);
-		}
-		else
-		{
-			try
-			{
-				String json = gson.toJson(new ArrayList<>(session.getCollectedItemsForPersistence()));
-				configManager.setConfiguration(CONFIG_GROUP, collectedKey, json);
-
-				Map<Integer, Integer> quantities = session.getCollectedQuantitiesForPersistence();
-				if (!quantities.isEmpty())
-				{
-					String qtyJson = gson.toJson(quantities);
-					configManager.setConfiguration(CONFIG_GROUP, quantitiesKey, qtyJson);
-				}
-				else
-				{
-					configManager.unsetConfiguration(CONFIG_GROUP, quantitiesKey);
-				}
-
-				configManager.setConfiguration(CONFIG_GROUP, savedAtKey, Long.toString(System.currentTimeMillis()));
-
-				log.debug("Persisted {} collected item IDs for {} (active flips)", session.getCollectedItemIds().size(), session.getRsn());
-			}
-			catch (Exception e)
-			{
-				log.error("Failed to persist collected items for {}: {}", session.getRsn(), e.getMessage());
-			}
-		}
+		// The collected set is NOT persisted. It is derived state — "buys I hold that no longer
+		// occupy a slot" — which the persisted offer records plus live inventory already answer,
+		// and rebuildCollectedItems reconstructs it on each sync. Storing it separately meant a
+		// cache that drifted from its own source, which pruneStaleCollectedItems then existed to
+		// repair; the repair in turn re-fired the GE History prompt for entries the reconciler had
+		// deliberately suppressed as already-known history.
 
 		// Persist the Flip Finder-sourced set so the free-tier cap survives a client restart.
 		Set<Integer> sourced = session.getFlipFinderSourcedItems();
@@ -671,27 +572,19 @@ public class OfflineSyncService
 			}
 		}
 
-		// Each offline-collected record represents an offer whose slot is now gone on login.
-		// Register exactly one backfill per record, using the reconciled filled qty — never
-		// the order total — so a partial-cancel contributes only what was actually traded.
+		// Rebuild the collected set before anything reads it. Driven by the whole persisted blob
+		// rather than plan.offlineCollected, so a position the player has held across several
+		// sessions — whose record long ago stopped being "recently vanished" — is still recovered.
+		rebuildCollectedItems(persistedRecords);
+
+		// Each offline-collected record represents an offer whose slot is now gone on login, and
+		// the reconciler has already dropped anything older than the freshness cutoff. This is the
+		// sole path that registers a History backfill, so the cutoff governs every prompt.
 		for (OfferRecord record : plan.offlineCollected)
 		{
-			int itemId = record.getItemId();
-			if (record.isBuy() && record.getFilledQuantity() > 0)
+			if (!record.isBuy() || record.getFilledQuantity() > 0)
 			{
-				// Only re-add a collected buy that is actually still in inventory. A buy the
-				// player already sold/used offline has no inventory and must not be re-injected,
-				// or it strands a phantom collect/sell prompt every login. Backfill always fires.
-				int inventory = inventoryCountOrZero(itemId);
-				if (inventory > 0)
-				{
-					session.addCollectedItem(itemId, Math.min(inventory, record.getFilledQuantity()));
-				}
-				geHistoryService.registerOfflineFill(itemId);
-			}
-			else if (!record.isBuy())
-			{
-				geHistoryService.registerOfflineFill(itemId);
+				geHistoryService.registerOfflineFill(record.getItemId());
 			}
 		}
 
@@ -702,6 +595,7 @@ public class OfflineSyncService
 		}
 
 		pruneStaleCollectedItems();
+		clearLegacyCollectedKeys();
 		writeOfflineSyncMarker(now);
 		persistOfferState();
 
@@ -758,9 +652,70 @@ public class OfflineSyncService
 	}
 
 	/**
+	 * Rebuild the collected set — items bought into inventory but not yet sold — from the persisted
+	 * offer records and live inventory, replacing the config-backed restore this used to do.
+	 *
+	 * <p>Driven by the full persisted blob rather than the reconciler's offline-collected bucket, so
+	 * a position held across several sessions is recovered even once its record has stopped being
+	 * recently-vanished. Quantities are capped at the current inventory count, which makes a holding
+	 * partly sold or used offline land at its true remainder instead of the figure recorded when it
+	 * was first collected.</p>
+	 *
+	 * <p>Adds only: a collect observed live earlier in this session keeps its entry, and
+	 * {@link #pruneStaleCollectedItems} drops whatever has no backing. Must run on the client
+	 * thread — it reads inventory.</p>
+	 */
+	private void rebuildCollectedItems(List<OfferRecord> persistedRecords)
+	{
+		Map<Integer, Integer> filledByItem = new HashMap<>();
+		for (OfferRecord r : persistedRecords)
+		{
+			if (r != null && r.isBuy() && r.getFilledQuantity() > 0)
+			{
+				filledByItem.merge(r.getItemId(), r.getFilledQuantity(), Integer::sum);
+			}
+		}
+
+		int rebuilt = 0;
+		for (Map.Entry<Integer, Integer> entry : filledByItem.entrySet())
+		{
+			int inventory = inventoryCountOrZero(entry.getKey());
+			if (inventory > 0)
+			{
+				session.addCollectedItem(entry.getKey(), Math.min(inventory, entry.getValue()));
+				rebuilt++;
+			}
+		}
+		if (rebuilt > 0)
+		{
+			log.debug("Rebuilt {} collected item(s) for {} from persisted offers", rebuilt, session.getRsn());
+		}
+	}
+
+	/** Remove the config keys the collected set used to be stored in. Idempotent. */
+	private void clearLegacyCollectedKeys()
+	{
+		String rsn = resolvePersistenceRsn();
+		for (String prefix : LEGACY_COLLECTED_KEY_PREFIXES)
+		{
+			configManager.unsetConfiguration(CONFIG_GROUP, prefix + UNKNOWN_RSN_FALLBACK);
+			if (rsn != null)
+			{
+				configManager.unsetConfiguration(CONFIG_GROUP, prefix + rsn);
+			}
+		}
+	}
+
+	/**
 	 * Drop collectedItems entries with no inventory, in-flight/uncollected buy,
 	 * or active sell — they are "phantom" sell prompts from prior sessions (#451).
 	 * Must be called from the client thread.
+	 *
+	 * <p>Deliberately silent: an entry losing its backing is not evidence of a fresh offline sell.
+	 * Registering a History backfill here bypassed the reconciler's freshness cutoff entirely, so
+	 * records it had just routed to staleHistory as already-known were prompted for anyway — every
+	 * login, because a set pruned to empty never cleared its own persisted blob. The genuine
+	 * signal is the reconciler's offline-collected bucket, which is cutoff-gated.</p>
 	 */
 	int pruneStaleCollectedItems()
 	{
@@ -780,10 +735,6 @@ public class OfflineSyncService
 		}
 		for (int itemId : toRemove)
 		{
-			// A collected item disappearing without a tracked sell having
-			// happened in this session means it was sold offline. Register
-			// it for History backfill before we drop it from local state.
-			geHistoryService.registerOfflineFill(itemId);
 			session.removeCollectedItem(itemId);
 		}
 		return toRemove.size();
@@ -874,87 +825,6 @@ public class OfflineSyncService
 			return PERSISTED_OFFERS_KEY_PREFIX + UNKNOWN_RSN_FALLBACK;
 		}
 		return PERSISTED_OFFERS_KEY_PREFIX + session.getRsn();
-	}
-
-	public String getCollectedItemsKey()
-	{
-		if (session.getRsn() == null || session.getRsn().isEmpty())
-		{
-			return COLLECTED_ITEMS_KEY_PREFIX + UNKNOWN_RSN_FALLBACK;
-		}
-		return COLLECTED_ITEMS_KEY_PREFIX + session.getRsn();
-	}
-
-	public String getCollectedQuantitiesKey()
-	{
-		if (session.getRsn() == null || session.getRsn().isEmpty())
-		{
-			return COLLECTED_QUANTITIES_KEY_PREFIX + UNKNOWN_RSN_FALLBACK;
-		}
-		return COLLECTED_QUANTITIES_KEY_PREFIX + session.getRsn();
-	}
-
-	public String getCollectedItemsSavedAtKey()
-	{
-		if (session.getRsn() == null || session.getRsn().isEmpty())
-		{
-			return COLLECTED_ITEMS_SAVED_AT_KEY_PREFIX + UNKNOWN_RSN_FALLBACK;
-		}
-		return COLLECTED_ITEMS_SAVED_AT_KEY_PREFIX + session.getRsn();
-	}
-
-	/**
-	 * Load previously persisted collected item IDs from config.
-	 */
-	private Set<Integer> loadPersistedCollectedItems()
-	{
-		String key = getCollectedItemsKey();
-
-		try
-		{
-			String json = configManager.getConfiguration(CONFIG_GROUP, key);
-			if (json == null || json.isEmpty())
-			{
-				return new HashSet<>();
-			}
-
-			Type type = new TypeToken<List<Integer>>(){}.getType();
-			List<Integer> items = gson.fromJson(json, type);
-			log.debug("Loaded {} persisted collected items for {}", items != null ? items.size() : 0, session.getRsn());
-			return items != null ? new HashSet<>(items) : new HashSet<>();
-		}
-		catch (Exception e)
-		{
-			log.error("Failed to load persisted collected items for {}: {}", session.getRsn(), e.getMessage());
-			return new HashSet<>();
-		}
-	}
-
-	/**
-	 * Load previously persisted collected quantities from config.
-	 */
-	private Map<Integer, Integer> loadPersistedCollectedQuantities()
-	{
-		String key = getCollectedQuantitiesKey();
-
-		try
-		{
-			String json = configManager.getConfiguration(CONFIG_GROUP, key);
-			if (json == null || json.isEmpty())
-			{
-				return new HashMap<>();
-			}
-
-			Type type = new TypeToken<Map<Integer, Integer>>(){}.getType();
-			Map<Integer, Integer> quantities = gson.fromJson(json, type);
-			log.debug("Loaded {} persisted collected quantities for {}", quantities != null ? quantities.size() : 0, session.getRsn());
-			return quantities != null ? quantities : new HashMap<>();
-		}
-		catch (Exception e)
-		{
-			log.error("Failed to load persisted collected quantities for {}: {}", session.getRsn(), e.getMessage());
-			return new HashMap<>();
-		}
 	}
 
 	/**

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -58,10 +58,17 @@ public class OfflineSyncService
 
 	/**
 	 * Terminal (already-collected/cancelled) offer records this old are no longer carried across a
-	 * reconcile. They exist to keep the cost basis of a position the player still holds, so the
-	 * window only has to outlive a realistic buy-to-sell gap.
+	 * reconcile. They keep the cost basis of a position the player still holds.
+	 *
+	 * <p>Matches the seven days the {@code collectedItems_<rsn>} blob used to retain for, because
+	 * the collected set is now derived from these records rather than stored separately. A shorter
+	 * window is fine while {@link RoundTripLedger} knows the held quantity — that exemption keeps a
+	 * backing record alive regardless of age — but a client with no persisted ledger cold-starts
+	 * from live unmatched buys only, so an already-collected holding gets {@code heldQuantity 0} and
+	 * would age out. At 24 hours that silently dropped positions bought the previous day on the
+	 * first login after upgrading.</p>
 	 */
-	static final long TERMINAL_HISTORY_RETENTION_MS = 24L * 60 * 60 * 1000;
+	static final long TERMINAL_HISTORY_RETENTION_MS = 7L * 24 * 60 * 60 * 1000;
 
 	/** Hard ceiling on retained terminal records so the persisted blob stays bounded. */
 	static final int MAX_RETAINED_TERMINAL_RECORDS = 300;

--- a/src/main/java/com/flipsmart/PlayerSession.java
+++ b/src/main/java/com/flipsmart/PlayerSession.java
@@ -171,14 +171,6 @@ public class PlayerSession
 		return collectedItemIds.remove(itemId);
 	}
 
-	public void clearCollectedItems()
-	{
-		collectedItemIds.clear();
-		collectedQuantities.clear();
-		collectOrigins.clear();
-		collectedAtMillis.clear();
-	}
-
 	/** Mark an item as sourced from a Flip Finder recommendation (a focused buy was placed). */
 	public void markFlipFinderSourced(int itemId, long nowMs)
 	{
@@ -237,34 +229,6 @@ public class PlayerSession
 			}
 		}
 		return count;
-	}
-
-	public void restoreCollectedItems(Set<Integer> items)
-	{
-		collectedItemIds.clear();
-		collectedQuantities.clear();
-		collectOrigins.clear();
-		collectedAtMillis.clear();
-		if (items != null)
-		{
-			collectedItemIds.addAll(items);
-		}
-	}
-
-	public void restoreCollectedItems(Set<Integer> items, Map<Integer, Integer> quantities)
-	{
-		collectedItemIds.clear();
-		collectedQuantities.clear();
-		collectOrigins.clear();
-		collectedAtMillis.clear();
-		if (items != null)
-		{
-			collectedItemIds.addAll(items);
-		}
-		if (quantities != null)
-		{
-			collectedQuantities.putAll(quantities);
-		}
 	}
 
 	// =====================
@@ -377,24 +341,6 @@ public class PlayerSession
 	// =====================
 	// Query Methods
 	// =====================
-
-	/**
-	 * Get a snapshot of collected item IDs for persistence.
-	 * Returns a new HashSet to avoid concurrent modification during serialization.
-	 */
-	public Set<Integer> getCollectedItemsForPersistence()
-	{
-		return new HashSet<>(collectedItemIds);
-	}
-
-	/**
-	 * Get a snapshot of collected quantities for persistence.
-	 * Returns a new HashMap to avoid concurrent modification during serialization.
-	 */
-	public Map<Integer, Integer> getCollectedQuantitiesForPersistence()
-	{
-		return new HashMap<>(collectedQuantities);
-	}
 
 	// =====================
 	// Auto-Recommend Stale Notification Methods

--- a/src/main/java/com/flipsmart/plugin/EventRouter.java
+++ b/src/main/java/com/flipsmart/plugin/EventRouter.java
@@ -119,6 +119,13 @@ public class EventRouter
 		{
 			session.onLoginStateChange(client.getTickCount());
 
+			// These transitions clear offlineSyncCompleted, so the sync will run again on the
+			// LOGGED_IN that follows. GEHistoryService has to be cleared with it: its
+			// historyReadThisSession latch used to survive here (only LOGIN_SCREEN reset it),
+			// so any session in which the player had opened the History tab once silently
+			// dropped every offline fill across every later hop and reconnect.
+			geHistoryService.reset();
+
 			if (!offerStore.export().isEmpty())
 			{
 				offlineSyncService.persistOfferState();

--- a/src/test/java/com/flipsmart/GEHistoryServiceTest.java
+++ b/src/test/java/com/flipsmart/GEHistoryServiceTest.java
@@ -282,6 +282,74 @@ public class GEHistoryServiceTest
 		verify(api, times(1)).recordHistoryBackfillBatchAsync(eq("Zezima"), anyList());
 	}
 
+	/** A visible History list whose rows the clientscripts have not written yet. */
+	private Widget unpopulatedHistoryList()
+	{
+		Widget list = mock(Widget.class);
+		when(list.isHidden()).thenReturn(false);
+		return list;
+	}
+
+	private GEHistoryService serviceReading(Widget list)
+	{
+		Client client = mock(Client.class);
+		when(client.getWidget(InterfaceID.GE_HISTORY, 3)).thenReturn(list);
+		return new GEHistoryService(client, mock(FlipSmartApiClient.class),
+			mock(PlayerSession.class), mock(ChatMessageManager.class), new OfferStore());
+	}
+
+	/** Drive the two-tick defer that {@code onHistoryWidgetLoaded} schedules. */
+	private static void runDeferredRead(GEHistoryService svc)
+	{
+		svc.onHistoryWidgetLoaded();
+		svc.onGameTick();
+		svc.onGameTick();
+	}
+
+	@Test
+	public void historyReadThatRecoveredNoRowsDoesNotLatchTheSessionFlag()
+	{
+		// WidgetLoaded fires when the interface is created, before the clientscripts
+		// populate the rows — so a deferred read can legitimately find nothing.
+		GEHistoryService svc = serviceReading(unpopulatedHistoryList());
+		runDeferredRead(svc);
+
+		svc.registerOfflineFill(4151);
+
+		// Pre-fix the flag latched on entry to readHistoryNow, ahead of the widget and
+		// row checks, so this registration was silently discarded and the fill stayed
+		// unrecoverable for the rest of the session.
+		assertTrue(svc.hasUnverifiedOfflineFills());
+	}
+
+	@Test
+	public void historyReadThatRecoveredRowsStillLatches()
+	{
+		// The other half of the fix: a read that actually parsed rows must keep
+		// suppressing further registrations, or the de-nag behaviour regresses.
+		GEHistoryService svc = serviceReading(visibleHistoryList());
+		runDeferredRead(svc);
+
+		svc.registerOfflineFill(4151);
+
+		assertFalse(svc.hasUnverifiedOfflineFills());
+	}
+
+	@Test
+	public void resetClearsTheLatchSoFillsAfterAHopRegisterAgain()
+	{
+		GEHistoryService svc = serviceReading(visibleHistoryList());
+		runDeferredRead(svc);
+		svc.registerOfflineFill(4151);
+		assertFalse(svc.hasUnverifiedOfflineFills());
+
+		// What EventRouter now does on HOPPING / CONNECTION_LOST.
+		svc.reset();
+		svc.registerOfflineFill(4151);
+
+		assertTrue(svc.hasUnverifiedOfflineFills());
+	}
+
 	@Test
 	public void proactiveRescanGatedUntilOfflineSyncCompletes()
 	{

--- a/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
+++ b/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
@@ -155,6 +155,39 @@ public class OfflineSyncPersistenceTest
 		assertFalse("collected savedAt must not be persisted", configStore.containsKey("collectedItemsSavedAt_Zezima"));
 	}
 
+	/**
+	 * A partially-filled buy still sitting in its GE slot has NOT been collected — those fills are
+	 * in the Exchange, not the inventory. It must not contribute to the collected set even when the
+	 * player holds units of that item for unrelated reasons (supplies, an earlier flip), or the
+	 * rebuild strands exactly the phantom sell prompt this change exists to remove.
+	 *
+	 * <p>Found during in-game QA on a live 28924 partial-fill.</p>
+	 */
+	@Test
+	public void reattachedLiveBuyIsNotRebuiltIntoCollectedSet()
+	{
+		when(session.getRsn()).thenReturn("Zezima");
+		when(session.isOfflineSyncCompleted()).thenReturn(false);
+		configStore.put(SYNC_MARKER_ZEZIMA, PRIOR_SYNC_AT);
+		when(activeFlipTracker.getInventoryCountForItem(28924)).thenReturn(7);
+
+		// A partial-fill buy that is still live in slot 0 when we log back in.
+		store.apply(sig(0, GrandExchangeOfferState.BUYING, 28924, 20, 100), 2000L);
+		service.persistOfferState();
+		store.importRecords(Collections.emptyList());
+
+		// Built before the outer stubbing calls — these helpers stub inner mocks, and Mockito
+		// rejects a when() that lands inside an in-progress one.
+		ItemComposition comp = itemComp("i28924");
+		GrandExchangeOffer live = geOffer(28924, GrandExchangeOfferState.BUYING, 100, 100);
+		when(itemManager.getItemComposition(28924)).thenReturn(comp);
+		when(client.getGrandExchangeOffers()).thenReturn(new GrandExchangeOffer[]{live});
+
+		service.syncOfflineFills();
+
+		verify(session, never()).addCollectedItem(eq(28924), anyInt());
+	}
+
 	/** Blobs written by an older client are cleaned up rather than left orphaned. */
 	@Test
 	public void legacyCollectedConfigKeysAreRemovedOnSync()

--- a/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
+++ b/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
@@ -188,6 +188,58 @@ public class OfflineSyncPersistenceTest
 		verify(session, never()).addCollectedItem(eq(28924), anyInt());
 	}
 
+	/**
+	 * When the GE snapshot is unreadable at preload, an offline-collected record must be carried
+	 * into the store unchanged rather than dropped.
+	 *
+	 * <p>It is non-terminal, so {@code retainRecentTerminalHistory} will not pick it up, and
+	 * {@code importRecords} replaces the store wholesale — omitting it drops the record, and the
+	 * persist that follows writes the truncated set back over the saved blob. That erases the cost
+	 * basis of a position the player still holds, and because the collected set is now derived from
+	 * these records, it erases the position from Active Flips too.</p>
+	 *
+	 * <p>Found during in-game QA: a 10,329-unit snape grass (231) buy disappeared after one login
+	 * where the slots were not yet loaded.</p>
+	 */
+	@Test
+	public void offlineCollectedRecordSurvivesPreloadWhenSlotsUnreadable()
+	{
+		when(session.getRsn()).thenReturn("Zezima");
+
+		// A filled buy that is gone from its slot, persisted from the previous session.
+		store.apply(sig(0, GrandExchangeOfferState.BUYING, 231, 0, 10329), 1000L);
+		store.apply(sig(0, GrandExchangeOfferState.BOUGHT, 231, 10329, 10329), 2000L);
+		service.persistOfferState();
+		store.importRecords(Collections.emptyList());
+
+		// GE snapshot not loaded yet — the state this regression needs.
+		when(client.getGrandExchangeOffers()).thenReturn(new GrandExchangeOffer[0]);
+
+		service.preloadPersistedOffers();
+
+		boolean survived = false;
+		for (OfferRecord r : store.export())
+		{
+			if (r.getItemId() == 231 && r.getFilledQuantity() == 10329)
+			{
+				survived = true;
+			}
+		}
+		assertTrue("offline-collected record must survive an unreadable-slot preload", survived);
+
+		// And the persist that follows must not write a set that has lost it.
+		service.persistOfferState();
+		boolean stillPersisted = false;
+		for (OfferRecord r : service.loadPersistedOfferRecords())
+		{
+			if (r.getItemId() == 231 && r.getFilledQuantity() == 10329)
+			{
+				stillPersisted = true;
+			}
+		}
+		assertTrue("record must remain in the persisted blob", stillPersisted);
+	}
+
 	/** Blobs written by an older client are cleaned up rather than left orphaned. */
 	@Test
 	public void legacyCollectedConfigKeysAreRemovedOnSync()
@@ -547,8 +599,15 @@ public class OfflineSyncPersistenceTest
 
 		service.preloadPersistedOffers();
 
-		assertTrue("no COLLECTED duplicate manufactured when GE slots are unloaded",
-			store.forItem(7777).isEmpty());
+		// The record must be CARRIED, not dropped. This assertion used to require the store to be
+		// empty for the item, which conflated "do not manufacture a terminal duplicate" with
+		// "discard the record" — and the discard erased a still-held position's cost basis on the
+		// persist that follows. Classification is deferred to the +2s sync, which cannot classify a
+		// record that is no longer there.
+		List<OfferRecord> carried = store.forItem(7777);
+		assertEquals("record carried across an unreadable-slot preload", 1, carried.size());
+		assertFalse("no COLLECTED duplicate manufactured when GE slots are unloaded",
+			carried.get(0).getState().isTerminal());
 	}
 
 	@Test

--- a/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
+++ b/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
@@ -37,6 +37,8 @@ public class OfflineSyncPersistenceTest
 {
 	private static final String CONFIG_GROUP = "flipsmart";
 	private static final String SYNC_MARKER_ZEZIMA = "offlineSyncAt_Zezima";
+	/** Prior-sync wall-clock: records with later activity count as fresh offline fills. */
+	private static final String PRIOR_SYNC_AT = "500";
 
 	private PlayerSession session;
 	private ConfigManager configManager;
@@ -131,7 +133,7 @@ public class OfflineSyncPersistenceTest
 	{
 		when(session.getRsn()).thenReturn("Zezima");
 		when(session.isOfflineSyncCompleted()).thenReturn(false);
-		configStore.put(SYNC_MARKER_ZEZIMA, "500");
+		configStore.put(SYNC_MARKER_ZEZIMA, PRIOR_SYNC_AT);
 		// Bought 10, but only 3 remain — the rest were sold or used while offline.
 		when(activeFlipTracker.getInventoryCountForItem(4824)).thenReturn(3);
 
@@ -303,7 +305,7 @@ public class OfflineSyncPersistenceTest
 		when(session.getRsn()).thenReturn("Zezima");
 		when(session.isOfflineSyncCompleted()).thenReturn(false);
 		// We've synced before (marker 500) and this fill is fresh since then (activity 2000).
-		configStore.put(SYNC_MARKER_ZEZIMA, "500");
+		configStore.put(SYNC_MARKER_ZEZIMA, PRIOR_SYNC_AT);
 		// Item still in inventory (2 traded units), so the inventory gate allows the re-add.
 		when(activeFlipTracker.getInventoryCountForItem(111)).thenReturn(2);
 
@@ -345,7 +347,7 @@ public class OfflineSyncPersistenceTest
 	{
 		when(session.getRsn()).thenReturn("Zezima");
 		when(session.isOfflineSyncCompleted()).thenReturn(false);
-		configStore.put(SYNC_MARKER_ZEZIMA, "500"); // fresh since last sync (activity 2000)
+		configStore.put(SYNC_MARKER_ZEZIMA, PRIOR_SYNC_AT); // fresh since last sync (activity 2000)
 		when(activeFlipTracker.getInventoryCountForItem(4824)).thenReturn(0);
 
 		store.apply(sig(0, GrandExchangeOfferState.BUYING, 4824, 0, 10), 1000L);
@@ -370,7 +372,7 @@ public class OfflineSyncPersistenceTest
 	{
 		when(session.getRsn()).thenReturn("Zezima");
 		when(session.isOfflineSyncCompleted()).thenReturn(false);
-		configStore.put(SYNC_MARKER_ZEZIMA, "500"); // fresh since last sync (activity 2000)
+		configStore.put(SYNC_MARKER_ZEZIMA, PRIOR_SYNC_AT); // fresh since last sync (activity 2000)
 		when(activeFlipTracker.getInventoryCountForItem(4824)).thenReturn(7);
 
 		store.apply(sig(0, GrandExchangeOfferState.BUYING, 4824, 0, 10), 1000L);

--- a/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
+++ b/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
@@ -100,6 +100,77 @@ public class OfflineSyncPersistenceTest
 			ledger);
 	}
 
+	/**
+	 * A collected entry that has lost its backing is dropped silently.
+	 *
+	 * <p>Registering a History backfill here bypassed the reconciler's freshness cutoff
+	 * entirely, so records it had just routed to staleHistory as already-known were
+	 * prompted for anyway — and on every login, because a set pruned to empty never
+	 * cleared its own persisted blob.</p>
+	 */
+	@Test
+	public void prunedCollectedItemDoesNotRegisterHistoryBackfill()
+	{
+		when(session.getRsn()).thenReturn("Zezima");
+		when(session.getCollectedItemIds())
+			.thenReturn(new java.util.HashSet<>(Collections.singletonList(4151)));
+		when(activeFlipTracker.getInventoryCountForItem(4151)).thenReturn(0);
+
+		assertEquals(1, service.pruneStaleCollectedItems());
+
+		verify(session, times(1)).removeCollectedItem(4151);
+		verify(geHistoryService, never()).registerOfflineFill(4151);
+	}
+
+	/**
+	 * The collected set is derived, not persisted: rebuilt from the persisted offer records
+	 * capped by what the player actually still holds, and never written to config.
+	 */
+	@Test
+	public void collectedSetIsRebuiltFromPersistedOffersAndNeverWrittenToConfig()
+	{
+		when(session.getRsn()).thenReturn("Zezima");
+		when(session.isOfflineSyncCompleted()).thenReturn(false);
+		configStore.put(SYNC_MARKER_ZEZIMA, "500");
+		// Bought 10, but only 3 remain — the rest were sold or used while offline.
+		when(activeFlipTracker.getInventoryCountForItem(4824)).thenReturn(3);
+
+		store.apply(sig(0, GrandExchangeOfferState.BUYING, 4824, 0, 10), 1000L);
+		store.apply(sig(0, GrandExchangeOfferState.BOUGHT, 4824, 10, 10), 2000L);
+
+		service.persistOfferState();
+		store.importRecords(Collections.emptyList()); // fresh login
+		when(client.getGrandExchangeOffers()).thenReturn(new GrandExchangeOffer[0]);
+
+		service.syncOfflineFills();
+
+		// Capped at the live inventory, not the 10 originally bought — the config-backed
+		// restore would have replayed the stale figure recorded at collect time.
+		verify(session, times(1)).addCollectedItem(4824, 3);
+
+		assertFalse("collected IDs must not be persisted", configStore.containsKey("collectedItems_Zezima"));
+		assertFalse("collected quantities must not be persisted", configStore.containsKey("collectedQuantities_Zezima"));
+		assertFalse("collected savedAt must not be persisted", configStore.containsKey("collectedItemsSavedAt_Zezima"));
+	}
+
+	/** Blobs written by an older client are cleaned up rather than left orphaned. */
+	@Test
+	public void legacyCollectedConfigKeysAreRemovedOnSync()
+	{
+		when(session.getRsn()).thenReturn("Zezima");
+		when(session.isOfflineSyncCompleted()).thenReturn(false);
+		configStore.put("collectedItems_Zezima", "[4151]");
+		configStore.put("collectedQuantities_Zezima", "{\"4151\":5}");
+		configStore.put("collectedItemsSavedAt_Zezima", "1700000000000");
+		when(client.getGrandExchangeOffers()).thenReturn(new GrandExchangeOffer[0]);
+
+		service.syncOfflineFills();
+
+		assertFalse(configStore.containsKey("collectedItems_Zezima"));
+		assertFalse(configStore.containsKey("collectedQuantities_Zezima"));
+		assertFalse(configStore.containsKey("collectedItemsSavedAt_Zezima"));
+	}
+
 	@Test
 	public void flipFinderSourced_persistsAndRestoresAcrossRestart()
 	{

--- a/src/test/java/com/flipsmart/PlayerSessionCollectOriginTest.java
+++ b/src/test/java/com/flipsmart/PlayerSessionCollectOriginTest.java
@@ -34,12 +34,4 @@ public class PlayerSessionCollectOriginTest {
         assertEquals(0L, s.getCollectedAtMillis(100));
     }
 
-    @Test
-    public void restoreClearsStaleOriginAndTimestamp() {
-        PlayerSession s = new PlayerSession();
-        s.addCollectedItem(100, 5, CollectOrigin.COMPLETED_BUY, 1234L);
-        s.restoreCollectedItems(new java.util.HashSet<>(java.util.Arrays.asList(200)));
-        assertNull(s.getCollectOrigin(100));
-        assertEquals(0L, s.getCollectedAtMillis(100));
-    }
 }

--- a/src/test/java/com/flipsmart/plugin/EventRouterHopResetTest.java
+++ b/src/test/java/com/flipsmart/plugin/EventRouterHopResetTest.java
@@ -1,0 +1,128 @@
+package com.flipsmart.plugin;
+
+import com.flipsmart.BankSnapshotService;
+import com.flipsmart.FlipSmartConfig;
+import com.flipsmart.FlipSmartPlugin;
+import com.flipsmart.FlipSmartApiClient;
+import com.flipsmart.GEHistoryService;
+import com.flipsmart.GeOfferDescriptionService;
+import com.flipsmart.GrandExchangeTracker;
+import com.flipsmart.OfflineSyncService;
+import com.flipsmart.PlayerSession;
+import com.flipsmart.WebhookSyncService;
+import com.flipsmart.trading.OfferStore;
+
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.chat.ChatMessageManager;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The GE History read latch has to be cleared on every transition that clears
+ * {@code offlineSyncCompleted}, not only on a full logout.
+ *
+ * <p>{@code HOPPING} and {@code CONNECTION_LOST} reset the session's sync flag so the
+ * offline sync runs again on the following {@code LOGGED_IN}, but
+ * {@code GEHistoryService.reset()} used to be reachable only from {@code LOGIN_SCREEN}.
+ * The latch therefore survived, and {@code registerOfflineFill} short-circuits on it — so
+ * once a player had opened the History tab at any point in a session, every subsequent
+ * world hop and reconnect dropped its offline fills with no prompt and no scrape.</p>
+ */
+public class EventRouterHopResetTest
+{
+	private GEHistoryService geHistoryService;
+	private EventRouter router;
+
+	/** A visible History list holding one "Bought:" row (4151 x5 @ 2,000). */
+	private Widget visibleHistoryList()
+	{
+		Widget header = mock(Widget.class);
+		when(header.getText()).thenReturn("Bought:");
+		Widget item = mock(Widget.class);
+		when(item.getItemId()).thenReturn(4151);
+		when(item.getItemQuantity()).thenReturn(5);
+		Widget price = mock(Widget.class);
+		when(price.getText()).thenReturn("<col=ffb83f>10,000 coins</col><br>= 2,000 each");
+
+		Widget list = mock(Widget.class);
+		when(list.isHidden()).thenReturn(false);
+		when(list.getDynamicChildren()).thenReturn(new Widget[]{header, item, price});
+		return list;
+	}
+
+	@Before
+	public void setUp()
+	{
+		Client client = mock(Client.class);
+		// Built before the outer stubbing call: Mockito rejects a nested when() that lands
+		// inside an in-progress one.
+		Widget historyList = visibleHistoryList();
+		when(client.getWidget(InterfaceID.GE_HISTORY, 3)).thenReturn(historyList);
+
+		geHistoryService = new GEHistoryService(client, mock(FlipSmartApiClient.class),
+			mock(PlayerSession.class), mock(ChatMessageManager.class), new OfferStore());
+
+		router = new EventRouter(
+			mock(FlipSmartPlugin.class),
+			client,
+			mock(FlipSmartConfig.class),
+			mock(PlayerSession.class),
+			mock(WebhookSyncService.class),
+			mock(OfflineSyncService.class),
+			mock(BankSnapshotService.class),
+			geHistoryService,
+			mock(GeOfferDescriptionService.class),
+			mock(GrandExchangeTracker.class),
+			new OfferStore());
+	}
+
+	private static GameStateChanged state(GameState gameState)
+	{
+		GameStateChanged event = new GameStateChanged();
+		event.setGameState(gameState);
+		return event;
+	}
+
+	/** Read the History tab so the latch is set, exactly as a real session would. */
+	private void latchHistoryRead()
+	{
+		geHistoryService.onHistoryWidgetLoaded();
+		geHistoryService.onGameTick();
+		geHistoryService.onGameTick();
+		geHistoryService.registerOfflineFill(4151);
+		assertFalse("precondition: a completed read latches the flag",
+			geHistoryService.hasUnverifiedOfflineFills());
+	}
+
+	@Test
+	public void worldHopClearsHistoryLatchSoLaterOfflineFillsRegister()
+	{
+		latchHistoryRead();
+
+		router.onGameStateChanged(state(GameState.HOPPING));
+		geHistoryService.registerOfflineFill(4151);
+
+		assertTrue(geHistoryService.hasUnverifiedOfflineFills());
+	}
+
+	@Test
+	public void connectionLostClearsHistoryLatchSoLaterOfflineFillsRegister()
+	{
+		latchHistoryRead();
+
+		router.onGameStateChanged(state(GameState.CONNECTION_LOST));
+		geHistoryService.registerOfflineFill(4151);
+
+		assertTrue(geHistoryService.hasUnverifiedOfflineFills());
+	}
+}


### PR DESCRIPTION
Closes Flip-Smart/flip-smart#1195
Part of Flip-Smart/flip-smart#1171

## Summary

The collected set — "buys I hold that no longer occupy a slot" — was persisted across three config keys and restored on login. That made it a cache of state the persisted offer records plus live inventory already answered, and it drifted from its own source; `pruneStaleCollectedItems` existed to repair the drift. The repair is where the bugs were.

This makes the collected set derived: rebuilt on each offline sync from the persisted offer records, capped by what the player actually still holds. Three confirmed defects fall out with it.

## What's new

**Collected items are derived, not persisted.** `rebuildCollectedItems` reconstructs the set from the persisted records at sync time — the same conclusion `pruneStaleCollectedItems` already reached from the other direction. Driven by the full persisted blob rather than the reconciler's offline-collected bucket, so a position held across several sessions is still recovered once its record stops being recently-vanished. Removes `collectedItems_<rsn>`, `collectedQuantities_<rsn>` and `collectedItemsSavedAt_<rsn>`, the 7-day staleness window, both loaders and the three key accessors. Existing keys are unset on the first sync after upgrade.

Quantities also get more accurate as a side effect: they are capped at the live inventory count, so a holding partly sold or used offline lands at its true remainder instead of the figure recorded when the buy was collected.

**The prune no longer prompts.** `pruneStaleCollectedItems` registered a GE History backfill for every entry it dropped, with no freshness gate — bypassing the cutoff `OfferReconciler` applies when it routes older records to `staleHistory` specifically so they never re-fire the prompt. Because a set pruned to empty never cleared its own persisted blob (the don't-destroy-on-empty guard), the same stale IDs were restored, pruned and prompted again on every login for up to 7 days. `registerOfflineFill` now has exactly one caller — the reconciler's offline-collected bucket — so the cutoff governs every prompt.

**Hop and reconnect no longer drop offline fills.** `GEHistoryService.reset()` was reachable only from `LOGIN_SCREEN`, while `HOPPING` and `CONNECTION_LOST` clear `offlineSyncCompleted`. The `historyReadThisSession` latch survived, and `registerOfflineFill` short-circuits on it — so once a player had opened the History tab at any point in a session, every subsequent world hop and reconnect registered nothing: no prompt, no scrape, `hasUnverifiedOfflineFills()` false. For an active flipper who hops, that was the normal case rather than an edge case.

**A read that recovered nothing no longer latches.** `readHistoryNow` set the flag on entry, ahead of the widget-null and empty-rows checks, so a `WidgetLoaded` whose clientscripts had not yet populated the list counted as a completed read.

**Dead API removed.** `PlayerSession.restoreCollectedItems` (both overloads), `clearCollectedItems`, `getCollectedItemsForPersistence` and `getCollectedQuantitiesForPersistence` lost their last callers.

## Found during in-game QA

Two real defects surfaced only under live gameplay against a real position. Neither was reachable from unit tests as written, and one of them is a regression this PR introduced.

### 1. Reattached live buys adopted into the collected set

`rebuildCollectedItems` originally walked *every* persisted buy with fills, including offers that had reattached to a live GE slot. Those fills sit in the Exchange, not the inventory. Since the quantity is capped at live inventory, a player holding units of that item for unrelated reasons would have them adopted into the collected set — stranding exactly the phantom sell prompt this PR removes. Surfaced on a live `28924` partial-fill holding 20,774 units in slot 0. Fixed by skipping reattached records; guarded by `reattachedLiveBuyIsNotRebuiltIntoCollectedSet`.

### 2. Offline-collected records dropped on an unreadable-slot preload — data loss

`reconcilePersistedIntoStore` terminalizes offline-collected records only when the GE snapshot is readable, "deferring classification to the +2s sync" otherwise. **The deferral was never implemented**: the records were simply left out of `toImport`. They are non-terminal, so `retainRecentTerminalHistory` does not pick them up either, and `importRecords` replaces the store wholesale — so the record was dropped, and the `persistOfferState` two seconds later wrote the truncated set back over the saved blob.

On `master` this destroyed the cost basis of a position the player still held, but the position itself survived in the separate `collectedItems_<rsn>` blob. **By deriving the collected set from these records, this PR removed that mask and turned a latent record-drop into visible position loss** — a live 10,329-unit snape grass (231) buy vanished from Active Flips after one login where the slots had not loaded.

Fixed by carrying the records unchanged so the sync can classify them once slots load. Guarded by `offlineCollectedRecordSurvivesPreloadWhenSlotsUnreadable`.

This also required retargeting an existing test. `preloadWithUnloadedSlots_doesNotManufactureTerminalDuplicate` asserted the store was **empty** for the item, conflating "do not manufacture a terminal duplicate" with "discard the record" — it was locking in the data loss. It now asserts the real invariant: the record is carried, and it is not terminal.

### Verified live on real gameplay

- legacy `collectedItems_*` keys removed from the active profile after a config flush, with `persistedOffers_` / `offlineSyncAt_` / `fillWatermarks_` / `roundTripLedger_` retained
- **zero** chat prompts across nine logins and a world hop
- the inventory cap applying twice with logged inputs:
  `Rebuilt collected item 231 qty=5329 (inventory=5329, persistedFilled=10329)` and
  `Rebuilt collected item 28924 qty=15774 (inventory=15774, persistedFilled=20774)` — on `master` both would have replayed the stale persisted figure
- the `RoundTripLedger` held-position exemption keeping a >24h-old `COLLECTED` buy alive (`heldQuantity=3`), which is what lets the rebuild still find long-held positions

### Not verified: offline-fill registration

`registerOfflineFill` never fired, because the pre-existing freshness marker suppresses genuine offline fills — filed as #1197. `git diff origin/master...HEAD` shows `OfferReconciler.java` unchanged and no edits to `readOfflineFillFreshnessThreshold` / `writeOfflineSyncMarker`, so this is not a gap introduced here. Two further pre-existing findings from the same session: #1199 (unguarded `reconcileOfflineFills`) and #1198 (executor not rebuilt on plugin toggle, PR #236).

## Test plan## Test plan

`./gradlew test` — **849 tests, 0 failures** (839 before; +10 net after removing one test that covered the deleted restore path).

Four new tests were each verified to **fail against pre-fix code** before being kept:

| Test | Guards |
|---|---|
| `EventRouterHopResetTest.worldHopClearsHistoryLatch…` | hop drops offline fills |
| `EventRouterHopResetTest.connectionLostClearsHistoryLatch…` | reconnect drops offline fills |
| `GEHistoryServiceTest.historyReadThatRecoveredNoRowsDoesNotLatch…` | premature latch |
| `OfflineSyncPersistenceTest.prunedCollectedItemDoesNotRegisterHistoryBackfill` | ungated prompt |

Plus `historyReadThatRecoveredRowsStillLatches` (guards against over-correcting the de-nag behaviour), `resetClearsTheLatchSoFillsAfterAHopRegisterAgain`, `collectedSetIsRebuiltFromPersistedOffersAndNeverWrittenToConfig` and `legacyCollectedConfigKeysAreRemovedOnSync`.

### Manual QA (in-game — `qa-verifier` cannot drive RuneLite)

1. **Upgrade path.** Log in on a client that has `collectedItems_<rsn>` in `settings.properties`. After the +2s sync, confirm the three legacy keys are gone and Active Flips still shows the items you hold.
2. **The hop fix.** Open GE → History tab (latches the read). Place a buy, let it fill, hop worlds. Confirm the fill is still detected after the hop — previously silent. Watch for `Registered offline fill for itemId=` in the client log.
3. **No false prompt.** Log in and out several times with a stale collected entry for an item you no longer hold. The "Offline trades detected" chat message must appear at most once, not on every login.
4. **Partial offline sell.** Buy 10 of an item, collect, log out, sell 7 elsewhere, log back in. Collected quantity should read 3, not 10.

## Token budget

Measured with `tools/token-budget.py`, both trees from a clean checkout with the same invocation:

```
master (1a420e8)   191,674
this branch        190,539   (-1,135)
```

`OfflineSyncService` 5,924 -> 4,785. Short of the ~2-3k the issue estimated, because a good share of the removed lines were comments and comments do not count toward the plugin-hub ceiling. The bug class is the point here; the budget saving is secondary.

## Codacy

| Finding | Disposition |
|---|---|
| `PMD GuardLogStatement` on the rebuild debug log | **Fixed** - guarded with `log.isDebugEnabled()` |
| `PMD AvoidDuplicateLiterals` - `"500"` x4 in the persistence test | **Fixed** - extracted `PRIOR_SYNC_AT` |
| `Lizard ccn-medium` - `rebuildCollectedItems` CCN 9, then 10 | **Fixed** twice - extracted `filledBuyQuantitiesByItem`, then `excludingReattached` |
| `PMD UseConcurrentHashMap` on a method-local `HashMap` | **Dismissed** - method-local, built and consumed on the client thread within one call; never shared |

Gate is green.

## Non-goals

- Sending a reported-watermark with the backfill batch so the backend's ~450 lines of phantom-overcount self-heal can be retired. Cross-repo, needs a design spike.
- Folding offers + watermarks + ledger into a single versioned blob with one `savedAt`.

## Follow-ups

- `GEHistoryService.recentlyPersistedOffers` is still a second in-memory copy of the persisted blob that `reconcilePersistedIntoStore` already imports into `OfferStore`. Largely redundant, but not fully — records dropped by `retainRecentTerminalHistory` survive only in that copy. Worth collapsing once the watermark work lands.
- `backfillOfflineFills` still posts every visible History row on each read, ignoring `pendingOfflineFillItemIds`. Unchanged here.
