### PR TITLE
fix(trade-station): rebuild the push executor after a plugin toggle

### DIFF
--- a/src/main/java/com/flipsmart/TradeStationSlotPushService.java
+++ b/src/main/java/com/flipsmart/TradeStationSlotPushService.java
@@ -107,7 +107,7 @@ public class TradeStationSlotPushService
 		scheduler().execute(() -> doPush(snapshot)); // NOPMD DoNotUseThreads
 	}
 
-	private static ScheduledExecutorService newScheduler()
+	private static ScheduledExecutorService newScheduler() // NOPMD DoNotUseThreads
 	{
 		return Executors.newSingleThreadScheduledExecutor(r ->
 		{
@@ -118,13 +118,16 @@ public class TradeStationSlotPushService
 	}
 
 	/** The live scheduler, replacing it first if a previous shutdown terminated it. */
-	private synchronized ScheduledExecutorService scheduler()
+	private ScheduledExecutorService scheduler() // NOPMD DoNotUseThreads
 	{
-		if (scheduler == null || scheduler.isShutdown())
+		synchronized (this)
 		{
-			scheduler = newScheduler();
+			if (scheduler == null || scheduler.isShutdown())
+			{
+				scheduler = newScheduler();
+			}
+			return scheduler;
 		}
-		return scheduler;
 	}
 
 	public void shutdown()

--- a/src/main/java/com/flipsmart/TradeStationSlotPushService.java
+++ b/src/main/java/com/flipsmart/TradeStationSlotPushService.java
@@ -63,7 +63,6 @@ public class TradeStationSlotPushService
 		this.client = client;
 		this.apiClient = apiClient;
 		this.session = session;
-		this.scheduler = newScheduler();
 	}
 
 	/**
@@ -107,24 +106,19 @@ public class TradeStationSlotPushService
 		scheduler().execute(() -> doPush(snapshot)); // NOPMD DoNotUseThreads
 	}
 
-	private static ScheduledExecutorService newScheduler() // NOPMD DoNotUseThreads
-	{
-		return Executors.newSingleThreadScheduledExecutor(r ->
-		{
-			Thread t = new Thread(r, "flipsmart-trade-station-push"); // NOPMD DoNotUseThreads
-			t.setDaemon(true);
-			return t;
-		});
-	}
-
-	/** The live scheduler, replacing it first if a previous shutdown terminated it. */
+	/** The live scheduler, created on first use and replaced if a shutdown terminated it. */
 	private ScheduledExecutorService scheduler() // NOPMD DoNotUseThreads
 	{
 		synchronized (this)
 		{
 			if (scheduler == null || scheduler.isShutdown())
 			{
-				scheduler = newScheduler();
+				scheduler = Executors.newSingleThreadScheduledExecutor(r ->
+				{
+					Thread t = new Thread(r, "flipsmart-trade-station-push"); // NOPMD DoNotUseThreads
+					t.setDaemon(true);
+					return t;
+				});
 			}
 			return scheduler;
 		}
@@ -139,7 +133,10 @@ public class TradeStationSlotPushService
 		}
 		synchronized (this)
 		{
-			scheduler.shutdownNow(); // NOPMD DoNotUseThreads
+			if (scheduler != null)
+			{
+				scheduler.shutdownNow(); // NOPMD DoNotUseThreads
+			}
 		}
 	}
 

--- a/src/main/java/com/flipsmart/TradeStationSlotPushService.java
+++ b/src/main/java/com/flipsmart/TradeStationSlotPushService.java
@@ -43,7 +43,13 @@ public class TradeStationSlotPushService
 	private final Client client;
 	private final FlipSmartApiClient apiClient;
 	private final PlayerSession session;
-	private final ScheduledExecutorService scheduler; // NOPMD DoNotUseThreads - desktop plugin, not J2EE
+	/**
+	 * Rebuilt on demand rather than created once. The service is a singleton and RuneLite reuses
+	 * the plugin instance across disable/enable, so a scheduler terminated by {@link #shutdown()}
+	 * would otherwise stay terminated for the life of the client and every later GE event would
+	 * throw RejectedExecutionException.
+	 */
+	private ScheduledExecutorService scheduler; // NOPMD DoNotUseThreads - desktop plugin, not J2EE
 
 	private final AtomicReference<ScheduledFuture<?>> pending = new AtomicReference<>();
 	private final AtomicReference<List<Integer>> lastPushed = new AtomicReference<>();
@@ -57,12 +63,7 @@ public class TradeStationSlotPushService
 		this.client = client;
 		this.apiClient = apiClient;
 		this.session = session;
-		this.scheduler = Executors.newSingleThreadScheduledExecutor(r ->
-		{
-			Thread t = new Thread(r, "flipsmart-trade-station-push"); // NOPMD DoNotUseThreads
-			t.setDaemon(true);
-			return t;
-		});
+		this.scheduler = newScheduler();
 	}
 
 	/**
@@ -84,7 +85,7 @@ public class TradeStationSlotPushService
 		{
 			existing.cancel(false);
 		}
-		ScheduledFuture<?> next = scheduler.schedule(
+		ScheduledFuture<?> next = scheduler().schedule(
 			() -> doPush(snapshot),
 			DEBOUNCE_MS,
 			TimeUnit.MILLISECONDS);
@@ -103,7 +104,27 @@ public class TradeStationSlotPushService
 		{
 			existing.cancel(false);
 		}
-		scheduler.execute(() -> doPush(snapshot)); // NOPMD DoNotUseThreads
+		scheduler().execute(() -> doPush(snapshot)); // NOPMD DoNotUseThreads
+	}
+
+	private static ScheduledExecutorService newScheduler()
+	{
+		return Executors.newSingleThreadScheduledExecutor(r ->
+		{
+			Thread t = new Thread(r, "flipsmart-trade-station-push"); // NOPMD DoNotUseThreads
+			t.setDaemon(true);
+			return t;
+		});
+	}
+
+	/** The live scheduler, replacing it first if a previous shutdown terminated it. */
+	private synchronized ScheduledExecutorService scheduler()
+	{
+		if (scheduler == null || scheduler.isShutdown())
+		{
+			scheduler = newScheduler();
+		}
+		return scheduler;
 	}
 
 	public void shutdown()
