### PR TITLE
Fix offer-id collision causing duplicate flip records

### DIFF
--- a/src/main/java/com/flipsmart/GEHistoryService.java
+++ b/src/main/java/com/flipsmart/GEHistoryService.java
@@ -29,11 +29,11 @@ import net.runelite.client.chat.QueuedMessage;
  * completed while offline, then posts them to the API as is_history_backfill.
  * <p>
  * The read is triggered on multiple lifecycle points so it does not depend on
- * the user acting on a one-shot chat nag: on the History WidgetLoaded, when an
- * unverified offline fill is registered while the tab is already open, and by a
- * throttled periodic re-scan for as long as the tab stays visible. All triggers
- * only ever <em>read</em> the widget already on screen — the plugin never opens
- * or drives the interface for the player.
+ * the user acting on a one-shot chat nag: on the History WidgetLoaded, which fires
+ * on every open of the tab; when an unverified offline fill is registered while
+ * the tab is already open; and by a throttled re-scan that retries until a read
+ * recovers rows. All triggers only ever <em>read</em> the widget already on screen
+ * — the plugin never opens or drives the interface for the player.
  */
 @Slf4j
 @Singleton
@@ -47,11 +47,9 @@ public class GEHistoryService
 	// fixed-stride to handle variable-width rows.
 	private static final int GE_HISTORY_LIST_CHILD = 3;
 
-	// Minimum gap between reads triggered by the proactive re-scan, in game
-	// ticks (~0.6s each). Long enough that leaving the tab open does not spam
-	// POST /history-backfill-batch; short enough to pick up fills that land
-	// while the user is looking at the tab. Explicit WidgetLoaded/offline-fill
-	// reads are not throttled — only the periodic re-scan honours this.
+	// Minimum gap between retries by the re-scan, in game ticks (~0.6s each), while it is
+	// still waiting for a read that recovers rows. Explicit WidgetLoaded/offline-fill reads
+	// are not throttled — only the re-scan honours this.
 	private static final long PROACTIVE_RESCAN_INTERVAL_TICKS = 17;
 
 	private final Client client;
