### PR TITLE
Fix offline sync freshness marker that could never pass

### DIFF
--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -44,9 +45,6 @@ public class OfflineSyncService
 	private static final String FLIP_FINDER_SOURCED_KEY_PREFIX = "flipFinderSourced_";
 	private static final String ROUND_TRIP_LEDGER_KEY_PREFIX = "roundTripLedger_";
 	private static final String LAST_KNOWN_RSN_KEY = "lastKnownRsn";
-	// Wall-clock of the last completed offline sync, per RSN. A persisted offer is only a genuine
-	// offline fill if it was active since this marker; older leftovers are already-known history.
-	private static final String OFFLINE_SYNC_MARKER_KEY_PREFIX = "offlineSyncAt_";
 	// High-water offer id, per RSN. The store derives its counter from the records it imports, and
 	// retention pruning drops the oldest terminal ones — so across a client restart the counter
 	// fell back and could remint an id the backend still holds fills under. Persisting the mark
@@ -613,10 +611,7 @@ public class OfflineSyncService
 	private void reconcileOfflineFills(List<OfferRecord> persistedRecords)
 	{
 		long now = System.currentTimeMillis();
-		long freshnessThreshold = readOfflineFillFreshnessThreshold(now);
 		Map<Integer, OfferRecord> currentOffers = liveOffersBySlot();
-		log.debug("Loaded {} persisted offers, comparing with {} current offers",
-			persistedRecords.size(), currentOffers.size());
 
 		// Hand the snapshot to GEHistoryService so fully-completed offline trades
 		// (whose live record no longer exists post-sync) can still be matched and
@@ -624,11 +619,14 @@ public class OfflineSyncService
 		geHistoryService.setRecentlyPersistedOffers(persistedRecords);
 
 		// Reconcile persisted records against live slots to determine which offers
-		// completed or were cancelled while offline. Records last active before the
-		// freshness cutoff are leftovers from prior sessions (already backfilled) and
-		// are routed to staleHistory so they never re-fire the "open GE History" prompt.
+		// completed or were cancelled while offline.
 		List<OfferSignal> liveSlots = buildLiveSlotSignals();
-		OfferReconciler.Plan plan = OfferReconciler.reconcile(persistedRecords, liveSlots, now, freshnessThreshold);
+		// liveSlots is the count that decides every classification below, and a zero-fill buy is
+		// terminalised without being registered — so without it in the log there is no way to tell
+		// a correct reattach from a silent misclassification after the fact.
+		log.debug("Loaded {} persisted offers, comparing with {} store-live and {} client slots",
+			persistedRecords.size(), currentOffers.size(), liveSlots.size());
+		OfferReconciler.Plan plan = OfferReconciler.reconcile(persistedRecords, liveSlots, now);
 
 		// Restore original timestamps on still-live offers whose persisted record is older.
 		for (OfferRecord reattached : plan.reattached)
@@ -647,26 +645,36 @@ public class OfflineSyncService
 		// the player's inventory, so they have not been collected yet.
 		rebuildCollectedItems(persistedRecords, plan.reattached);
 
-		// Each offline-collected record represents an offer whose slot is now gone on login, and
-		// the reconciler has already dropped anything older than the freshness cutoff. This is the
-		// sole path that registers a History backfill, so the cutoff governs every prompt.
-		for (OfferRecord record : plan.offlineCollected)
+		// "No live offers" and "GE data not loaded yet" both surface as an empty signal list, and
+		// only the second is a reason to hold off — the first is the whole point of this path, a
+		// player logging in with everything completed. The client distinguishes them: the offer
+		// array is null until GE data syncs, then present with EMPTY slots. Treating an empty
+		// signal list as unreadable suppressed every genuine offline fill, which is the same
+		// failure the freshness marker produced by a different route.
+		if (client.getGrandExchangeOffers() == null)
 		{
-			if (!record.isBuy() || record.getFilledQuantity() > 0)
-			{
-				geHistoryService.registerOfflineFill(record.getItemId());
-			}
+			log.debug("GE snapshot not loaded at sync — deferring offline-fill classification");
 		}
-
-		if (!plan.staleHistory.isEmpty() && log.isDebugEnabled())
+		else
 		{
-			log.debug("Skipped {} stale persisted offer(s) older than last sync — already-known history, not prompted",
-				plan.staleHistory.size());
+			// Each offline-collected record is an offer whose slot is gone on login. This is the
+			// sole path that registers a History backfill.
+			for (OfferRecord record : plan.offlineCollected)
+			{
+				if (!record.isBuy() || record.getFilledQuantity() > 0)
+				{
+					geHistoryService.registerOfflineFill(record.getItemId());
+				}
+			}
+			// Offered once, so terminalise. A freshness cutoff could not tell "already offered" from
+			// "never observed": a record's last-activity is when the plugin last SAW it change, and
+			// an offline fill is by definition a change it did not see, so comparing that against a
+			// marker written on every sync failed every genuine offline fill.
+			terminaliseOffered(plan.offlineCollected, now);
 		}
 
 		pruneStaleCollectedItems();
 		clearLegacyCollectedKeys();
-		writeOfflineSyncMarker(now);
 		persistOfferState();
 
 		if (onSyncComplete != null)
@@ -676,40 +684,34 @@ public class OfflineSyncService
 	}
 
 	/**
-	 * Freshness cutoff for treating a persisted offer as a genuine offline fill: the wall-clock of
-	 * the previous completed offline sync. On the first sync for an account (marker absent) the whole
-	 * persisted blob predates the marker, so we return {@code now} — every existing record is treated
-	 * as already-known history and suppressed, rather than nagging for a backlog the backend already has.
+	 * Mark records we have just offered for backfill as collected — their slot is gone, which is
+	 * what collected means. Terminal records are skipped by the reconciler, so this is what keeps
+	 * the next login from offering the same record again.
 	 */
