### PR TITLE
docs: refresh README to match the plugin as it actually ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,22 @@ A dedicated sidebar panel with three tabs to help you flip smarter:
 #### **Recommended Flips**
 - Get personalized flip recommendations based on your cash stack
 - Choose your flip style: **Conservative**, **Balanced**, or **Aggressive**
+- Pick a **timeframe** to match how long you want to hold: Active, 30 mins, 2 hours, 4 hours or 12 hours
 - See detailed information for each flip:
   - Recommended buy and sell prices
   - Expected profit and ROI
   - Item quantity and GE buy limit
   - Liquidity and risk ratings
+- Favourite items you like, or block ones you never want suggested again
 - Click any item to see more details
 
-<img width="247" height="806" alt="Screenshot 2026-01-13 at 11 47 30 PM" src="https://github.com/user-attachments/assets/b157f443-936f-4b7e-843f-6a8ec63e1c2a" />
+<img width="247" height="806" alt="Screenshot 2026-01-13 at 11 47 30 PM" src="https://github.com/user-attachments/assets/b157f443-936f-4b7e-843f-6a8ec63e1c2a" />
 
 
 #### **Active Flips**
 - Automatically tracks items you've bought and are holding
+- **Action row** on every card tells you at a glance whether you're **Buying** or **Selling** that item
+- An item you're buying and selling at the same time gets its own card for each side
 - Shows current profit potential with live market prices
 - Displays your total investment across all active flips
 - See pending GE buy orders that haven't filled yet
@@ -45,20 +49,39 @@ A dedicated sidebar panel with three tabs to help you flip smarter:
 - See profit/loss for each completed flip
 - Track your flipping performance over time
 - Click to expand and see flip duration and GE tax paid
-  
+
 <img width="558" height="1264" alt="image" src="https://github.com/user-attachments/assets/2067724a-0f60-4b80-a32b-437058e5dc1c" />
 
 
-### 📊 Exchange Viewer Overlay
+### 📈 Session Stats
 
+A collapsible summary at the top of the panel tracks how the current session is going:
+
+- **Profit this session** as flips complete
+- **Session duration**
+- **Realised GP/hour** from flips you've actually finished
+- **Projected GP/hour** including what you're still holding
+
+### 🏷️ Grand Exchange Offer Screen
+
+When you open a GE offer, the plugin adds the numbers you'd otherwise work out yourself:
+
+- **Breakeven, tax and profit** for the offer you're setting up
+- **Buy limit and cooldown timer** so you know when your 4-hour limit resets
+- **Offer timers** showing how long each offer has been sitting
+- **Competitiveness indicators** comparing your price to Wiki prices
+- **Coloured slot borders** so a glance across the GE tells you which offers are competitive
+- **Adjustment prompts** when prices move and an offer has gone stale
+- **Profit/loss on sell offer tooltips**, based on what you actually paid
+
+### 📊 Exchange Viewer Overlay
 
 A real-time on-screen display that shows all your active GE offers at a glance:
 
 - **Live offer tracking**: See all 8 GE slots with their current status
 - **Progress bars**: Visual progress showing how much of each offer has filled
 - **Item details**: Item names, icons, quantities, and prices
-- **Buy/Sell indicators**: Color-coded to easily identify buy (green) vs sell (red) offers
-- **Multiple display sizes**: Choose between Full or Compact layouts
+- **Buy/Sell indicators**: Colour-coded to easily identify buy vs sell offers
 - **Auto-hide empty slots**: Only shows active offers for a clean interface
 - **Smart visibility**: Automatically hides when at the Grand Exchange, shows everywhere else
 
@@ -71,6 +94,7 @@ The plugin automatically monitors your Grand Exchange activity:
 - **Detects sell orders** when you sell items
 - **Tracks profit/loss** automatically
 - **Links recommended prices** to your trades for better tracking
+- **Catches up after you log out**: trades that completed while you were away are reconciled from your GE history next time you log in
 
 ### 🧭 Flip Assistant (Guided Workflow)
 
@@ -86,12 +110,34 @@ A floating step-by-step guide that walks you through the entire flip process:
 The assistant automatically detects:
 - When you're searching for an item (prompts to press Enter/hotkey)
 - When you need to set quantity (shows recommended qty, hotkey hint)
-- When you need to set price (shows recommended price, hotkey hint)  
+- When you need to set price (shows recommended price, hotkey hint)
 - When you need to confirm the offer
 
 Perfect for learning the flip workflow or staying focused during multi-item flips!
 