@@ -113,15 +111,20 @@ public class GEHistoryService
 	}
 
 	/**
-	 * Proactive lifecycle trigger: while the History tab stays visible, re-read
-	 * it on a throttled cadence so fills that land after the initial open are
-	 * still recovered without waiting for another WidgetLoaded or a manual nag.
-	 * Gated on offline sync so we never latch {@code historyReadThisSession}
-	 * before the reconciler has had a chance to register offline fills.
+	 * Retry trigger for a read that recovered nothing. WidgetLoaded fires when the interface is
+	 * created, ahead of the clientscripts that populate the rows, so the deferred read can find an
+	 * empty list; re-read on a throttled cadence until one parses.
+	 * <p>
+	 * It does NOT exist to catch fills landing while the tab is open: an offer only enters the
+	 * History tab once collected, and collecting requires the main GE interface, which replaces
+	 * the History tab. The tab's contents cannot change while it is visible, so once a read has
+	 * succeeded there is nothing further to find until it is re-opened — which fires WidgetLoaded
+	 * again. Gated on offline sync so we never latch {@code historyReadThisSession} before the
+	 * reconciler has had a chance to register offline fills.
 	 */
 	private void maybeProactiveRescan()
 	{
-		if (!session.isOfflineSyncCompleted())
+		if (!session.isOfflineSyncCompleted() || historyReadThisSession)
 		{
 			return;
 		}

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -47,6 +47,11 @@ public class OfflineSyncService
 	// Wall-clock of the last completed offline sync, per RSN. A persisted offer is only a genuine
 	// offline fill if it was active since this marker; older leftovers are already-known history.
 	private static final String OFFLINE_SYNC_MARKER_KEY_PREFIX = "offlineSyncAt_";
+	// High-water offer id, per RSN. The store derives its counter from the records it imports, and
+	// retention pruning drops the oldest terminal ones — so across a client restart the counter
+	// fell back and could remint an id the backend still holds fills under. Persisting the mark
+	// separately keeps it monotonic even when the records backing it are long gone.
+	private static final String NEXT_OFFER_ID_KEY_PREFIX = "nextOfferId_";
 
 	/**
 	 * Config keys that held the collected set before it became derived state. Unset on the first
@@ -194,6 +199,9 @@ public class OfflineSyncService
 				log.error("Failed to persist offer state for {}: {}", rsn, e.getMessage());
 			}
 		}
+
+		// After the records, so a failure here can never cost us the blob itself.
+		persistNextOfferId(rsn);
 
 		// The collected set is NOT persisted. It is derived state — "buys I hold that no longer
 		// occupy a slot" — which the persisted offer records plus live inventory already answer,
@@ -345,6 +353,9 @@ public class OfflineSyncService
 		offerStore.watermarks().seedFrom(persistedRecords);
 		offerStore.watermarks().mergeFrom(loadPersistedWatermarks());
 
+		// Ahead of the reconcile, which mints ids for live slots no persisted record claims.
+		offerStore.raiseNextOfferId(loadPersistedNextOfferId(resolvePersistenceRsn()));
+
 		reconcilePersistedIntoStore(persistedRecords);
 		// Runs after reconciliation so cold-start seeding (when there is no persisted
 		// ledger at all) sees the just-reattached live buys, not a pre-reconcile snapshot.
@@ -435,6 +446,46 @@ public class OfflineSyncService
 		catch (Exception e)
 		{
 			log.error("Failed to persist fill watermarks for {}", rsn, e);
+		}
+	}
+
+	/**
+	 * Save the high-water offer id, but only when it would rise. The same don't-destroy-on-empty
+	 * guard the offer records carry: the store is transiently empty during the logout/hop
+	 * transition and its counter reads 1, and writing that would erase the only surviving record
+	 * of ids whose offers have since aged out of retention — exactly what this mark exists to
+	 * keep. Comparing rather than checking for an empty store keeps the guard independent of the
+	 * order in which the counter is seeded.
+	 */
+	private void persistNextOfferId(String rsn)
+	{
+		try
+		{
+			long current = offerStore.nextOfferId();
+			if (current > loadPersistedNextOfferId(rsn))
+			{
+				configManager.setConfiguration(CONFIG_GROUP, NEXT_OFFER_ID_KEY_PREFIX + rsn,
+					Long.toString(current));
+			}
+		}
+		catch (Exception e)
+		{
+			log.error("Failed to persist next offer id for {}", rsn, e);
+		}
+	}
+
+	/** Saved high-water offer id for {@code rsn}, or 0 when none is stored or it is unreadable. */
+	private long loadPersistedNextOfferId(String rsn)
+	{
+		String raw = rsn == null ? null : configManager.getConfiguration(CONFIG_GROUP, NEXT_OFFER_ID_KEY_PREFIX + rsn);
+		try
+		{
+			// Absent, blank and corrupt all mean the same thing: no usable mark, so do not raise.
+			return raw == null ? 0L : Long.parseLong(raw.trim());
+		}
+		catch (NumberFormatException e)
+		{
+			return 0L;
 		}
 	}
 

--- a/src/main/java/com/flipsmart/trading/OfferStore.java
+++ b/src/main/java/com/flipsmart/trading/OfferStore.java
@@ -139,8 +139,13 @@ public final class OfferStore
 
     /**
      * Replace all state with {@code records} (e.g. restored from persistence),
-     * rebuilding the slot index for live records and re-seeding the id counter
+     * rebuilding the slot index for live records and raising the id counter
      * above the largest imported offerId so subsequent offers cannot collide.
+     * The counter only ever moves forward: an import is routinely lossy — the
+     * login reconcile drops terminal records past the retention window, and it
+     * runs on every world hop, not just login — so assigning from the surviving
+     * maximum let the counter regress and hand a fresh offer an id the backend
+     * still holds fills under.
      */
     public synchronized void importRecords(List<OfferRecord> records)
     {
@@ -156,7 +161,7 @@ public final class OfferStore
             }
             maxId = Math.max(maxId, r.getOfferId());
         }
-        nextOfferId = maxId + 1;
+        nextOfferId = Math.max(nextOfferId, maxId + 1);
         // A record entering the store carries progress that has already been reported. Raising the
         // marks to match keeps the next observation measuring the increment rather than re-reporting
         // the whole cumulative.

--- a/src/main/java/com/flipsmart/trading/OfferStore.java
+++ b/src/main/java/com/flipsmart/trading/OfferStore.java
@@ -144,7 +144,7 @@ public final class OfferStore
      * The counter only ever moves forward: an import is routinely lossy — the
      * login reconcile drops terminal records past the retention window, and it
      * runs on every world hop, not just login — so assigning from the surviving