-	private long readOfflineFillFreshnessThreshold(long now)
+	private void terminaliseOffered(List<OfferRecord> offered, long now)
 	{
-		String rsn = resolvePersistenceRsn();
-		if (rsn == null)
+		if (offered.isEmpty())
 		{
-			return now;
+			return;
 		}
-		String raw = configManager.getConfiguration(CONFIG_GROUP, OFFLINE_SYNC_MARKER_KEY_PREFIX + rsn);
-		if (raw == null || raw.isEmpty())
+		// Merged rather than replaced in place: the store holds these only if the preload managed
+		// to import them, and the preload skips that when the GE slots were not yet readable. An
+		// offered record that never reached the store would otherwise stay non-terminal in the
+		// blob and be offered again on the next login.
+		Map<Long, OfferRecord> byId = new LinkedHashMap<>();
+		for (OfferRecord r : offerStore.export())
 		{
-			return now;
+			byId.put(r.getOfferId(), r);
 		}
-		try
+		for (OfferRecord r : offered)
 		{
-			return Long.parseLong(raw);
+			OfferRecord current = byId.getOrDefault(r.getOfferId(), r);
+			if (!current.getState().isTerminal())
+			{
+				byId.put(r.getOfferId(), current.withState(OfferState.COLLECTED, now));
+			}
 		}
-		catch (NumberFormatException e)
-		{
-			return now;
-		}
-	}
-
-	private void writeOfflineSyncMarker(long now)
-	{
-		String rsn = resolvePersistenceRsn();
-		if (rsn != null)
-		{
-			configManager.setConfiguration(CONFIG_GROUP, OFFLINE_SYNC_MARKER_KEY_PREFIX + rsn, Long.toString(now));
-		}
+		offerStore.importRecords(new ArrayList<>(byId.values()));
 	}
 
 	private OfferRecord findLiveRecordForSlot(Integer slot, Map<Integer, OfferRecord> currentOffers)
@@ -828,10 +830,10 @@ public class OfflineSyncService
 	 * Must be called from the client thread.
 	 *
 	 * <p>Deliberately silent: an entry losing its backing is not evidence of a fresh offline sell.