@@ -113,7 +134,10 @@ public class TradeStationSlotPushService
 		{
 			existing.cancel(false);
 		}
-		scheduler.shutdownNow(); // NOPMD DoNotUseThreads
+		synchronized (this)
+		{
+			scheduler.shutdownNow(); // NOPMD DoNotUseThreads
+		}
 	}
 
 	/**

--- a/src/test/java/com/flipsmart/TradeStationSlotPushServiceTest.java
+++ b/src/test/java/com/flipsmart/TradeStationSlotPushServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -40,6 +41,32 @@ public class TradeStationSlotPushServiceTest
 		when(apiClient.pushTradeStationSlotsAsync(any(), any()))
 			.thenReturn(CompletableFuture.completedFuture(true));
 		service = new TradeStationSlotPushService(client, apiClient, session);
+	}
+
+	/**
+	 * The service is a singleton and RuneLite reuses the plugin instance across disable/enable, so a
+	 * scheduler terminated by shutdown() used to stay terminated for the life of the client. Every
+	 * GE offer event after a plugin toggle then threw RejectedExecutionException out of the event
+	 * subscriber. Observed in-game on 2026-08-02.
+	 */
+	@Test
+	public void scheduleAfterShutdownRebuildsTheExecutorInsteadOfThrowing()
+	{
+		service.shutdown();
+
+		// Previously threw RejectedExecutionException from the terminated executor.
+		service.scheduleSnapshotPush(java.util.Collections.singletonList(ABYSSAL_WHIP));
+	}
+
+	@Test
+	public void pushNowAfterShutdownRebuildsTheExecutorInsteadOfThrowing()
+	{
+		service.shutdown();
+
+		service.pushNow(java.util.Collections.singletonList(ABYSSAL_WHIP));
+
+		verify(apiClient, timeout(2000).times(1))
+			.pushTradeStationSlotsAsync(eq(RSN), eq(java.util.Collections.singletonList(ABYSSAL_WHIP)));
 	}
 
 	@Test

--- a/src/test/java/com/flipsmart/TradeStationSlotPushServiceTest.java
+++ b/src/test/java/com/flipsmart/TradeStationSlotPushServiceTest.java
@@ -56,6 +56,10 @@ public class TradeStationSlotPushServiceTest
 
 		// Previously threw RejectedExecutionException from the terminated executor.
 		service.scheduleSnapshotPush(java.util.Collections.singletonList(ABYSSAL_WHIP));
+
+		// The debounced task must actually run on the rebuilt executor, not merely be accepted.
+		verify(apiClient, timeout(5000).times(1))
+			.pushTradeStationSlotsAsync(eq(RSN), eq(java.util.Collections.singletonList(ABYSSAL_WHIP)));
 	}
 
 	@Test


### PR DESCRIPTION
Closes Flip-Smart/flip-smart#1198

## Summary

Disabling and re-enabling the FlipSmart plugin without restarting the client left `TradeStationSlotPushService` permanently broken — every subsequent GE offer event threw:

```
RejectedExecutionException: ... rejected from ScheduledThreadPoolExecutor[Terminated, pool size = 0, ...]
	at com.flipsmart.TradeStationSlotPushService.scheduleSnapshotPush(TradeStationSlotPushService.java:87)
	at com.flipsmart.plugin.EventRouter.onGrandExchangeOfferChanged(EventRouter.java:227)
```

The executor was created once in the constructor and terminated by `shutdown()`. Since the service is a singleton and RuneLite reuses the plugin instance across disable/enable, `startUp()` never rebuilt it.

## What's new

`scheduler()` rebuilds the executor when the current one is shut down, and both `scheduleSnapshotPush` and `pushNow` go through it. Chosen over recreating in `startUp()` so any future path that shuts the service down independently is also covered.

## Test plan

`./gradlew test` — **842 tests, 0 failures**.

Two new tests, both verified to fail against pre-fix code (reverting only the source file, keeping the tests):

- `scheduleAfterShutdownRebuildsTheExecutorInsteadOfThrowing`
- `pushNowAfterShutdownRebuildsTheExecutorInsteadOfThrowing`

### Manual

Enable the plugin, disable it, re-enable it, then place or modify a GE offer. No `RejectedExecutionException` in `~/.runelite/logs/client.log`, and the trade-station push still fires.

## Notes

Found during in-game QA for #1195. Impact is low in normal use — players rarely toggle plugins mid-session — but it breaks the "Import from RuneLite" path (#683 AC7) for anyone who does, and it makes plugin-toggle a landmine for QA, which is how it surfaced.

Worth a follow-up audit of other services owning executors for the same pattern.