-     * maximum let the counter regress and hand a fresh offer an id the backend
+     * maximum would let the counter regress and hand a fresh offer an ID the backend
      * still holds fills under.
      */
     public synchronized void importRecords(List<OfferRecord> records)

--- a/src/main/java/com/flipsmart/trading/OfferStore.java
+++ b/src/main/java/com/flipsmart/trading/OfferStore.java
@@ -36,6 +36,21 @@ public final class OfferStore
         return fillWatermarks;
     }
 
+    /** The id the next minted offer will take. Persisted so pruning cannot recycle ids. */
+    public synchronized long nextOfferId()
+    {
+        return nextOfferId;
+    }
+
+    /**
+     * Raise the counter to at least {@code candidate}, e.g. from a persisted high-water mark.
+     * Never lowers it, so restoring a stale value cannot reintroduce a collision.
+     */
+    public synchronized void raiseNextOfferId(long candidate)
+    {
+        nextOfferId = Math.max(nextOfferId, candidate);
+    }
+
     /** Register a listener to receive an {@link OfferEvent} after each successful state change. */
     public synchronized void addListener(Consumer<OfferEvent> listener)
     {

--- a/src/test/java/com/flipsmart/GEHistoryServiceTest.java
+++ b/src/test/java/com/flipsmart/GEHistoryServiceTest.java
@@ -282,6 +282,77 @@ public class GEHistoryServiceTest
 		verify(api, times(1)).recordHistoryBackfillBatchAsync(eq("Zezima"), anyList());
 	}
 