-	 * Registering a History backfill here bypassed the reconciler's freshness cutoff entirely, so
-	 * records it had just routed to staleHistory as already-known were prompted for anyway — every
-	 * login, because a set pruned to empty never cleared its own persisted blob. The genuine
-	 * signal is the reconciler's offline-collected bucket, which is cutoff-gated.</p>
+	 * Registering a History backfill here prompted for records the reconciler had already handled,
+	 * on every login, because a set pruned to empty never cleared its own persisted blob. The
+	 * genuine signal is the reconciler's offline-collected bucket, which is offered exactly once
+	 * because offering terminalises the record.</p>
 	 */
 	int pruneStaleCollectedItems()
 	{

--- a/src/main/java/com/flipsmart/OfflineSyncService.java
+++ b/src/main/java/com/flipsmart/OfflineSyncService.java
@@ -624,8 +624,11 @@ public class OfflineSyncService
 		// liveSlots is the count that decides every classification below, and a zero-fill buy is
 		// terminalised without being registered — so without it in the log there is no way to tell
 		// a correct reattach from a silent misclassification after the fact.
-		log.debug("Loaded {} persisted offers, comparing with {} store-live and {} client slots",
-			persistedRecords.size(), currentOffers.size(), liveSlots.size());
+		if (log.isDebugEnabled())
+		{
+			log.debug("Loaded {} persisted offers, comparing with {} store-live and {} client slots",
+				persistedRecords.size(), currentOffers.size(), liveSlots.size());
+		}
 		OfferReconciler.Plan plan = OfferReconciler.reconcile(persistedRecords, liveSlots, now);
 
 		// Restore original timestamps on still-live offers whose persisted record is older.

--- a/src/main/java/com/flipsmart/trading/OfferReconciler.java
+++ b/src/main/java/com/flipsmart/trading/OfferReconciler.java
@@ -16,25 +16,17 @@ public final class OfferReconciler
         public final List<OfferRecord> reattached = new ArrayList<>();
         public final List<OfferSignal> minted = new ArrayList<>();
         public final List<OfferRecord> offlineCollected = new ArrayList<>();
-        // Non-terminal records last active before the freshness cutoff: leftovers from older
-        // sessions (already known to the backend). Terminalize them, but never prompt.
-        public final List<OfferRecord> staleHistory = new ArrayList<>();
-    }
-
-    public static Plan reconcile(List<OfferRecord> persisted, List<OfferSignal> liveSlots, long now)
-    {
-        // No freshness gate: every non-terminal unmatched record is treated as offline-collected.
-        // Used by the preload pass, which terminalizes both buckets regardless.
-        return reconcile(persisted, liveSlots, now, Long.MIN_VALUE);
     }
 
     /**
-     * @param freshnessThresholdMillis a non-terminal unmatched record counts as a genuine offline
-     *     fill only if its last activity is at or after this cutoff; older records are leftovers
-     *     from prior sessions and go to {@link Plan#staleHistory} instead of driving a prompt.
+     * A non-terminal record no live slot claims is an offer that completed while we were not
+     * watching. There is deliberately no timestamp gate on that: a record's last-activity is when
+     * the plugin last <em>observed</em> a change, and an offline fill is by definition a change it
+     * did not observe, so the timestamp can only ever say "older than the last sync". Whether a
+     * record has already been offered for backfill is answered by terminalising it once offered,
+     * not by comparing clocks.
      */
-    public static Plan reconcile(List<OfferRecord> persisted, List<OfferSignal> liveSlots, long now,
-        long freshnessThresholdMillis)
+    public static Plan reconcile(List<OfferRecord> persisted, List<OfferSignal> liveSlots, long now)
     {
         Plan plan = new Plan();
         List<OfferRecord> remaining = new ArrayList<>(persisted);
@@ -68,14 +60,7 @@ public final class OfferReconciler
             {
                 continue;
             }
-            if (r.getEffectiveLastActivityAtMillis() < freshnessThresholdMillis)
-            {
-                plan.staleHistory.add(r);
-            }
-            else
-            {
-                plan.offlineCollected.add(r);
-            }
+            plan.offlineCollected.add(r);
         }
         return plan;
     }

--- a/src/test/java/com/flipsmart/OfferReconcilerTest.java
+++ b/src/test/java/com/flipsmart/OfferReconcilerTest.java
@@ -94,51 +94,37 @@ public class OfferReconcilerTest
     }
 
     @Test