-<img width="245" height="195" alt="Screenshot 2026-01-13 at 11 49 32 PM" src="https://github.com/user-attachments/assets/8aafc3a2-85b4-46bb-ad7f-267e43551379" />
+<img width="245" height="195" alt="Screenshot 2026-01-13 at 11 49 32 PM" src="https://github.com/user-attachments/assets/8aafc3a2-85b4-46bb-ad7f-267e43551379" />
+
+### 🔁 Auto Mode
+
+Turn on **Auto-Recommend** and the plugin cycles through recommendations one at a time,
+loading each into Flip Assist as you go, so you can work a list without going back to the
+panel between every flip.
+
+### 🚦 Active Offer Advisor
+
+For offers you already have open, the advisor tells you whether to **wait**, **move your
+price**, or **exit** an offer that's been sitting too long — so a slow offer doesn't quietly
+tie up a slot all day.
+
+### 🔔 Notifications
+
+Get told when something needs you, instead of watching the GE:
+
+- **Sale completed**: a sell order finished
+- **Flip suggestion**: a new suggestion is ready
+- **Action alert**: a GE offer needs attention — sound and desktop popup follow your
+  RuneLite notification settings unless you override them
+- **Discord webhook**: send the same alerts to a Discord channel
 
 ### 💰 Smart Recommendations
 
@@ -108,6 +154,10 @@ Recommendations consider:
 - ROI and profit margins
 - GE buy limits
 
+You can also narrow what gets suggested with **F2P Mode**, a **minimum volume** floor, a
+**minimum profit** threshold, and a **cashstack override** if you want to plan flips for a
+budget other than the coins currently in your inventory.
+
 ### 📈 Real-Time Market Data
 
 All prices and calculations are based on live market data:
@@ -122,17 +172,25 @@ Access settings via the RuneLite configuration panel (wrench icon) → "FlipSmar
 
 ### Flip Finder
 - **Enable Flip Finder**: Toggle the sidebar panel on/off
-- **Number of Recommendations**: How many flips to show (1-50)
+- **Number of Recommendations**: How many flips to show
 - **Flip Style**: Choose Conservative, Balanced, or Aggressive
-- **Refresh Interval**: How often to update recommendations (1-60 minutes)
+- **Timeframe**: Active, 30 mins, 2 hours, 4 hours or 12 hours
+- **Refresh Interval (minutes)**: How often to update recommendations
+- **F2P Mode**: Only show F2P items, even on members worlds
 - **Minimum Profit**: Only show items above this profit threshold
+- **Minimum Volume**: Hide recommendations with daily trade volume below this value
+- **Cashstack Override** / **Override Amount**: Suggest flips for a fixed budget instead of your actual inventory cash (supports `500k`, `2.5m`, `10M`)
 
 ### Display
 - **Show Exchange Viewer**: Toggle the GE offer overlay on/off (disabled by default, hides when at the GE area)
-- **Display Size**: Choose between Full or Compact layouts
-- **Show Item Names**: Display item names in the Exchange Viewer (Full mode only)
-- **Show Item Icons**: Display item icons in the Exchange Viewer
-- **Show Detailed Info**: Show quantity, price per item, and total value (Full mode only)
+- **Show Item Info**: Show breakeven, tax and profit on the GE offer screen
+- **Show Offer Timers**: Display elapsed time for each GE offer
+- **Show Competitiveness**: Indicators comparing your price to Wiki prices
+- **Highlight Slot Borders**: Draw coloured borders around GE slots based on competitiveness
+- **Show Adjustment Prompts**: Prompt to adjust stale GE offers when prices have moved
+- **Show Profit/Loss**: Display profit/loss on GE sell offer tooltips based on your buy price
+- **Colorblind Mode**: Use blue/orange instead of green/red
+- **Active Offer Advisor**: In Active mode, advise when to wait, move price down, or exit aging offers
 
 ### Flip Assistant
 - **Enable Flip Assistant**: Toggle the guided workflow overlay on/off
@@ -140,9 +198,19 @@ Access settings via the RuneLite configuration panel (wrench icon) → "FlipSmar
 - **Highlight GE Buttons**: Highlight buy/sell buttons and input fields in the GE
 - **Show When GE Closed**: Keep the assistant visible even outside the Grand Exchange
 - **Price Offset (GP)**: Adjust buy/sell prices to fill faster (positive = buy higher, sell lower)
+- **Auto-Recommend**: Automatically cycle through recommendations one by one into Flip Assist
 
-### General
-- **Track History**: Save flip history across sessions
+### Notifications
+- **Sale Completed**: Notify when a sell order completes in the GE
+- **Flip Suggestion**: Notify when a new flip suggestion is available
+- **Action Alert**: Notify when a GE offer needs action
+- **Discord Webhook URL**: Send notifications to a Discord channel
+
+### Experimental
+- **Aggressive Advisor**: Experimental advisor behaviour — expect rough edges
+
+### Advanced
+- **API URL Override**: Leave empty to use the production server
 
 ## 🚀 Getting Started
 
@@ -157,13 +225,14 @@ Access settings via the RuneLite configuration panel (wrench icon) → "FlipSmar
 
 - **Start small**: Test with low-cost items to get familiar with the plugin
 - **Use the Exchange Viewer**: Enable it in Display settings to monitor all your offers at a glance anywhere in the game