+	@Test
+	public void rescanStopsOnceAReadHasSucceeded()
+	{
+		// The rescan exists to retry a read that found no rows, not to catch fills landing while
+		// the tab is open — an offer only enters History once collected, and collecting requires
+		// the main GE interface, which replaces the tab. So once a read parses rows there is
+		// nothing more to find. Previously it re-posted the same forty rows every ten seconds for
+		// as long as the tab stayed open; verified live at inserted=0 deduped=40, twenty times.
+		Client client = mock(Client.class);
+		Widget list = visibleHistoryList();
+		when(client.getWidget(InterfaceID.GE_HISTORY, 3)).thenReturn(list);
+
+		PlayerSession session = mock(PlayerSession.class);
+		when(session.isOfflineSyncCompleted()).thenReturn(true);
+		when(session.getRsnSafe()).thenReturn(Optional.of("Zezima"));
+
+		FlipSmartApiClient api = mock(FlipSmartApiClient.class);
+		when(api.recordHistoryBackfillBatchAsync(eq("Zezima"), anyList()))
+			.thenReturn(CompletableFuture.completedFuture(null));
+
+		GEHistoryService svc = new GEHistoryService(
+			client, api, session, mock(ChatMessageManager.class), new OfferStore());
+
+		for (int tick = 0; tick < 120; tick++)
+		{
+			svc.onGameTick();
+		}
+
+		verify(api, times(1)).recordHistoryBackfillBatchAsync(eq("Zezima"), anyList());
+	}
+
+	@Test
+	public void reopeningTheTabWithChangedContentsPostsAgain()
+	{
+		// New content is only ever reachable through a re-open, which fires WidgetLoaded again.
+		// This is the case the rescan gate must not swallow: collect an offer, come back to the
+		// History tab, and the new row still has to reach the backend.
+		Widget[] before = new Widget[]{
+			headerWidget("Bought:"), itemWidget(4151, 5),
+			priceWidget(GE_YELLOW + "10,000 coins</col><br>= 2,000 each")};
+		Widget[] after = new Widget[]{
+			headerWidget("Bought:"), itemWidget(4151, 9),
+			priceWidget(GE_YELLOW + "18,000 coins</col><br>= 2,000 each")};
+		Widget list = mock(Widget.class);
+		when(list.isHidden()).thenReturn(false);
+		when(list.getDynamicChildren()).thenReturn(before, after);
+
+		Client client = mock(Client.class);
+		when(client.getWidget(InterfaceID.GE_HISTORY, 3)).thenReturn(list);
+
+		PlayerSession session = mock(PlayerSession.class);
+		when(session.isOfflineSyncCompleted()).thenReturn(true);
+		when(session.getRsnSafe()).thenReturn(Optional.of("Zezima"));
+
+		FlipSmartApiClient api = mock(FlipSmartApiClient.class);
+		when(api.recordHistoryBackfillBatchAsync(eq("Zezima"), anyList()))
+			.thenReturn(CompletableFuture.completedFuture(null));
+
+		GEHistoryService svc = new GEHistoryService(
+			client, api, session, mock(ChatMessageManager.class), new OfferStore());
+
+		svc.onGameTick();
+
+		// Re-open the tab: WidgetLoaded, then the two-tick defer it schedules.
+		svc.onHistoryWidgetLoaded();
+		svc.onGameTick();
+		svc.onGameTick();
+
+		verify(api, times(2)).recordHistoryBackfillBatchAsync(eq("Zezima"), anyList());
+	}
+
 	/** A visible History list whose rows the clientscripts have not written yet. */
 	private Widget unpopulatedHistoryList()
 	{

--- a/src/test/java/com/flipsmart/OfferStoreTest.java
+++ b/src/test/java/com/flipsmart/OfferStoreTest.java
@@ -7,6 +7,7 @@ import com.flipsmart.trading.OfferStore;
 import net.runelite.api.GrandExchangeOfferState;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -252,7 +253,7 @@ public class OfferStoreTest
         store.apply(sig(1, GrandExchangeOfferState.BUYING, 5678, 0, 10), NOW);
         long prunedId = store.bySlot(1).getOfferId();
 
-        List<OfferRecord> survivors = new java.util.ArrayList<>();
+        List<OfferRecord> survivors = new ArrayList<>();
         for (OfferRecord r : store.export())
         {
             if (r.getOfferId() != prunedId)

--- a/src/test/java/com/flipsmart/OfferStoreTest.java
+++ b/src/test/java/com/flipsmart/OfferStoreTest.java
@@ -241,6 +241,33 @@ public class OfferStoreTest
     }
 
     @Test
+    public void lossyImport_doesNotRecycleAnIdTheBackendAlreadyHoldsFillsUnder()
+    {
+        // The login reconcile drops terminal records past the retention window and
+        // runs on every world hop, so an import is routinely a SUBSET of what the
+        // store held. Seeding the counter from the survivors let it regress and
+        // remint an id the backend still has fills recorded against.
+        OfferStore store = new OfferStore();
+        store.apply(sig(0, GrandExchangeOfferState.BUYING, 1234, 0, 10), NOW);
+        store.apply(sig(1, GrandExchangeOfferState.BUYING, 5678, 0, 10), NOW);
+        long prunedId = store.bySlot(1).getOfferId();
+
+        List<OfferRecord> survivors = new java.util.ArrayList<>();
+        for (OfferRecord r : store.export())
+        {
+            if (r.getOfferId() != prunedId)
+            {
+                survivors.add(r);
+            }
+        }
+        store.importRecords(survivors);
+
+        store.apply(sig(2, GrandExchangeOfferState.BUYING, 9999, 0, 10), NOW);
+        assertTrue("id counter must not regress past a pruned record",
+            store.bySlot(2).getOfferId() > prunedId);
+    }
+
+    @Test
     public void importRecords_reseedsNextOfferIdAboveMax()
     {
         OfferStore source = new OfferStore();

--- a/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
+++ b/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
@@ -259,6 +259,61 @@ public class OfflineSyncPersistenceTest
 	}
 
 	@Test
+	public void nextOfferIdSurvivesARestartThatPrunesTheRecordsBackingIt()
+	{
+		// The counter is derived from the records the store imports, and retention pruning drops
+		// the oldest terminal ones. Across a restart that let it fall back and remint an id the
+		// backend still holds fills under, so the high-water mark is persisted separately.
+		when(session.getRsn()).thenReturn("Zezima");
+		store.apply(sig(0, GrandExchangeOfferState.BUYING, 1234, 0, 10), 1000L);
+		store.apply(sig(1, GrandExchangeOfferState.BUYING, 5678, 0, 10), 1000L);
+		long highWater = store.nextOfferId();
+
+		service.persistOfferState();
+		assertTrue("high-water offer id key written", configStore.containsKey("nextOfferId_Zezima"));
+
+		// A restart with an empty store, as if every record had aged out of retention.
+		OfferStore restarted = new OfferStore();
+		restarted.raiseNextOfferId(Long.parseLong(configStore.get("nextOfferId_Zezima")));
+		assertEquals("counter must not fall back below what was already issued",
+			highWater, restarted.nextOfferId());
+	}
+
+	@Test
+	public void transientlyEmptyStoreDoesNotClobberTheHighWaterOfferId()
+	{
+		// persistOfferState runs during the logout/hop transition, where the store is empty and
+		// its counter reads 1. Writing that erased the mark — and the mark is the only surviving
+		// record of ids whose offers have aged out of retention, so it is precisely the case the
+		// persistence exists for. Caught in-game: the key was written as 1 against persisted
+		// records topping out at offerId 22.
+		when(session.getRsn()).thenReturn("Zezima");
+		configStore.put("nextOfferId_Zezima", "60");
+
+		service.persistOfferState();
+
+		assertEquals("an empty store must never lower the mark",
+			"60", configStore.get("nextOfferId_Zezima"));
+	}
+
+	@Test
+	public void unparseableOrAbsentNextOfferIdIsIgnoredRatherThanThrowing()
+	{
+		when(session.getRsn()).thenReturn("Zezima");
+		when(session.isOfflineSyncCompleted()).thenReturn(false);
+		when(client.getGrandExchangeOffers()).thenReturn(new GrandExchangeOffer[0]);
+
+		// Absent, blank and corrupt are all handled by one parse rather than separate branches,
+		// so each shape needs to survive it.
+		for (String stored : new String[]{"not-a-number", "", "   "})
+		{
+			configStore.put("nextOfferId_Zezima", stored);
+			service.syncOfflineFills();
+			assertTrue("a mark of '" + stored + "' must not break the sync", store.nextOfferId() >= 1);
+		}
+	}
+
+	@Test
 	public void flipFinderSourced_persistsAndRestoresAcrossRestart()
 	{
 		when(session.getRsn()).thenReturn("Zezima");

--- a/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
+++ b/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
@@ -37,6 +37,7 @@ public class OfflineSyncPersistenceTest
 {
 	private static final String CONFIG_GROUP = "flipsmart";
 	private static final String SYNC_MARKER_ZEZIMA = "offlineSyncAt_Zezima";
+	private static final String NEXT_OFFER_ID_MARKER_ZEZIMA = "nextOfferId_Zezima";
 	/** Prior-sync wall-clock: records with later activity count as fresh offline fills. */
 	private static final String PRIOR_SYNC_AT = "500";
 
@@ -270,11 +271,11 @@ public class OfflineSyncPersistenceTest
 		long highWater = store.nextOfferId();
 
 		service.persistOfferState();
-		assertTrue("high-water offer id key written", configStore.containsKey("nextOfferId_Zezima"));
+		assertTrue("high-water offer id key written", configStore.containsKey(NEXT_OFFER_ID_MARKER_ZEZIMA));
 
 		// A restart with an empty store, as if every record had aged out of retention.
 		OfferStore restarted = new OfferStore();
-		restarted.raiseNextOfferId(Long.parseLong(configStore.get("nextOfferId_Zezima")));
+		restarted.raiseNextOfferId(Long.parseLong(configStore.get(NEXT_OFFER_ID_MARKER_ZEZIMA)));
 		assertEquals("counter must not fall back below what was already issued",
 			highWater, restarted.nextOfferId());
 	}
@@ -288,12 +289,12 @@ public class OfflineSyncPersistenceTest
 		// persistence exists for. Caught in-game: the key was written as 1 against persisted
 		// records topping out at offerId 22.
 		when(session.getRsn()).thenReturn("Zezima");
-		configStore.put("nextOfferId_Zezima", "60");
+		configStore.put(NEXT_OFFER_ID_MARKER_ZEZIMA, "60");
 
 		service.persistOfferState();
 
 		assertEquals("an empty store must never lower the mark",
-			"60", configStore.get("nextOfferId_Zezima"));
+			"60", configStore.get(NEXT_OFFER_ID_MARKER_ZEZIMA));
 	}
 
 	@Test