-    public void staleNonTerminalRecord_olderThanFreshness_isHistoryNotOfflineCollected()
+    public void ageDoesNotDisqualifyAnOfflineFill()
     {
-        // A non-terminal record last active before the freshness cutoff is a leftover from an
-        // older session (already known to the backend). It must not drive an offline-fill prompt;
-        // it belongs to staleHistory so the caller can terminalize it without nagging.
-        OfferRecord stale = OfferRecord.newOffer(30L, 1, 400, "i400", false, 3, 100, NOW - 10_000)
-            .withActivityAtMillis(NOW - 10_000);
-        long freshnessThreshold = NOW - 5_000;
-
-        OfferReconciler.Plan plan = OfferReconciler.reconcile(
-            Collections.singletonList(stale), Collections.emptyList(), NOW, freshnessThreshold);
-
-        assertTrue("stale leftover must not be an offline fill", plan.offlineCollected.isEmpty());
-        assertEquals(1, plan.staleHistory.size());
-        assertEquals(30L, plan.staleHistory.get(0).getOfferId());
-    }
-
-    @Test
-    public void recentNonTerminalRecord_newerThanFreshness_isOfflineCollected()
-    {
-        OfferRecord fresh = OfferRecord.newOffer(31L, 2, 500, "i500", false, 3, 100, NOW - 2_000)
-            .withActivityAtMillis(NOW - 2_000);
-        long freshnessThreshold = NOW - 5_000;
-
-        OfferReconciler.Plan plan = OfferReconciler.reconcile(
-            Collections.singletonList(fresh), Collections.emptyList(), NOW, freshnessThreshold);
-
-        assertEquals(1, plan.offlineCollected.size());
-        assertEquals(31L, plan.offlineCollected.get(0).getOfferId());
-        assertTrue(plan.staleHistory.isEmpty());
-    }
-
-    @Test
-    public void threeArgReconcile_appliesNoFreshnessGate()
-    {
-        // Back-compat: the 3-arg form (used by the preload pass, which terminalizes everything
-        // anyway) keeps treating every non-terminal unmatched record as offline-collected.
-        OfferRecord old = OfferRecord.newOffer(32L, 1, 600, "i600", false, 3, 100, NOW - 999_999)
+        // #1197: reconcile used to demand that a record's last activity be at or after the
+        // previous sync marker. That test can never pass for a real offline fill — last-activity
+        // is when the plugin last OBSERVED a change, and an offline fill is by definition a change
+        // it did not observe, so the timestamp always trails a marker written on every sync.
+        // Observed live: lastActivity=19:45:19 against a marker of 19:45:20, and the prompt fired
+        // zero times across nine logins.
+        OfferRecord ancient = OfferRecord.newOffer(30L, 1, 400, "i400", false, 3, 100, NOW - 999_999)
             .withActivityAtMillis(NOW - 999_999);
 
         OfferReconciler.Plan plan = OfferReconciler.reconcile(
-            Collections.singletonList(old), Collections.emptyList(), NOW);
+            Collections.singletonList(ancient), Collections.emptyList(), NOW);
 
-        assertEquals(1, plan.offlineCollected.size());
-        assertTrue(plan.staleHistory.isEmpty());
+        assertEquals("an unmatched non-terminal record is an offline fill regardless of age",
+            1, plan.offlineCollected.size());
+        assertEquals(30L, plan.offlineCollected.get(0).getOfferId());
+    }
+
+    @Test
+    public void terminalRecordIsNeverOfferedAgain()
+    {
+        // What replaces the freshness cutoff: offering a record terminalises it, and the
+        // reconciler skips terminal records outright. That is what stops a re-prompt each login.
+        OfferRecord collected = OfferRecord.newOffer(33L, 1, 700, "i700", false, 3, 100, NOW - 1_000)
+            .withState(OfferState.COLLECTED, NOW - 500);
+
+        OfferReconciler.Plan plan = OfferReconciler.reconcile(
+            Collections.singletonList(collected), Collections.emptyList(), NOW);
+
+        assertTrue("already-offered record must not be offered again", plan.offlineCollected.isEmpty());
     }
 
     @Test

--- a/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
+++ b/src/test/java/com/flipsmart/OfflineSyncPersistenceTest.java
@@ -591,13 +591,15 @@ public class OfflineSyncPersistenceTest
 	 * for it. This is the false-nag the user hit: a relog with no new trades still prompted.
 	 */
 	@Test
-	public void staleOfflineRecordOlderThanLastSync_doesNotPrompt()
+	public void unresolvedOfflineRecordIsOfferedOnceThenNeverAgain()
 	{
+		// #1197: the freshness cutoff suppressed every genuine offline fill. A record's
+		// last-activity is when the plugin last OBSERVED a change, and an offline fill is by
+		// definition a change it did not observe, so the timestamp always trailed a marker that
+		// advanced on every sync. Offering now terminalises the record, and the reconciler skips
+		// terminal records — that, not a clock comparison, is what bounds it to exactly once.
 		when(session.getRsn()).thenReturn("Zezima");
 		when(session.isOfflineSyncCompleted()).thenReturn(false);
-		// Last sync ran at 5000; this record's last activity (2000) predates it → already-known history.
-		configStore.put(SYNC_MARKER_ZEZIMA, "5000");
-
 		store.apply(sig(0, GrandExchangeOfferState.BUYING, 222, 0, 5), 1000L);
 		store.apply(sig(0, GrandExchangeOfferState.CANCELLED_BUY, 222, 2, 5), 2000L);
 		service.persistOfferState();
@@ -605,33 +607,43 @@ public class OfflineSyncPersistenceTest
 		when(client.getGrandExchangeOffers()).thenReturn(new GrandExchangeOffer[0]);
 
 		service.syncOfflineFills();
+		verify(geHistoryService, times(1)).registerOfflineFill(222);
 
-		verify(geHistoryService, never()).registerOfflineFill(222);
+		// A second login over the now-terminal record must not offer it again.
+		service.syncOfflineFills();
+		verify(geHistoryService, times(1)).registerOfflineFill(222);
 	}
 