-- **Try different sizes**: Use Compact mode for minimal screen usage
-- **Check Active Flips**: Monitor your active flips to see current profit potential
+- **Pick a timeframe that matches you**: Active is for flips you'll babysit; 12 hours suits overnight holds
+- **Check Active Flips**: The Action row tells you which side each item is on without opening the GE
 - **Use Recommended Prices**: When buying a recommended item, the plugin remembers the suggested sell price
 - **Watch your cash**: The plugin considers your cash stack when recommending flips
 - **Refresh recommendations**: Click the refresh button to get updated market data
 - **Dismiss items**: Right-click active flips to remove items you no longer want to track
 - **Use Price Offset**: If offers aren't filling fast enough, set a small price offset (e.g., 1-5 GP) to improve fill rates
+- **Let the advisor watch slow offers**: Active Offer Advisor will tell you when an offer has gone stale rather than you checking manually
 
 ## 🎮 In-Game Usage
 
@@ -190,7 +259,8 @@ Access settings via the RuneLite configuration panel (wrench icon) → "FlipSmar
 
 **No recommendations showing up**
 - Make sure you have enough cash in your inventory
-- Try lowering the "Minimum Profit" setting
+- Try lowering the "Minimum Profit" or "Minimum Volume" setting
+- Check whether "F2P Mode" is on and you're expecting members items
 - Check that you're logged into OSRS
 - Try clicking the Refresh button
 
@@ -209,6 +279,10 @@ Access settings via the RuneLite configuration panel (wrench icon) → "FlipSmar
 **Orders not filling quickly**
 - Try increasing the "Price Offset" setting in Flip Assistant configuration
 - This will automatically adjust your buy/sell prices to fill faster
+
+**Not getting notified about offers**
+- Check the Notifications section - "Action Alert" and "Sale Completed" are configured separately
+- Desktop notifications follow your RuneLite notification settings unless you override them
 
 ## 🌐 Web Dashboard
 


### PR DESCRIPTION
## Summary

The README had drifted from what the plugin actually ships: it documented five settings that no longer exist anywhere in the codebase, and left roughly a dozen real, shipped features — including two entire config sections — undocumented. This PR is a documentation audit and correction, not a feature or ticket implementation: every setting listed was checked against an actual `@ConfigItem` in `FlipSmartConfig.java`, and the Configuration section now mirrors the six real config sections one-for-one.

## Changes

### 📝 Documentation
- **Removed** five settings with zero references anywhere in `src/main`: Display Size, Show Item Names, Show Item Icons, Show Detailed Info, Track History.
- **Added** documentation for real shipped features that were missing:
  - Timeframe selection (Active / 30 mins / 2 hours / 4 hours / 12 hours)
  - The Active Flips "Action row" (Buying / Selling), shipped in #255
  - Session Stats (profit this session, duration, realised and projected GP/hour)
  - GE offer screen additions: breakeven/tax/profit, buy limit + 4h cooldown timer, offer timers, competitiveness indicators, coloured slot borders, adjustment prompts, sell-offer profit/loss tooltips
  - Auto Mode (Auto-Recommend)
  - Active Offer Advisor
  - Notifications in full: Sale Completed, Flip Suggestion, Action Alert, Discord webhook
  - Offline reconciliation (trades completed while logged out)
  - F2P Mode, Minimum Volume, Cashstack Override filters
  - Favourite / block items
- **Rewrote the Configuration section** to mirror the six real config sections one-for-one: Flip Finder, Display, Flip Assistant, Notifications, Experimental, Advanced.
- Setting descriptions were taken from the actual `@ConfigItem` description strings in `FlipSmartConfig.java` rather than freely invented or paraphrased.
- The README deliberately does not describe how the recommendation engine decides anything internally (pricing, timeframes, volume thresholds, risk math) — it documents user-facing controls only, matching the existing level of detail and the project's standing guardrail against leaking algorithm internals.

No source files (`src/main/**`) were touched — README.md only, 92 insertions / 18 deletions.

## Testing

This is a docs-only change; there is no code to build, lint, or test.

### Automated Tests
- N/A — no source changed. CI test/build workflows are expected to skip on this PR via `paths-ignore` for `**.md`. A skipped run here is correct, not a broken pipeline.

### Manual Testing
- [x] Every one of the 30 documented settings checked against an actual `@ConfigItem` keyName in `FlipSmartConfig.java` — zero missing.
- [x] All five removed settings confirmed to have zero references in `src/main` before removal.
- [x] All 4 screenshot URLs in the README diffed byte-identical before and after — the images updated in #256 are untouched by this PR.
- [x] Plugin token budget confirmed unchanged at 186,400 / 200,000 — README.md is not under `src/main` so it does not count toward the Plugin Hub token ceiling.

## Deployment Notes

None — docs only.

## Checklist

- [x] Docs updated (this is the change)
- [x] No source files touched
- [x] Commits are clean and descriptive
- [x] No stale/incorrect settings left in the README
- [x] Screenshots verified untouched
- [ ] Reviewed by teammate

## Related Issues

Not tied to a tracked GitHub issue — this is a standalone documentation drift-correction, not a ticket implementation. No issue is closed by this PR.