@@ -307,7 +308,7 @@ public class OfflineSyncPersistenceTest
 		// so each shape needs to survive it.
 		for (String stored : new String[]{"not-a-number", "", "   "})
 		{
-			configStore.put("nextOfferId_Zezima", stored);
+			configStore.put(NEXT_OFFER_ID_MARKER_ZEZIMA, stored);
 			service.syncOfflineFills();
 			assertTrue("a mark of '" + stored + "' must not break the sync", store.nextOfferId() >= 1);
 		}


### PR DESCRIPTION
Closes Flip-Smart/flip-smart#1201

## Summary

`OfferStore.importRecords` assigned `nextOfferId = maxId + 1` from the largest id among the records it was handed. That set is routinely a **subset** of what the store held — the login reconcile drops terminal records past `TERMINAL_HISTORY_RETENTION_MS` and `MAX_RETAINED_TERMINAL_RECORDS`, and it runs on every world hop, not only at login.

So the counter regressed, and a fresh offer could take an id the backend still holds fills under. The method's own comment claimed re-seeding meant "subsequent offers cannot collide" — true within a single import, false once pruning is in the picture.

`apply()` already guarded the counter with `Math.max`; `importRecords` was the outlier. Raise rather than assign, so the counter only ever moves forward.

## Why it matters