-	/**
-	 * First sync for an account (no marker yet): the persisted blob predates the feature and is
-	 * already known to the backend, so nothing is prompted — and the marker is written so genuinely
-	 * new offline fills on later logins are detected.
-	 */
 	@Test
-	public void firstSyncWithNoMarker_suppressesPreExistingBlob_andWritesMarker()
+	public void unloadedGeSnapshotAtSyncDefersInsteadOfOffering()
 	{
+		// A null offer array means GE data has not synced; reconciling against it would read every
+		// live offer as gone. Distinct from an array of EMPTY slots, which genuinely means no live
+		// offers and MUST still be offered — that is the case #1197 exists for.
 		when(session.getRsn()).thenReturn("Zezima");
 		when(session.isOfflineSyncCompleted()).thenReturn(false);
-		// No offlineSyncAt_Zezima marker present.
-
-		store.apply(sig(0, GrandExchangeOfferState.BUYING, 333, 0, 5), 1000L);
-		store.apply(sig(0, GrandExchangeOfferState.CANCELLED_BUY, 333, 2, 5), 2000L);
+		store.apply(sig(0, GrandExchangeOfferState.SELLING, 444, 0, 10), 1000L);
 		service.persistOfferState();
-		store.importRecords(Collections.emptyList());
+		// GE data has not synced yet: the client returns no offer array at all.
+		when(client.getGrandExchangeOffers()).thenReturn(null);
+
+		service.syncOfflineFills();
+
+		verify(geHistoryService, never()).registerOfflineFill(444);
+	}
+
+	@Test
+	public void noOfflineSyncMarkerIsWritten()
+	{
+		// The offlineSyncAt_<rsn> key is gone: it could not distinguish "already offered" from
+		// "never observed", and advancing it on every sync is what broke the prompt.
+		when(session.getRsn()).thenReturn("Zezima");
+		when(session.isOfflineSyncCompleted()).thenReturn(false);
 		when(client.getGrandExchangeOffers()).thenReturn(new GrandExchangeOffer[0]);
 
 		service.syncOfflineFills();
 
-		verify(geHistoryService, never()).registerOfflineFill(333);
-		assertTrue("a sync marker is written so later genuine fills are detected",
-			configStore.containsKey(SYNC_MARKER_ZEZIMA));
+		assertFalse(configStore.containsKey(SYNC_MARKER_ZEZIMA));
 	}
 
 	/**


### PR DESCRIPTION
Closes Flip-Smart/flip-smart#1197
Part of Flip-Smart/flip-smart#933

## Summary

`OfferReconciler.reconcile` admitted a record as a genuine offline fill only when its last activity was at or after the `offlineSyncAt_<rsn>` marker. **That test can never pass.** A record's `lastActivityAtMillis` is when the plugin last *observed* a change; an offline fill is by definition a change it did **not** observe; and `writeOfflineSyncMarker(now)` ran at the end of every sync — every login, every hop. The condition that makes something an offline fill is the same condition that makes it fail the freshness test.

Observed live: `lastActivity=19:45:19` against a marker of `19:45:20`, and the prompt fired **zero** times across a full day of logins.

## The fix is a deletion

The timestamp never contributed to *identifying* an offline fill — "unmatched with a live slot, and non-terminal" already does that completely. It was only answering a different question: *have we already offered this record?*

So answer that directly. **Offering a record terminalises it**, and the reconciler skips terminal records. `reconcilePersistedIntoStore` already did exactly this when slots were readable; `reconcileOfflineFills` never did, which is why the cutoff had to be invented.

Removed: `readOfflineFillFreshnessThreshold`, `writeOfflineSyncMarker`, the `offlineSyncAt_` config key, the `staleHistory` bucket, and one of the two `reconcile` overloads.

## Token budget

```
190,816  master
190,646  this branch      (-170)
191,750  .github/token-ceiling   (1,104 headroom)
```

A net reduction: 129 deletions against 114 insertions.

## The guard, and why the obvious one was wrong

`reconcileOfflineFills` never checked whether the GE snapshot was readable, unlike the preload. Removing the marker exposed that: a run offered three records, **two of which were still in their slots**, and terminalised them — confirmed on disk.

The first guard copied the preload's discriminator (empty signal list + store holds live offers). That was wrong in the opposite direction. Every real-gameplay reconcile that day logged `slots readable: false` — not because data was missing, but because the player genuinely had no live offers. That is precisely the case this path exists for, so the guard suppressed the fix exactly as the marker had.

The client distinguishes them: `getGrandExchangeOffers()` returns **null** until GE data syncs, then a present array with `EMPTY` slots. The guard keys on null. Both directions are covered by tests.

## Verified in-game

Every check run against a live client, and each failure mode tested in both directions:

| Check | Evidence |
|---|---|
| Prompt fires at all | 2 registrations where the day's baseline was 0 |
| Correct records only | item `1941` excluded — genuinely collected |
| Offered exactly once | full logout/login: `0 offline-collected`, terminal count 15 -> 17 |
| Chat message visible | confirmed in-game by the user |
| **Live offer survives the sync** | a still-filling buy reattached and remained in the panel |
| Unloaded snapshot defers | test (`null` array) |
| Genuinely-empty slots still offer | test (`EMPTY` array) |

The live-offer case was the one that could cost data, and it was **invisible in the log**: a zero-fill buy is terminalised without being registered, so "zero registrations" looks identical to success. `reconcileOfflineFills` now logs its `liveSlots` count so the log can answer that directly — folded into an existing debug line, so it costs nothing.

## Behaviour change — please review deliberately

The issue states: *"a first-ever sync must not nag for the entire pre-existing backlog."* **This changes that.** A first sync now offers an unresolved pre-existing record **once** instead of never.

Judged acceptable: the backlog is bounded by the eight GE slots, it is a single chat message guarded by `chatPromptSent`, and it leads only to a History read the backend dedups. Preserving the old behaviour would need a "have we synced before" flag costing back most of the 170 tokens. Flagging it rather than letting it slide through.

## Residual

- The `null` vs `EMPTY` discriminator is inferred from observed client behaviour, not documentation — now backed by live observations in both directions. If the client ever returns a non-null unpopulated array, the cost is a spurious prompt plus a premature terminalisation, not lost data.
- `terminaliseOffered` merges records the store did not hold, so it can re-add one that retention had pruned. Re-bounded by the 300-record cap.

## Test plan

`./gradlew test` — **855 tests, BUILD SUCCESSFUL.**

Both end-to-end tests were verified to **fail against pre-fix code**:

| Test | Guards |
|---|---|
| `unresolvedOfflineRecordIsOfferedOnceThenNeverAgain` | the bug, and the offered-once property replacing the cutoff |
| `noOfflineSyncMarkerIsWritten` | the marker is gone |
| `unloadedGeSnapshotAtSyncDefersInsteadOfOffering` | null array defers |
| `ageDoesNotDisqualifyAnOfflineFill` | age must never disqualify |
| `terminalRecordIsNeverOfferedAgain` | terminal records skipped |



### 🩺 Codacy Quality Gate — fixed in this PR
- `72134d9` PMD_category_java_bestpractices_GuardLogStatement `src/main/java/com/flipsmart/OfflineSyncService.java:627` — wrapped the debug log in `log.isDebugEnabled()`

### 🩺 Codacy Quality Gate — dismissed via API (noise)
- PMD_category_java_multithreading_UseConcurrentHashMap `src/main/java/com/flipsmart/OfflineSyncService.java:701` — false positive; `byId` is a method-local `LinkedHashMap` in `terminaliseOffered`, never shared across threads, and the `LinkedHashMap` is deliberate (insertion-order merge semantics), not an oversight

### 🤖 Codacy AI Reviewer — fixed in this PR
- `72134d9` `src/main/java/com/flipsmart/OfflineSyncService.java:628` — same guard-log fix as the quality-gate finding above

### 🤖 Codacy AI Reviewer — deferred (in-thread rationale)
- `src/main/java/com/flipsmart/OfflineSyncService.java:657` — `session.setOfflineSyncCompleted(true)` is set synchronously before the async `reconcileOfflineFills` callback runs, so the null-GE-data guard added in this PR can't actually retry a deferred sync. Confirmed real, but the ordering predates this PR and a proper fix touches the completion-flag lifecycle across all call sites — tracked in Flip-Smart/flip-smart#1203