The backend reconciles GE History rows per `offer_id`, and that path deliberately bypasses the item-level dedup window for precision. A recycled id corrupts it in both directions: a fresh offer inheriting an old id's fills is masked (data loss), and a renumbered position duplicates (profit inflation — observed live as 41,548 units recorded for a real 20,774-unit position, ~8M gp of phantom buy cost).

The backend-side containment for the duplication direction ships separately under the same issue. This change is the plugin-side half: stop generating bad identities in the first place.

## Scope

This does not make `offer_id` durable. A live position the offline reconciler re-mints still takes a brand-new id while the backend holds its fills under the old one — no choice of counter fixes that, which is why the backend cap exists. Server-side offer identity is tracked in epic #933.

The counter is still derived from the persisted blob at client start, so it can regress across a restart once records age out of retention. Closing that needs the high-water id persisted alongside the records; not done here.

## Changes

### 🐛 Bug Fixes
- `OfferStore.importRecords` now raises `nextOfferId` via `Math.max(nextOfferId, maxId + 1)` instead of assigning it outright, matching the guard `apply()` already had — the counter can only move forward, never regress on a lossy (partial) import.

## Testing

### Automated Tests
- `./gradlew test` — BUILD SUCCESSFUL, no failures.
- New test `OfferStoreTest.lossyImport_doesNotRecycleAnIdTheBackendAlreadyHoldsFillsUnder`, verified to **fail against pre-fix code**: it imports a subset with the highest-id record removed (simulating retention pruning), then places a fresh offer and asserts its id still exceeds the pruned one.

### Manual Testing
- [ ] N/A — this is an internal id-bookkeeping fix with no UI surface; coverage is via the unit test above.

## Token budget

`tools/token-budget.py`: **190,546** against the `.github/token-ceiling` of 191,750. The change is +6 counted tokens — the explanatory comment does not count toward the plugin-hub total.

## Checklist

- [x] Tests added/updated
- [x] Code follows style guidelines (Plugin Hub LOC/comment discipline — no issue refs in source)
- [x] Commits are clean and descriptive
- [x] No console.log / debug code left
- [ ] Reviewed by teammate

## Related Issues

Closes Flip-Smart/flip-smart#1201
Related to Flip-Smart/flip-smart#933

### 🩺 Codacy Quality Gate — fixed in this PR
- `b7b3c43` `PMD_category_java_errorprone_AvoidDuplicateLiterals` src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java:273 — extracted the repeated `"nextOfferId_Zezima"` literal into a `NEXT_OFFER_ID_MARKER_ZEZIMA` constant, matching the existing `SYNC_MARKER_ZEZIMA` pattern in the same file.

### 🩺 Codacy Quality Gate — dismissed via API (noise)
- `PMD_category_java_multithreading_AvoidSynchronizedAtMethodLevel` src/main/java/com/flipsmart/trading/OfferStore.java:40 (`nextOfferId()`) — method-level `synchronized` is semantically identical to wrapping the whole body in `synchronized(this)`; not a real concurrency issue. The class already has 10+ other methods using this exact pattern (`addListener`, `bySlot`, `forItem`, `allRecords`, `export`, `importRecords`, `correctCreatedAt`, `correctActivityAt`, `completedAwaitingCollection`, `hasActiveSellOfferForItem`, `hasLiveBuyOfferForItem`); converting only the 2 new methods to block-level would make the file internally inconsistent for no functional benefit.
- `PMD_category_java_multithreading_AvoidSynchronizedAtMethodLevel` src/main/java/com/flipsmart/trading/OfferStore.java:49 (`raiseNextOfferId()`) — same rationale as above.

### 🤖 Codacy AI Reviewer — fixed in this PR
- `3f87ece` src/test/java/com/flipsmart/OfferStoreTest.java:255 — use simple `ArrayList` class name instead of fully-qualified `java.util.ArrayList`.
- `074c0f0` src/main/java/com/flipsmart/trading/OfferStore.java:148 — tightened Javadoc grammar ("would let" instead of "let") and capitalized "ID".

_(Both AI Reviewer threads were already resolved in the prior pass at head `074c0f0`; no new AI Reviewer comments landed on the two commits added since.)_

---

## Added after in-game QA

Three further changes, all verified against a live client rather than unit tests alone.

### The rescan was built for a state the game cannot reach

`maybeProactiveRescan` re-read the History tab every ~10s for as long as it stayed visible and posted every row each time, to "catch fills that land after the initial open". Those fills cannot land: an offer only enters the History tab once **collected**, and collecting requires the main GE interface, which *replaces* the tab. The tab's contents cannot change while it is visible.

Measured in-game at `inserted=0 deduped=40` on **twenty consecutive reads** — six full forty-row round-trips a minute per player sitting on the tab.

The rescan's real job is retrying a read that recovered nothing, since `WidgetLoaded` fires ahead of the clientscripts that populate the rows. It now stops once a read parses rows. New content arrives via re-opening the tab, which fires `WidgetLoaded` again — confirmed in-game by observing a read on re-open *with the rescan disabled*, where nothing else could have triggered it.

An earlier attempt used a content-signature check on the posted batch. That was ~30 lines solving a problem the gate solves in one, and it has been removed.

### High-water offer id is now persisted

`Math.max` in `importRecords` keeps the counter monotonic within a session, but the store derives it from the records it is given and retention pruning drops the oldest terminal ones. Across a **client restart** the surviving maximum is all that remains, so the counter still fell back. The mark is now persisted per-RSN and raised ahead of the reconcile — which is what mints ids for live slots no persisted record claims.

**Bug found during QA:** written unconditionally, it was clobbered with `1`. The store is transiently empty during the logout/hop transition and its counter reads 1, and the key was written as `1` against persisted records topping out at offerId 22 — destroying the mark in exactly the case it exists for. It is now written only when it would rise. Comparing, rather than testing for an empty store, keeps the guard independent of the order the counter is seeded in.

Verified end-to-end through a real client restart: with the stored mark seeded to **500** and records topping out at 22, fresh offers minted **500 and 501** rather than 25. A correct load and a broken load both yield 23 without that seeding, so the test was staged to distinguish them.

## Verified in-game

| Behaviour | Evidence |
|---|---|
| Backend cap blocks a stale-id duplicate | 6/6 reads, `offer_delta=20774 available=0` |
| Backend cap allows a genuine recovery | `inserted=1`, 20,774 units, no cap line |
| Rescan stops after first success | 1 read, then silence for 5½ min |
| `WidgetLoaded` fires per tab open | read observed with the rescan disabled |
| High-water id persists **and loads** | offers minted at 500/501, not 25 |
| Empty store does not clobber the mark | mark held through the login reconcile |

## Token budget

```
190,546  previous head (Math.max only)
190,816  this head                       (+270)
191,750  .github/token-ceiling            (934 headroom)
```

The rescan simplification is a net deletion; the +270 is the persisted-id feature. A cheaper design — never pruning the highest-id record — was considered and rejected: it leaves a hole, since `plan.staleHistory` records are dropped from the import too, so a max id sitting on one would still regress.

## Tests

`./gradlew test` — BUILD SUCCESSFUL. Seven new tests; five verified to **fail against pre-fix code**:

| Test | Pre-fix |
|---|---|
| `lossyImport_doesNotRecycleAnIdTheBackendAlreadyHoldsFillsUnder` | FAILED |
| `rescanStopsOnceAReadHasSucceeded` | FAILED |
| `reopeningTheTabWithChangedContentsPostsAgain` | FAILED |
| `nextOfferIdSurvivesARestartThatPrunesTheRecordsBackingIt` | FAILED |
| `transientlyEmptyStoreDoesNotClobberTheHighWaterOfferId` | FAILED |
| `unparseableOrAbsentNextOfferIdIsIgnoredRatherThanThrowing` | robustness guard |
